### PR TITLE
feat(csghub): sandbox API client, build split, unified Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Go build/test artifacts
 .gocache/
 bin/
+bin-csghub/
 dist/
 *.test
 *.out
@@ -19,6 +20,11 @@ manager-data/
 # Editor directories
 .idea/
 .vscode/
-
+.cursor/
 # Vendored native libraries fetched on demand
 third_party/boxlite-go/libboxlite.a
+third_party/boxlite-go/boxlite-c-v0.7.6-linux-x64-gnu/
+
+# Keep local-only deployment docs/scripts out of remote history
+/docker/
+/docs/saas-env-contract.md

--- a/cli/sandboxopts/service_options_csghub.go
+++ b/cli/sandboxopts/service_options_csghub.go
@@ -1,0 +1,24 @@
+//go:build csghub
+// +build csghub
+
+package sandboxopts
+
+import (
+	"csgclaw/internal/agent"
+	"csgclaw/internal/config"
+	"csgclaw/internal/sandbox/csghub"
+)
+
+// ServiceOptions wires the CSGHub sandbox provider for csghub builds.
+// Provider params are resolved from env inside sandbox/csghub so the
+// agent layer stays backend-agnostic.
+func ServiceOptions(_ config.SandboxConfig) ([]agent.ServiceOption, error) {
+	provider, err := csghub.NewProviderFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return []agent.ServiceOption{
+		agent.WithSandboxProvider(provider),
+		agent.WithSandboxHomeDirName(config.DefaultSandboxHomeDirName),
+	}, nil
+}

--- a/docs/agent-provider-injection-plan.zh.md
+++ b/docs/agent-provider-injection-plan.zh.md
@@ -1,0 +1,278 @@
+# 方案文档：Agent 仅通过 ServiceOptions 注入 Sandbox Provider
+
+## 1. 背景与问题
+
+当前 `agent` 层已经引入了较多 BoxLite/CSGHub 分叉逻辑（backend、manager 生命周期差异实现、部分 env 读取路径差异）。  
+目标是将后端差异尽量下沉到 `internal/sandbox/*`，让 `internal/agent` 保持接近 `main` 分支的通用业务形态。
+
+本方案要求：
+
+1. 后端选择只发生在 `cli/sandboxopts.ServiceOptions(...)`。
+2. `agent` 层只依赖 `sandbox.Provider/Runtime` 抽象，不直接感知 `csghub` 类型。
+3. `csghub` 专属 env 在 `internal/sandbox/csghub` 内读取，不由 `agent` 读取。
+
+---
+
+## 2. 目标架构
+
+### 2.1 模块边界
+
+- `cli/sandboxopts/*`
+  - 唯一后端注入点。
+  - `!csghub`：boxlite / boxlite-cli 二选一。
+  - `csghub`：显式注入 `csghub.Provider`。
+
+- `internal/agent/*`
+  - 负责业务语义：manager 唯一性、agent 注册表、权限/角色、workspace/config 生成、状态持久化。
+  - 调用统一 `runtime.Create/Get/Remove/Run`。
+  - 不读取 csghub 专属 env，不依赖 `*csghub.Runtime`。
+
+- `internal/sandbox/csghub/*`
+  - 负责运行时差异：Hub API、状态机、重试、等待 Running、错误映射、日志流。
+  - 负责读取 csghub 专属 env（或内部 `LoadEnv`）。
+
+- `internal/sandbox/sandbox.go`
+  - 保持后端无关抽象，不反向依赖具体后端包。
+
+### 2.2 调用关系
+
+`serve/onboard -> sandboxopts.ServiceOptions -> agent.NewService(...) -> provider.Open(...) -> runtime.Create/Get/Remove`
+
+---
+
+## 3. 配置与环境变量流转
+
+## 3.1 共性配置（config.toml）
+
+- `config.toml` 仍是业务配置基线（server/llm/channels/sandbox 基础项）。
+- `serve` 启动时：先自动初始化（仅首次），再读配置，再叠加运行时覆盖。
+
+## 3.2 后端注入
+
+- `ServiceOptions(cfg.Sandbox)` 决定注入哪个 provider。
+- `agent` 构造函数不再“隐式默认”创建 csghub provider。
+
+## 3.3 csghub 专属 env
+
+- 例如 `CSGHUB_*`、`CSGCLAW_SANDBOX_*`、`CSGCLAW_PVC_MOUNT_PATH`、`CSGCLAW_SANDBOX_SUBPATH_ROOT`。
+- 在 `internal/sandbox/csghub` 内部读取并校验。
+- `agent` 不透传这类参数，避免边界污染。
+
+---
+
+## 4. 关键语义约束（必须保留）
+
+1. `ForceRecreate` 语义保留（manager 需要可强制重建）。
+2. manager 业务语义保留（唯一 manager、普通删除不可删 manager）。
+3. `Delete` 幂等性保留（not found 视为成功）。
+4. `CreateWorker/Create/StreamLogs` 外部行为保持兼容。
+
+---
+
+## 5. 设计选择
+
+## 5.1 外层仅调用 Create
+
+`agent` 外层只调用 `runtime.Create(...)`，不依赖 `Reconcile`。  
+CSGHub 的“收敛到 Running”逻辑下沉到 `csghub.Runtime.Create()` 内部实现：
+
+- get existing
+- create/apply
+- start（必要时）
+- wait until Running/Ready（含 timeout/poll）
+
+这样外层不需要感知后端生命周期差异。
+
+## 5.2 ForceRecreate 处理
+
+推荐在 `agent.EnsureManager(force=true)` 使用：
+
+1. `runtime.Remove(managerIDOrName, Force=true)`  
+2. 再 `runtime.Create(managerSpec)`
+
+即保持老语义，不扩散新接口复杂度。
+
+## 5.3 guest path 契约统一（boxlite/csghub）
+
+`csghub` 与 `boxlite` 必须共享同一套容器内挂载点（guest path）契约，例如：
+
+- `/home/picoclaw/.picoclaw`
+- `/home/picoclaw/.picoclaw/workspace`
+- `/home/picoclaw/.picoclaw/workspace/projects`
+
+差异只允许存在于后端对同一字段的消费语义：
+
+- boxlite: `HostPath` 按主机路径直接消费。
+- csghub: `HostPath` 按 PVC subpath 直接消费（映射到 Hub `sandbox_mount_subpath`）。
+
+因此，`CSGCLAW_PVC_MOUNT_PATH` 仍保留为 csghub 后端内部的部署参数，不上浮到 `agent` 通用层；
+`agent` 层继续只表达“挂载意图 + 固定 guest path 契约”。
+
+---
+
+## 6. 分阶段实施计划
+
+## Phase 1：注入点收口（低风险）
+
+1. `service_options_csghub.go` 改为显式注入 `agent.WithSandboxProvider(csghub.NewProvider(...))`。
+2. `agent.NewService...` 取消 csghub 默认 provider 构造逻辑。
+3. 验证：`go test ./...`、`go test -tags csghub ./...`。
+
+## Phase 2：env 读取下沉（中风险）
+
+1. 新增 `internal/sandbox/csghub/env.go`（或等价 loader）。
+2. 将 csghub 专属 env 读取从 `agent` 移出。
+3. 保持 `agent` 输入为通用 spec，不持有 csghub params。
+
+## Phase 3：Create 语义收敛（中风险）
+
+1. `csghub.Runtime.Create` 内部实现 reconcile+wait。
+2. `agent` 去掉对 `ManagedRuntime/Reconcile` 的依赖路径。
+3. 回归测试覆盖 create/delete/stream logs/manager recreate。
+
+## Phase 4：代码清理（低风险）
+
+1. 删除冗余 backend 分叉（如果不再需要）。
+2. 精简注释、死代码、测试钩子（仅删无引用项）。
+
+---
+
+## 7. 风险与阻塞点
+
+## 7.1 风险
+
+1. provider 未注入导致启动失败（unconfigured provider）。
+2. `Create` 变阻塞后 timeout/poll 配置不合理引发假失败。
+3. `ForceRecreate` 丢失导致 manager 无法按预期重建。
+4. 挂载字段配置错误导致后端创建失败（由后端返回错误）。
+5. not-found 分类不一致破坏 delete 幂等。
+
+## 7.2 阻塞点（先决策）
+
+1. `csghub` build 是否强制由 `ServiceOptions` 注入 provider（建议：是）。
+2. `ForceRecreate` 走 `Remove+Create` 还是扩展 spec 标志（建议：Remove+Create）。
+3. `Create` 的最终语义是否统一为“确保 Running”（建议：是）。
+
+---
+
+## 8. 验收标准
+
+1. `agent` 不再读取 csghub 专属 env。  
+2. `agent` 不依赖 `*csghub.Runtime` 或 csghub 私有类型。  
+3. 后端注入只在 `cli/sandboxopts`。  
+4. 全量测试通过：
+   - `go test ./...`
+   - `go test -tags csghub ./...`
+   - `go list -deps ./... | rg -n "internal/sandbox/csghub|internal/sandbox/csghubsdk"` 在非 csghub 构建下应无结果
+   - `go list -deps -tags csghub ./... | rg -n "internal/sandbox/boxlite|third_party/boxlite-go"` 在 csghub 构建下应无结果
+5. manager/recreate/delete/logs 行为与现网预期一致。
+6. boxlite/csghub 的 guest path 完全一致；`HostPath` 字段值按配置直通并由各后端直接消费。
+
+---
+
+## 9. 回滚策略
+
+若 Phase 2/3 出现回归：
+
+1. 保留 Phase 1（注入点收口）不回退。  
+2. 回退 `Create` 收敛实现到旧路径（临时恢复 `Reconcile` 调用链）。  
+3. 逐项恢复 env 读取路径并补测试后再推进。
+
+---
+
+## 10. 结论
+
+该方案能在不牺牲 manager 业务语义的前提下，把后端差异集中在 sandbox 层，并让 `agent` 回归 `main` 风格。  
+推荐按 Phase 1 -> 2 -> 3 小步推进，每步都跑双构建测试并可独立回滚。
+
+---
+
+## 11. 文件级改动清单（对应 Phase）
+
+### Phase 1：注入点收口
+
+1. [service_options_csghub.go](/home/jhw/opcsg/csgclaw/cli/sandboxopts/service_options_csghub.go)
+- 从“返回 nil”改为显式注入 `agent.WithSandboxProvider(csghub.NewProvider(...))`。
+
+2. [service_csghub.go](/home/jhw/opcsg/csgclaw/internal/agent/service_csghub.go)
+- 去掉构造函数里的“默认创建 csghub provider”分支，只消费注入结果。
+
+3. [service.go](/home/jhw/opcsg/csgclaw/internal/agent/service.go)（可选）
+- 对齐 `unconfiguredSandboxProvider` 失败语义，保证 boxlite/csghub 构造行为一致。
+
+### Phase 2：csghub env 下沉到 sandbox
+
+1. 新增 [env.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghub/env.go)
+- 集中读取/校验 csghub 专属环境变量。
+
+2. [provider.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghub/provider.go)
+- `Open/NewProvider` 改为依赖 csghub 内部 env loader。
+
+3. [runtime.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghub/runtime.go)
+- 不再依赖 agent 透传的 csghub params（改用 provider/runtime 内部配置）。
+
+4. [service_csghub.go](/home/jhw/opcsg/csgclaw/internal/agent/service_csghub.go)
+- 删除 `loadSandboxParams/csghubParamsFrom` 调用路径。
+
+5. [env_csghub.go](/home/jhw/opcsg/csgclaw/internal/agent/env_csghub.go)
+- 删除或显著瘦身（仅保留 agent 侧确实需要的逻辑）。
+
+### Phase 3：Create 语义收敛（外层只调 Create）
+
+1. [runtime.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghub/runtime.go)
+- `Create` 内部完整实现 `get/create/apply/start/wait running`。
+
+2. [service_csghub.go](/home/jhw/opcsg/csgclaw/internal/agent/service_csghub.go)
+- 去掉对 `ManagedRuntime.Reconcile` 的直接依赖，统一走 `runtime.Create`。
+
+3. [service_common.go](/home/jhw/opcsg/csgclaw/internal/agent/service_common.go)
+- 如果仍存在 Reconcile 分支，收敛到 Create 路径。
+
+4. [instance.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghub/instance.go)（可选）
+- 保留 `CachedInfo` 零 round-trip 优化能力。
+
+### Phase 4：行为统一与清理
+
+1. [service_common.go](/home/jhw/opcsg/csgclaw/internal/agent/service_common.go)
+- 统一普通 agent 的 `role/image` 校验策略。
+
+2. [service.go](/home/jhw/opcsg/csgclaw/internal/agent/service.go)
+3. [service_csghub.go](/home/jhw/opcsg/csgclaw/internal/agent/service_csghub.go)
+- 统一 `BoxID` 的持久化/刷新时机。
+
+4. 清理死代码/过时注释/仅测试残留钩子（先 `rg` 确认无业务引用再删除）。
+
+### 每个 Phase 的验证命令
+
+1. `go test ./...`
+2. `go test -tags csghub ./...`
+
+重点回归文件：
+
+1. [service_test.go](/home/jhw/opcsg/csgclaw/internal/agent/service_test.go)
+2. [service_csghub_test.go](/home/jhw/opcsg/csgclaw/internal/agent/service_csghub_test.go)
+3. [adapter_test.go](/home/jhw/opcsg/csgclaw/internal/sandbox/boxlite/adapter_test.go)
+4. [client_test.go](/home/jhw/opcsg/csgclaw/internal/sandbox/csghubsdk/client_test.go)
+
+---
+
+## 12. 定稿约束（本轮结论）
+
+1. 路径统一方式
+- 使用同一组挂载字段同时承载 boxlite host 路径与 csghub PVC subpath。
+- 配置文件写什么，运行时就使用什么：不在 `agent` 层做语义转换，不在 provider/runtime 层做语义转换。
+- 对该字段不增加额外格式校验；由后端接口按其原生协议处理并返回错误。
+- `agent` 仅负责组装挂载项与固定 guest path 契约。
+
+2. 生命周期封装
+- `csghub` 生命周期完全封装在 `internal/sandbox/csghub`（provider/runtime）内部。
+- 对 `agent` 仅暴露 `Create/Get/Remove/Run` 抽象。
+- `Create` 内部负责 `create/start/wait ready`，`agent` 不感知 csghub 生命周期细节。
+
+3. csghub 专属 env
+- `CSGHUB_*`、`CSGCLAW_PVC_MOUNT_PATH` 等专属环境变量只在 `internal/sandbox/csghub` 内读取。
+- `agent` 与通用 `sandbox` 抽象层不读取、不透传 csghub 专属 env。
+
+4. build tag 边界
+- build tag 主要出现在 `internal/sandbox/csghub/*` 与注入文件（如 `cli/sandboxopts/*_csghub.go`）。
+- 非 csghub 构建不得引入 csghub sdk 依赖链，避免编译串味。

--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -4,13 +4,15 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"csgclaw/internal/config"
 )
+
+// managerAgentsDirName is the sub-directory that holds per-agent state under
+// the server's home root (shared between both deployment backends).
 
 const managerAgentsDirName = "agents"
 
@@ -20,15 +22,7 @@ var defaultManagerPicoClawConfig []byte
 //go:embed defaults/manager-security.yml
 var defaultManagerSecurityConfig string
 
