### PR TITLE
Integrate with CSGHub-lite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ onboard: boxlite-setup
 	env GOCACHE=$(GOCACHE) $(GO) run -ldflags "$(LDFLAGS)" ./cmd/csgclaw onboard \
 		--base-url $(ONBOARD_BASE_URL) \
 		--api-key $(ONBOARD_API_KEY) \
-		--model-id $(ONBOARD_MODEL_ID) \
+		--models $(ONBOARD_MODEL_ID) \
 		--manager-image $(ONBOARD_MANAGER_IMAGE)
 
 package: boxlite-setup sync-agent-runtimes

--- a/README.md
+++ b/README.md
@@ -34,14 +34,45 @@ go build ./cmd/csgclaw
 ## Quick Start
 
 ```bash
-csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]
+csgclaw onboard
 csgclaw serve
 ```
 
 Open the printed URL (e.g. `http://127.0.0.1:18080/`) in your browser to enter the IM workspace.
-For a fresh config, `onboard` creates a single `default` provider and sets `models.default` to `default.<first-model>`.
+For a fresh interactive setup, `onboard` defaults to `csghub-lite` at `http://127.0.0.1:11435/v1`, lets you override that URL, and imports models from its OpenAI-compatible `/v1/models` endpoint. Start CSGHub-lite first, for example:
+
+```bash
+csghub-lite run Qwen/Qwen3-0.6B-GGUF
+```
+
+For scripts or non-interactive environments, pass model flags explicitly:
+
+```bash
+csgclaw onboard --provider csghub-lite --models Qwen/Qwen3-0.6B-GGUF
+csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]
+```
 
 ## Model Provider Examples
+
+### Local CSGHub-lite
+
+```toml
+[server]
+listen_addr = "0.0.0.0:18080"
+advertise_base_url = "http://127.0.0.1:18080"
+access_token = "your_access_token"
+
+[models]
+default = "csghub-lite.Qwen/Qwen3-0.6B-GGUF"
+
+[models.providers.csghub-lite]
+base_url = "http://127.0.0.1:11435/v1"
+api_key = "local"
+models = ["Qwen/Qwen3-0.6B-GGUF"]
+
+[bootstrap]
+manager_image = "ghcr.io/russellluo/picoclaw:2026.4.15.3"
+```
 
 ### Remote LLM API
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,14 +34,45 @@ go build ./cmd/csgclaw
 ## 快速开始
 
 ```bash
-csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]
+csgclaw onboard
 csgclaw serve
 ```
 
 执行后 CLI 会打印访问地址（例如 `http://127.0.0.1:18080/`），在浏览器中打开即可进入 IM 工作区。
-对于全新配置，`onboard` 会创建一个名为 `default` 的 provider，并把 `models.default` 设为 `default.<第一个模型>`。
+全新交互式配置会默认选择 `csghub-lite`，访问 `http://127.0.0.1:11435/v1`，也可以在提示中覆盖这个 URL，并从 OpenAI 兼容的 `/v1/models` 自动导入模型。请先启动 CSGHub-lite，例如：
+
+```bash
+csghub-lite run Qwen/Qwen3-0.6B-GGUF
+```
+
+脚本或非交互环境请显式传入模型参数：
+
+```bash
+csgclaw onboard --provider csghub-lite --models Qwen/Qwen3-0.6B-GGUF
+csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]
+```
 
 ## Model Provider 配置示例
