### PR TITLE
feat(config): default OpenCSG picoclaw image and Debian registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ TARGET_ARCH ?= $(shell $(GO) env GOARCH)
 ONBOARD_BASE_URL ?= http://127.0.0.1:4000
 ONBOARD_API_KEY ?= sk-1234567890
 ONBOARD_MODEL_ID ?= minimax-m2.7
-ONBOARD_MANAGER_IMAGE ?= ghcr.io/russellluo/picoclaw:2026.4.24.0
+ONBOARD_MANAGER_IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0
 
-IMAGE ?= ghcr.io/russellluo/picoclaw
+IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw
 TAG ?= 2026.4.24.0
 LOCAL_IMAGE ?= picoclaw:local
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@ ok
   "provider": "llm-api",
   "model_id": "gpt-5.4",
   "reasoning_effort": "medium",
-  "image": "ghcr.io/russellluo/picoclaw:2026.4.15.3"
+  "image": "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 }
 ```
 
@@ -81,7 +81,7 @@ ok
   "provider": "llm-api",
   "model_id": "gpt-5.4",
   "reasoning_effort": "medium",
-  "image": "ghcr.io/russellluo/picoclaw:2026.4.15.3"
+  "image": "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 }
 ```
 

--- a/docs/archived/usage.md
+++ b/docs/archived/usage.md
@@ -28,7 +28,7 @@ csgclaw onboard \
   --base-url http://127.0.0.1:4000 \
   --api-key sk-please-change-me \
   --model-id gpt-4o-mini \
-  --manager-image ghcr.io/russellluo/picoclaw:2026.4.14.5
+  --manager-image opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0
 ```
 
 参数含义：
@@ -223,7 +223,7 @@ api_key = "sk-please-change-me"
 model_id = "gpt-4o-mini"
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.14.5"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 ```
 
 ## 6. 联调建议

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,7 +46,7 @@ api_key = "local"
 models = ["Qwen/Qwen3-0.6B-GGUF"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -73,7 +73,7 @@ api_key = "sk-your-api-key"
 models = ["gpt-5.4"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -100,7 +100,7 @@ api_key = "local"
 models = ["gpt-5.4"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -125,7 +125,7 @@ debian_registries = ["harbor.opencsg.com", "docker.io"]
 
 `boxlite_cli_path` is the executable path used only by `provider = "boxlite-cli"`. The default value, `boxlite`, resolves from `PATH`; set an absolute path if the binary is installed elsewhere.
 
-`debian_registries` controls where BoxLite pulls `debian:bookworm-slim`. Use `onboard` to persist it:
+`debian_registries` controls where BoxLite pulls `debian:bookworm-slim`. If omitted or empty, CSGClaw defaults to `harbor.opencsg.com` then `docker.io`. Use `onboard` to persist a custom list:
 
 ```bash
 csgclaw onboard --debian-registries "harbor.opencsg.com,docker.io"

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -46,7 +46,7 @@ api_key = "local"
 models = ["Qwen/Qwen3-0.6B-GGUF"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -73,7 +73,7 @@ api_key = "sk-your-api-key"
 models = ["gpt-5.4"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -100,7 +100,7 @@ api_key = "local"
 models = ["gpt-5.4"]
 
 [bootstrap]
-manager_image = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+manager_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 
 [sandbox]
 provider = "boxlite-sdk"
@@ -125,7 +125,7 @@ debian_registries = ["harbor.opencsg.com", "docker.io"]
 
 `boxlite_cli_path` 只在 `provider = "boxlite-cli"` 时使用。默认值 `boxlite` 会从 `PATH` 中查找；如果二进制安装在其他位置，可以配置为绝对路径。
 
-`debian_registries` 用于控制 BoxLite 拉取 `debian:bookworm-slim` 时的仓库顺序。可通过 `onboard` 持久化：
+`debian_registries` 用于控制 BoxLite 拉取 `debian:bookworm-slim` 时的仓库顺序。若省略或为空，默认顺序为 `harbor.opencsg.com`、`docker.io`。可通过 `onboard` 持久化自定义列表：
 
 ```bash
 csgclaw onboard --debian-registries "harbor.opencsg.com,docker.io"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,10 @@ func (c SandboxConfig) Resolved() SandboxConfig {
 	if strings.TrimSpace(c.BoxLiteCLIPath) == "" {
 		c.BoxLiteCLIPath = DefaultBoxLiteCLIPath
 	}
+	c.DebianRegistries = normalizeStringList(c.DebianRegistries)
+	if len(c.DebianRegistries) == 0 {
+		c.DebianRegistries = append([]string(nil), DefaultDebianRegistries...)
+	}
 	return c
 }
 
@@ -114,7 +118,7 @@ const (
 
 	DefaultHTTPPort           = apiclient.DefaultHTTPPort
 	DefaultAccessToken        = "your_access_token"
-	DefaultManagerImage       = "ghcr.io/russellluo/picoclaw:2026.4.24.0"
+	DefaultManagerImage       = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.24.0"
 	CSGHubProvider            = "csghub"
 	BoxLiteSDKProvider        = "boxlite-sdk"
 	BoxLiteCLIProvider        = "boxlite-cli"
@@ -122,6 +126,10 @@ const (
 	DefaultSandboxHomeDirName = "boxlite"
 	RuntimeHomeDirName        = DefaultSandboxHomeDirName
 )
+
+// DefaultDebianRegistries is the default BoxLite Debian registry lookup order when
+// [sandbox].debian_registries is unset or empty after normalization.
+var DefaultDebianRegistries = []string{"harbor.opencsg.com", "docker.io"}
 
 func DefaultListenAddr() string {
 	return net.JoinHostPort("0.0.0.0", DefaultHTTPPort)
@@ -367,7 +375,6 @@ func Load(path string) (Config, error) {
 	if cfg.Server.AccessToken == "" {
 		cfg.Server.AccessToken = DefaultAccessToken
 	}
-	cfg.Sandbox.DebianRegistries = normalizeStringList(cfg.Sandbox.DebianRegistries)
 	cfg.Sandbox = cfg.Sandbox.Resolved()
 
 	if !modelsCfg.IsZero() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,9 @@ models = ["minimax-m2.7"]
 	if got, want := cfg.Sandbox.BoxLiteCLIPath, DefaultBoxLiteCLIPath; got != want {
 		t.Fatalf("cfg.Sandbox.BoxLiteCLIPath = %q, want %q", got, want)
 	}
+	if got, want := strings.Join(cfg.Sandbox.DebianRegistries, ","), strings.Join(DefaultDebianRegistries, ","); got != want {
+		t.Fatalf("cfg.Sandbox.DebianRegistries = %q, want %q", got, want)
+	}
 	if got, want := cfg.Model.Provider, ProviderLLMAPI; got != want {
 		t.Fatalf("cfg.Model.Provider = %q, want %q", got, want)
 	}


### PR DESCRIPTION
Set DefaultManagerImage to the opencsg-registry picoclaw tag, apply DefaultDebianRegistries when sandbox.debian_registries is empty, align make onboard/docker variables, and refresh docs and API examples.

Made-with: Cursor