### PR TITLE
[codex] propagate skills poll interval

### DIFF
--- a/internal/sandbox/csghub/provider.go
+++ b/internal/sandbox/csghub/provider.go
@@ -246,6 +246,7 @@ func (r *Runtime) createEnvironments(specEnv map[string]string) map[string]strin
 	}
 	env["CSGHUB_API_BASE_URL"] = strings.TrimSpace(r.cfg.clientCfg.BaseURL)
 	env["CSGHUB_USER_TOKEN"] = strings.TrimSpace(r.cfg.clientCfg.Token)
+	env["SKILLS_POLL_INTERVAL"] = os.Getenv("SKILLS_POLL_INTERVAL")
 	return env
 }
 


### PR DESCRIPTION
## Summary

Propagates the host `SKILLS_POLL_INTERVAL` environment variable into CSGHub sandbox create requests so manager / worker sandboxes can receive the same polling configuration.

## Impact

Sandboxes created through the CSGHub provider will include `SKILLS_POLL_INTERVAL` alongside the existing CSGHub API base URL and user token environment variables.

## Validation

- `go test ./internal/sandbox/csghub`
