### PR TITLE
[codex] make run use built binary and avoid PATH dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ build-csgclaw-cli-for-picoclaw:
 
 build-all: build-csgclaw build-csgclaw-cli
 
-run: sync-agent-runtimes
-	env GOCACHE=$(GOCACHE) $(GO) run -ldflags "$(LDFLAGS)" ./cmd/csgclaw serve
+run: build-csgclaw
+	$(BIN) serve
 
-run-with-boxlite-sdk: boxlite-setup sync-agent-runtimes
-	env GOCACHE=$(GOCACHE) $(GO) run -tags $(BOXLITE_SDK_TAG) -ldflags "$(LDFLAGS)" ./cmd/csgclaw serve
+run-with-boxlite-sdk: build-with-boxlite-sdk
+	$(BIN) serve
 
 onboard: sync-agent-runtimes
 	env GOCACHE=$(GOCACHE) $(GO) run -ldflags "$(LDFLAGS)" ./cmd/csgclaw onboard \


### PR DESCRIPTION
## Summary
- update `make run` to build `bin/csgclaw` first and then execute `bin/csgclaw serve`
- update `make run-with-boxlite-sdk` to build with `boxlite_sdk` and then execute `bin/csgclaw serve`
- remove the `go run` startup path from both run targets

## Why
Startup failed when `make run` used `go run` because the runtime resolved `boxlite` relative to a temporary executable location and then fell back to `PATH`. In environments where `PATH` does not include repo `bin/`, startup hit:
`inspect boxlite cli box: boxlite cli exited with code -1: command failed`.

## Impact
- `make run` no longer depends on shell `PATH` for locating bundled `bin/boxlite`
- behavior is consistent with bundled layout (`bin/csgclaw` + `bin/boxlite`)
- no changes to onboarding/config schema

## Validation
- `make -n run` now shows `bin/csgclaw serve`
- `make -n run-with-boxlite-sdk` now shows `bin/csgclaw serve`
- `make run` no longer emits the previous `inspect boxlite cli box ... code -1` error in this environment