-func ensureManagerPicoClawConfig(server config.ServerConfig, model config.ModelConfig) (string, error) {
-	return ensureAgentPicoClawConfig(ManagerName, "u-manager", server, model)
-}
-
-func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConfig, model config.ModelConfig) (string, error) {
-	hostRoot, err := agentPicoClawRoot(agentName)
-	if err != nil {
-		return "", err
-	}
+func ensureAgentPicoClawConfigAt(hostRoot, botID string, server config.ServerConfig, model config.ModelConfig) (string, error) {
 	if err := os.MkdirAll(filepath.Join(hostRoot, hostPicoClawLogs), 0o755); err != nil {
 		return "", fmt.Errorf("create manager picoclaw logs dir: %w", err)
 	}
@@ -47,22 +41,6 @@ func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConf
 		return "", fmt.Errorf("write manager security config: %w", err)
 	}
 	return hostRoot, nil
-}
-
-func managerPicoClawRoot() (string, error) {
-	return agentPicoClawRoot(ManagerName)
-}
-
-func agentPicoClawRoot(agentName string) (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve host home dir: %w", err)
-	}
-	return filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, agentName, hostPicoClawDir), nil
-}
-
-func renderManagerPicoClawConfig(server config.ServerConfig, model config.ModelConfig) ([]byte, error) {
-	return renderAgentPicoClawConfig("u-manager", server, model)
 }
 
 func renderAgentPicoClawConfig(botID string, server config.ServerConfig, model config.ModelConfig) ([]byte, error) {
@@ -150,83 +128,6 @@ func updateCSGClawChannel(cfg map[string]any, botID string, server config.Server
 	channel["bot_id"] = botID
 	channel["enabled"] = true
 	return nil
-}
-
-func resolveManagerBaseURL(server config.ServerConfig) string {
-	if server.AdvertiseBaseURL != "" {
-		return strings.TrimRight(server.AdvertiseBaseURL, "/")
-	}
-	port := config.ListenPort(server.ListenAddr)
-	if ip := localIPv4Resolver(); ip != "" {
-		return fmt.Sprintf("http://%s:%s", ip, port)
-	}
-	return ""
-}
-
-func localIPv4() string {
-	if ip := outboundIPv4(); ip != "" {
-		return ip
-	}
-	return interfaceIPv4()
-}
-
-func outboundIPv4() string {
-	conn, err := net.Dial("udp4", "8.8.8.8:80")
-	if err != nil {
-		return ""
-	}
-	defer conn.Close()
-
-	addr, ok := conn.LocalAddr().(*net.UDPAddr)
-	if !ok || addr.IP == nil {
-		return ""
-	}
-	ip := addr.IP.To4()
-	if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
-		return ""
-	}
-	return ip.String()
-}
-
-func interfaceIPv4() string {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return ""
-	}
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			if ip := ipv4FromAddr(addr); ip != "" {
-				return ip
-			}
-		}
-	}
-	return ""
-}
-
-func ipv4FromAddr(addr net.Addr) string {
-	switch v := addr.(type) {
-	case *net.IPNet:
-		ip := v.IP.To4()
-		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
-			return ""
-		}
-		return ip.String()
-	case *net.IPAddr:
-		ip := v.IP.To4()
-		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
-			return ""
-		}
-		return ip.String()
-	default:
-		return ""
-	}
 }
 
 func renderManagerSecurityConfig(server config.ServerConfig, model config.ModelConfig) string {

--- a/internal/agent/manager_config_boxlite.go
+++ b/internal/agent/manager_config_boxlite.go
@@ -1,0 +1,26 @@
+//go:build !csghub
+// +build !csghub
+
+package agent
+
+import (
+	"path/filepath"
+
+	"csgclaw/internal/config"
+)
+
+func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConfig, model config.ModelConfig) (string, error) {
+	hostRoot, err := agentPicoClawRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return ensureAgentPicoClawConfigAt(hostRoot, botID, server, model)
+}
+
+func agentPicoClawRoot(agentName string) (string, error) {
+	home, err := agentHomeDir(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, hostPicoClawDir), nil
+}