+
+### 本地 CSGHub-lite
+
+```toml
+[server]
+listen_addr = "0.0.0.0:18080"
+advertise_base_url = "http://127.0.0.1:18080"
+access_token = "your_access_token"
+
+[models]
+default = "csghub-lite.Qwen/Qwen3-0.6B-GGUF"
+
+[models.providers.csghub-lite]
+base_url = "http://127.0.0.1:11435/v1"
+api_key = "local"
+models = ["Qwen/Qwen3-0.6B-GGUF"]
+
+[bootstrap]
+manager_image = "ghcr.io/russellluo/picoclaw:2026.4.15.3"
+```
 
 ### 远程 LLM API
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -27,6 +27,7 @@ const (
 )
 
 type App struct {
+	stdin      io.Reader
 	stdout     io.Writer
 	stderr     io.Writer
 	httpClient HTTPClient
@@ -44,6 +45,7 @@ type GlobalOptions struct {
 
 func New() *App {
 	app := &App{
+		stdin:      os.Stdin,
 		stdout:     os.Stdout,
 		stderr:     os.Stderr,
 		httpClient: &http.Client{},
@@ -278,8 +280,13 @@ func (g GlobalOptions) commandOptions() command.GlobalOptions {
 }
 
 func (a *App) commandContext() *command.Context {
+	stdin := a.stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
 	return &command.Context{
 		Program:    "csgclaw",
+		Stdin:      stdin,
 		Stdout:     a.stdout,
 		Stderr:     a.stderr,
 		HTTPClient: a.httpClient,

--- a/cli/app.go
+++ b/cli/app.go
@@ -280,13 +280,9 @@ func (g GlobalOptions) commandOptions() command.GlobalOptions {
 }
 
 func (a *App) commandContext() *command.Context {
-	stdin := a.stdin
-	if stdin == nil {
-		stdin = os.Stdin
-	}
 	return &command.Context{
 		Program:    "csgclaw",
-		Stdin:      stdin,
+		Stdin:      a.stdin,
 		Stdout:     a.stdout,
 		Stderr:     a.stderr,
 		HTTPClient: a.httpClient,

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -52,6 +52,7 @@ type ActionResult struct {
 
 type Context struct {
 	Program    string
+	Stdin      io.Reader
 	Stdout     io.Writer
 	Stderr     io.Writer
 	HTTPClient apiclient.HTTPClient

--- a/cli/csgclawcli/app.go
+++ b/cli/csgclawcli/app.go
@@ -248,13 +248,9 @@ func (g GlobalOptions) commandOptions() command.GlobalOptions {
 }
 
 func (a *App) commandContext() *command.Context {
-	stdin := a.stdin
-	if stdin == nil {
-		stdin = os.Stdin
-	}
 	return &command.Context{
 		Program:    "csgclaw-cli",
-		Stdin:      stdin,
+		Stdin:      a.stdin,
 		Stdout:     a.stdout,
 		Stderr:     a.stderr,
 		HTTPClient: a.httpClient,

--- a/cli/csgclawcli/app.go
+++ b/cli/csgclawcli/app.go
@@ -24,6 +24,7 @@ const (
 )
 
 type App struct {
+	stdin      io.Reader
 	stdout     io.Writer
 	stderr     io.Writer
 	httpClient apiclient.HTTPClient
@@ -40,6 +41,7 @@ type GlobalOptions struct {
 
 func New() *App {
 	app := &App{
+		stdin:      os.Stdin,
 		stdout:     os.Stdout,
 		stderr:     os.Stderr,
 		httpClient: &http.Client{},
@@ -246,8 +248,13 @@ func (g GlobalOptions) commandOptions() command.GlobalOptions {
 }
 
 func (a *App) commandContext() *command.Context {
+	stdin := a.stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
 	return &command.Context{
 		Program:    "csgclaw-cli",
+		Stdin:      stdin,
 		Stdout:     a.stdout,
 		Stderr:     a.stderr,
 		HTTPClient: a.httpClient,

--- a/cli/onboard/onboard.go
+++ b/cli/onboard/onboard.go
@@ -1,9 +1,12 @@
 package onboard
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,11 +16,23 @@ import (
 	"csgclaw/internal/bot"
 	"csgclaw/internal/config"
 	"csgclaw/internal/im"
+	"csgclaw/internal/modelprovider"
+
+	"golang.org/x/term"
 )
 
 var (
 	CreateManagerBot       = createManagerBot
 	EnsureIMBootstrapState = im.EnsureBootstrapState
+	ListOpenAIModels       = modelprovider.ListOpenAIModels
+	isTerminalFD           = term.IsTerminal
+)
+
+const providerCustom = "custom"
+
+var (
+	defaultCSGHubLiteBaseURL = modelprovider.CSGHubLiteDefaultBaseURL
+	defaultCSGHubLiteAPIKey  = modelprovider.CSGHubLiteDefaultAPIKey
 )
 
 type cmd struct{}
@@ -36,6 +51,7 @@ func (cmd) Summary() string {
 
 func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
 	fs := run.NewFlagSet("onboard", run.Program+" onboard [flags]", c.Summary())
+	provider := fs.String("provider", "", "LLM provider preset: csghub-lite or custom")
 	baseURL := fs.String("base-url", "", "LLM provider base URL")
 	apiKey := fs.String("api-key", "", "LLM provider API key")
 	modelsValue := fs.String("models", "", "comma-separated LLM model identifiers")
@@ -45,6 +61,7 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	visited := visitedFlags(fs)
 
 	path, err := configPath(globals.Config)
 	if err != nil {
@@ -66,31 +83,22 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 			},
 		}
 	}
+
 	llmCfg := effectiveLLMConfig(cfg)
-	targetProvider := configuredProviderName(llmCfg)
-	providerCfg := llmCfg.Providers[targetProvider]
-	if *baseURL != "" {
-		providerCfg.BaseURL = *baseURL
-	}
-	if *apiKey != "" {
-		providerCfg.APIKey = *apiKey
-	}
-	if *modelsValue != "" {
-		models, err := parseModelsFlag(*modelsValue)
+	if hasExplicitLLMFlags(visited) {
+		var err error
+		llmCfg, err = applyExplicitModelFlags(ctx, llmCfg, hasExistingConfig, *provider, *baseURL, *apiKey, *modelsValue, *reasoningEffort, visited)
 		if err != nil {
 			return err
 		}
-		providerCfg.Models = models
+	} else if canPrompt(run, globals.Output) {
+		var err error
+		llmCfg, err = promptModelConfig(ctx, run, llmCfg, hasExistingConfig)
+		if err != nil {
+			return err
+		}
 	}
-	if *reasoningEffort != "" {
-		providerCfg.ReasoningEffort = *reasoningEffort
-	}
-	llmCfg.Providers[targetProvider] = providerCfg
-	if len(providerCfg.Models) > 0 && (*modelsValue != "" || strings.TrimSpace(llmCfg.Default) == "" || strings.TrimSpace(llmCfg.DefaultProfile) == "") {
-		defaultSelector := config.ModelSelector(targetProvider, providerCfg.Models[0])
-		llmCfg.Default = defaultSelector
-		llmCfg.DefaultProfile = defaultSelector
-	}
+
 	syncConfigWithLLM(&cfg, llmCfg)
 	if *managerImage != "" {
 		cfg.Bootstrap.ManagerImage = *managerImage
@@ -139,6 +147,391 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 		fmt.Fprintln(run.Stdout, "manager box was force-recreated")
 	}
 	return nil
+}
+
+func visitedFlags(fs interface{ Visit(func(*flag.Flag)) }) map[string]bool {
+	visited := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	return visited
+}
+
+func hasExplicitLLMFlags(visited map[string]bool) bool {
+	for _, name := range []string{"provider", "base-url", "api-key", "models", "reasoning-effort"} {
+		if visited[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func applyExplicitModelFlags(ctx context.Context, llmCfg config.LLMConfig, hasExistingConfig bool, providerName, baseURL, apiKey, modelsValue, reasoningEffort string, visited map[string]bool) (config.LLMConfig, error) {
+	providerName = strings.TrimSpace(providerName)
+	switch providerName {
+	case "", providerCustom:
+		return applyCustomModelFlags(llmCfg, hasExistingConfig, baseURL, apiKey, modelsValue, reasoningEffort, visited)
+	case modelprovider.CSGHubLiteProviderName:
+		return applyCSGHubLiteModelFlags(ctx, llmCfg, baseURL, apiKey, modelsValue, reasoningEffort, visited)
+	default:
+		return config.LLMConfig{}, fmt.Errorf("unsupported --provider %q; supported values are %q and %q", providerName, modelprovider.CSGHubLiteProviderName, providerCustom)
+	}
+}
+
+func applyCustomModelFlags(llmCfg config.LLMConfig, _ bool, baseURL, apiKey, modelsValue, reasoningEffort string, visited map[string]bool) (config.LLMConfig, error) {
+	targetProvider := configuredProviderName(llmCfg)
+	providerCfg := llmCfg.Providers[targetProvider]
+	if visited["base-url"] {
+		providerCfg.BaseURL = baseURL
+	}
+	if visited["api-key"] {
+		providerCfg.APIKey = apiKey
+	}
+	if visited["models"] {
+		models, err := parseModelsFlag(modelsValue)
+		if err != nil {
+			return config.LLMConfig{}, err
+		}
+		providerCfg.Models = models
+	}
+	if visited["reasoning-effort"] {
+		providerCfg.ReasoningEffort = reasoningEffort
+	}
+	llmCfg.Providers[targetProvider] = providerCfg
+	if len(providerCfg.Models) > 0 && (visited["models"] || strings.TrimSpace(llmCfg.Default) == "" || strings.TrimSpace(llmCfg.DefaultProfile) == "") {
+		defaultSelector := config.ModelSelector(targetProvider, providerCfg.Models[0])
+		llmCfg.Default = defaultSelector
+		llmCfg.DefaultProfile = defaultSelector
+	}
+	return llmCfg, nil
+}
+
+func applyCSGHubLiteModelFlags(ctx context.Context, llmCfg config.LLMConfig, baseURL, apiKey, modelsValue, reasoningEffort string, visited map[string]bool) (config.LLMConfig, error) {
+	if !visited["base-url"] || strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultCSGHubLiteBaseURL
+	}
+	if !visited["api-key"] || strings.TrimSpace(apiKey) == "" {
+		apiKey = defaultCSGHubLiteAPIKey
+	}
+
+	var models []string
+	var err error
+	if visited["models"] {
+		models, err = parseModelsFlag(modelsValue)
+		if err != nil {
+			return config.LLMConfig{}, err
+		}
+	} else {
+		models, err = discoverCSGHubLiteModels(ctx, baseURL, apiKey)
+		if err != nil {
+			return config.LLMConfig{}, err
+		}
+	}
+
+	providerCfg := llmCfg.Providers[modelprovider.CSGHubLiteProviderName]
+	providerCfg.BaseURL = baseURL
+	providerCfg.APIKey = apiKey
+	providerCfg.Models = models
+	if visited["reasoning-effort"] {
+		providerCfg.ReasoningEffort = reasoningEffort
+	}
+	if isEmptyProvider(llmCfg.Providers[config.DefaultLLMProfile]) {
+		delete(llmCfg.Providers, config.DefaultLLMProfile)
+		delete(llmCfg.Profiles, config.DefaultLLMProfile)
+	}
+	llmCfg.Providers[modelprovider.CSGHubLiteProviderName] = providerCfg
+
+	defaultModel := chooseCSGHubLiteDefaultModel(llmCfg, models)
+	llmCfg.Default = config.ModelSelector(modelprovider.CSGHubLiteProviderName, defaultModel)
+	llmCfg.DefaultProfile = llmCfg.Default
+	return llmCfg, nil
+}
+
+func isEmptyProvider(provider config.ProviderConfig) bool {
+	provider = provider.Resolved()
+	return provider.BaseURL == "" && provider.APIKey == "" && len(provider.Models) == 0 && provider.ReasoningEffort == ""
+}
+
+func promptModelConfig(ctx context.Context, run *command.Context, llmCfg config.LLMConfig, hasExistingConfig bool) (config.LLMConfig, error) {
+	reader := bufio.NewReader(run.Stdin)
+	defaultProvider := modelprovider.CSGHubLiteProviderName
+	printProviderPromptIntro(run.Stdout, llmCfg, hasExistingConfig)
+	if hasExistingConfig {
+		if current := configuredProviderName(llmCfg); current != "" {
+			defaultProvider = "keep"
+		}
+	}
+
+	fmt.Fprintf(run.Stdout, "Provider [%s]: ", providerPromptDefaultLabel(defaultProvider, llmCfg))
+	answer, err := readPromptLine(reader)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+	answer = normalizeProviderSelection(answer, defaultProvider, hasExistingConfig)
+
+	switch answer {
+	case "keep":
+		printModelConfigSummary(run.Stdout, "Keeping current model provider", llmCfg)
+		return llmCfg, nil
+	case modelprovider.CSGHubLiteProviderName:
+		updated, err := promptCSGHubLiteModelConfig(ctx, reader, run, llmCfg)
+		if err != nil {
+			return config.LLMConfig{}, err
+		}
+		printModelConfigSummary(run.Stdout, "Using CSGHub-lite provider", updated)
+		return updated, nil
+	case providerCustom:
+		updated, err := promptCustomModelConfig(reader, run, llmCfg)
+		if err != nil {
+			return config.LLMConfig{}, err
+		}
+		printModelConfigSummary(run.Stdout, "Using custom provider", updated)
+		return updated, nil
+	default:
+		return config.LLMConfig{}, fmt.Errorf("unsupported provider selection %q; enter %q, %q, or a listed number", answer, modelprovider.CSGHubLiteProviderName, providerCustom)
+	}
+}
+
+func promptCSGHubLiteModelConfig(ctx context.Context, reader *bufio.Reader, run *command.Context, llmCfg config.LLMConfig) (config.LLMConfig, error) {
+	fmt.Fprintln(run.Stdout)
+	fmt.Fprintln(run.Stdout, "CSGHub-lite provider")
+	fmt.Fprintln(run.Stdout, "  Endpoint must be OpenAI-compatible and include the /v1 suffix.")
+	fmt.Fprintln(run.Stdout, "  CSGClaw will read models from <base-url>/models.")
+	baseURL, err := promptValue(reader, run.Stdout, "CSGHub-lite base URL", defaultCSGHubLitePromptBaseURL(llmCfg), true)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+	fmt.Fprintf(run.Stdout, "\nChecking CSGHub-lite models at %s/models ...\n", strings.TrimRight(baseURL, "/"))
+	return applyCSGHubLiteModelFlags(ctx, llmCfg, baseURL, "", "", "", map[string]bool{
+		"provider": true,
+		"base-url": true,
+	})
+}
+
+func defaultCSGHubLitePromptBaseURL(llmCfg config.LLMConfig) string {
+	providerCfg := llmCfg.Providers[modelprovider.CSGHubLiteProviderName].Resolved()
+	if strings.TrimSpace(providerCfg.BaseURL) != "" {
+		return providerCfg.BaseURL
+	}
+	return defaultCSGHubLiteBaseURL
+}
+
+func promptCustomModelConfig(reader *bufio.Reader, run *command.Context, llmCfg config.LLMConfig) (config.LLMConfig, error) {
+	targetProvider := configuredProviderName(llmCfg)
+	providerCfg := llmCfg.Providers[targetProvider]
+
+	fmt.Fprintln(run.Stdout)
+	fmt.Fprintln(run.Stdout, "Custom OpenAI-compatible provider")
+	fmt.Fprintln(run.Stdout, "  Base URL example: https://api.openai.com/v1")
+	fmt.Fprintln(run.Stdout, "  Models: comma-separated; the first model becomes the default.")
+	baseURL, err := promptValue(reader, run.Stdout, "Base URL", providerCfg.BaseURL, true)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+	apiKey, err := promptSecretValue(reader, run.Stdout, "API key", providerCfg.APIKey, true)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+	modelsRaw, err := promptValue(reader, run.Stdout, "Models (comma-separated)", strings.Join(providerCfg.Models, ","), true)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+	models, err := parseModelsFlag(modelsRaw)
+	if err != nil {
+		return config.LLMConfig{}, err
+	}
+
+	providerCfg.BaseURL = baseURL
+	providerCfg.APIKey = apiKey
+	providerCfg.Models = models
+	llmCfg.Providers[targetProvider] = providerCfg
+	llmCfg.Default = config.ModelSelector(targetProvider, models[0])
+	llmCfg.DefaultProfile = llmCfg.Default
+	return llmCfg, nil
+}
+
+func printProviderPromptIntro(w io.Writer, llmCfg config.LLMConfig, hasExistingConfig bool) {
+	fmt.Fprintln(w, "CSGClaw model provider setup")
+	fmt.Fprintln(w, "Choose how CSGClaw should reach an OpenAI-compatible model endpoint.")
+	if hasExistingConfig {
+		fmt.Fprintln(w)
+		printCurrentModelConfig(w, llmCfg)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Options:")
+		fmt.Fprintln(w, "  1. keep current - leave the existing model provider unchanged")
+		fmt.Fprintf(w, "  2. %s - local CSGHub-lite at %s; models are read from /models\n", modelprovider.CSGHubLiteProviderName, defaultCSGHubLiteBaseURL)
+		fmt.Fprintln(w, "  3. custom - enter another OpenAI-compatible base URL, API key, and models")
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Options:")
+	fmt.Fprintf(w, "  1. %s - local default at %s\n", modelprovider.CSGHubLiteProviderName, defaultCSGHubLiteBaseURL)
+	fmt.Fprintln(w, "     Start it first with: csghub-lite run <model>  or  csghub-lite serve")
+	fmt.Fprintln(w, "     CSGClaw will call /v1/models and use the first discovered model by default.")
+	fmt.Fprintln(w, "  2. custom - enter another OpenAI-compatible base URL, API key, and models")
+	fmt.Fprintln(w)
+}
+
+func printCurrentModelConfig(w io.Writer, llmCfg config.LLMConfig) {
+	providerName := configuredProviderName(llmCfg)
+	providerCfg := llmCfg.Providers[providerName].Resolved()
+	fmt.Fprintln(w, "Current model configuration:")
+	fmt.Fprintf(w, "  Provider: %s\n", providerName)
+	if strings.TrimSpace(providerCfg.BaseURL) != "" {
+		fmt.Fprintf(w, "  Base URL: %s\n", providerCfg.BaseURL)
+	}
+	if len(providerCfg.Models) > 0 {
+		fmt.Fprintf(w, "  Models: %s\n", strings.Join(providerCfg.Models, ", "))
+	}
+	if strings.TrimSpace(llmCfg.Default) != "" {
+		fmt.Fprintf(w, "  Default model: %s\n", llmCfg.Default)
+	}
+	if strings.TrimSpace(providerCfg.ReasoningEffort) != "" {
+		fmt.Fprintf(w, "  Reasoning effort: %s\n", providerCfg.ReasoningEffort)
+	}
+}
+
+func providerPromptDefaultLabel(defaultProvider string, llmCfg config.LLMConfig) string {
+	if defaultProvider == "keep" {
+		if current := configuredProviderName(llmCfg); current != "" {
+			return "keep current: " + current
+		}
+		return "keep current"
+	}
+	return defaultProvider
+}
+
+func normalizeProviderSelection(answer, defaultProvider string, hasExistingConfig bool) string {
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer == "" {
+		return defaultProvider
+	}
+	if hasExistingConfig {
+		switch answer {
+		case "1":
+			return "keep"
+		case "2":
+			return modelprovider.CSGHubLiteProviderName
+		case "3":
+			return providerCustom
+		}
+	} else {
+		switch answer {
+		case "1":
+			return modelprovider.CSGHubLiteProviderName
+		case "2":
+			return providerCustom
+		}
+	}
+	return answer
+}
+
+func printModelConfigSummary(w io.Writer, title string, llmCfg config.LLMConfig) {
+	providerName := configuredProviderName(llmCfg)
+	providerCfg := llmCfg.Providers[providerName].Resolved()
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, title)
+	fmt.Fprintf(w, "  Provider: %s\n", providerName)
+	if strings.TrimSpace(providerCfg.BaseURL) != "" {
+		fmt.Fprintf(w, "  Base URL: %s\n", providerCfg.BaseURL)
+	}
+	if len(providerCfg.Models) > 0 {
+		fmt.Fprintf(w, "  Models: %s\n", strings.Join(providerCfg.Models, ", "))
+	}
+	if strings.TrimSpace(llmCfg.Default) != "" {
+		fmt.Fprintf(w, "  Default model: %s\n", llmCfg.Default)
+	}
+}
+
+func promptValue(reader *bufio.Reader, w io.Writer, label, defaultValue string, required bool) (string, error) {
+	if strings.TrimSpace(defaultValue) != "" {
+		fmt.Fprintf(w, "%s [%s]: ", label, defaultValue)
+	} else {
+		fmt.Fprintf(w, "%s: ", label)
+	}
+	value, err := readPromptLine(reader)
+	if err != nil {
+		return "", err
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = strings.TrimSpace(defaultValue)
+	}
+	if required && value == "" {
+		return "", fmt.Errorf("%s is required", strings.ToLower(label))
+	}
+	return value, nil
+}
+
+func promptSecretValue(reader *bufio.Reader, w io.Writer, label, defaultValue string, required bool) (string, error) {
+	if strings.TrimSpace(defaultValue) != "" {
+		fmt.Fprintf(w, "%s [keep existing]: ", label)
+	} else {
+		fmt.Fprintf(w, "%s: ", label)
+	}
+	value, err := readPromptLine(reader)
+	if err != nil {
+		return "", err
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = strings.TrimSpace(defaultValue)
+	}
+	if required && value == "" {
+		return "", fmt.Errorf("%s is required", strings.ToLower(label))
+	}
+	return value, nil
+}
+
+func readPromptLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func discoverCSGHubLiteModels(ctx context.Context, baseURL, apiKey string) ([]string, error) {
+	models, err := ListOpenAIModels(ctx, baseURL, apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("csghub-lite is not reachable at %s (%v); start it with `csghub-lite run <model>` or `csghub-lite serve`, then retry", strings.TrimRight(baseURL, "/"), err)
+	}
+	return models, nil
+}
+
+func chooseCSGHubLiteDefaultModel(llmCfg config.LLMConfig, models []string) string {
+	current := strings.TrimSpace(llmCfg.Default)
+	if current == "" {
+		current = strings.TrimSpace(llmCfg.DefaultProfile)
+	}
+	const prefix = modelprovider.CSGHubLiteProviderName + "."
+	if strings.HasPrefix(current, prefix) {
+		modelID := strings.TrimPrefix(current, prefix)
+		for _, model := range models {
+			if strings.TrimSpace(model) == modelID {
+				return model
+			}
+		}
+	}
+	return models[0]
+}
+
+func canPrompt(run *command.Context, output string) bool {
+	if output != "" && output != "table" {
+		return false
+	}
+	if strings.TrimSpace(os.Getenv("CI")) != "" {
+		return false
+	}
+	return isTerminal(run.Stdin) && isTerminal(run.Stdout)
+}
+
+func isTerminal(value any) bool {
+	file, ok := value.(interface{ Fd() uintptr })
+	if !ok {
+		return false
+	}
+	return isTerminalFD(int(file.Fd()))
 }
 
 func createManagerBot(ctx context.Context, agentsPath, imStatePath string, cfg config.Config, forceRecreateManager bool) (bot.Bot, error) {
@@ -196,7 +589,7 @@ func validateModelConfig(cfg config.Config) error {
 		var validationErr *config.ModelValidationError
 		if errors.As(err, &validationErr) && len(validationErr.MissingFields) > 0 {
 			return fmt.Errorf(
-				"models config is incomplete (%s); run `csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]`",
+				"models config is incomplete (%s); run `csgclaw onboard --provider csghub-lite --models <model>` or `csgclaw onboard --base-url <url> --api-key <key> --models <model[,model...]> [--reasoning-effort <effort>]`",
 				strings.Join(missingModelFlags(validationErr.MissingFields), ", "),
 			)
 		}

--- a/cli/onboard/onboard_test.go
+++ b/cli/onboard/onboard_test.go
@@ -3,6 +3,8 @@ package onboard
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,119 @@ import (
 	"csgclaw/internal/bot"
 	"csgclaw/internal/config"
 )
+
+func TestRunInteractiveDefaultUsesCSGHubLiteModels(t *testing.T) {
+	restore := stubBootstrap(t, func(_ context.Context, _, _ string, cfg config.Config, _ bool) (bot.Bot, error) {
+		if got, want := cfg.Models.Default, "csghub-lite.Qwen/Qwen3-0.6B-GGUF"; got != want {
+			t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+		}
+		provider, ok := cfg.Models.Providers["csghub-lite"]
+		if !ok {
+			t.Fatal(`cfg.Models.Providers["csghub-lite"] missing`)
+		}
+		if provider.BaseURL == "" || provider.APIKey != "local" {
+			t.Fatalf("provider = %#v, want csghub-lite base URL and local API key", provider)
+		}
+		if got, want := strings.Join(provider.Models, ","), "Qwen/Qwen3-0.6B-GGUF,Qwen/Qwen3-1.7B-GGUF"; got != want {
+			t.Fatalf("provider models = %q, want %q", got, want)
+		}
+		return bot.Bot{}, nil
+	})
+	defer restore()
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer local" {
+			t.Fatalf("Authorization = %q, want Bearer local", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"Qwen/Qwen3-0.6B-GGUF"},{"id":"Qwen/Qwen3-1.7B-GGUF"}]}`))
+	}))
+	defer modelServer.Close()
+
+	restoreInteractive := enableInteractiveTest(t, modelServer.URL+"/v1")
+	defer restoreInteractive()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	run := interactiveTestContext("\n\n")
+	if err := NewCmd().Run(context.Background(), run, nil, command.GlobalOptions{Config: configPath, Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := run.Stdout.(*fakeTerminalBuffer).String()
+	for _, want := range []string{
+		"CSGClaw model provider setup",
+		"Options:",
+		"csghub-lite - local default at " + modelServer.URL + "/v1",
+		"csghub-lite run <model>",
+		"CSGHub-lite base URL [" + modelServer.URL + "/v1]",
+		"Checking CSGHub-lite models",
+		"Using CSGHub-lite provider",
+		"Default model: csghub-lite.Qwen/Qwen3-0.6B-GGUF",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt output missing %q:\n%s", want, output)
+		}
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`default = "csghub-lite.Qwen/Qwen3-0.6B-GGUF"`,
+		`[models.providers.csghub-lite]`,
+		`api_key = "local"`,
+		`models = ["Qwen/Qwen3-0.6B-GGUF", "Qwen/Qwen3-1.7B-GGUF"]`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("saved config missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestRunInteractiveCSGHubLiteUsesSpecifiedBaseURL(t *testing.T) {
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"Qwen/Qwen3-0.6B-GGUF"}]}`))
+	}))
+	defer modelServer.Close()
+
+	restore := stubBootstrap(t, func(_ context.Context, _, _ string, cfg config.Config, _ bool) (bot.Bot, error) {
+		provider := cfg.Models.Providers["csghub-lite"]
+		if got, want := provider.BaseURL, modelServer.URL+"/v1"; got != want {
+			t.Fatalf("provider.BaseURL = %q, want %q", got, want)
+		}
+		if got, want := cfg.Models.Default, "csghub-lite.Qwen/Qwen3-0.6B-GGUF"; got != want {
+			t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+		}
+		return bot.Bot{}, nil
+	})
+	defer restore()
+	restoreInteractive := enableInteractiveTest(t, "http://unused.test/v1")
+	defer restoreInteractive()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	run := interactiveTestContext("1\n" + modelServer.URL + "/v1\n")
+	if err := NewCmd().Run(context.Background(), run, nil, command.GlobalOptions{Config: configPath, Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := run.Stdout.(*fakeTerminalBuffer).String()
+	for _, want := range []string{
+		"CSGHub-lite base URL [http://unused.test/v1]",
+		"Checking CSGHub-lite models at " + modelServer.URL + "/v1/models",
+		"Base URL: " + modelServer.URL + "/v1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt output missing %q:\n%s", want, output)
+		}
+	}
+}
 
 func TestRunRequiresLLMFlagsForFirstTimeSetup(t *testing.T) {
 	origCreateManager := CreateManagerBot
@@ -37,6 +152,174 @@ func TestRunRequiresLLMFlagsForFirstTimeSetup(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--base-url") || !strings.Contains(err.Error(), "--api-key") || !strings.Contains(err.Error(), "--models") {
 		t.Fatalf("Run() error = %q, want all required LLM flags", err)
+	}
+}
+
+func TestRunInteractiveExistingConfigKeepsCurrentProviderByDefault(t *testing.T) {
+	restore := stubBootstrap(t, func(_ context.Context, _, _ string, cfg config.Config, _ bool) (bot.Bot, error) {
+		if got, want := cfg.Models.Default, "default.gpt-test"; got != want {
+			t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+		}
+		if _, ok := cfg.Models.Providers["csghub-lite"]; ok {
+			t.Fatal("csghub-lite provider should not be added when keeping existing config")
+		}
+		return bot.Bot{}, nil
+	})
+	defer restore()
+	restoreInteractive := enableInteractiveTest(t, "http://unused.test/v1")
+	defer restoreInteractive()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := writeConfig(configPath, `# Generated by csgclaw onboard.
+
+[server]
+listen_addr = "0.0.0.0:18080"
+advertise_base_url = ""
+access_token = "your_access_token"
+
+[bootstrap]
+manager_image = "img"
+
+[models]
+default = "default.gpt-test"
+
+[models.providers.default]
+base_url = "http://llm.test/v1"
+api_key = "secret"
+models = ["gpt-test"]
+`); err != nil {
+		t.Fatalf("writeConfig() error = %v", err)
+	}
+
+	run := interactiveTestContext("\n")
+	if err := NewCmd().Run(context.Background(), run, nil, command.GlobalOptions{Config: configPath, Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := run.Stdout.(*fakeTerminalBuffer).String()
+	for _, want := range []string{
+		"Current model configuration:",
+		"Provider: default",
+		"Default model: default.gpt-test",
+		"keep current - leave the existing model provider unchanged",
+		"Keeping current model provider",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "secret") {
+		t.Fatalf("prompt output should not contain API key:\n%s", output)
+	}
+}
+
+func TestRunInteractiveCustomProvider(t *testing.T) {
+	restore := stubBootstrap(t, func(_ context.Context, _, _ string, cfg config.Config, _ bool) (bot.Bot, error) {
+		if got, want := cfg.Models.Default, "default.gpt-custom"; got != want {
+			t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+		}
+		provider := cfg.Models.Providers["default"]
+		if provider.BaseURL != "http://llm.test/v1" || provider.APIKey != "secret" {
+			t.Fatalf("provider = %#v, want custom base URL/API key", provider)
+		}
+		if got, want := strings.Join(provider.Models, ","), "gpt-custom,gpt-mini"; got != want {
+			t.Fatalf("provider models = %q, want %q", got, want)
+		}
+		return bot.Bot{}, nil
+	})
+	defer restore()
+	restoreInteractive := enableInteractiveTest(t, "http://unused.test/v1")
+	defer restoreInteractive()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	run := interactiveTestContext("2\nhttp://llm.test/v1\nsecret\ngpt-custom,gpt-mini\n")
+	if err := NewCmd().Run(context.Background(), run, nil, command.GlobalOptions{Config: configPath, Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := run.Stdout.(*fakeTerminalBuffer).String()
+	for _, want := range []string{
+		"Custom OpenAI-compatible provider",
+		"Base URL example: https://api.openai.com/v1",
+		"Using custom provider",
+		"Default model: default.gpt-custom",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRunInteractiveCustomProviderKeepsExistingSecretWithoutEchoing(t *testing.T) {
+	restore := stubBootstrap(t, func(_ context.Context, _, _ string, cfg config.Config, _ bool) (bot.Bot, error) {
+		provider := cfg.Models.Providers["default"]
+		if provider.BaseURL != "http://llm.test/v1" || provider.APIKey != "secret-token" {
+			t.Fatalf("provider = %#v, want existing base URL/API key", provider)
+		}
+		if got, want := cfg.Models.Default, "default.gpt-new"; got != want {
+			t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+		}
+		return bot.Bot{}, nil
+	})
+	defer restore()
+	restoreInteractive := enableInteractiveTest(t, "http://unused.test/v1")
+	defer restoreInteractive()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := writeConfig(configPath, `# Generated by csgclaw onboard.
+
+[server]
+listen_addr = "0.0.0.0:18080"
+advertise_base_url = ""
+access_token = "your_access_token"
+
+[bootstrap]
+manager_image = "img"
+
+[models]
+default = "default.gpt-old"
+
+[models.providers.default]
+base_url = "http://llm.test/v1"
+api_key = "secret-token"
+models = ["gpt-old"]
+`); err != nil {
+		t.Fatalf("writeConfig() error = %v", err)
+	}
+
+	run := interactiveTestContext("3\n\n\ngpt-new\n")
+	if err := NewCmd().Run(context.Background(), run, nil, command.GlobalOptions{Config: configPath, Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := run.Stdout.(*fakeTerminalBuffer).String()
+	if strings.Contains(output, "secret-token") {
+		t.Fatalf("prompt output should not contain existing API key:\n%s", output)
+	}
+	if !strings.Contains(output, "API key [keep existing]:") {
+		t.Fatalf("prompt output missing keep-existing API key prompt:\n%s", output)
+	}
+}
+
+func TestRunCSGHubLiteProviderUnavailableReturnsStartHint(t *testing.T) {
+	restore := stubBootstrap(t, func(context.Context, string, string, config.Config, bool) (bot.Bot, error) {
+		t.Fatal("bot manager create should not run when csghub-lite is unavailable")
+		return bot.Bot{}, nil
+	})
+	defer restore()
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer modelServer.Close()
+
+	run := testContext()
+	err := NewCmd().Run(context.Background(), run, []string{
+		"--provider", "csghub-lite",
+		"--base-url", modelServer.URL + "/v1",
+	}, command.GlobalOptions{Config: filepath.Join(t.TempDir(), "config.toml")})
+	if err == nil {
+		t.Fatal("Run() error = nil, want csghub-lite availability error")
+	}
+	if !strings.Contains(err.Error(), "csghub-lite is not reachable") || !strings.Contains(err.Error(), "csghub-lite run <model>") {
+		t.Fatalf("Run() error = %q, want start hint", err)
 	}
 }
 
@@ -119,4 +402,60 @@ func testContext() *command.Context {
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},
 	}
+}
+
+func interactiveTestContext(input string) *command.Context {
+	return &command.Context{
+		Program: "csgclaw",
+		Stdin:   fakeTerminalInput{Reader: strings.NewReader(input)},
+		Stdout:  &fakeTerminalBuffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+}
+
+type fakeTerminalInput struct {
+	*strings.Reader
+}
+
+func (fakeTerminalInput) Fd() uintptr {
+	return 1
+}
+
+type fakeTerminalBuffer struct {
+	bytes.Buffer
+}
+
+func (*fakeTerminalBuffer) Fd() uintptr {
+	return 1
+}
+
+func enableInteractiveTest(t *testing.T, baseURL string) func() {
+	t.Helper()
+	origTerminal := isTerminalFD
+	origBaseURL := defaultCSGHubLiteBaseURL
+	isTerminalFD = func(int) bool { return true }
+	defaultCSGHubLiteBaseURL = baseURL
+	return func() {
+		isTerminalFD = origTerminal
+		defaultCSGHubLiteBaseURL = origBaseURL
+	}
+}
+
+func stubBootstrap(t *testing.T, create func(context.Context, string, string, config.Config, bool) (bot.Bot, error)) func() {
+	t.Helper()
+	origCreateManager := CreateManagerBot
+	origEnsureIMBootstrapState := EnsureIMBootstrapState
+	CreateManagerBot = create
+	EnsureIMBootstrapState = func(string) error { return nil }
+	return func() {
+		CreateManagerBot = origCreateManager
+		EnsureIMBootstrapState = origEnsureIMBootstrapState
+	}
+}
+
+func writeConfig(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -23,6 +24,7 @@ import (
 	"csgclaw/internal/config"
 	"csgclaw/internal/im"
 	"csgclaw/internal/llm"
+	"csgclaw/internal/modelprovider"
 	"csgclaw/internal/server"
 )
 
@@ -33,6 +35,7 @@ var (
 	NewIMService           = newIMService
 	NewFeishuService       = newFeishuService
 	NewLLMService          = newLLMService
+	CheckModelProvider     = checkModelProvider
 	EnsureBootstrapManager = func(ctx context.Context, svc *agent.Service, forceRecreate bool) error {
 		if svc == nil {
 			return nil
@@ -192,6 +195,9 @@ func (c internalServeCmd) Run(ctx context.Context, run *command.Context, args []
 	if globals.Endpoint != "" {
 		cfg.Server.AdvertiseBaseURL = strings.TrimRight(globals.Endpoint, "/")
 	}
+	if err := preflightDefaultModelProvider(ctx, cfg); err != nil {
+		return err
+	}
 
 	printEffectiveConfig(run, cfg, globals.Output)
 	svc, err := NewAgentService(cfg)
@@ -214,6 +220,9 @@ func (c internalServeCmd) Run(ctx context.Context, run *command.Context, args []
 }
 
 func serveForeground(ctx context.Context, run *command.Context, cfg config.Config, output string) error {
+	if err := preflightDefaultModelProvider(ctx, cfg); err != nil {
+		return err
+	}
 	svc, err := NewAgentService(cfg)
 	if err != nil {
 		return err
@@ -332,6 +341,40 @@ func startServer(ctx context.Context, cfg config.Config, svc *agent.Service, bot
 		AccessToken: cfg.Server.AccessToken,
 		Context:     ctx,
 	})
+}
+
+func preflightDefaultModelProvider(ctx context.Context, cfg config.Config) error {
+	llmCfg := effectiveLLMConfig(cfg)
+	providerName := llmCfg.EffectiveDefaultProvider()
+	_, modelCfg, err := llmCfg.Resolve("")
+	if err != nil {
+		return err
+	}
+	if !requiresCSGHubLitePreflight(providerName, modelCfg.BaseURL) {
+		return nil
+	}
+	if err := CheckModelProvider(ctx, modelCfg); err != nil {
+		return fmt.Errorf("csghub-lite provider is not reachable at %s (%w); start it with `csghub-lite run <model>` or `csghub-lite serve`, then retry", strings.TrimRight(modelCfg.BaseURL, "/"), err)
+	}
+	return nil
+}
+
+func checkModelProvider(ctx context.Context, modelCfg config.ModelConfig) error {
+	_, err := modelprovider.ListOpenAIModels(ctx, modelCfg.BaseURL, modelCfg.APIKey)
+	return err
+}
+
+func requiresCSGHubLitePreflight(providerName, baseURL string) bool {
+	if strings.TrimSpace(providerName) == modelprovider.CSGHubLiteProviderName {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	return port == "11435" && (host == "127.0.0.1" || host == "localhost")
 }
 
 func defaultServerLogPath() (string, error) {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -3,6 +3,8 @@ package serve
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -15,6 +17,52 @@ import (
 	"csgclaw/internal/llm"
 	"csgclaw/internal/server"
 )
+
+func TestServeForegroundPreflightsCSGHubLiteProvider(t *testing.T) {
+	restore := stubServeDependencies(t)
+	defer restore()
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer local" {
+			t.Fatalf("Authorization = %q, want Bearer local", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"Qwen/Qwen3-0.6B-GGUF"}]}`))
+	}))
+	defer modelServer.Close()
+
+	cfg := csgHubLiteServeConfig(modelServer.URL + "/v1")
+	if err := serveForeground(context.Background(), testContext(), cfg, "json"); err != nil {
+		t.Fatalf("serveForeground() error = %v", err)
+	}
+}
+
+func TestServeForegroundFailsBeforeManagerWhenCSGHubLiteUnavailable(t *testing.T) {
+	origNewAgentService := NewAgentService
+	t.Cleanup(func() {
+		NewAgentService = origNewAgentService
+	})
+	NewAgentService = func(config.Config) (*agent.Service, error) {
+		t.Fatal("NewAgentService should not run when csghub-lite preflight fails")
+		return nil, nil
+	}
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer modelServer.Close()
+
+	err := serveForeground(context.Background(), testContext(), csgHubLiteServeConfig(modelServer.URL+"/v1"), "json")
+	if err == nil {
+		t.Fatal("serveForeground() error = nil, want preflight error")
+	}
+	if !strings.Contains(err.Error(), "csghub-lite provider is not reachable") || !strings.Contains(err.Error(), "csghub-lite run <model>") {
+		t.Fatalf("serveForeground() error = %q, want csghub-lite start hint", err)
+	}
+}
 
 func TestServeForegroundPassesContextToServer(t *testing.T) {
 	origRunServer := RunServer
@@ -154,6 +202,56 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 	}
 	if strings.Contains(got, "manager-secret") {
 		t.Fatalf("stdout leaked feishu app secret:\n%s", got)
+	}
+}
+
+func csgHubLiteServeConfig(baseURL string) config.Config {
+	return config.Config{
+		Server: config.ServerConfig{
+			ListenAddr:  "127.0.0.1:18080",
+			AccessToken: "pc-secret",
+		},
+		Models: config.LLMConfig{
+			Default:        "csghub-lite.Qwen/Qwen3-0.6B-GGUF",
+			DefaultProfile: "csghub-lite.Qwen/Qwen3-0.6B-GGUF",
+			Providers: map[string]config.ProviderConfig{
+				"csghub-lite": {
+					BaseURL: baseURL,
+					APIKey:  "local",
+					Models:  []string{"Qwen/Qwen3-0.6B-GGUF"},
+				},
+			},
+		},
+		Bootstrap: config.BootstrapConfig{
+			ManagerImage: "ghcr.io/example/manager:latest",
+		},
+	}
+}
+
+func stubServeDependencies(t *testing.T) func() {
+	t.Helper()
+	origRunServer := RunServer
+	origNewAgentService := NewAgentService
+	origNewBotService := NewBotService
+	origNewIMService := NewIMService
+	origNewFeishuService := NewFeishuService
+	origNewLLMService := NewLLMService
+	origEnsureBootstrapManager := EnsureBootstrapManager
+	RunServer = func(server.Options) error { return nil }
+	NewAgentService = func(config.Config) (*agent.Service, error) { return &agent.Service{}, nil }
+	NewBotService = func() (*bot.Service, error) { return &bot.Service{}, nil }
+	NewIMService = func() (*im.Service, error) { return nil, nil }
+	NewFeishuService = func(config.Config) (*channel.FeishuService, error) { return nil, nil }
+	NewLLMService = func(config.Config, *agent.Service) (*llm.Service, error) { return nil, nil }
+	EnsureBootstrapManager = func(context.Context, *agent.Service, bool) error { return nil }
+	return func() {
+		RunServer = origRunServer
+		NewAgentService = origNewAgentService
+		NewBotService = origNewBotService
+		NewIMService = origNewIMService
+		NewFeishuService = origNewFeishuService
+		NewLLMService = origNewLLMService
+		EnsureBootstrapManager = origEnsureBootstrapManager
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -123,6 +123,45 @@ reasoning_effort = "medium"
 	}
 }
 
+func TestLoadReadsCSGHubLiteProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `[server]
+listen_addr = "127.0.0.1:18080"
+
+[models]
+default = "csghub-lite.Qwen/Qwen3-0.6B-GGUF"
+
+[models.providers.csghub-lite]
+base_url = "http://127.0.0.1:11435/v1"
+api_key = "local"
+models = ["Qwen/Qwen3-0.6B-GGUF", "Qwen/Qwen3-1.7B-GGUF"]
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Models.Default, "csghub-lite.Qwen/Qwen3-0.6B-GGUF"; got != want {
+		t.Fatalf("cfg.Models.Default = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.BaseURL, "http://127.0.0.1:11435/v1"; got != want {
+		t.Fatalf("cfg.Model.BaseURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.APIKey, "local"; got != want {
+		t.Fatalf("cfg.Model.APIKey = %q, want %q", got, want)
+	}
+	if got, want := cfg.Model.ModelID, "Qwen/Qwen3-0.6B-GGUF"; got != want {
+		t.Fatalf("cfg.Model.ModelID = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(cfg.Models.Providers["csghub-lite"].Models, ","), "Qwen/Qwen3-0.6B-GGUF,Qwen/Qwen3-1.7B-GGUF"; got != want {
+		t.Fatalf("csghub-lite models = %q, want %q", got, want)
+	}
+}
+
 func TestLoadRejectsLegacyLLMSections(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -270,6 +309,54 @@ func TestSaveWritesModelsSection(t *testing.T) {
 		"[channels.feishu.manager]",
 		`app_id = "cli_manager"`,
 		`app_secret = "manager-secret"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("saved config missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestSaveWritesCSGHubLiteProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	models := LLMConfig{
+		Default:        "csghub-lite.Qwen/Qwen3-0.6B-GGUF",
+		DefaultProfile: "csghub-lite.Qwen/Qwen3-0.6B-GGUF",
+		Providers: map[string]ProviderConfig{
+			"csghub-lite": {
+				BaseURL: "http://127.0.0.1:11435/v1",
+				APIKey:  "local",
+				Models:  []string{"Qwen/Qwen3-0.6B-GGUF", "Qwen/Qwen3-1.7B-GGUF"},
+			},
+		},
+	}
+	cfg := Config{
+		Server: ServerConfig{
+			ListenAddr:  "127.0.0.1:18080",
+			AccessToken: "shared-token",
+		},
+		Models: models,
+		LLM:    models,
+		Bootstrap: BootstrapConfig{
+			ManagerImage: "img",
+		},
+	}
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`default = "csghub-lite.Qwen/Qwen3-0.6B-GGUF"`,
+		`[models.providers.csghub-lite]`,
+		`base_url = "http://127.0.0.1:11435/v1"`,
+		`api_key = "local"`,
+		`models = ["Qwen/Qwen3-0.6B-GGUF", "Qwen/Qwen3-1.7B-GGUF"]`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("saved config missing %q:\n%s", want, content)

--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -1,0 +1,70 @@
+package modelprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	CSGHubLiteProviderName   = "csghub-lite"
+	CSGHubLiteDefaultBaseURL = "http://127.0.0.1:11435/v1"
+	CSGHubLiteDefaultAPIKey  = "local"
+)
+
+type openAIModelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+func ListOpenAIModels(ctx context.Context, baseURL, apiKey string) ([]string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("base URL is required")
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build models request: %w", err)
+	}
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request models from %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("request models from %s: status %s", baseURL, resp.Status)
+	}
+
+	var payload openAIModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode models response from %s: %w", baseURL, err)
+	}
+
+	models := make([]string, 0, len(payload.Data))
+	seen := make(map[string]struct{}, len(payload.Data))
+	for _, item := range payload.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, id)
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("no models returned from %s", baseURL)
+	}
+	return models, nil
+}


### PR DESCRIPTION
## Implemented CSGHub-lite integration for csgclaw onboard and serve.

- Added --provider csghub-lite|custom while preserving existing non-interactive flags.
- Made interactive onboard provider-aware: fresh configs default to CSGHub-lite, existing configs default to keeping the current provider.
- Added CSGHub-lite /v1/models discovery, configurable base URL prompt, and local defaults: http://127.0.0.1:11435/v1 + API key local.
- Added startup/preflight checks before serve creates the manager when the default provider is local CSGHub-lite.
- Added stdin abstraction for testable interactive prompts.
- Updated README/README.zh and Makefile onboard example.
- Added tests for interactive onboard flows, CSGHub-lite model discovery, config persistence, and serve preflight.