### PR TITLE
Normalize PicoClaw bridge model IDs

### DIFF
--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -157,7 +157,6 @@ func picoclawBoxEnvVars(baseURL, accessToken, botID, llmBaseURL, modelID string)
 	env["PICOCLAW_CHANNELS_CSGCLAW_BASE_URL"] = baseURL
 	env["PICOCLAW_CHANNELS_CSGCLAW_ACCESS_TOKEN"] = accessToken
 	env["PICOCLAW_CHANNELS_CSGCLAW_BOT_ID"] = botID
-	env["PICOCLAW_AGENTS_DEFAULTS_MODEL"] = modelID
 	env["PICOCLAW_AGENTS_DEFAULTS_MODEL_NAME"] = modelID
 	env["PICOCLAW_CUSTOM_MODEL_NAME"] = modelID
 	env["PICOCLAW_CUSTOM_MODEL_ID"] = picoclawModelID

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -151,14 +151,16 @@ func bridgeLLMEnvVars(llmBaseURL, accessToken, modelID string) map[string]string
 
 func picoclawBoxEnvVars(baseURL, accessToken, botID, llmBaseURL, modelID string) map[string]string {
 	env := bridgeLLMEnvVars(llmBaseURL, accessToken, modelID)
+	picoclawModelID := picoclawBridgeModelID(modelID)
 	env["CSGCLAW_BASE_URL"] = baseURL
 	env["CSGCLAW_ACCESS_TOKEN"] = accessToken
 	env["PICOCLAW_CHANNELS_CSGCLAW_BASE_URL"] = baseURL
 	env["PICOCLAW_CHANNELS_CSGCLAW_ACCESS_TOKEN"] = accessToken
 	env["PICOCLAW_CHANNELS_CSGCLAW_BOT_ID"] = botID
+	env["PICOCLAW_AGENTS_DEFAULTS_MODEL"] = modelID
 	env["PICOCLAW_AGENTS_DEFAULTS_MODEL_NAME"] = modelID
 	env["PICOCLAW_CUSTOM_MODEL_NAME"] = modelID
-	env["PICOCLAW_CUSTOM_MODEL_ID"] = modelID
+	env["PICOCLAW_CUSTOM_MODEL_ID"] = picoclawModelID
 	env["PICOCLAW_CUSTOM_MODEL_API_KEY"] = accessToken
 	env["PICOCLAW_CUSTOM_MODEL_BASE_URL"] = llmBaseURL
 	return env

--- a/internal/agent/defaults/picoclaw-config.json
+++ b/internal/agent/defaults/picoclaw-config.json
@@ -9,7 +9,6 @@
       "restrict_to_workspace": false,
       "allow_read_outside_workspace": true,
       "provider": "",
-      "model": "minimax-m2.7",
       "model_name": "minimax-m2.7",
       "max_tokens": 32768,
       "max_tool_iterations": 50,

--- a/internal/agent/defaults/picoclaw-config.json
+++ b/internal/agent/defaults/picoclaw-config.json
@@ -9,6 +9,7 @@
       "restrict_to_workspace": false,
       "allow_read_outside_workspace": true,
       "provider": "",
+      "model": "minimax-m2.7",
       "model_name": "minimax-m2.7",
       "max_tokens": 32768,
       "max_tool_iterations": 50,
@@ -73,7 +74,7 @@
   "model_list": [
     {
       "model_name": "minimax-m2.7",
-      "model": "minimax-m2.7",
+      "model": "openai/minimax-m2.7",
       "api_base": "http://127.0.0.1:4000",
       "api_key": "sk-1234567890"
     }

--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -94,13 +94,16 @@ func updateModelList(cfg map[string]any, botID string, server config.ServerConfi
 	if !ok {
 		return fmt.Errorf("embedded manager picoclaw config has invalid model_list[0]")
 	}
-	if modelCfg.ModelID != "" {
-		model["model_name"] = modelCfg.ModelID
-		model["model"] = modelCfg.ModelID
+	if modelID := strings.TrimSpace(modelCfg.ModelID); modelID != "" {
+		model["model_name"] = modelID
+		model["model"] = picoclawBridgeModelID(modelID)
 	}
 	if agents, ok := cfg["agents"].(map[string]any); ok {
-		if defaults, ok := agents["defaults"].(map[string]any); ok && modelCfg.ModelID != "" {
-			defaults["model_name"] = modelCfg.ModelID
+		if defaults, ok := agents["defaults"].(map[string]any); ok {
+			if modelID := strings.TrimSpace(modelCfg.ModelID); modelID != "" {
+				defaults["model_name"] = modelID
+				defaults["model"] = modelID
+			}
 		}
 	}
 
@@ -111,6 +114,23 @@ func updateModelList(cfg map[string]any, botID string, server config.ServerConfi
 		model["api_key"] = server.AccessToken
 	}
 	return nil
+}
+
+func picoclawBridgeModelID(modelID string) string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(modelID), "openai/") {
+		return modelID
+	}
+	if prefix, rest, ok := strings.Cut(modelID, ":"); ok && strings.EqualFold(strings.TrimSpace(prefix), "openai") && strings.TrimSpace(rest) != "" {
+		return "openai/" + strings.TrimSpace(rest)
+	}
+	// The local bridge always exposes an OpenAI-compatible endpoint, so the
+	// PicoClaw model entry must use the OpenAI protocol even if the upstream
+	// model identifier itself contains slashes.
+	return "openai/" + modelID
 }
 
 func updateCSGClawChannel(cfg map[string]any, botID string, server config.ServerConfig) error {

--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -102,7 +102,6 @@ func updateModelList(cfg map[string]any, botID string, server config.ServerConfi
 		if defaults, ok := agents["defaults"].(map[string]any); ok {
 			if modelID := strings.TrimSpace(modelCfg.ModelID); modelID != "" {
 				defaults["model_name"] = modelID
-				defaults["model"] = modelID
 			}
 		}
 	}

--- a/internal/agent/manager_config_test.go
+++ b/internal/agent/manager_config_test.go
@@ -52,7 +52,6 @@ func TestRenderAgentPicoClawConfigUsesBridgeModelEndpoint(t *testing.T) {
 
 	text := string(data)
 	for _, want := range []string{
-		`"model": "gpt-5.4"`,
 		`"model_name": "gpt-5.4"`,
 		`"model": "openai/gpt-5.4"`,
 		`"api_base": "http://10.0.0.8:18080/api/bots/u-ux/llm"`,

--- a/internal/agent/manager_config_test.go
+++ b/internal/agent/manager_config_test.go
@@ -52,7 +52,9 @@ func TestRenderAgentPicoClawConfigUsesBridgeModelEndpoint(t *testing.T) {
 
 	text := string(data)
 	for _, want := range []string{
+		`"model": "gpt-5.4"`,
 		`"model_name": "gpt-5.4"`,
+		`"model": "openai/gpt-5.4"`,
 		`"api_base": "http://10.0.0.8:18080/api/bots/u-ux/llm"`,
 		`"api_key": "shared-token"`,
 		`"bot_id": "u-ux"`,
@@ -66,7 +68,16 @@ func TestRenderAgentPicoClawConfigUsesBridgeModelEndpoint(t *testing.T) {
 	}
 }
 
-func TestEnsureAgentPicoClawConfigWritesConfigFiles(t *testing.T) {
+func TestPicoclawBridgeModelIDPrefixesOpenAIForSlashModelNames(t *testing.T) {
+	if got, want := picoclawBridgeModelID("Qwen/Qwen3-0.6B-GGUF"), "openai/Qwen/Qwen3-0.6B-GGUF"; got != want {
+		t.Fatalf("picoclawBridgeModelID() = %q, want %q", got, want)
+	}
+	if got, want := picoclawBridgeModelID("openai/gpt-5.4"), "openai/gpt-5.4"; got != want {
+		t.Fatalf("picoclawBridgeModelID() = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureAgentPicoClawConfigUsesDirectoryMountRoot(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1118,7 +1118,6 @@ func TestPicoclawBoxEnvVars(t *testing.T) {
 		"OPENAI_BASE_URL":                        "http://10.0.0.8:18080/api/bots/u-worker-1/llm",
 		"OPENAI_API_KEY":                         "shared-token",
 		"OPENAI_MODEL":                           "minimax-m2.7",
-		"PICOCLAW_AGENTS_DEFAULTS_MODEL":         "minimax-m2.7",
 		"PICOCLAW_AGENTS_DEFAULTS_MODEL_NAME":    "minimax-m2.7",
 		"PICOCLAW_CUSTOM_MODEL_NAME":             "minimax-m2.7",
 		"PICOCLAW_CUSTOM_MODEL_ID":               "openai/minimax-m2.7",

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1118,9 +1118,10 @@ func TestPicoclawBoxEnvVars(t *testing.T) {
 		"OPENAI_BASE_URL":                        "http://10.0.0.8:18080/api/bots/u-worker-1/llm",
 		"OPENAI_API_KEY":                         "shared-token",
 		"OPENAI_MODEL":                           "minimax-m2.7",
+		"PICOCLAW_AGENTS_DEFAULTS_MODEL":         "minimax-m2.7",
 		"PICOCLAW_AGENTS_DEFAULTS_MODEL_NAME":    "minimax-m2.7",
 		"PICOCLAW_CUSTOM_MODEL_NAME":             "minimax-m2.7",
-		"PICOCLAW_CUSTOM_MODEL_ID":               "minimax-m2.7",
+		"PICOCLAW_CUSTOM_MODEL_ID":               "openai/minimax-m2.7",
 		"PICOCLAW_CUSTOM_MODEL_API_KEY":          "shared-token",
 		"PICOCLAW_CUSTOM_MODEL_BASE_URL":         "http://10.0.0.8:18080/api/bots/u-worker-1/llm",
 	}
@@ -1128,6 +1129,23 @@ func TestPicoclawBoxEnvVars(t *testing.T) {
 		if got[key] != want {
 			t.Fatalf("%s = %q, want %q", key, got[key], want)
 		}
+	}
+}
+
+func TestPicoclawBoxEnvVarsPrefixesCustomModelIDForSlashNames(t *testing.T) {
+	got := picoclawBoxEnvVars(
+		"http://10.0.0.8:18080",
+		"shared-token",
+		"u-worker-1",
+		"http://10.0.0.8:18080/api/bots/u-worker-1/llm",
+		"Qwen/Qwen3-0.6B-GGUF",
+	)
+
+	if got["PICOCLAW_CUSTOM_MODEL_ID"] != "openai/Qwen/Qwen3-0.6B-GGUF" {
+		t.Fatalf("PICOCLAW_CUSTOM_MODEL_ID = %q, want %q", got["PICOCLAW_CUSTOM_MODEL_ID"], "openai/Qwen/Qwen3-0.6B-GGUF")
+	}
+	if got["PICOCLAW_CUSTOM_MODEL_NAME"] != "Qwen/Qwen3-0.6B-GGUF" {
+		t.Fatalf("PICOCLAW_CUSTOM_MODEL_NAME = %q, want %q", got["PICOCLAW_CUSTOM_MODEL_NAME"], "Qwen/Qwen3-0.6B-GGUF")
 	}
 }
 


### PR DESCRIPTION
## Normalize PicoClaw bridge model IDs

- Prefix PicoClaw provider-facing model IDs with `openai/` when routing through the local OpenAI-compatible bridge.
- Preserve raw model names for CSGClaw profile/model display and default agent selection.
- Update the embedded PicoClaw config template and env var tests to cover slash-containing model IDs like `Qwen/Qwen3-0.6B-GGUF`.