--- a/internal/agent/manager_url.go
+++ b/internal/agent/manager_url.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"csgclaw/internal/config"
+)
+
+// localIPv4Resolver lets tests override IP discovery.
+var localIPv4Resolver = localIPv4
+
+// envK8sPodIP is optionally populated in Kubernetes-style deployments.
+const envK8sPodIP = "POD_IP"
+
+// resolveManagerBaseURL picks the URL that manager/worker sandboxes should
+// use to reach the csgclaw server:
+// AdvertiseBaseURL -> POD_IP -> discovered local IPv4.
+func resolveManagerBaseURL(server config.ServerConfig) string {
+	if url := strings.TrimRight(strings.TrimSpace(server.AdvertiseBaseURL), "/"); url != "" {
+		return url
+	}
+	port := config.ListenPort(server.ListenAddr)
+	if ip := strings.TrimSpace(os.Getenv(envK8sPodIP)); ip != "" {
+		return fmt.Sprintf("http://%s:%s", ip, port)
+	}
+	if ip := localIPv4Resolver(); ip != "" {
+		return fmt.Sprintf("http://%s:%s", ip, port)
+	}
+	return ""
+}
+
+func localIPv4() string {
+	if ip := outboundIPv4(); ip != "" {
+		return ip
+	}
+	return interfaceIPv4()
+}
+
+func outboundIPv4() string {
+	conn, err := net.Dial("udp4", "8.8.8.8:80")
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr.IP == nil {
+		return ""
+	}
+	ip := addr.IP.To4()
+	if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
+func interfaceIPv4() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			if ip := ipv4FromAddr(addr); ip != "" {
+				return ip
+			}
+		}
+	}
+	return ""
+}
+
+func ipv4FromAddr(addr net.Addr) string {
+	switch v := addr.(type) {
+	case *net.IPNet:
+		ip := v.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+			return ""
+		}
+		return ip.String()
+	case *net.IPAddr:
+		ip := v.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+			return ""
+		}
+		return ip.String()
+	default:
+		return ""
+	}
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,3 +1,6 @@
+//go:build !csghub
+// +build !csghub
+
 package agent
 
 import (
@@ -13,24 +16,6 @@ import (
 	"csgclaw/internal/config"
 	"csgclaw/internal/sandbox"
 )
-
-const (
-	ManagerName        = "manager"
-	ManagerUserID      = "u-manager"
-	managerHostPort    = 18790
-	managerGuestPort   = 18790
-	managerDebugMode   = true
-	hostPicoClawDir    = ".picoclaw"
-	hostWorkspaceDir   = "workspace"
-	hostProjectsDir    = "projects"
-	hostPicoClawConfig = "config.json"
-	hostPicoClawLogs   = "logs"
-	boxPicoClawDir     = "/home/picoclaw/.picoclaw"
-	boxWorkspaceDir    = boxPicoClawDir + "/workspace"
-	boxProjectsDir     = "/home/picoclaw/.picoclaw/workspace/projects"
-)
-
-var localIPv4Resolver = localIPv4
 
 var defaultSandboxProvider sandbox.Provider = unconfiguredSandboxProvider{}
 
@@ -127,7 +112,262 @@ type Service struct {
 	agents       map[string]Agent
 }
 
-type ServiceOption func(*Service) error
+func (s *Service) createWorkerBackend(ctx context.Context, name, id string, model config.ModelConfig) (sandbox.Info, string, error) {
+	rt, err := s.ensureRuntime(name)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(name)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	defer func() { _ = s.closeRuntime(runtimeHome, rt) }()
+
+	box, info, err := s.createGatewayBox(ctx, rt, s.managerImage, name, id, model)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	defer func() { _ = s.closeBox(box) }()
+
+	return info, info.ID, nil
+}
+
+func (s *Service) deleteSandboxBackend(ctx context.Context, agent Agent) error {
+	rt, err := s.ensureRuntime(agent.Name)
+	if err != nil {
+		return err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(agent.Name)
+	if err != nil {
+		return err
+	}
+	// testEnsureRuntimeHook may return (nil, nil) to simulate "no live
+	// runtime, nothing to tear down". Honor that so the registry-only
+	// delete path stays exercisable from tests without a full fake.
+	if rt == nil {
+		return nil
+	}
+	boxIDOrName := strings.TrimSpace(agent.BoxID)
+	if boxIDOrName == "" {
+		boxIDOrName = agent.Name
+	}
+	if _, resolvedKey, resolveErr := s.resolveAgentBox(ctx, rt, agent); resolveErr == nil && strings.TrimSpace(resolvedKey) != "" {
+		boxIDOrName = resolvedKey
+	}
+	if err := s.forceRemoveBox(ctx, rt, boxIDOrName); err != nil && !sandbox.IsNotFound(err) {
+		return fmt.Errorf("remove agent box: %w", err)
+	}
+	_ = s.closeRuntime(runtimeHome, rt)
+	return nil
+}
+
+// postDeleteLockedBackend prunes the per-agent runtime map in case
+// deleteSandboxBackend returned before reaching closeRuntime (e.g. the
+// test-only rt == nil short-circuit) and a stale entry is still
+// cached. closeRuntime already performs this prune atomically on
+// the happy path; this is defensive bookkeeping that mirrors the
+// pre-refactor behavior of Service.Delete.
+func (s *Service) postDeleteLockedBackend(agent Agent) {
+	home, err := s.sandboxRuntimeHome(agent.Name)
+	if err != nil {
+		return
+	}
+	if _, ok := s.runtimes[home]; ok {
+		delete(s.runtimes, home)
+	}
+}
+
+func (s *Service) agentHomeDirBackend(agentName string) (string, error) {
+	return agentHomeDir(agentName)
+}
+
+// ensureManager drives the BoxLite-specific bootstrap flow:
+// lookup via the ManagerName runtime, optional force-recreate
+// (remove box + drop runtime + wipe per-agent home + recreate
+// runtime), create-or-start branching, and background image-pull
+// progress logging. The heavy side-effect lifecycle lives here so
+// common EnsureManager only cares about registry persistence.
+func (s *Service) ensureManagerBackend(ctx context.Context, forceRecreate bool, model config.ModelConfig) (sandbox.Info, string, error) {
+	rt, box, err := s.lookupBootstrapManager(ctx)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(ManagerName)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	defer func() {
+		_ = s.closeRuntime(runtimeHome, rt)
+	}()
+
+	if forceRecreate {
+		log.Printf("force recreating bootstrap manager box %q", ManagerName)
+		managerBoxIDOrName := s.bootstrapManagerBoxIDOrName()
+		if err := s.forceRemoveBox(ctx, rt, managerBoxIDOrName); err != nil {
+			if sandbox.IsNotFound(err) {
+				log.Printf("bootstrap manager box %q (%q) does not exist yet; continuing", ManagerName, managerBoxIDOrName)
+			} else {
+				return sandbox.Info{}, "", fmt.Errorf("force remove bootstrap manager box %q (%q): %w", ManagerName, managerBoxIDOrName, err)
+			}
+		} else {
+			log.Printf("bootstrap manager box %q (%q) removed", ManagerName, managerBoxIDOrName)
+		}
+		if err := s.closeRuntime(runtimeHome, rt); err != nil {
+			return sandbox.Info{}, "", fmt.Errorf("close bootstrap manager runtime before recreate: %w", err)
+		}
+		rt = nil
+		managerHome, err := agentHomeDir(ManagerName)
+		if err != nil {
+			return sandbox.Info{}, "", err
+		}
+		if err := os.RemoveAll(managerHome); err != nil {
+			return sandbox.Info{}, "", fmt.Errorf("remove bootstrap manager home: %w", err)
+		}
+		rt, err = s.ensureRuntimeAtHome(runtimeHome)
+		if err != nil {
+			return sandbox.Info{}, "", err
+		}
+		box = nil
+	}
+
+	var info sandbox.Info
+	if box == nil {
+		log.Printf("bootstrap manager box %q not found, creating it with image %q", ManagerName, s.managerImage)
+		log.Printf("if the image is not present locally, the first pull may take a while")
+		progressDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(10 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-progressDone:
+					return
+				case <-ticker.C:
+					log.Printf("still creating bootstrap manager box %q with image %q; image download may still be in progress", ManagerName, s.managerImage)
+				}
+			}
+		}()
+		box, info, err = s.createGatewayBox(ctx, rt, s.managerImage, ManagerName, ManagerUserID, model)
+		close(progressDone)
+		if err != nil {
+			return sandbox.Info{}, "", fmt.Errorf("create bootstrap manager box: %w", err)
+		}
+		log.Printf("bootstrap manager box %q created", ManagerName)
+	} else {
+		if err := s.startBox(ctx, box); err != nil {
+			return sandbox.Info{}, "", fmt.Errorf("start bootstrap manager box: %w", err)
+		}
+		info, err = s.boxInfo(ctx, box)
+		if err != nil {
+			return sandbox.Info{}, "", fmt.Errorf("read bootstrap manager box info: %w", err)
+		}
+	}
+	defer func() {
+		_ = s.closeBox(box)
+	}()
+
+	return info, info.ID, nil
+}
+
+// createAgent provisions a non-worker, non-manager role agent via the
+// BoxLite per-agent runtime. An empty image is rejected (BoxLite has
+// no "managed" default image to fall back to, unlike csghub). The
+// returned result intentionally leaves BoxID blank and Info zero so
+// that common Create applies its legacy time.Now()/"running"
+// fallback — this preserves pre-refactor behavior where
+// Service.Create never persisted a BoxID and always stamped
+// Status="running" regardless of sandbox state.
+func (s *Service) createAgentBackend(ctx context.Context, req createAgentRequest) (createAgentResult, error) {
+	image := strings.TrimSpace(req.Image)
+	if image == "" {
+		return createAgentResult{}, fmt.Errorf("image is required")
+	}
+
+	rt, err := s.ensureRuntime(req.Name)
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(req.Name)
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	defer func() { _ = s.closeRuntime(runtimeHome, rt) }()
+
+	projectsRoot, err := ensureAgentProjectsRoot()
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	managerBaseURL := resolveManagerBaseURL(s.server)
+	llmBaseURL := llmBridgeBaseURL(managerBaseURL, req.ID)
+	boxSpec := sandbox.CreateSpec{
+		Image:      image,
+		Name:       req.Name,
+		Detach:     true,
+		AutoRemove: false,
+		Mounts: []sandbox.Mount{
+			{HostPath: projectsRoot, GuestPath: boxProjectsDir},
+		},
+		Env: make(map[string]string),
+	}
+	for key, value := range bridgeLLMEnvVars(llmBaseURL, s.server.AccessToken, req.Model.ModelID) {
+		boxSpec.Env[key] = value
+	}
+	box, err := s.createBox(ctx, rt, boxSpec)
+	if err != nil {
+		return createAgentResult{}, fmt.Errorf("create sandbox agent: %w", err)
+	}
+	defer func() { _ = s.closeBox(box) }()
+
+	return createAgentResult{Image: image}, nil
+}
+
+// streamLogs opens a per-agent runtime, resolves the live box, and
+// tails gateway.log via an in-box `tail` exec. The sandbox runtime
+// (for this agent) and the resolved box handle are closed on return
+// so the logs call does not leak resources even when ctx is cancelled
+// mid-stream.
+func (s *Service) streamLogsBackend(ctx context.Context, agent Agent, follow bool, lines int, w io.Writer) error {
+	rt, err := s.ensureRuntime(agent.Name)
+	if err != nil {
+		return err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(agent.Name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = s.closeRuntime(runtimeHome, rt) }()
+
+	box, resolvedKey, err := s.resolveAgentBox(ctx, rt, agent)
+	if err != nil {
+		if sandbox.IsNotFound(err) {
+			boxIDOrName := strings.TrimSpace(agent.BoxID)
+			if boxIDOrName == "" {
+				boxIDOrName = agent.Name
+			}
+			return fmt.Errorf("agent box %q not found", boxIDOrName)
+		}
+		return err
+	}
+	defer func() { _ = s.closeBox(box) }()
+	if err := s.refreshAgentBoxID(agent, resolvedKey, box); err != nil {
+		return err
+	}
+
+	args := []string{"-n", fmt.Sprintf("%d", lines)}
+	if follow {
+		args = append(args, "-f")
+	}
+	args = append(args, boxPicoClawDir+"/gateway.log")
+
+	exitCode, err := s.runBoxCommand(ctx, box, "tail", args, w)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("tail exited with code %d", exitCode)
+	}
+	return nil
+}
 
 func WithSandboxProvider(provider sandbox.Provider) ServiceOption {
 	return func(s *Service) error {
@@ -150,31 +390,12 @@ func WithSandboxHomeDirName(name string) ServiceOption {
 	}
 }
 
-func NewService(model config.ModelConfig, server config.ServerConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
-	return NewServiceWithLLM(config.SingleProfileLLM(model), server, managerImage, statePath, opts...)
-}
-
-func NewServiceWithChannels(model config.ModelConfig, server config.ServerConfig, channels config.ChannelsConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
-	return NewServiceWithLLMAndChannels(config.SingleProfileLLM(model), server, channels, managerImage, statePath, opts...)
-}
-
-func NewServiceWithLLM(llmCfg config.LLMConfig, server config.ServerConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
-	return NewServiceWithLLMAndChannels(llmCfg, server, config.ChannelsConfig{}, managerImage, statePath, opts...)
-}
-
 func NewServiceWithLLMAndChannels(llmCfg config.LLMConfig, server config.ServerConfig, channels config.ChannelsConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
 	// agent.Service owns the persisted registry and the live sandbox lifecycle.
 	if managerImage == "" {
 		managerImage = config.DefaultManagerImage
 	}
-	defaultProfile, model, err := llmCfg.Resolve("")
-	if err != nil {
-		defaultProfile = strings.TrimSpace(llmCfg.Normalized().Default)
-		if defaultProfile == "" {
-			defaultProfile = strings.TrimSpace(llmCfg.Normalized().DefaultProfile)
-		}
-		model = config.ModelConfig{}.Resolved()
-	}
+	defaultProfile, model := resolveDefaultProfileAndModel(llmCfg)
 	svc := &Service{
 		model:        model,
 		llm:          llmCfg.Normalized(),
@@ -204,34 +425,6 @@ func NewServiceWithLLMAndChannels(llmCfg config.LLMConfig, server config.ServerC
 	return svc, nil
 }
 
-func cloneChannelsConfig(channels config.ChannelsConfig) config.ChannelsConfig {
-	cloned := config.ChannelsConfig{
-		FeishuAdminOpenID: channels.FeishuAdminOpenID,
-	}
-	if len(channels.Feishu) > 0 {
-		cloned.Feishu = make(map[string]config.FeishuConfig, len(channels.Feishu))
-		for name, feishu := range channels.Feishu {
-			cloned.Feishu[name] = feishu
-		}
-	}
-	return cloned
-}
-
-func EnsureBootstrapState(ctx context.Context, statePath string, server config.ServerConfig, model config.ModelConfig, managerImage string, forceRecreate bool) error {
-	return EnsureBootstrapStateWithLLM(ctx, statePath, server, config.SingleProfileLLM(model), managerImage, forceRecreate)
-}
-
-func EnsureBootstrapStateWithLLM(ctx context.Context, statePath string, server config.ServerConfig, llmCfg config.LLMConfig, managerImage string, forceRecreate bool) error {
-	svc, err := NewServiceWithLLM(llmCfg, server, managerImage, statePath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = svc.Close()
-	}()
-	return svc.EnsureBootstrapManager(ctx, forceRecreate)
-}
-
 func (svc *Service) EnsureBootstrapManager(ctx context.Context, forceRecreate bool) error {
 	if svc == nil {
 		return nil
@@ -248,119 +441,6 @@ func (svc *Service) EnsureBootstrapManager(ctx context.Context, forceRecreate bo
 	return err
 }
 
-func (s *Service) EnsureManager(ctx context.Context, forceRecreate bool) (Agent, error) {
-	if s == nil {
-		return Agent{}, fmt.Errorf("agent service is required")
-	}
-	defaultProfile, defaultModel, err := s.llm.Resolve("")
-	if err != nil {
-		return Agent{}, err
-	}
-
-	rt, box, err := s.lookupBootstrapManager(ctx)
-	if err != nil {
-		return Agent{}, err
-	}
-	runtimeHome, err := s.sandboxRuntimeHome(ManagerName)
-	if err != nil {
-		return Agent{}, err
-	}
-	defer func() {
-		_ = s.closeRuntime(runtimeHome, rt)
-	}()
-	if forceRecreate {
-		log.Printf("force recreating bootstrap manager box %q", ManagerName)
-		managerBoxIDOrName := s.bootstrapManagerBoxIDOrName()
-		if err := s.forceRemoveBox(ctx, rt, managerBoxIDOrName); err != nil {
-			if sandbox.IsNotFound(err) {
-				log.Printf("bootstrap manager box %q (%q) does not exist yet; continuing", ManagerName, managerBoxIDOrName)
-			} else {
-				return Agent{}, fmt.Errorf("force remove bootstrap manager box %q (%q): %w", ManagerName, managerBoxIDOrName, err)
-			}
-		} else {
-			log.Printf("bootstrap manager box %q (%q) removed", ManagerName, managerBoxIDOrName)
-		}
-		if err := s.closeRuntime(runtimeHome, rt); err != nil {
-			return Agent{}, fmt.Errorf("close bootstrap manager runtime before recreate: %w", err)
-		}
-		rt = nil
-		managerHome, err := agentHomeDir(ManagerName)
-		if err != nil {
-			return Agent{}, err
-		}
-		if err := os.RemoveAll(managerHome); err != nil {
-			return Agent{}, fmt.Errorf("remove bootstrap manager home: %w", err)
-		}
-		rt, err = s.ensureRuntimeAtHome(runtimeHome)
-		if err != nil {
-			return Agent{}, err
-		}
-		box = nil
-	}
-	var info sandbox.Info
-	if box == nil {
-		log.Printf("bootstrap manager box %q not found, creating it with image %q", ManagerName, s.managerImage)
-		log.Printf("if the image is not present locally, the first pull may take a while")
-		progressDone := make(chan struct{})
-		go func() {
-			ticker := time.NewTicker(10 * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-progressDone:
-					return
-				case <-ticker.C:
-					log.Printf("still creating bootstrap manager box %q with image %q; image download may still be in progress", ManagerName, s.managerImage)
-				}
-			}
-		}()
-		box, info, err = s.createGatewayBox(ctx, rt, s.managerImage, ManagerName, ManagerUserID, defaultModel)
-		close(progressDone)
-		if err != nil {
-			return Agent{}, fmt.Errorf("create bootstrap manager box: %w", err)
-		}
-		log.Printf("bootstrap manager box %q created", ManagerName)
-	} else {
-		if err := s.startBox(ctx, box); err != nil {
-			return Agent{}, fmt.Errorf("start bootstrap manager box: %w", err)
-		}
-		info, err = s.boxInfo(ctx, box)
-		if err != nil {
-			return Agent{}, fmt.Errorf("read bootstrap manager box info: %w", err)
-		}
-	}
-	defer func() {
-		_ = s.closeBox(box)
-	}()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	manager := Agent{
-		ID:              ManagerUserID,
-		Name:            ManagerName,
-		Image:           s.managerImage,
-		BoxID:           info.ID,
-		Status:          string(info.State),
-		CreatedAt:       info.CreatedAt.UTC(),
-		Profile:         defaultProfile,
-		Provider:        defaultModel.Resolved().Provider,
-		ModelID:         defaultModel.Resolved().ModelID,
-		ReasoningEffort: defaultModel.Resolved().ReasoningEffort,
-		Role:            RoleManager,
-	}
-	for id, a := range s.agents {
-		if isManagerAgent(a) && id != manager.ID {
-			delete(s.agents, id)
-		}
-	}
-	s.agents[manager.ID] = manager
-	if err := s.saveLocked(); err != nil {
-		return Agent{}, err
-	}
-	return *cloneAgent(&manager), nil
-}
-
 func (s *Service) bootstrapManagerBoxIDOrName() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -374,135 +454,6 @@ func (s *Service) bootstrapManagerBoxIDOrName() string {
 		}
 	}
 	return ManagerName
-}
-
-func (s *Service) Create(ctx context.Context, req CreateRequest) (Agent, error) {
-	id := strings.TrimSpace(req.ID)
-	name := strings.TrimSpace(req.Name)
-	description := strings.TrimSpace(req.Description)
-	image := strings.TrimSpace(req.Image)
-	role := normalizeRole(req.Role)
-	if name == "" {
-		return Agent{}, fmt.Errorf("name is required")
-	}
-	if image == "" {
-		return Agent{}, fmt.Errorf("image is required")
-	}
-	if role == RoleManager {
-		return Agent{}, fmt.Errorf("role %q is reserved", role)
-	}
-	if id == "" {
-		id = fmt.Sprintf("%s-%d", role, time.Now().UnixNano())
-	}
-
-	s.mu.RLock()
-	idExists := false
-	if _, ok := s.agents[id]; ok {
-		idExists = true
-	}
-	nameExists := s.hasNameLocked(name)
-	s.mu.RUnlock()
-	if idExists {
-		return Agent{}, fmt.Errorf("agent id %q already exists", id)
-	}
-	if nameExists {
-		return Agent{}, fmt.Errorf("agent name %q already exists", name)
-	}
-
-	rt, err := s.ensureRuntime(name)
-	if err != nil {
-		return Agent{}, err
-	}
-	runtimeHome, err := s.sandboxRuntimeHome(name)
-	if err != nil {
-		return Agent{}, err
-	}
-	defer func() {
-		_ = s.closeRuntime(runtimeHome, rt)
-	}()
-
-	requestedProfile := strings.TrimSpace(req.Profile)
-	if requestedProfile == "" && strings.TrimSpace(req.ModelID) != "" {
-		matchedProfile, _, ok := s.llm.MatchProfile(config.ModelConfig{ModelID: req.ModelID})
-		if !ok {
-			return Agent{}, fmt.Errorf("no llm profile matches model %q", strings.TrimSpace(req.ModelID))
-		}
-		requestedProfile = matchedProfile
-	}
-
-	profileName, resolvedModel, err := s.resolveModelProfile(requestedProfile)
-	if err != nil {
-		return Agent{}, err
-	}
-
-	projectsRoot, err := ensureAgentProjectsRoot()
-	if err != nil {
-		return Agent{}, err
-	}
-	managerBaseURL := resolveManagerBaseURL(s.server)
-	llmBaseURL := llmBridgeBaseURL(managerBaseURL, id)
-	boxSpec := sandbox.CreateSpec{
-		Image:      image,
-		Name:       name,
-		Detach:     true,
-		AutoRemove: false,
-		Mounts: []sandbox.Mount{
-			{HostPath: projectsRoot, GuestPath: boxProjectsDir},
-		},
-		Env: make(map[string]string),
-	}
-	for key, value := range bridgeLLMEnvVars(llmBaseURL, s.server.AccessToken, resolvedModel.ModelID) {
-		boxSpec.Env[key] = value
-	}
-	box, err := s.createBox(ctx, rt, boxSpec)
-	if err != nil {
-		return Agent{}, fmt.Errorf("create sandbox agent: %w", err)
-	}
-	defer func() {
-		_ = s.closeBox(box)
-	}()
-
-	createdAt := req.CreatedAt.UTC()
-	if req.CreatedAt.IsZero() {
-		createdAt = time.Now().UTC()
-	}
-	status := strings.TrimSpace(req.Status)
-	if status == "" {
-		status = "running"
-	}
-	agent := Agent{
-		ID:              id,
-		Name:            name,
-		Description:     description,
-		Image:           image,
-		Role:            role,
-		Status:          status,
-		CreatedAt:       createdAt,
-		Profile:         profileName,
-		Provider:        resolvedModel.Provider,
-		ModelID:         resolvedModel.ModelID,
-		ReasoningEffort: resolvedModel.ReasoningEffort,
-	}
-
-	s.mu.Lock()
-	s.agents[id] = agent
-	err = s.saveLocked()
-	s.mu.Unlock()
-	if err != nil {
-		return Agent{}, err
-	}
-	return agent, nil
-}
-
-func (s *Service) Agent(id string) (Agent, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	a, ok := s.agents[strings.TrimSpace(id)]
-	if !ok {
-		return Agent{}, false
-	}
-	return *cloneAgent(&a), true
 }
 
 func (s *Service) resolveAgentBox(ctx context.Context, rt sandbox.Runtime, got Agent) (sandbox.Instance, string, error) {
@@ -537,7 +488,7 @@ func (s *Service) resolveAgentBox(ctx context.Context, rt sandbox.Runtime, got A
 	return nil, "", fmt.Errorf("agent box %q not found", got.Name)
 }
 
-func (s *Service) refreshAgentBoxID(id string, got Agent, resolvedKey string, box sandbox.Instance) error {
+func (s *Service) refreshAgentBoxID(got Agent, resolvedKey string, box sandbox.Instance) error {
 	if box == nil {
 		return nil
 	}
@@ -553,7 +504,7 @@ func (s *Service) refreshAgentBoxID(id string, got Agent, resolvedKey string, bo
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	current, ok := s.agents[id]
+	current, ok := s.agents[got.ID]
 	if !ok {
 		return nil
 	}
@@ -561,238 +512,8 @@ func (s *Service) refreshAgentBoxID(id string, got Agent, resolvedKey string, bo
 		return nil
 	}
 	current.BoxID = info.ID
-	s.agents[id] = current
+	s.agents[got.ID] = current
 	return s.saveLocked()
-}
-
-func (s *Service) Delete(ctx context.Context, id string) error {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return fmt.Errorf("agent id is required")
-	}
-
-	s.mu.RLock()
-	existing, ok := s.agents[id]
-	s.mu.RUnlock()
-	if !ok {
-		return fmt.Errorf("agent %q not found", id)
-	}
-	if isManagerAgent(existing) {
-		return fmt.Errorf("agent %q is reserved", id)
-	}
-
-	rt, err := s.ensureRuntime(existing.Name)
-	if err != nil {
-		return err
-	}
-	runtimeHome, err := s.sandboxRuntimeHome(existing.Name)
-	if err != nil {
-		return err
-	}
-	if rt != nil {
-		boxIDOrName := strings.TrimSpace(existing.BoxID)
-		if boxIDOrName == "" {
-			boxIDOrName = existing.Name
-		}
-		if _, resolvedKey, resolveErr := s.resolveAgentBox(ctx, rt, existing); resolveErr == nil && strings.TrimSpace(resolvedKey) != "" {
-			boxIDOrName = resolvedKey
-		}
-		if err := s.forceRemoveBox(ctx, rt, boxIDOrName); err != nil && !sandbox.IsNotFound(err) {
-			return fmt.Errorf("remove agent box: %w", err)
-		}
-		_ = s.closeRuntime(runtimeHome, rt)
-	}
-
-	agentHome, err := agentHomeDir(existing.Name)
-	if err != nil {
-		return err
-	}
-	if err := os.RemoveAll(agentHome); err != nil {
-		return fmt.Errorf("remove agent home: %w", err)
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	current, ok := s.agents[id]
-	if !ok {
-		return fmt.Errorf("agent %q not found", id)
-	}
-	delete(s.agents, id)
-	runtimeHome, err = s.sandboxRuntimeHome(current.Name)
-	if err != nil {
-		return err
-	}
-	if rt := s.runtimes[runtimeHome]; rt != nil {
-		delete(s.runtimes, runtimeHome)
-	}
-	return s.saveLocked()
-}
-
-func (s *Service) List() []Agent {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return sortedAgentsFromMap(s.agents)
-}
-
-func (s *Service) CreateWorker(ctx context.Context, req CreateRequest) (Agent, error) {
-	id := strings.TrimSpace(req.ID)
-	name := strings.TrimSpace(req.Name)
-	description := strings.TrimSpace(req.Description)
-	switch {
-	case name == "":
-		return Agent{}, fmt.Errorf("name is required")
-	case strings.EqualFold(name, ManagerName):
-		return Agent{}, fmt.Errorf("name %q is reserved", name)
-	}
-	if id == "" {
-		// id = fmt.Sprintf("%s-%d", RoleWorker, time.Now().UnixNano())
-		id = fmt.Sprintf("u-%s", name)
-	}
-
-	s.mu.RLock()
-	idExists := false
-	if _, ok := s.agents[id]; ok {
-		idExists = true
-	}
-	nameExists := s.hasNameLocked(name)
-	s.mu.RUnlock()
-	if idExists {
-		return Agent{}, fmt.Errorf("agent id %q already exists", id)
-	}
-	if nameExists {
-		return Agent{}, fmt.Errorf("agent name %q already exists", name)
-	}
-
-	rt, err := s.ensureRuntime(name)
-	if err != nil {
-		return Agent{}, err
-	}
-	runtimeHome, err := s.sandboxRuntimeHome(name)
-	if err != nil {
-		return Agent{}, err
-	}
-	defer func() {
-		_ = s.closeRuntime(runtimeHome, rt)
-	}()
-	profileName, resolvedModel, err := s.resolveModelProfile(req.Profile)
-	if err != nil {
-		return Agent{}, err
-	}
-	box, info, err := s.createGatewayBox(ctx, rt, s.managerImage, name, id, resolvedModel)
-	if err != nil {
-		return Agent{}, fmt.Errorf("create worker box: %w", err)
-	}
-	defer func() {
-		_ = s.closeBox(box)
-	}()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.agents[id]; ok {
-		return Agent{}, fmt.Errorf("agent id %q already exists", id)
-	}
-	if s.hasNameLocked(name) {
-		return Agent{}, fmt.Errorf("agent name %q already exists", name)
-	}
-
-	worker := Agent{
-		ID:              id,
-		Name:            name,
-		Image:           s.managerImage,
-		BoxID:           info.ID,
-		Description:     description,
-		Status:          string(info.State),
-		CreatedAt:       info.CreatedAt.UTC(),
-		Profile:         profileName,
-		Provider:        resolvedModel.Provider,
-		ModelID:         resolvedModel.ModelID,
-		ReasoningEffort: resolvedModel.ReasoningEffort,
-		Role:            RoleWorker,
-	}
-	s.agents[worker.ID] = worker
-	if err := s.saveLocked(); err != nil {
-		delete(s.agents, worker.ID)
-		return Agent{}, err
-	}
-	return *cloneAgent(&worker), nil
-}
-
-func (s *Service) ListWorkers() []Agent {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	workers := make(map[string]Agent)
-	for id, a := range s.agents {
-		if a.Role == RoleWorker {
-			workers[id] = a
-		}
-	}
-	return sortedAgentsFromMap(workers)
-}
-
-func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines int, w io.Writer) error {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return fmt.Errorf("agent id is required")
-	}
-	if w == nil {
-		return fmt.Errorf("log writer is required")
-	}
-	if lines <= 0 {
-		lines = 20
-	}
-
-	got, ok := s.Agent(id)
-	if !ok {
-		return fmt.Errorf("agent %q not found", id)
-	}
-
-	rt, err := s.ensureRuntime(got.Name)
-	if err != nil {
-		return err
-	}
-	runtimeHome, err := s.sandboxRuntimeHome(got.Name)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = s.closeRuntime(runtimeHome, rt)
-	}()
-
-	box, resolvedKey, err := s.resolveAgentBox(ctx, rt, got)
-	if err != nil {
-		if sandbox.IsNotFound(err) {
-			boxIDOrName := strings.TrimSpace(got.BoxID)
-			if boxIDOrName == "" {
-				boxIDOrName = got.Name
-			}
-			return fmt.Errorf("agent box %q not found", boxIDOrName)
-		}
-		return err
-	}
-	defer func() {
-		_ = s.closeBox(box)
-	}()
-	if err := s.refreshAgentBoxID(id, got, resolvedKey, box); err != nil {
-		return err
-	}
-
-	args := []string{"-n", fmt.Sprintf("%d", lines)}
-	if follow {
-		args = append(args, "-f")
-	}
-	args = append(args, boxPicoClawDir+"/gateway.log")
-
-	exitCode, err := s.runBoxCommand(ctx, box, "tail", args, w)
-	if err != nil {
-		return err
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("tail exited with code %d", exitCode)
-	}
-	return nil
 }
 
 func (s *Service) Close() error {
@@ -807,13 +528,4 @@ func (s *Service) Close() error {
 		delete(s.runtimes, name)
 	}
 	return closeErr
-}
-
-func (s *Service) hasNameLocked(name string) bool {
-	for _, existing := range s.agents {
-		if strings.EqualFold(existing.Name, name) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/agent/service_common.go
+++ b/internal/agent/service_common.go
@@ -1,0 +1,493 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"csgclaw/internal/config"
+	"csgclaw/internal/sandbox"
+)
+
+// Per-build backend lifecycle hooks are implemented directly as Service
+// methods in service.go (!csghub) and service_csghub.go (csghub):
+// createWorkerBackend / deleteSandboxBackend / postDeleteLockedBackend /
+// streamLogsBackend / createAgentBackend / ensureManagerBackend /
+// agentHomeDirBackend.
+
+// createAgentRequest collects the already-normalized inputs the
+// backend needs to provision a Create-style (non-worker) sandbox.
+// Fields mirror agent.CreateRequest minus the validation / defaulting
+// that common Create has already applied.
+type createAgentRequest struct {
+	Name  string
+	ID    string
+	Image string
+	Model config.ModelConfig
+}
+
+// createAgentResult carries runtime metadata common Create needs to
+// assemble the persisted Agent record. Image lets the backend report
+// the image it actually used (CSGHub may override when req.Image is
+// empty); BoxID is the sandbox identifier to persist (empty string
+// preserves BoxLite's legacy "no BoxID" behavior); Info is used for
+// CreatedAt / Status fallback when req does not supply them.
+type createAgentResult struct {
+	Info  sandbox.Info
+	BoxID string
+	Image string
+}
+
+// ServiceOption configures a Service during construction. The concrete
+// Service struct differs between build tags, so options must live in a
+// build-tag-specific file whenever they touch backend fields; pure
+// option wiring can live here.
+type ServiceOption func(*Service) error
+
+// NewService constructs a default single-profile LLM Service.
+func NewService(model config.ModelConfig, server config.ServerConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
+	return NewServiceWithLLM(config.SingleProfileLLM(model), server, managerImage, statePath, opts...)
+}
+
+// NewServiceWithChannels accepts the legacy single-profile + channels signature.
+func NewServiceWithChannels(model config.ModelConfig, server config.ServerConfig, channels config.ChannelsConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
+	return NewServiceWithLLMAndChannels(config.SingleProfileLLM(model), server, channels, managerImage, statePath, opts...)
+}
+
+// NewServiceWithLLM accepts a multi-profile LLM config without channels.
+func NewServiceWithLLM(llmCfg config.LLMConfig, server config.ServerConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
+	return NewServiceWithLLMAndChannels(llmCfg, server, config.ChannelsConfig{}, managerImage, statePath, opts...)
+}
+
+// EnsureBootstrapState is the legacy entrypoint used by cmd/csgclaw onboarding.
+func EnsureBootstrapState(ctx context.Context, statePath string, server config.ServerConfig, model config.ModelConfig, managerImage string, forceRecreate bool) error {
+	return EnsureBootstrapStateWithLLM(ctx, statePath, server, config.SingleProfileLLM(model), managerImage, forceRecreate)
+}
+
+// EnsureBootstrapStateWithLLM constructs a service, guarantees the bootstrap
+// manager sandbox, and closes the service.
+func EnsureBootstrapStateWithLLM(ctx context.Context, statePath string, server config.ServerConfig, llmCfg config.LLMConfig, managerImage string, forceRecreate bool) error {
+	svc, err := NewServiceWithLLM(llmCfg, server, managerImage, statePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = svc.Close()
+	}()
+	return svc.EnsureBootstrapManager(ctx, forceRecreate)
+}
+
+// resolveDefaultProfileAndModel returns the effective default profile name and
+// resolved model snapshot used to initialize Service defaults. When LLM
+// resolution fails (no model configured yet) we still produce a best-effort
+// profile name so the constructor can proceed.
+func resolveDefaultProfileAndModel(llmCfg config.LLMConfig) (string, config.ModelConfig) {
+	defaultProfile, model, err := llmCfg.Resolve("")
+	if err == nil {
+		return defaultProfile, model
+	}
+	defaultProfile = strings.TrimSpace(llmCfg.Normalized().Default)
+	if defaultProfile == "" {
+		defaultProfile = strings.TrimSpace(llmCfg.Normalized().DefaultProfile)
+	}
+	return defaultProfile, config.ModelConfig{}.Resolved()
+}
+
+// --- Public agent API shared across builds ----------------------------------
+
+// CreateWorker creates a worker agent using the backend strategy for
+// the active build tag. Worker agents are the common case driven by
+// `csgclaw agents create` and the IM layer; they always use the
+// Service-default manager image and derive id from name via the
+// "u-<name>" convention.
+func (s *Service) CreateWorker(ctx context.Context, req CreateRequest) (Agent, error) {
+	id := strings.TrimSpace(req.ID)
+	name := strings.TrimSpace(req.Name)
+	description := strings.TrimSpace(req.Description)
+	switch {
+	case name == "":
+		return Agent{}, fmt.Errorf("name is required")
+	case strings.EqualFold(name, ManagerName):
+		return Agent{}, fmt.Errorf("name %q is reserved", name)
+	}
+	if id == "" {
+		id = fmt.Sprintf("u-%s", name)
+	}
+
+	s.mu.RLock()
+	_, idExists := s.agents[id]
+	nameExists := s.hasNameLocked(name)
+	s.mu.RUnlock()
+	if idExists {
+		return Agent{}, fmt.Errorf("agent id %q already exists", id)
+	}
+	if nameExists {
+		return Agent{}, fmt.Errorf("agent name %q already exists", name)
+	}
+
+	profileName, resolvedModel, err := s.resolveModelProfile(req.Profile)
+	if err != nil {
+		return Agent{}, err
+	}
+
+	info, boxID, err := s.createWorkerBackend(ctx, name, id, resolvedModel)
+	if err != nil {
+		return Agent{}, fmt.Errorf("create worker box: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.agents[id]; ok {
+		return Agent{}, fmt.Errorf("agent id %q already exists", id)
+	}
+	if s.hasNameLocked(name) {
+		return Agent{}, fmt.Errorf("agent name %q already exists", name)
+	}
+
+	createdAt := info.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	worker := Agent{
+		ID:              id,
+		Name:            name,
+		Image:           s.managerImage,
+		BoxID:           boxID,
+		Description:     description,
+		Status:          string(info.State),
+		CreatedAt:       createdAt,
+		Profile:         profileName,
+		Provider:        resolvedModel.Provider,
+		ModelID:         resolvedModel.ModelID,
+		ReasoningEffort: resolvedModel.ReasoningEffort,
+		Role:            RoleWorker,
+	}
+	s.agents[worker.ID] = worker
+	if err := s.saveLocked(); err != nil {
+		delete(s.agents, worker.ID)
+		return Agent{}, err
+	}
+	return *cloneAgent(&worker), nil
+}
+
+// Delete removes an agent and the sandbox backing it. The persisted
+// registry update happens last and only after the sandbox and the
+// on-disk agent home have been cleaned up; a sandbox "not found"
+// response is swallowed so callers can retry safely.
+//
+// The `manager` agent is reserved and cannot be deleted through this
+// path; use EnsureManager(force=true) to rebuild it.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("agent id is required")
+	}
+
+	s.mu.RLock()
+	existing, ok := s.agents[id]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("agent %q not found", id)
+	}
+	if isManagerAgent(existing) {
+		return fmt.Errorf("agent %q is reserved", id)
+	}
+
+	if err := s.deleteSandboxBackend(ctx, existing); err != nil {
+		return err
+	}
+
+	agentHome, err := s.agentHomeDirBackend(existing.Name)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(agentHome); err != nil {
+		return fmt.Errorf("remove agent home: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, ok := s.agents[id]
+	if !ok {
+		return fmt.Errorf("agent %q not found", id)
+	}
+	delete(s.agents, id)
+	s.postDeleteLockedBackend(current)
+	return s.saveLocked()
+}
+
+// Create registers a non-worker, non-manager role agent. The heavy
+// lifting (image defaulting, sandbox spec construction, Hub round
+// trips) lives in backend.createAgent; common logic here handles
+// validation, id generation, duplicate detection, LLM profile
+// resolution, CreatedAt/Status fallback, and registry persistence.
+//
+// Semantics preserved across builds:
+//   - a blank req.ID defaults to "<role>-<unixnano>",
+//   - role == manager is reserved,
+//   - duplicate id or case-insensitive name returns an error,
+//   - when req does not pin CreatedAt/Status, the backend's reported
+//     sandbox.Info is used; when that is also blank we fall back to
+//     time.Now() / "running" so legacy BoxLite callers are unaffected.
+func (s *Service) Create(ctx context.Context, req CreateRequest) (Agent, error) {
+	id := strings.TrimSpace(req.ID)
+	name := strings.TrimSpace(req.Name)
+	description := strings.TrimSpace(req.Description)
+	image := strings.TrimSpace(req.Image)
+	role := normalizeRole(req.Role)
+	if name == "" {
+		return Agent{}, fmt.Errorf("name is required")
+	}
+	if role == RoleManager {
+		return Agent{}, fmt.Errorf("role %q is reserved", role)
+	}
+	if id == "" {
+		id = fmt.Sprintf("%s-%d", role, time.Now().UnixNano())
+	}
+
+	s.mu.RLock()
+	_, idExists := s.agents[id]
+	nameExists := s.hasNameLocked(name)
+	s.mu.RUnlock()
+	if idExists {
+		return Agent{}, fmt.Errorf("agent id %q already exists", id)
+	}
+	if nameExists {
+		return Agent{}, fmt.Errorf("agent name %q already exists", name)
+	}
+
+	requestedProfile := strings.TrimSpace(req.Profile)
+	if requestedProfile == "" && strings.TrimSpace(req.ModelID) != "" {
+		matchedProfile, _, ok := s.llm.MatchProfile(config.ModelConfig{ModelID: req.ModelID})
+		if !ok {
+			return Agent{}, fmt.Errorf("no llm profile matches model %q", strings.TrimSpace(req.ModelID))
+		}
+		requestedProfile = matchedProfile
+	}
+	profileName, resolvedModel, err := s.resolveModelProfile(requestedProfile)
+	if err != nil {
+		return Agent{}, err
+	}
+
+	result, err := s.createAgentBackend(ctx, createAgentRequest{
+		Name:  name,
+		ID:    id,
+		Image: image,
+		Model: resolvedModel,
+	})
+	if err != nil {
+		return Agent{}, err
+	}
+
+	effectiveImage := strings.TrimSpace(result.Image)
+	if effectiveImage == "" {
+		effectiveImage = image
+	}
+
+	createdAt := req.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		if !result.Info.CreatedAt.IsZero() {
+			createdAt = result.Info.CreatedAt.UTC()
+		} else {
+			createdAt = time.Now().UTC()
+		}
+	}
+	status := strings.TrimSpace(req.Status)
+	if status == "" {
+		status = strings.TrimSpace(string(result.Info.State))
+	}
+	if status == "" {
+		status = "running"
+	}
+
+	agent := Agent{
+		ID:              id,
+		Name:            name,
+		Description:     description,
+		Image:           effectiveImage,
+		BoxID:           result.BoxID,
+		Role:            role,
+		Status:          status,
+		CreatedAt:       createdAt,
+		Profile:         profileName,
+		Provider:        resolvedModel.Provider,
+		ModelID:         resolvedModel.ModelID,
+		ReasoningEffort: resolvedModel.ReasoningEffort,
+	}
+
+	s.mu.Lock()
+	s.agents[id] = agent
+	err = s.saveLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return Agent{}, err
+	}
+	return agent, nil
+}
+
+// EnsureManager guarantees that the bootstrap manager sandbox exists
+// and is running, then upserts the manager entry in the registry. It
+// also evicts any stale manager-role agents with a different ID so
+// the registry never carries multiple managers (can happen if state
+// migrated from a previous ManagerUserID convention).
+//
+// The heavy sandbox lifecycle lives in backend.ensureManager, which
+// differs substantially between builds (BoxLite: per-agent runtime
+// lookup + image-pull progress logging + rebuild-on-force; CSGHub:
+// shared runtime Create with optional Remove+Create on force). Common
+// logic here is only the registry assembly and persistence.
+func (s *Service) EnsureManager(ctx context.Context, forceRecreate bool) (Agent, error) {
+	if s == nil {
+		return Agent{}, fmt.Errorf("agent service is required")
+	}
+	defaultProfile, defaultModel, err := s.llm.Resolve("")
+	if err != nil {
+		return Agent{}, err
+	}
+
+	info, boxID, err := s.ensureManagerBackend(ctx, forceRecreate, defaultModel)
+	if err != nil {
+		return Agent{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	createdAt := info.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	manager := Agent{
+		ID:              ManagerUserID,
+		Name:            ManagerName,
+		Image:           s.managerImage,
+		BoxID:           boxID,
+		Status:          string(info.State),
+		CreatedAt:       createdAt,
+		Profile:         defaultProfile,
+		Provider:        defaultModel.Resolved().Provider,
+		ModelID:         defaultModel.Resolved().ModelID,
+		ReasoningEffort: defaultModel.Resolved().ReasoningEffort,
+		Role:            RoleManager,
+	}
+	for id, a := range s.agents {
+		if isManagerAgent(a) && id != manager.ID {
+			delete(s.agents, id)
+		}
+	}
+	s.agents[manager.ID] = manager
+	if err := s.saveLocked(); err != nil {
+		return Agent{}, err
+	}
+	return *cloneAgent(&manager), nil
+}
+
+// StreamLogs tails the gateway log for the given agent, writing lines
+// to w. When follow is true the stream stays open until ctx is
+// cancelled or the sandbox terminates. Validation (trim, default line
+// count, agent lookup) lives here so both backends share identical
+// error messages; the actual log source differs per backend and is
+// handled by backend.streamLogs.
+func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines int, w io.Writer) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	if w == nil {
+		return fmt.Errorf("log writer is required")
+	}
+	if lines <= 0 {
+		lines = 20
+	}
+
+	got, ok := s.Agent(id)
+	if !ok {
+		return fmt.Errorf("agent %q not found", id)
+	}
+
+	return s.streamLogsBackend(ctx, got, follow, lines, w)
+}
+
+// --- Generic accessors shared across builds ---------------------------------
+//
+// These methods only touch the backend-neutral fields on *Service
+// (`s.mu`, `s.agents`) and helpers defined in model.go. They used to
+// live duplicated in service.go and service_csghub.go; consolidating
+// them here lets the per-build files focus on sandbox lifecycle logic.
+
+// Agent returns a copy of the agent with the given id, if present.
+func (s *Service) Agent(id string) (Agent, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	a, ok := s.agents[strings.TrimSpace(id)]
+	if !ok {
+		return Agent{}, false
+	}
+	return *cloneAgent(&a), true
+}
+
+// List returns every known agent sorted by id.
+func (s *Service) List() []Agent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return sortedAgentsFromMap(s.agents)
+}
+
+// ListWorkers returns every worker agent sorted by id.
+func (s *Service) ListWorkers() []Agent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	workers := make(map[string]Agent)
+	for id, a := range s.agents {
+		if a.Role == RoleWorker {
+			workers[id] = a
+		}
+	}
+	return sortedAgentsFromMap(workers)
+}
+
+// hasNameLocked reports whether any agent is already registered under
+// the given name (case-insensitive). Caller must hold s.mu.
+func (s *Service) hasNameLocked(name string) bool {
+	for _, existing := range s.agents {
+		if strings.EqualFold(existing.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// sandboxNameFromInfo returns the most stable identifier for a sandbox
+// given backend-neutral metadata, preferring Name over ID and falling
+// back to the caller-supplied value when both are empty.
+func sandboxNameFromInfo(info sandbox.Info, fallback string) string {
+	if v := strings.TrimSpace(info.Name); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(info.ID); v != "" {
+		return v
+	}
+	return strings.TrimSpace(fallback)
+}
+
+// cloneChannelsConfig returns a deep-ish copy of channels so Service
+// construction does not share the caller's Feishu map.
+func cloneChannelsConfig(channels config.ChannelsConfig) config.ChannelsConfig {
+	cloned := config.ChannelsConfig{
+		FeishuAdminOpenID: channels.FeishuAdminOpenID,
+	}
+	if len(channels.Feishu) > 0 {
+		cloned.Feishu = make(map[string]config.FeishuConfig, len(channels.Feishu))
+		for name, feishu := range channels.Feishu {
+			cloned.Feishu[name] = feishu
+		}
+	}
+	return cloned
+}

--- a/internal/agent/service_csghub.go
+++ b/internal/agent/service_csghub.go
@@ -1,0 +1,452 @@
+//go:build csghub
+// +build csghub
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"csgclaw/internal/config"
+	"csgclaw/internal/sandbox"
+)
+
+// --- Service ----------------------------------------------------------------
+
+// Service owns the persisted agent registry and the CSGHub Sandbox
+// lifecycle calls used to back it. The struct intentionally mirrors the
+// public surface of the BoxLite Service (methods, field semantics) so
+// upstream callers (cli/, internal/api/, internal/bot/) do not need to
+// branch on build tags.
+//
+// Lifecycle is delegated to a sandbox.Provider injected by
+// cli/sandboxopts so WithSandboxProvider is honored symmetrically with
+// the BoxLite build.
+type Service struct {
+	llm          config.LLMConfig
+	server       config.ServerConfig
+	channels     config.ChannelsConfig
+	managerImage string
+	downstream   map[string]string
+	state        string
+	mu           sync.RWMutex
+	provider     sandbox.Provider
+	runtime      sandbox.Runtime
+	agents       map[string]Agent
+}
+
+var defaultSandboxProvider sandbox.Provider = unconfiguredSandboxProvider{}
+
+type unconfiguredSandboxProvider struct{}
+
+func (unconfiguredSandboxProvider) Name() string { return "unconfigured" }
+
+func (unconfiguredSandboxProvider) Open(context.Context, string) (sandbox.Runtime, error) {
+	return nil, fmt.Errorf("sandbox provider is not configured")
+}
+
+type streamExecuteRuntime interface {
+	sandbox.Runtime
+	StreamExecute(ctx context.Context, name, command string, emit func(line string) error) error
+}
+
+type providerAgentDefaults interface {
+	SandboxDownstreamEnv() map[string]string
+	SandboxManagerImage() string
+}
+
+type providerAgentNamer interface {
+	AgentSandboxName(agentID string) string
+}
+
+type providerAgentMountPaths interface {
+	AgentMountHostPaths(agentName string) (picoClaw, workspace, projects string, err error)
+}
+
+type gatewayHostPaths struct {
+	PicoClaw  string
+	Workspace string
+	Projects  string
+}
+
+func (s *Service) createWorkerBackend(ctx context.Context, name, id string, model config.ModelConfig) (sandbox.Info, string, error) {
+	rt, err := s.runtimeOrOpen()
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	paths, mounts, err := s.gatewayMounts(name)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	if _, err := ensureAgentPicoClawConfigAt(paths.PicoClaw, id, s.server, model); err != nil {
+		return sandbox.Info{}, "", err
+	}
+	if _, err := ensureAgentWorkspaceAt(paths.Workspace, workspaceTemplateForAgent(name, id)); err != nil {
+		return sandbox.Info{}, "", err
+	}
+	env := agentSandboxEnv(s.downstream, s.server, s.channels, id, model.ModelID)
+	spec := buildGatewaySpec(s.managerImage, s.sandboxName(id), env, mounts)
+
+	info, err := s.ensureAgentSandbox(ctx, rt, spec, false)
+	if err != nil {
+		return sandbox.Info{}, "", fmt.Errorf("create worker sandbox: %w", err)
+	}
+	return info, sandboxNameFromInfo(info, spec.Name), nil
+}
+
+func (s *Service) deleteSandboxBackend(ctx context.Context, agent Agent) error {
+	rt, err := s.runtimeOrOpen()
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(agent.BoxID)
+	if name == "" {
+		name = s.sandboxName(agent.ID)
+	}
+	if err := rt.Remove(ctx, name, sandbox.RemoveOptions{}); err != nil && !sandbox.IsNotFound(err) {
+		return fmt.Errorf("stop sandbox %q: %w", name, err)
+	}
+	return nil
+}
+
+// postDeleteLocked is a no-op on CSGHub: a single shared runtime is
+// owned by the Service, so there is no per-agent bookkeeping to prune
+// when an agent is removed.
+func (s *Service) postDeleteLockedBackend(Agent) {}
+
+func (s *Service) agentHomeDirBackend(agentName string) (string, error) {
+	paths, err := s.agentMountHostPaths(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(paths.PicoClaw), nil
+}
+
+// ensureManager materializes the manager's picoclaw config + tenant
+// workspace and then drives the shared runtime via Create (and
+// force-recreate Remove+Create when requested). No per-agent runtime
+// handle exists in the csghub build, so there is no runtime lookup /
+// close phase to manage.
+func (s *Service) ensureManagerBackend(ctx context.Context, forceRecreate bool, model config.ModelConfig) (sandbox.Info, string, error) {
+	rt, err := s.runtimeOrOpen()
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	paths, mounts, err := s.gatewayMounts(ManagerName)
+	if err != nil {
+		return sandbox.Info{}, "", err
+	}
+	if _, err := ensureAgentPicoClawConfigAt(paths.PicoClaw, ManagerUserID, s.server, model); err != nil {
+		return sandbox.Info{}, "", err
+	}
+	if _, err := ensureAgentWorkspaceAt(paths.Workspace, workspaceTemplateForAgent(ManagerName, ManagerUserID)); err != nil {
+		return sandbox.Info{}, "", err
+	}
+	env := agentSandboxEnv(s.downstream, s.server, s.channels, ManagerUserID, model.ModelID)
+	spec := buildGatewaySpec(s.managerImage, s.sandboxName(ManagerUserID), env, mounts)
+
+	info, err := s.ensureAgentSandbox(ctx, rt, spec, forceRecreate)
+	if err != nil {
+		return sandbox.Info{}, "", fmt.Errorf("ensure bootstrap manager sandbox: %w", err)
+	}
+	return info, sandboxNameFromInfo(info, spec.Name), nil
+}
+
+// createAgent provisions a non-worker, non-manager role agent on the
+// Hub. An empty image is defaulted to s.managerImage (the
+// Hub-provided CSGCLAW_SANDBOX_IMAGE), matching the pre-refactor
+// Service.Create behavior. Spec construction mirrors createWorker so
+// per-agent workspace, picoclaw config, mounts, and env contract are
+// identical for both spawn paths; Create just allows an alternative
+// image override when callers want it.
+func (s *Service) createAgentBackend(ctx context.Context, req createAgentRequest) (createAgentResult, error) {
+	rt, err := s.runtimeOrOpen()
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	image := strings.TrimSpace(req.Image)
+	if image == "" {
+		image = s.managerImage
+	}
+
+	paths, mounts, err := s.gatewayMounts(req.Name)
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	if _, err := ensureAgentPicoClawConfigAt(paths.PicoClaw, req.ID, s.server, req.Model); err != nil {
+		return createAgentResult{}, err
+	}
+	if _, err := ensureAgentWorkspaceAt(paths.Workspace, workspaceTemplateForAgent(req.Name, req.ID)); err != nil {
+		return createAgentResult{}, err
+	}
+	env := agentSandboxEnv(s.downstream, s.server, s.channels, req.ID, req.Model.ModelID)
+	spec := buildGatewaySpec(image, s.sandboxName(req.ID), env, mounts)
+
+	info, err := s.ensureAgentSandbox(ctx, rt, spec, false)
+	if err != nil {
+		return createAgentResult{}, err
+	}
+	return createAgentResult{
+		Info:  info,
+		BoxID: sandboxNameFromInfo(info, spec.Name),
+		Image: image,
+	}, nil
+}
+
+// streamLogs tails gateway.log via the shared CSGHub runtime's
+// StreamExecute RPC. The command string mirrors BoxLite's per-box
+// `tail` invocation so operator-visible log output is identical
+// across builds.
+func (s *Service) streamLogsBackend(ctx context.Context, agent Agent, follow bool, lines int, w io.Writer) error {
+	rt, err := s.runtimeOrOpen()
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(agent.BoxID)
+	if name == "" {
+		name = s.sandboxName(agent.ID)
+	}
+
+	cmd := fmt.Sprintf("tail -n %d %s", lines, boxPicoClawDir+"/gateway.log")
+	if follow {
+		cmd = fmt.Sprintf("tail -n %d -f %s", lines, boxPicoClawDir+"/gateway.log")
+	}
+	streamer, ok := rt.(streamExecuteRuntime)
+	if !ok {
+		return fmt.Errorf("sandbox provider %q runtime does not support stream execute", s.provider.Name())
+	}
+	return streamer.StreamExecute(ctx, name, cmd, func(line string) error {
+		if _, err := io.WriteString(w, line+"\n"); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// WithSandboxProvider overrides the default sandbox provider.
+func WithSandboxProvider(provider sandbox.Provider) ServiceOption {
+	return func(s *Service) error {
+		if provider == nil {
+			return fmt.Errorf("sandbox provider is required")
+		}
+		s.provider = provider
+		return nil
+	}
+}
+
+// WithSandboxHomeDirName is a no-op in csghub builds; filesystem layout is
+// derived from the tenant PVC env contract.
+func WithSandboxHomeDirName(string) ServiceOption {
+	return func(*Service) error { return nil }
+}
+
+// NewServiceWithLLMAndChannels is the canonical constructor.
+func NewServiceWithLLMAndChannels(llmCfg config.LLMConfig, server config.ServerConfig, channels config.ChannelsConfig, managerImage, statePath string, opts ...ServiceOption) (*Service, error) {
+	if strings.TrimSpace(managerImage) == "" {
+		managerImage = config.DefaultManagerImage
+	}
+
+	defaultProfile, _ := resolveDefaultProfileAndModel(llmCfg)
+
+	svc := &Service{
+		llm:          llmCfg.Normalized(),
+		server:       server,
+		channels:     cloneChannelsConfig(channels),
+		managerImage: managerImage,
+		state:        statePath,
+		provider:     defaultSandboxProvider,
+		agents:       make(map[string]Agent),
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(svc); err != nil {
+			return nil, err
+		}
+	}
+	svc.applyProviderDefaults()
+	if strings.TrimSpace(svc.llm.DefaultProfile) == "" {
+		svc.llm.DefaultProfile = defaultProfile
+	}
+	if err := svc.load(); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func (s *Service) applyProviderDefaults() {
+	p, ok := s.provider.(providerAgentDefaults)
+	if !ok {
+		return
+	}
+	if img := strings.TrimSpace(p.SandboxManagerImage()); img != "" {
+		s.managerImage = img
+	}
+	if env := p.SandboxDownstreamEnv(); len(env) > 0 {
+		s.downstream = make(map[string]string, len(env))
+		for k, v := range env {
+			s.downstream[k] = v
+		}
+	}
+}
+
+func (s *Service) sandboxName(agentID string) string {
+	if namer, ok := s.provider.(providerAgentNamer); ok {
+		return namer.AgentSandboxName(agentID)
+	}
+	return "csgclaw-" + strings.TrimSpace(agentID)
+}
+
+// --- Bootstrap manager ------------------------------------------------------
+
+func (svc *Service) EnsureBootstrapManager(ctx context.Context, forceRecreate bool) error {
+	if svc == nil {
+		return nil
+	}
+	_, defaultModel, err := svc.llm.Resolve("")
+	if err != nil {
+		return err
+	}
+	paths, _, err := svc.gatewayMounts(ManagerName)
+	if err != nil {
+		return err
+	}
+	if _, err := ensureAgentPicoClawConfigAt(paths.PicoClaw, ManagerUserID, svc.server, defaultModel); err != nil {
+		return err
+	}
+	if _, err := ensureAgentWorkspaceAt(paths.Workspace, workspaceTemplateForAgent(ManagerName, ManagerUserID)); err != nil {
+		return err
+	}
+	_, err = svc.EnsureManager(ctx, forceRecreate)
+	return err
+}
+
+// ensureAgentSandbox drives runtime Create and
+// returns runtime-neutral metadata for persistence code.
+//
+// Runtime implementations may expose CachedInfo() on the returned
+// instance; we prefer that snapshot and only fall back to live
+// Info(ctx) when unavailable.
+func (s *Service) ensureAgentSandbox(ctx context.Context, rt sandbox.Runtime, spec sandbox.CreateSpec, forceRecreate bool) (sandbox.Info, error) {
+	if forceRecreate {
+		if err := rt.Remove(ctx, spec.Name, sandbox.RemoveOptions{Force: true}); err != nil && !sandbox.IsNotFound(err) {
+			return sandbox.Info{}, fmt.Errorf("force remove sandbox %q: %w", spec.Name, err)
+		}
+	}
+	inst, err := rt.Create(ctx, spec)
+	if err != nil {
+		return sandbox.Info{}, err
+	}
+	if cached, ok := cachedSandboxInfo(inst); ok {
+		return cached, nil
+	}
+	info, err := inst.Info(ctx)
+	if err != nil {
+		return sandbox.Info{}, err
+	}
+	return info, nil
+}
+
+// cachedSandboxInfo unwraps a ManagedInstance that exposes a
+// zero-round-trip snapshot of its last-known Response. Kept as a free
+// function so ensureAgentSandbox stays oblivious to the concrete
+// backend type while still benefiting from the optimization when the
+// underlying instance is *csghub.Instance.
+func cachedSandboxInfo(inst sandbox.Instance) (sandbox.Info, bool) {
+	if c, ok := inst.(interface {
+		CachedInfo() (sandbox.Info, bool)
+	}); ok {
+		return c.CachedInfo()
+	}
+	return sandbox.Info{}, false
+}
+
+func (s *Service) runtimeOrOpen() (sandbox.Runtime, error) {
+	if s.runtime != nil {
+		return s.runtime, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.runtime != nil {
+		return s.runtime, nil
+	}
+	rt, err := s.provider.Open(context.Background(), "")
+	if err != nil {
+		return nil, fmt.Errorf("open csghub sandbox runtime: %w", err)
+	}
+	s.runtime = rt
+	return rt, nil
+}
+
+func (s *Service) agentMountHostPaths(agentName string) (gatewayHostPaths, error) {
+	provider, ok := s.provider.(providerAgentMountPaths)
+	if !ok {
+		return gatewayHostPaths{}, fmt.Errorf("sandbox provider %q does not provide agent mount paths", s.provider.Name())
+	}
+	picoClaw, workspace, projects, err := provider.AgentMountHostPaths(agentName)
+	if err != nil {
+		return gatewayHostPaths{}, err
+	}
+	return gatewayHostPaths{
+		PicoClaw:  picoClaw,
+		Workspace: workspace,
+		Projects:  projects,
+	}, nil
+}
+
+func (s *Service) gatewayMounts(agentName string) (gatewayHostPaths, []sandbox.Mount, error) {
+	paths, err := s.agentMountHostPaths(agentName)
+	if err != nil {
+		return gatewayHostPaths{}, nil, err
+	}
+	return paths, []sandbox.Mount{
+		{HostPath: paths.PicoClaw, GuestPath: boxPicoClawDir},
+		{HostPath: paths.Workspace, GuestPath: boxWorkspaceDir},
+		{HostPath: paths.Projects, GuestPath: boxProjectsDir},
+	}, nil
+}
+
+// agentSandboxEnv assembles the env map injected into a manager or
+// worker sandbox. Both roles receive the same env — they share the
+// csgclaw-agent-sandbox image (FROM picoclaw + supervisor + python-
+// sandbox) and only differ by sandbox name. The manager also uses this
+// env to call back into the server for worker-spawn requests (D11);
+// the hub admin token is NOT forwarded, worker creation goes through
+// the csgclaw server HTTP API gated by CSGCLAW_ACCESS_TOKEN.
+func agentSandboxEnv(downstream map[string]string, server config.ServerConfig, channels config.ChannelsConfig, botID, modelID string) map[string]string {
+	managerBaseURL := resolveManagerBaseURL(server)
+	llmBaseURL := llmBridgeBaseURL(managerBaseURL, botID)
+	env := picoclawBoxEnvVars(managerBaseURL, server.AccessToken, botID, llmBaseURL, modelID)
+	addFeishuBoxEnvVars(env, botID, channels)
+
+	env["HOME"] = "/home/picoclaw"
+
+	for k, v := range downstream {
+		env[k] = v
+	}
+	return env
+}
+
+// buildGatewaySpec composes the generic sandbox.CreateSpec for a
+// gateway (manager or worker) sandbox. Provisioning fields
+// (ClusterID / ResourceID / Port / Timeout) are injected later by
+// the csghub provider from its own Params.
+func buildGatewaySpec(image, sandboxName string, env map[string]string, mounts []sandbox.Mount) sandbox.CreateSpec {
+	return sandbox.CreateSpec{
+		Image:  strings.TrimSpace(image),
+		Name:   strings.TrimSpace(sandboxName),
+		Env:    env,
+		Mounts: mounts,
+	}
+}
+
+// Close releases SDK resources. The HTTP client is shared-Goroutine-safe
+// so there is nothing to close today, but we keep the method for parity.
+func (s *Service) Close() error {
+	return nil
+}

--- a/internal/agent/service_csghub_test.go
+++ b/internal/agent/service_csghub_test.go
@@ -1,0 +1,183 @@
+//go:build csghub
+// +build csghub
+
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/config"
+	"csgclaw/internal/sandbox"
+	"csgclaw/internal/sandbox/csghub"
+)
+
+type fakeManagedProvider struct {
+	runtime sandbox.Runtime
+}
+
+func (p fakeManagedProvider) Name() string { return "fake-managed" }
+
+func (p fakeManagedProvider) Open(context.Context, string) (sandbox.Runtime, error) {
+	return p.runtime, nil
+}
+
+type fakeManagedRuntime struct{}
+
+func (fakeManagedRuntime) Create(context.Context, sandbox.CreateSpec) (sandbox.Instance, error) {
+	return fakeManagedInstance{}, nil
+}
+
+func (fakeManagedRuntime) Get(context.Context, string) (sandbox.Instance, error) {
+	return fakeManagedInstance{}, nil
+}
+
+func (fakeManagedRuntime) Remove(context.Context, string, sandbox.RemoveOptions) error {
+	return nil
+}
+
+func (fakeManagedRuntime) Close() error { return nil }
+
+func (fakeManagedRuntime) StreamExecute(context.Context, string, string, func(string) error) error {
+	return nil
+}
+
+type fakeManagedInstance struct{}
+
+func (fakeManagedInstance) Start(context.Context) error { return nil }
+
+func (fakeManagedInstance) Stop(context.Context, sandbox.StopOptions) error { return nil }
+
+func (fakeManagedInstance) Info(context.Context) (sandbox.Info, error) { return sandbox.Info{}, nil }
+
+func (fakeManagedInstance) Run(context.Context, sandbox.CommandSpec) (sandbox.CommandResult, error) {
+	return sandbox.CommandResult{}, nil
+}
+
+func (fakeManagedInstance) Close() error { return nil }
+
+func TestNewServiceWithSandboxProviderAcceptsRuntime(t *testing.T) {
+	t.Setenv(config.EnvHubAPIBase, "https://hub.example.test")
+	t.Setenv(config.EnvHubUserToken, "token")
+	t.Setenv(config.EnvSandboxImage, "sandbox-image")
+	t.Setenv(config.EnvTenantID, "tenant-1")
+	t.Setenv(config.EnvPVCMountPath, t.TempDir())
+
+	rt := &fakeManagedRuntime{}
+	svc, err := NewServiceWithLLM(
+		config.SingleProfileLLM(config.ModelConfig{Provider: "openai", ModelID: "gpt-4o-mini"}),
+		config.ServerConfig{},
+		"",
+		filepath.Join(t.TempDir(), "state.json"),
+		WithSandboxProvider(fakeManagedProvider{runtime: rt}),
+	)
+	if err != nil {
+		t.Fatalf("NewServiceWithLLM() error = %v", err)
+	}
+	defer func() {
+		_ = svc.Close()
+	}()
+
+	gotRuntime, err := svc.runtimeOrOpen()
+	if err != nil {
+		t.Fatalf("runtimeOrOpen() error = %v", err)
+	}
+	if svc.runtime != rt {
+		t.Fatalf("runtime = %#v, want injected runtime %#v", svc.runtime, rt)
+	}
+	if gotRuntime != rt {
+		t.Fatalf("runtimeOrOpen() = %#v, want %#v", gotRuntime, rt)
+	}
+}
+
+func TestRuntimeOpenRequiresConfiguredSandboxProvider(t *testing.T) {
+	t.Setenv(config.EnvHubAPIBase, "https://hub.example.test")
+	t.Setenv(config.EnvHubUserToken, "token")
+	t.Setenv(config.EnvSandboxImage, "sandbox-image")
+	t.Setenv(config.EnvTenantID, "tenant-1")
+	t.Setenv(config.EnvPVCMountPath, t.TempDir())
+
+	svc, err := NewServiceWithLLM(
+		config.SingleProfileLLM(config.ModelConfig{Provider: "openai", ModelID: "gpt-4o-mini"}),
+		config.ServerConfig{},
+		"",
+		filepath.Join(t.TempDir(), "state.json"),
+	)
+	if err == nil {
+		_, openErr := svc.runtimeOrOpen()
+		if openErr == nil {
+			t.Fatal("runtimeOrOpen() error = nil, want unconfigured sandbox provider error")
+		}
+		return
+	}
+	t.Fatalf("NewServiceWithLLM() error = %v, want nil", err)
+}
+
+type fakePlainProvider struct{}
+
+func (fakePlainProvider) Name() string { return "fake-plain" }
+
+func (fakePlainProvider) Open(context.Context, string) (sandbox.Runtime, error) {
+	return fakePlainRuntime{}, nil
+}
+
+type fakePlainRuntime struct{}
+
+func (fakePlainRuntime) Create(context.Context, sandbox.CreateSpec) (sandbox.Instance, error) {
+	return fakeManagedInstance{}, nil
+}
+
+func (fakePlainRuntime) Get(context.Context, string) (sandbox.Instance, error) {
+	return fakeManagedInstance{}, nil
+}
+
+func (fakePlainRuntime) Remove(context.Context, string, sandbox.RemoveOptions) error {
+	return nil
+}
+
+func (fakePlainRuntime) Close() error { return nil }
+
+var (
+	_ sandbox.Runtime  = (*fakeManagedRuntime)(nil)
+	_ sandbox.Instance = fakeManagedInstance{}
+	_ sandbox.Runtime  = fakePlainRuntime{}
+)
+
+func TestGatewayMountsUseLocalPVCPaths(t *testing.T) {
+	pvcRoot := t.TempDir()
+	t.Setenv(config.EnvHubAPIBase, "https://hub.example.test")
+	t.Setenv(config.EnvHubUserToken, "token")
+	t.Setenv(config.EnvSandboxImage, "sandbox-image")
+	t.Setenv(config.EnvTenantID, "tenant-1")
+	t.Setenv(config.EnvPVCMountPath, pvcRoot)
+
+	provider, err := csghub.NewProviderFromEnv()
+	if err != nil {
+		t.Fatalf("NewProviderFromEnv() error = %v", err)
+	}
+	svc, err := NewServiceWithLLM(
+		config.SingleProfileLLM(config.ModelConfig{Provider: "openai", ModelID: "gpt-4o-mini"}),
+		config.ServerConfig{},
+		"",
+		filepath.Join(t.TempDir(), "state.json"),
+		WithSandboxProvider(provider),
+	)
+	if err != nil {
+		t.Fatalf("NewServiceWithLLM() error = %v", err)
+	}
+
+	_, mounts, err := svc.gatewayMounts("alice")
+	if err != nil {
+		t.Fatalf("svc.gatewayMounts() error = %v", err)
+	}
+	if len(mounts) != 3 {
+		t.Fatalf("gatewayMounts() len = %d, want 3", len(mounts))
+	}
+	for i, m := range mounts {
+		if !strings.HasPrefix(m.HostPath, pvcRoot) {
+			t.Fatalf("mount[%d].HostPath = %q, want prefix %q", i, m.HostPath, pvcRoot)
+		}
+	}
+}

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -20,11 +20,7 @@ func workspaceTemplateForAgent(name, botID string) string {
 	return workspaceTemplateWorker
 }
 
-func ensureAgentWorkspace(agentName, template string) (string, error) {
-	hostRoot, err := agentWorkspaceRoot(agentName)
-	if err != nil {
-		return "", err
-	}
+func ensureAgentWorkspaceAt(hostRoot, template string) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		return "", fmt.Errorf("workspace template is required")
 	}
@@ -35,14 +31,6 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 		return "", err
 	}
 	return hostRoot, nil
-}
-
-func agentWorkspaceRoot(agentName string) (string, error) {
-	agentHome, err := agentHomeDir(agentName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(agentHome, hostWorkspaceDir), nil
 }
 
 func copyEmbeddedWorkspace(template, dstRoot string) error {

--- a/internal/agent/workspace_boxlite.go
+++ b/internal/agent/workspace_boxlite.go
@@ -1,0 +1,22 @@
+//go:build !csghub
+// +build !csghub
+
+package agent
+
+import "path/filepath"
+
+func ensureAgentWorkspace(agentName, template string) (string, error) {
+	hostRoot, err := agentWorkspaceRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return ensureAgentWorkspaceAt(hostRoot, template)
+}
+
+func agentWorkspaceRoot(agentName string) (string, error) {
+	agentHome, err := agentHomeDir(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(agentHome, hostWorkspaceDir), nil
+}

--- a/internal/sandbox/boxlitesdk/adapter.go
+++ b/internal/sandbox/boxlitesdk/adapter.go
@@ -1,16 +1,22 @@
-// Package boxlitesdk adapts the BoxLite SDK to the generic sandbox interfaces.
-package boxlitesdk
+//go:build !csghub
+// +build !csghub
+
+// Package boxlite adapts the BoxLite SDK to the generic sandbox interfaces.
+package boxlite
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	boxlitesdk "github.com/RussellLuo/boxlite/sdks/go"
 
 	"csgclaw/internal/sandbox"
 )
 
-const providerName = "boxlite-sdk"
+const providerName = "boxlite"
 
 // Provider opens BoxLite-backed sandbox runtimes.
 type Provider struct{}
@@ -88,6 +94,62 @@ func (r *Runtime) Remove(ctx context.Context, idOrName string, opts sandbox.Remo
 	return wrapError("remove boxlite box", err)
 }
 
+// StreamExecute runs a shell command inside the named box and invokes
+// emit once per stdout line. Used by agent.Service to tail per-agent
+// gateway logs without caring which backend hosts the sandbox.
+func (r *Runtime) StreamExecute(ctx context.Context, name, command string, emit func(line string) error) error {
+	if r == nil || r.runtime == nil {
+		return fmt.Errorf("invalid boxlite runtime")
+	}
+	if emit == nil {
+		return fmt.Errorf("emit callback is required")
+	}
+	inst, err := r.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = inst.Close() }()
+	bi, ok := inst.(*Instance)
+	if !ok || bi.box == nil {
+		return fmt.Errorf("invalid boxlite instance")
+	}
+
+	pr, pw := io.Pipe()
+	cmd := bi.box.Command("sh", "-c", command)
+	cmd.Stdout = pw
+
+	errCh := make(chan error, 1)
+	go func() {
+		runErr := cmd.Run(ctx)
+		_ = pw.Close()
+		errCh <- runErr
+	}()
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	var emitErr error
+	for scanner.Scan() {
+		if emitErr = emit(scanner.Text()); emitErr != nil {
+			_ = pr.CloseWithError(emitErr)
+			break
+		}
+	}
+	if scanErr := scanner.Err(); emitErr == nil && scanErr != nil {
+		emitErr = scanErr
+	}
+	runErr := <-errCh
+	if emitErr != nil {
+		return emitErr
+	}
+	if runErr != nil {
+		return wrapError("stream boxlite command", runErr)
+	}
+	if code := cmd.ExitCode(); code != 0 {
+		return fmt.Errorf("boxlite command exited with code %d", code)
+	}
+	return nil
+}
+
 // Close releases the BoxLite runtime handle.
 func (r *Runtime) Close() error {
 	if r == nil || r.runtime == nil {
@@ -162,6 +224,43 @@ func (i *Instance) Close() error {
 	err := i.box.Close()
 	i.box = nil
 	return wrapError("close boxlite box", err)
+}
+
+func boxOptions(spec sandbox.CreateSpec) ([]boxlitesdk.BoxOption, error) {
+	var opts []boxlitesdk.BoxOption
+	if strings.TrimSpace(spec.Name) != "" {
+		opts = append(opts, boxlitesdk.WithName(spec.Name))
+	}
+	opts = append(opts,
+		boxlitesdk.WithDetach(spec.Detach),
+		boxlitesdk.WithAutoRemove(spec.AutoRemove),
+	)
+	for key, value := range spec.Env {
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("invalid sandbox env: key is required")
+		}
+		opts = append(opts, boxlitesdk.WithEnv(key, value))
+	}
+	for _, mount := range spec.Mounts {
+		if strings.TrimSpace(mount.HostPath) == "" {
+			return nil, fmt.Errorf("invalid sandbox mount: host path is required")
+		}
+		if strings.TrimSpace(mount.GuestPath) == "" {
+			return nil, fmt.Errorf("invalid sandbox mount: guest path is required")
+		}
+		if mount.ReadOnly {
+			opts = append(opts, boxlitesdk.WithVolumeReadOnly(mount.HostPath, mount.GuestPath))
+			continue
+		}
+		opts = append(opts, boxlitesdk.WithVolume(mount.HostPath, mount.GuestPath))
+	}
+	if len(spec.Entrypoint) > 0 {
+		opts = append(opts, boxlitesdk.WithEntrypoint(spec.Entrypoint...))
+	}
+	if len(spec.Cmd) > 0 {
+		opts = append(opts, boxlitesdk.WithCmd(spec.Cmd...))
+	}
+	return opts, nil
 }
 
 func boxInfo(info boxlitesdk.BoxInfo) sandbox.Info {

--- a/internal/sandbox/csghub/agent_defaults.go
+++ b/internal/sandbox/csghub/agent_defaults.go
@@ -1,0 +1,38 @@
+//go:build csghub
+// +build csghub
+
+package csghub
+
+import (
+	"strings"
+
+	"csgclaw/internal/config"
+)
+
+func LoadAgentDefaultsFromEnv() (AgentDefaults, error) {
+	env, err := config.LoadCSGHubSandboxEnv()
+	if err != nil {
+		return AgentDefaults{}, err
+	}
+	params := fillMountPathEnv(Params{})
+	scope := sanitizeNameScope(params.subpathRoot)
+
+	downstream := map[string]string{
+		config.EnvHubAPIBase:   env.HubAPIBase,
+		config.EnvHubUserToken: env.HubUserToken,
+		config.EnvHubAIGateway: env.HubAIGatewayURL,
+	}
+	if strings.TrimSpace(env.HubUserName) != "" {
+		downstream[config.EnvHubUserName] = strings.TrimSpace(env.HubUserName)
+	}
+	return AgentDefaults{
+		ManagerImage: strings.TrimSpace(env.Image),
+		NameScope:    scope,
+		Downstream:   downstream,
+	}, nil
+}
+
+func sanitizeNameScope(raw string) string {
+	scope := strings.NewReplacer("/", "-", "_", "-", ".", "-").Replace(strings.TrimSpace(raw))
+	return strings.Trim(scope, "-")
+}

--- a/internal/sandbox/csghub/agent_defaults_types.go
+++ b/internal/sandbox/csghub/agent_defaults_types.go
@@ -1,0 +1,9 @@
+package csghub
+
+// AgentDefaults are csghub-specific agent-layer defaults carried by
+// the provider so callers can keep a provider-only injection shape.
+type AgentDefaults struct {
+	ManagerImage string
+	NameScope    string
+	Downstream   map[string]string
+}

--- a/internal/sandbox/csghub/instance.go
+++ b/internal/sandbox/csghub/instance.go
@@ -1,0 +1,179 @@
+package csghub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"csgclaw/internal/sandbox"
+	"csgclaw/internal/sandbox/csghubsdk"
+)
+
+// Instance implements sandbox.Instance by delegating to CSGHub Sandbox
+// HTTP routes keyed on the sandbox name. `last` caches the most recent
+// Response observed by the runtime so callers can read the current
+// Spec/State without an extra round-trip.
+type Instance struct {
+	runtime *Runtime
+	name    string
+	last    *csghubsdk.Response
+}
+
+var _ sandbox.Instance = (*Instance)(nil)
+
+// Name returns the Hub-side sandbox name (the primary key).
+func (i *Instance) Name() string { return i.name }
+
+// Start transitions the sandbox to Running, honoring the same
+// fallback-on-unsupported-endpoint behavior Reconcile uses.
+func (i *Instance) Start(ctx context.Context) error {
+	if err := i.valid(); err != nil {
+		return err
+	}
+	resp, err := i.runtime.startOrAssumeAutoStart(ctx, i.name, i.last)
+	if err != nil {
+		return err
+	}
+	i.last = resp
+	return nil
+}
+
+// Stop calls the Hub stop endpoint. Force / Timeout are ignored: the
+// Hub decides the teardown primitive.
+func (i *Instance) Stop(ctx context.Context, _ sandbox.StopOptions) error {
+	if err := i.valid(); err != nil {
+		return err
+	}
+	err := i.runtime.client.Stop(ctx, i.name)
+	if csghubsdk.IsNotFound(err) {
+		return fmt.Errorf("%w: %w", sandbox.ErrNotFound, err)
+	}
+	return err
+}
+
+// Info returns runtime-neutral metadata. It issues a fresh Hub GET so
+// the State reflects current reality.
+func (i *Instance) Info(ctx context.Context) (sandbox.Info, error) {
+	if err := i.valid(); err != nil {
+		return sandbox.Info{}, err
+	}
+	resp, err := i.runtime.client.Get(ctx, i.name)
+	if err != nil {
+		if csghubsdk.IsNotFound(err) {
+			return sandbox.Info{}, fmt.Errorf("%w: %w", sandbox.ErrNotFound, err)
+		}
+		return sandbox.Info{}, err
+	}
+	i.last = resp
+	return infoFromResponse(resp, i.name), nil
+}
+
+// CachedInfo returns the most recent Response observed by Reconcile /
+// Start / Get / Info, converted to runtime-neutral sandbox.Info. It
+// performs no HTTP round-trip. ok is false when no Response has been
+// cached yet (raw handles minted via Runtime.Instance(name) without a
+// subsequent call). Callers that need guaranteed-live state must use
+// Info(ctx) instead.
+//
+// The primary consumer is the agent layer right after Runtime.Create,
+// where the returned instance already carries the authoritative Response
+// Create validated, and an additional GET would be wasted work.
+func (i *Instance) CachedInfo() (sandbox.Info, bool) {
+	if i == nil || i.last == nil {
+		return sandbox.Info{}, false
+	}
+	return infoFromResponse(i.last, i.name), true
+}
+
+// Run executes a command inside the sandbox via the AI gateway
+// stream-execute endpoint. Stdout and Stderr (if set on the spec) are
+// both written with the raw line from the gateway; the Hub does not
+// demultiplex stdout/stderr on this route.
+//
+// The returned ExitCode is zero on successful stream completion. Since
+// StreamExecute does not expose the guest process exit code, callers
+// that require it should use sandbox-runtime's /run endpoint directly
+// (exposed on *csghubsdk.Client).
+func (i *Instance) Run(ctx context.Context, spec sandbox.CommandSpec) (sandbox.CommandResult, error) {
+	if err := i.valid(); err != nil {
+		return sandbox.CommandResult{}, err
+	}
+	if strings.TrimSpace(spec.Name) == "" {
+		return sandbox.CommandResult{}, fmt.Errorf("invalid sandbox command: name is required")
+	}
+	command := spec.Name
+	if len(spec.Args) > 0 {
+		command = command + " " + strings.Join(spec.Args, " ")
+	}
+	err := i.runtime.client.StreamExecute(ctx, i.name, command, func(line string) error {
+		if spec.Stdout != nil {
+			if _, werr := spec.Stdout.Write([]byte(line + "\n")); werr != nil {
+				return werr
+			}
+		}
+		if spec.Stderr != nil {
+			if _, werr := spec.Stderr.Write([]byte(line + "\n")); werr != nil {
+				return werr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return sandbox.CommandResult{}, err
+	}
+	return sandbox.CommandResult{ExitCode: 0}, nil
+}
+
+// StreamExecute is a thin pass-through to csghubsdk.Client.StreamExecute
+// preserving the emit-callback contract used by log tailing.
+func (i *Instance) StreamExecute(ctx context.Context, command string, emit func(line string) error) error {
+	if err := i.valid(); err != nil {
+		return err
+	}
+	return i.runtime.client.StreamExecute(ctx, i.name, command, emit)
+}
+
+// Close releases the Instance handle. No Hub resources to reclaim.
+func (i *Instance) Close() error { return nil }
+
+func (i *Instance) valid() error {
+	if i == nil || i.runtime == nil || i.runtime.client == nil {
+		return fmt.Errorf("invalid csghub instance")
+	}
+	if strings.TrimSpace(i.name) == "" {
+		return fmt.Errorf("csghub sandbox name is required")
+	}
+	return nil
+}
+
+// infoFromResponse converts a Hub Response into the runtime-neutral
+// sandbox.Info contract. The ID is the sandbox name because the Hub
+// never exposes its internal UUID on the wire.
+func infoFromResponse(resp *csghubsdk.Response, fallbackName string) sandbox.Info {
+	name := strings.TrimSpace(resp.Spec.SandboxName)
+	if name == "" {
+		name = fallbackName
+	}
+	return sandbox.Info{
+		ID:        name,
+		Name:      name,
+		State:     mapState(resp.State.Status),
+		CreatedAt: resp.State.CreatedAt.UTC(),
+	}
+}
+
+func mapState(status string) sandbox.State {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "ready":
+		return sandbox.StateRunning
+	case "stopped", "terminated", "dead":
+		return sandbox.StateStopped
+	case "failed", "error", "errored", "crashed":
+		return sandbox.StateExited
+	case "creating", "pending", "deploying", "starting":
+		return sandbox.StateCreated
+	case "":
+		return sandbox.StateUnknown
+	}
+	return sandbox.StateUnknown
+}

--- a/internal/sandbox/csghub/mount_paths.go
+++ b/internal/sandbox/csghub/mount_paths.go
@@ -1,0 +1,51 @@
+package csghub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"csgclaw/internal/config"
+)
+
+const defaultPVCMountPath = "/opt/csgclaw"
+
+func fillMountPathEnv(params Params) Params {
+	if strings.TrimSpace(params.pvcMountPath) == "" {
+		params.pvcMountPath = strings.TrimSpace(os.Getenv(config.EnvPVCMountPath))
+	}
+	if strings.TrimSpace(params.pvcMountPath) == "" {
+		params.pvcMountPath = defaultPVCMountPath
+	}
+	if strings.TrimSpace(params.subpathRoot) == "" {
+		params.subpathRoot = strings.Trim(strings.TrimSpace(os.Getenv(config.EnvSandboxSubpathRoot)), "/")
+	}
+	if strings.TrimSpace(params.subpathRoot) == "" {
+		params.subpathRoot = strings.Trim(strings.TrimSpace(os.Getenv(config.EnvTenantID)), "/")
+	}
+	return params
+}
+
+func (p Params) resolveMountHostPath(hostPath string) string {
+	raw := strings.TrimSpace(hostPath)
+	if raw == "" {
+		return raw
+	}
+	root := strings.TrimSpace(p.pvcMountPath)
+	prefix := strings.TrimSpace(p.subpathRoot)
+	if root == "" || prefix == "" || !filepath.IsAbs(raw) {
+		return raw
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(raw))
+	if err != nil {
+		return raw
+	}
+	if rel == "." {
+		return filepath.ToSlash(prefix)
+	}
+	if strings.HasPrefix(rel, "..") {
+		return raw
+	}
+	return filepath.ToSlash(filepath.Join(prefix, rel))
+}

--- a/internal/sandbox/csghub/mount_paths_test.go
+++ b/internal/sandbox/csghub/mount_paths_test.go
@@ -1,0 +1,27 @@
+package csghub
+
+import "testing"
+
+func TestResolveMountHostPathFromEnvLayout(t *testing.T) {
+	t.Setenv("CSGCLAW_PVC_MOUNT_PATH", "/opt/csgclaw")
+	t.Setenv("CSGCLAW_SANDBOX_SUBPATH_ROOT", "tenant-a")
+
+	p := fillMountPathEnv(Params{})
+	got := p.resolveMountHostPath("/opt/csgclaw/agents/alice/workspace")
+	want := "tenant-a/agents/alice/workspace"
+	if got != want {
+		t.Fatalf("resolveMountHostPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveMountHostPathPassThroughOutsidePVCRoot(t *testing.T) {
+	t.Setenv("CSGCLAW_PVC_MOUNT_PATH", "/opt/csgclaw")
+	t.Setenv("CSGCLAW_SANDBOX_SUBPATH_ROOT", "tenant-a")
+
+	p := fillMountPathEnv(Params{})
+	got := p.resolveMountHostPath("/tmp/not-under-pvc")
+	want := "/tmp/not-under-pvc"
+	if got != want {
+		t.Fatalf("resolveMountHostPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/sandbox/csghub/provider.go
+++ b/internal/sandbox/csghub/provider.go
@@ -1,0 +1,152 @@
+// Package csghub adapts the CSGHub Sandbox HTTP API to the generic
+// sandbox.Provider / Runtime / Instance facade used by internal/agent.
+//
+// The package encapsulates three concerns that used to live in
+// internal/agent/service_csghub.go:
+//
+//  1. The HTTP client wiring (internal/sandbox/csghubsdk.Client).
+//  2. The reconcile-and-wait lifecycle (get → create/apply → start →
+//     poll for Running) that the Hub's async provisioning requires.
+//  3. Runtime-neutral knowledge of Hub-reported sandbox states.
+//
+// With this package in place both BoxLite and CSGHub backends are wired
+// symmetrically through sandbox.Provider, and WithSandboxProvider is
+// honored on both builds.
+package csghub
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"csgclaw/internal/sandbox"
+	"csgclaw/internal/sandbox/csghubsdk"
+)
+
+const providerName = "csghub"
+
+// Params captures everything the provider needs to talk to CSGHub and
+// materialize sandbox specs. It is assembled by the caller (typically
+// from env vars in internal/agent) and handed to NewProvider.
+type Params struct {
+	// Hub endpoints / credentials.
+	BaseURL      string
+	AIGatewayURL string
+	Token        string
+
+	// Default CreateRequest provisioning fields applied to every spec.
+	ClusterID  string
+	ResourceID int
+	Port       int
+	Timeout    int
+
+	// Timing knobs for WaitReady / reconcile polling.
+	ReadyTimeout time.Duration
+	PollInterval time.Duration
+
+	// Logger is optional; forwarded to the underlying HTTP client.
+	Logger csghubsdk.Logger
+
+	// Mount path env contract is resolved inside sandbox/csghub so
+	// caller layers stay backend-agnostic.
+	pvcMountPath string
+	subpathRoot  string
+}
+
+// Provider implements sandbox.Provider for CSGHub-hosted sandboxes.
+type Provider struct {
+	params Params
+	client *csghubsdk.Client
+	agent  AgentDefaults
+}
+
+// NewProvider builds a Provider using a fresh csghubsdk.Client configured
+// from params. Callers that need to share an HTTP client can construct
+// the Provider manually via NewProviderWithClient.
+func NewProvider(params Params) Provider {
+	params = fillMountPathEnv(params)
+	client := csghubsdk.New(csghubsdk.Config{
+		BaseURL:      params.BaseURL,
+		AIGatewayURL: params.AIGatewayURL,
+		Token:        params.Token,
+	}, loggerOption(params.Logger)...)
+	return Provider{params: params, client: client}
+}
+
+// NewProviderWithClient injects a pre-built csghubsdk.Client. Useful for
+// tests that install a transport-level fake.
+func NewProviderWithClient(params Params, client *csghubsdk.Client) Provider {
+	params = fillMountPathEnv(params)
+	return Provider{params: params, client: client}
+}
+
+// Name returns the provider name.
+func (Provider) Name() string { return providerName }
+
+// Open returns a Runtime. The homeDir argument is ignored: CSGHub
+// sandboxes live on the Hub side, not on the server's local filesystem.
+func (p Provider) Open(_ context.Context, _ string) (sandbox.Runtime, error) {
+	return &Runtime{client: p.client, params: p.params}, nil
+}
+
+// Params returns a copy of the provider's configuration.
+func (p Provider) Params() Params { return p.params }
+
+// Client exposes the underlying HTTP client for callers that need
+// direct access (e.g. Hub-only endpoints not surfaced on Runtime).
+func (p Provider) Client() *csghubsdk.Client { return p.client }
+
+// SandboxManagerImage returns provider-derived default manager image.
+func (p Provider) SandboxManagerImage() string { return p.agent.ManagerImage }
+
+// SandboxDownstreamEnv returns a copy of provider-derived downstream env.
+func (p Provider) SandboxDownstreamEnv() map[string]string {
+	if len(p.agent.Downstream) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(p.agent.Downstream))
+	for k, v := range p.agent.Downstream {
+		out[k] = v
+	}
+	return out
+}
+
+// AgentSandboxName returns the provider-managed sandbox name for an agent id.
+func (p Provider) AgentSandboxName(agentID string) string {
+	aid := strings.TrimSpace(agentID)
+	if p.agent.NameScope == "" {
+		return "csgclaw-" + aid
+	}
+	return "csgclaw-" + p.agent.NameScope + "-" + aid
+}
+
+// AgentMountHostPaths exposes host-side mount layout so agent code does
+// not need to know csghub-specific path rules.
+func (p Provider) AgentMountHostPaths(agentName string) (picoClaw, workspace, projects string, err error) {
+	name := strings.TrimSpace(agentName)
+	if name == "" {
+		return "", "", "", fmt.Errorf("agent name is required")
+	}
+	root := strings.TrimSpace(p.params.pvcMountPath)
+	if root == "" {
+		root = defaultPVCMountPath
+	}
+	agentRoot := filepath.Join(root, "agents", name)
+	projects = filepath.Join(root, "projects")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		return "", "", "", fmt.Errorf("create projects dir: %w", err)
+	}
+	return filepath.Join(agentRoot, ".picoclaw"), filepath.Join(agentRoot, "workspace"), projects, nil
+}
+
+var _ sandbox.Provider = Provider{}
+
+func loggerOption(l csghubsdk.Logger) []csghubsdk.Option {
+	if l == nil {
+		return nil
+	}
+	return []csghubsdk.Option{csghubsdk.WithLogger(l)}
+}

--- a/internal/sandbox/csghub/provider_env_csghub.go
+++ b/internal/sandbox/csghub/provider_env_csghub.go
@@ -1,0 +1,36 @@
+//go:build csghub
+// +build csghub
+
+package csghub
+
+import (
+	"fmt"
+
+	"csgclaw/internal/config"
+)
+
+// NewProviderFromEnv builds a provider from the canonical csghub env
+// contract, keeping env parsing inside sandbox/csghub.
+func NewProviderFromEnv() (Provider, error) {
+	env, err := config.LoadCSGHubSandboxEnv()
+	if err != nil {
+		return Provider{}, fmt.Errorf("load csghub sandbox env: %w", err)
+	}
+	defaults, err := LoadAgentDefaultsFromEnv()
+	if err != nil {
+		return Provider{}, fmt.Errorf("load csghub agent defaults: %w", err)
+	}
+	p := NewProvider(Params{
+		BaseURL:      env.HubAPIBase,
+		AIGatewayURL: env.HubAIGatewayURL,
+		Token:        env.HubUserToken,
+		ClusterID:    env.ClusterID,
+		ResourceID:   env.ResourceID,
+		Port:         env.Port,
+		Timeout:      env.Timeout,
+		ReadyTimeout: env.ReadyTimeout,
+		PollInterval: env.PollInterval,
+	})
+	p.agent = defaults
+	return p, nil
+}

--- a/internal/sandbox/csghub/runtime.go
+++ b/internal/sandbox/csghub/runtime.go
@@ -1,0 +1,322 @@
+package csghub
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"csgclaw/internal/sandbox"
+	"csgclaw/internal/sandbox/csghubsdk"
+)
+
+// Runtime implements sandbox.Runtime on top of the CSGHub Sandbox HTTP
+// API. It owns the reconcile-and-wait lifecycle (previously embedded in
+// internal/agent/service_csghub.go) so that, from the agent layer's
+// point of view, Create/Reconcile returns an Instance only after the
+// Hub has reported Running.
+type Runtime struct {
+	client *csghubsdk.Client
+	params Params
+}
+
+var _ sandbox.Runtime = (*Runtime)(nil)
+
+// Create applies desired-state lifecycle and returns only after sandbox
+// reaches Running/Ready (or returns a clear failure).
+func (r *Runtime) Create(ctx context.Context, spec sandbox.CreateSpec) (sandbox.Instance, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("invalid csghub runtime")
+	}
+	req := r.createRequestFromSpec(spec)
+	name := req.SandboxName
+	begin := time.Now()
+	log.Printf(
+		"component=csghub_sandbox sandbox=%q phase=reconcile event=start force_recreate=%t image=%q mounts=%d env=%d",
+		name,
+		false,
+		req.Image,
+		len(req.Volumes),
+		len(req.Environments),
+	)
+	seed, err := r.ensureSandboxStarted(ctx, req, false)
+	if err != nil {
+		log.Printf("component=csghub_sandbox sandbox=%q phase=reconcile event=fail step=ensure_start elapsed_ms=%d err=%q", name, time.Since(begin).Milliseconds(), err)
+		return nil, err
+	}
+	resp, err := r.waitForRunning(ctx, name, seed)
+	if err != nil {
+		log.Printf("component=csghub_sandbox sandbox=%q phase=reconcile event=fail step=wait_running elapsed_ms=%d err=%q", name, time.Since(begin).Milliseconds(), err)
+		return nil, err
+	}
+	if err := validateCreateResponse(resp, name); err != nil {
+		log.Printf("component=csghub_sandbox sandbox=%q phase=reconcile event=fail step=validate_response elapsed_ms=%d err=%q", name, time.Since(begin).Milliseconds(), err)
+		return nil, err
+	}
+	log.Printf("component=csghub_sandbox sandbox=%q phase=reconcile event=success elapsed_ms=%d status=%q", name, time.Since(begin).Milliseconds(), strings.TrimSpace(resp.State.Status))
+	return &Instance{runtime: r, name: name, last: resp}, nil
+}
+
+// Get returns a lightweight Instance handle by sandbox name. It does
+// one Hub GET so callers get a live Response snapshot.
+func (r *Runtime) Get(ctx context.Context, idOrName string) (sandbox.Instance, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("invalid csghub runtime")
+	}
+	resp, err := r.client.Get(ctx, idOrName)
+	if err != nil {
+		if csghubsdk.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: %w", sandbox.ErrNotFound, err)
+		}
+		return nil, err
+	}
+	name := strings.TrimSpace(resp.Spec.SandboxName)
+	if name == "" {
+		name = idOrName
+	}
+	return &Instance{runtime: r, name: name, last: resp}, nil
+}
+
+// Remove stops a sandbox. The Hub has no DELETE endpoint; stop is the
+// teardown primitive (matching pycsghub semantics). Force is ignored.
+func (r *Runtime) Remove(ctx context.Context, idOrName string, _ sandbox.RemoveOptions) error {
+	if r == nil || r.client == nil {
+		return fmt.Errorf("invalid csghub runtime")
+	}
+	err := r.client.Stop(ctx, idOrName)
+	if csghubsdk.IsNotFound(err) {
+		return fmt.Errorf("%w: %w", sandbox.ErrNotFound, err)
+	}
+	return err
+}
+
+// Close releases runtime resources. The HTTP client is goroutine-safe
+// and has no explicit close, so this is a no-op today.
+func (r *Runtime) Close() error { return nil }
+
+// Instance returns a lightweight Instance by name without issuing any
+// HTTP calls. Handy when the caller already knows the sandbox exists
+// and just needs a handle (e.g. to call StreamExecute for log tailing).
+func (r *Runtime) Instance(name string) *Instance {
+	return &Instance{runtime: r, name: strings.TrimSpace(name)}
+}
+
+// StreamExecute is a convenience wrapper equivalent to
+// runtime.Instance(name).StreamExecute(ctx, cmd, emit). It saves the
+// caller one allocation when no Instance handle is needed.
+func (r *Runtime) StreamExecute(ctx context.Context, name, command string, emit func(line string) error) error {
+	if r == nil || r.client == nil {
+		return fmt.Errorf("invalid csghub runtime")
+	}
+	return r.client.StreamExecute(ctx, name, command, emit)
+}
+
+// Params exposes the runtime configuration. Read-only accessor used by
+// tests that need to observe the values the provider computed.
+func (r *Runtime) Params() Params { return r.params }
+
+// Client exposes the underlying HTTP client. Used by specialized
+// callers that need access to endpoints not surfaced on Runtime /
+// Instance.
+func (r *Runtime) Client() *csghubsdk.Client { return r.client }
+
+// createRequestFromSpec folds the generic CreateSpec with the provider
+// Params to produce a Hub CreateRequest. Provider-managed fields
+// (ClusterID / ResourceID / Port / Timeout) always come from Params.
+func (r *Runtime) createRequestFromSpec(spec sandbox.CreateSpec) csghubsdk.CreateRequest {
+	volumes := make([]csghubsdk.VolumeSpec, 0, len(spec.Mounts))
+	for _, m := range spec.Mounts {
+		volumes = append(volumes, csghubsdk.VolumeSpec{
+			SandboxMountSubpath: r.params.resolveMountHostPath(m.HostPath),
+			SandboxMountPath:    m.GuestPath,
+			ReadOnly:            m.ReadOnly,
+		})
+	}
+	return csghubsdk.CreateRequest{
+		Image:        strings.TrimSpace(spec.Image),
+		ClusterID:    r.params.ClusterID,
+		ResourceID:   r.params.ResourceID,
+		SandboxName:  strings.TrimSpace(spec.Name),
+		Environments: spec.Env,
+		Volumes:      volumes,
+		Port:         r.params.Port,
+		Timeout:      r.params.Timeout,
+	}
+}
+
+// ensureSandboxStarted performs the create / start handshake against
+// the Hub but does NOT wait for the Running state. It returns the
+// latest Response observed in this turn (authoritative for spec,
+// non-authoritative for state).
+func (r *Runtime) ensureSandboxStarted(ctx context.Context, req csghubsdk.CreateRequest, forceRecreate bool) (*csghubsdk.Response, error) {
+	name := req.SandboxName
+	probeBegin := time.Now()
+	existing, err := r.client.Get(ctx, name)
+	switch {
+	case err == nil:
+		status := strings.ToLower(strings.TrimSpace(existing.State.Status))
+		log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=probe_hit elapsed_ms=%d status=%q", name, time.Since(probeBegin).Milliseconds(), status)
+		if forceRecreate {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=force_recreate status=%q", name, status)
+			stopBegin := time.Now()
+			if err := r.client.Stop(ctx, name); err != nil && !csghubsdk.IsNotFound(err) {
+				return nil, fmt.Errorf("stop sandbox %q: %w", name, err)
+			}
+			log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=stop_done elapsed_ms=%d", name, time.Since(stopBegin).Milliseconds())
+			applyBegin := time.Now()
+			if _, err := r.client.Apply(ctx, req); err != nil {
+				return nil, fmt.Errorf("apply sandbox %q: %w", name, err)
+			}
+			log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=apply_done elapsed_ms=%d", name, time.Since(applyBegin).Milliseconds())
+			return r.startOrAssumeAutoStart(ctx, name, existing)
+		}
+		if isSandboxUpOrComingUp(status) {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=start_skipped reason=already_up status=%q", name, status)
+			return existing, nil
+		}
+		return r.startOrAssumeAutoStart(ctx, name, existing)
+	case csghubsdk.IsNotFound(err):
+		log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=probe_miss_not_found elapsed_ms=%d", name, time.Since(probeBegin).Milliseconds())
+		createBegin := time.Now()
+		created, err := r.client.Create(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("create sandbox %q: %w", name, err)
+		}
+		log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=create_done elapsed_ms=%d", name, time.Since(createBegin).Milliseconds())
+		status := strings.ToLower(strings.TrimSpace(created.State.Status))
+		if isSandboxUpOrComingUp(status) {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=start_skipped reason=post_create_up status=%q", name, status)
+			return created, nil
+		}
+		return r.startOrAssumeAutoStart(ctx, name, created)
+	default:
+		log.Printf("component=csghub_sandbox sandbox=%q phase=ensure_start event=probe_fail elapsed_ms=%d err=%q", name, time.Since(probeBegin).Milliseconds(), err)
+		return nil, fmt.Errorf("probe sandbox %q: %w", name, err)
+	}
+}
+
+// startOrAssumeAutoStart issues PUT /status/start, falling back to
+// `fallback` on Hub deployments that omit the endpoint (404/405/501).
+func (r *Runtime) startOrAssumeAutoStart(ctx context.Context, name string, fallback *csghubsdk.Response) (*csghubsdk.Response, error) {
+	startBegin := time.Now()
+	log.Printf("component=csghub_sandbox sandbox=%q phase=start event=request", name)
+	started, err := r.client.Start(ctx, name)
+	if err != nil {
+		if isStartUnsupported(err) {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=start event=unsupported_assume_autostart elapsed_ms=%d", name, time.Since(startBegin).Milliseconds())
+			return fallback, nil
+		}
+		log.Printf("component=csghub_sandbox sandbox=%q phase=start event=fail elapsed_ms=%d err=%q", name, time.Since(startBegin).Milliseconds(), err)
+		return nil, fmt.Errorf("start sandbox %q: %w", name, err)
+	}
+	log.Printf("component=csghub_sandbox sandbox=%q phase=start event=success elapsed_ms=%d status=%q", name, time.Since(startBegin).Milliseconds(), strings.TrimSpace(started.State.Status))
+	return started, nil
+}
+
+// waitForRunning blocks until the sandbox reports Running/Ready,
+// returns an error on terminal failure states, or gives up after the
+// configured timeout. `seed` is the Response observed by the caller
+// right before calling us — if it already shows Running/Ready we
+// return immediately without a wasted GET.
+func (r *Runtime) waitForRunning(ctx context.Context, name string, seed *csghubsdk.Response) (*csghubsdk.Response, error) {
+	if seed != nil && isSandboxRunning(seed.State.Status) {
+		return seed, nil
+	}
+
+	timeout := r.readyTimeout()
+	interval := r.pollInterval()
+	start := time.Now()
+	deadline := start.Add(timeout)
+
+	lastStatus := ""
+	if seed != nil {
+		lastStatus = strings.TrimSpace(seed.State.Status)
+		log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=start seed_status=%q timeout_ms=%d", name, lastStatus, timeout.Milliseconds())
+	}
+
+	last := seed
+	for {
+		pollBegin := time.Now()
+		resp, err := r.client.Get(ctx, name)
+		if err != nil {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=poll_fail elapsed_ms=%d err=%q", name, time.Since(pollBegin).Milliseconds(), err)
+			return nil, fmt.Errorf("poll sandbox %q: %w", name, err)
+		}
+		last = resp
+		status := strings.TrimSpace(resp.State.Status)
+		if status != lastStatus {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=status_change elapsed_ms=%d from=%q to=%q", name, time.Since(start).Milliseconds(), lastStatus, status)
+			lastStatus = status
+		}
+		switch {
+		case isSandboxRunning(status):
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=success elapsed_ms=%d status=%q", name, time.Since(start).Milliseconds(), status)
+			return resp, nil
+		case isSandboxTerminalFailure(status):
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=terminal_failure elapsed_ms=%d status=%q", name, time.Since(start).Milliseconds(), status)
+			return nil, fmt.Errorf("sandbox %q entered terminal state %q before reaching Running", name, status)
+		}
+
+		if time.Now().After(deadline) {
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=timeout elapsed_ms=%d timeout_ms=%d last_status=%q", name, time.Since(start).Milliseconds(), timeout.Milliseconds(), status)
+			return last, fmt.Errorf("sandbox %q did not reach Running within %s (last status=%q)", name, timeout, status)
+		}
+		select {
+		case <-ctx.Done():
+			log.Printf("component=csghub_sandbox sandbox=%q phase=wait_running event=canceled elapsed_ms=%d err=%q", name, time.Since(start).Milliseconds(), ctx.Err())
+			return last, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// Default timing bounds used when Params leaves the corresponding
+// field zero. Values mirror the pre-refactor defaults in
+// internal/agent/env_csghub.go so behavior is bit-for-bit identical.
+const (
+	defaultReadyTimeout = 5 * time.Minute
+	defaultPollInterval = 3 * time.Second
+	minReadyTimeout     = 5 * time.Second
+	minPollInterval     = 500 * time.Millisecond
+	maxPollInterval     = 30 * time.Second
+)
+
+func (r *Runtime) readyTimeout() time.Duration {
+	d := r.params.ReadyTimeout
+	if d <= 0 {
+		d = defaultReadyTimeout
+	}
+	if d < minReadyTimeout {
+		return minReadyTimeout
+	}
+	return d
+}
+
+func (r *Runtime) pollInterval() time.Duration {
+	d := r.params.PollInterval
+	if d <= 0 {
+		d = defaultPollInterval
+	}
+	switch {
+	case d < minPollInterval:
+		return minPollInterval
+	case d > maxPollInterval:
+		return maxPollInterval
+	}
+	return d
+}
+
+// validateCreateResponse ensures the Hub API returned the fields we
+// care about before we persist them. When the Hub echoes only a
+// partial spec we fall back to the expected name so the caller can
+// still index into the response.
+func validateCreateResponse(resp *csghubsdk.Response, expectedName string) error {
+	if resp == nil {
+		return fmt.Errorf("sandbox API returned empty response")
+	}
+	if strings.TrimSpace(resp.Spec.SandboxName) == "" {
+		resp.Spec.SandboxName = expectedName
+	}
+	return nil
+}


### PR DESCRIPTION
Add CSGHub sandbox backend behind -tags csghub (paths, service, box wiring). Split config DefaultDir for boxlite vs tenant PVC; shared env helpers for PicoClaw. Add docker/Dockerfile.unified, supervisord role configs, and SaaS env contract doc. Extend Makefile, onboarding/serve bootstrap, and ignore bin-csghub build outputs.

