### PR TITLE
Introduce auth for codex/claude code & Fix agent not receiving messages after server restarted

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,323 @@
+# Design System Inspired by VoltAgent
+
+## 1. Visual Theme & Atmosphere
+
+VoltAgent's interface is a deep-space command terminal for the AI age — a developer-facing darkness built on near-pure-black surfaces (`#050507`) where the only interruption is the electric pulse of emerald green energy. The entire experience evokes the feeling of staring into a high-powered IDE at 2am: dark, focused, and alive with purpose. This is not a friendly SaaS landing page — it's an engineering platform that announces itself through code snippets, architectural diagrams, and raw technical confidence.
+
+The green accent (`#00d992`) is used with surgical precision — it glows from headlines, borders, and interactive elements like a circuit board carrying a signal. Against the carbon-black canvas, this green reads as "power on" — a deliberate visual metaphor for an AI agent engineering platform. The supporting palette is built entirely from warm-neutral grays (`#3d3a39`, `#8b949e`, `#b8b3b0`) that soften the darkness without introducing color noise, creating a cockpit-like warmth that pure blue-grays would lack.
+
+Typography leans on the system font stack for headings — achieving maximum rendering speed and native-feeling authority — while Inter carries the body and UI text with geometric precision. Code blocks use SFMono-Regular, the same font developers see in their terminals, reinforcing the tool's credibility at every scroll.
+
+**Key Characteristics:**
+- Carbon-black canvas (`#050507`) with warm-gray border containment (`#3d3a39`) — not cold or sterile
+- Single-accent identity: Emerald Signal Green (`#00d992`) as the sole chromatic energy source
+- Dual-typography system: system-ui for authoritative headings, Inter for precise UI/body text, SFMono for code credibility
+- Ultra-tight heading line-heights (1.0–1.11) creating dense, compressed power blocks
+- Warm neutral palette (`#3d3a39`, `#8b949e`, `#b8b3b0`) that prevents the dark theme from feeling clinical
+- Developer-terminal aesthetic where code snippets ARE the hero content
+- Green glow effects (`drop-shadow`, border accents) that make UI elements feel electrically alive
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Emerald Signal Green** (`#00d992`): The core brand energy — used for accent borders, glow effects, and the highest-signal interactive moments. This is the "power-on" indicator of the entire interface.
+- **VoltAgent Mint** (`#2fd6a1`): The button-text variant of the brand green — slightly warmer and more readable than pure Signal Green, used specifically for CTA text on dark surfaces.
+- **Tailwind Emerald** (`#10b981`): The ecosystem-standard green used at low opacity (30%) for subtle background tints and link defaults. Bridges VoltAgent's custom palette with Tailwind's utility classes.
+
+### Secondary & Accent
+- **Soft Purple** (`#818cf8`): A cool indigo-violet used sparingly for secondary categorization, code syntax highlights, and visual variety without competing with green.
+- **Cobalt Primary** (`#306cce`): Docusaurus primary dark — used in documentation contexts for links and interactive focus states.
+- **Deep Cobalt** (`#2554a0`): The darkest primary shade, reserved for pressed/active states in documentation UI.
+- **Ring Blue** (`#3b82f6`): Tailwind's ring color at 50% opacity — visible only during keyboard focus for accessibility compliance.
+
+### Surface & Background
+- **Abyss Black** (`#050507`): The landing page canvas — a near-pure black with the faintest warm undertone, darker than most "dark themes" for maximum contrast with green accents.
+- **Carbon Surface** (`#101010`): The primary card and button background — one shade lighter than Abyss, creating a barely perceptible elevation layer. Used across all contained surfaces.
+- **Warm Charcoal Border** (`#3d3a39`): The signature containment color — not a cold gray but a warm, almost brownish dark tone that prevents borders from feeling harsh against the black canvas.
+
+### Neutrals & Text
+- **Snow White** (`#f2f2f2`): The primary text color on dark surfaces — not pure white (`#ffffff`) but a softened, eye-friendly off-white. The most-used color on the site (1008 instances).
+- **Pure White** (`#ffffff`): Reserved for the highest-emphasis moments — ghost button text and maximum-contrast headings. Used at low opacity (5%) for subtle overlay effects.
+- **Warm Parchment** (`#b8b3b0`): Secondary body text — a warm light gray with a slight pinkish undertone that reads as "paper" against the dark canvas.
+- **Steel Slate** (`#8b949e`): Tertiary text, metadata, timestamps, and de-emphasized content. A cool blue-gray that provides clear hierarchy below Warm Parchment.
+- **Fog Gray** (`#bdbdbd`): Footer links and supporting navigation text — brightens on hover to Pure White.
+- **Mist Gray** (`#dcdcdc`): Slightly brighter than Fog, used for secondary link text that transitions to bright green on hover.
+- **Near White** (`#eeeeee`): Highest-contrast secondary text, one step below Snow White.
+
+### Semantic & Accent
+- **Success Emerald** (`#008b00`): Deep green for success states and positive confirmations in documentation contexts.
+- **Success Light** (`#80d280`): Soft pastel green for success backgrounds and subtle positive indicators.
+- **Warning Amber** (`#ffba00`): Bright amber for warning alerts and caution states.
+- **Warning Pale** (`#ffdd80`): Softened amber for warning background fills.
+- **Danger Coral** (`#fb565b`): Vivid red for error states and destructive action warnings.
+- **Danger Rose** (`#fd9c9f`): Softened coral-pink for error backgrounds.
+- **Info Teal** (`#4cb3d4`): Cool teal-blue for informational callouts and tip admonitions.
+- **Dashed Border Slate** (`#4f5d75` at 40%): A muted blue-gray used exclusively for decorative dashed borders in workflow diagrams.
+
+### Gradient System
+- **Green Signal Glow**: `drop-shadow(0 0 2px #00d992)` animating to `drop-shadow(0 0 8px #00d992)` — creates a pulsing "electric charge" effect on the VoltAgent bolt logo and interactive elements. The glow expands and contracts like a heartbeat.
+- **Warm Ambient Haze**: `rgba(92, 88, 85, 0.2) 0px 0px 15px` — a warm-toned diffused shadow that creates a soft atmospheric glow around elevated cards, visible at the edges without sharp boundaries.
+- **Deep Dramatic Elevation**: `rgba(0, 0, 0, 0.7) 0px 20px 60px` with `rgba(148, 163, 184, 0.1) 0px 0px 0px 1px inset` — a heavy, dramatic downward shadow paired with a faint inset slate ring for the most prominent floating elements.
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary (Headings)**: `system-ui`, with fallbacks: `-apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol`
+- **Secondary (Body/UI)**: `Inter`, with fallbacks inheriting from system-ui stack. OpenType features: `"calt", "rlig"` (contextual alternates and required ligatures)
+- **Monospace (Code)**: `SFMono-Regular`, with fallbacks: `Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display / Hero | system-ui | 60px (3.75rem) | 400 | 1.00 (tight) | -0.65px | Maximum impact, compressed blocks |
+| Section Heading | system-ui | 36px (2.25rem) | 400 | 1.11 (tight) | -0.9px | Tightest letter-spacing in the system |
+| Sub-heading | system-ui | 24px (1.50rem) | 700 | 1.33 | -0.6px | Bold weight for emphasis at this size |
+| Sub-heading Light | system-ui / Inter | 24px (1.50rem) | 300–400 | 1.33 | -0.6px | Light weight variant for softer hierarchy |
+| Overline | system-ui | 20px (1.25rem) | 600 | 1.40 | 0.5px | Uppercase transform, positive letter-spacing |
+| Feature Title | Inter | 20px (1.25rem) | 500–600 | 1.40 | normal | Card headings, feature names |
+| Overline Small | Inter | 18px (1.13rem) | 600 | 1.56 | 0.45px | Uppercase section labels |
+| Body / Button | Inter | 16px (1.00rem) | 400–600 | 1.50–1.65 | normal | Standard text, nav links, buttons |
+| Nav Link | Inter | 14.45px (0.90rem) | 500 | 1.65 | normal | Navigation-specific sizing |
+| Caption / Label | Inter | 14px (0.88rem) | 400–600 | 1.43–1.65 | normal | Descriptions, metadata, badge text |
+| Tag / Overline Tiny | system-ui | 14px (0.88rem) | 600 | 1.43 | 2.52px | Widest letter-spacing — reserved for uppercase tags |
+| Micro | Inter | 12px (0.75rem) | 400–500 | 1.33 | normal | Smallest sans-serif text |
+| Code Body | SFMono-Regular | 13–14px | 400–686 | 1.23–1.43 | normal | Inline code, terminal output, variable weight for syntax |
+| Code Small | SFMono-Regular | 11–12px | 400 | 1.33–1.45 | normal | Tiny code references, line numbers |
+| Code Button | monospace | 13px (0.81rem) | 700 | 1.65 | normal | Copy-to-clipboard button labels |
+
+### Principles
+- **System-native authority**: Display headings use system-ui rather than a custom web font — this means the largest text renders instantly (no FOIT/FOUT) and inherits the operating system's native personality. On macOS it's SF Pro, on Windows it's Segoe UI. The design accepts this variability as a feature, not a bug.
+- **Tight compression creates density**: Hero line-heights are extremely compressed (1.0) with negative letter-spacing (-0.65px to -0.9px), creating text blocks that feel like dense technical specifications rather than airy marketing copy.
+- **Weight gradient, not weight contrast**: The system uses a gentle 300→400→500→600→700 weight progression. Bold (700) is reserved for sub-headings and code-button emphasis. Most body text lives at 400–500, creating subtle rather than dramatic hierarchy.
+- **Uppercase is earned and wide**: When uppercase appears, it's always paired with generous letter-spacing (0.45px–2.52px), transforming dense words into spaced-out overline labels. This treatment is never applied to headings.
+- **OpenType by default**: Both system-ui and Inter enable `"calt"` and `"rlig"` features, ensuring contextual character adjustments and ligature rendering throughout.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Ghost / Outline (Standard)**
+- Background: transparent
+- Text: Pure White (`#ffffff`)
+- Padding: comfortable (12px 16px)
+- Border: thin solid Warm Charcoal (`1px solid #3d3a39`)
+- Radius: comfortably rounded (6px)
+- Hover: background darkens to `rgba(0, 0, 0, 0.2)`, opacity drops to 0.4
+- Outline: subtle green tint (`rgba(33, 196, 93, 0.5)`)
+- The default interactive element — unassuming but clearly clickable
+
+**Primary Green CTA**
+- Background: Carbon Surface (`#101010`)
+- Text: VoltAgent Mint (`#2fd6a1`)
+- Padding: comfortable (12px 16px)
+- Border: none visible (outline-based focus indicator)
+- Outline: VoltAgent Mint (`rgb(47, 214, 161)`)
+- Hover: same darkening behavior as Ghost
+- The "powered on" button — green text on dark surface reads as an active terminal command
+
+**Tertiary / Emphasized Container Button**
+- Background: Carbon Surface (`#101010`)
+- Text: Snow White (`#f2f2f2`)
+- Padding: generous (20px all sides)
+- Border: thick solid Warm Charcoal (`3px solid #3d3a39`)
+- Radius: comfortably rounded (8px)
+- A card-like button treatment for larger interactive surfaces (code copy blocks, feature CTAs)
+
+### Cards & Containers
+- Background: Carbon Surface (`#101010`) — one shade lighter than the page canvas
+- Border: `1px solid #3d3a39` (Warm Charcoal) for standard containment; `2px solid #00d992` for highlighted/active cards
+- Radius: comfortably rounded (8px) for content cards; subtly rounded (4–6px) for smaller inline containers
+- Shadow Level 1: Warm Ambient Haze (`rgba(92, 88, 85, 0.2) 0px 0px 15px`) for standard elevation
+- Shadow Level 2: Deep Dramatic (`rgba(0, 0, 0, 0.7) 0px 20px 60px` + `rgba(148, 163, 184, 0.1) 0px 0px 0px 1px inset`) for hero/feature showcase cards
+- Hover behavior: likely border color shift toward green accent or subtle opacity increase
+- Dashed variant: `1px dashed rgba(79, 93, 117, 0.4)` for workflow/diagram containers — visually distinct from solid-border content cards
+
+### Inputs & Forms
+- No explicit input token data extracted — the site is landing-page focused with minimal form UI
+- The npm install command (`npm create voltagent-app@latest`) is presented as a code block rather than an input field
+- Inferred style: Carbon Surface background, Warm Charcoal border, VoltAgent Mint focus ring, Snow White text
+
+### Navigation
+- Sticky top nav bar on Abyss Black canvas
+- Logo: VoltAgent bolt icon with animated green glow (`drop-shadow` cycling 2px–8px)
+- Nav structure: Logo → Product dropdown → Use Cases dropdown → Resources dropdown → GitHub stars badge → Docs CTA
+- Link text: Snow White (`#f2f2f2`) at 14–16px Inter, weight 500
+- Hover: links transition to green variants (`#00c182` or `#00ffaa`)
+- GitHub badge: social proof element integrated directly into nav
+- Mobile: collapses to hamburger menu, single-column vertical layout
+
+### Image Treatment
+- Dark-themed product screenshots and architectural diagrams dominate
+- Code blocks are treated as primary visual content — syntax-highlighted with SFMono-Regular
+- Agent workflow visualizations appear as interactive node graphs with green connection lines
+- Decorative dot-pattern backgrounds appear behind hero sections
+- Full-bleed within card containers, respecting 8px radius rounding
+
+### Distinctive Components
+
+**npm Install Command Block**
+- A prominent code snippet (`npm create voltagent-app@latest`) styled as a copyable command
+- SFMono-Regular on Carbon Surface with a copy-to-clipboard button
+- Functions as the primary CTA — "install first, read later" developer psychology
+
+**Company Logo Marquee**
+- Horizontal scrolling strip of developer/company logos
+- Infinite animation (`scrollLeft`/`scrollRight`, 25–80s durations)
+- Pauses on hover and for users with reduced-motion preferences
+- Demonstrates ecosystem adoption without cluttering the layout
+
+**Feature Section Cards**
+- Large cards combining code examples with descriptive text
+- Left: code snippet with syntax highlighting; Right: feature description
+- Green accent border (`2px solid #00d992`) on highlighted/active features
+- Internal padding: generous (24–32px estimated)
+
+**Agent Flow Diagrams**
+- Interactive node-graph visualizations showing agent coordination
+- Connection lines use VoltAgent green variants
+- Nodes styled as mini-cards within the Warm Charcoal border system
+
+**Community / GitHub Section**
+- Large GitHub icon as the visual anchor
+- Star count and contributor metrics prominently displayed
+- Warm social proof: Discord, X, Reddit, LinkedIn, YouTube links in footer
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 8px
+- Scale: 2px, 4px, 5px, 6px, 6.4px, 8px, 12px, 16px, 20px, 24px, 28px, 32px, 40px, 48px, 64px
+- Button padding: 12px 16px (standard), 20px (container-button)
+- Card internal padding: approximately 24–32px
+- Section vertical spacing: generous (estimated 64–96px between major sections)
+- Component gap: 16–24px between sibling cards/elements
+
+### Grid & Container
+- Max container width: approximately 1280–1440px, centered
+- Hero: centered single-column with maximum breathing room
+- Feature sections: alternating asymmetric layouts (code left / text right, then reversed)
+- Logo marquee: full-width horizontal scroll, breaking the container constraint
+- Card grids: 2–3 column for feature showcases
+- Integration grid: responsive multi-column for partner/integration icons
+
+### Whitespace Philosophy
+- **Cinematic breathing room between sections**: Massive vertical gaps create a "scroll-through-chapters" experience — each section feels like a new scene.
+- **Dense within components**: Cards and code blocks are internally compact, with tight line-heights and controlled padding. Information is concentrated, not spread thin.
+- **Border-defined separation**: Rather than relying solely on whitespace, VoltAgent uses the Warm Charcoal border system (`#3d3a39`) to delineate content zones. The border IS the whitespace signal.
+- **Hero-first hierarchy**: The top of the page commands the most space — the "AI Agent Engineering Platform" headline and npm command get maximum vertical runway before the first content section appears.
+
+### Border Radius Scale
+- Nearly squared (4px): Small inline elements, SVG containers, code spans — the sharpest treatment, conveying technical precision
+- Subtly rounded (6px): Buttons, links, clipboard actions — the workhorse radius for interactive elements
+- Code-specific (6.4px): Code blocks, `pre` elements, clipboard copy targets — a deliberate micro-distinction from standard 6px
+- Comfortably rounded (8px): Content cards, feature containers, emphasized buttons — the standard containment radius
+- Pill-shaped (9999px): Tags, badges, status indicators, pill-shaped navigation elements — the roundest treatment for small categorical labels
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, no border | Page background (`#050507`), inline text |
+| Contained (Level 1) | `1px solid #3d3a39`, no shadow | Standard cards, nav bar, code blocks |
+| Emphasized (Level 2) | `3px solid #3d3a39`, no shadow | Large interactive buttons, emphasized containers |
+| Accent (Level 3) | `2px solid #00d992`, no shadow | Active/highlighted feature cards, selected states |
+| Ambient Glow (Level 4) | `rgba(92, 88, 85, 0.2) 0px 0px 15px` | Elevated cards, hover states, soft atmospheric lift |
+| Dramatic Float (Level 5) | `rgba(0, 0, 0, 0.7) 0px 20px 60px` + `rgba(148, 163, 184, 0.1) 1px inset` | Hero feature showcase, modals, maximum-elevation content |
+
+**Shadow Philosophy**: VoltAgent communicates depth primarily through **border weight and color**, not shadows. The standard `1px solid #3d3a39` border IS the elevation — adding a `3px` border weight or switching to green (`#00d992`) communicates importance more than adding shadow does. When shadows do appear, they're either warm and diffused (Level 4) or cinematic and dramatic (Level 5) — never medium or generic.
+
+### Decorative Depth
+- **Green Signal Glow**: The VoltAgent bolt logo pulses with a `drop-shadow` animation cycling between 2px and 8px blur radius in Emerald Signal Green. This is the most distinctive decorative element — it makes the logo feel "powered on."
+- **Warm Charcoal Containment Lines**: The warm tone of `#3d3a39` borders creates a subtle visual warmth against the cool black, as if the cards are faintly heated from within.
+- **Dashed Workflow Lines**: `1px dashed rgba(79, 93, 117, 0.4)` creates a blueprint-like aesthetic for architecture diagrams, visually distinct from solid content borders.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Abyss Black (`#050507`) as the landing page background and Carbon Surface (`#101010`) for all contained elements — the two-shade dark system is essential
+- Reserve Emerald Signal Green (`#00d992`) exclusively for high-signal moments: active borders, glow effects, and the most important interactive accents
+- Use VoltAgent Mint (`#2fd6a1`) for button text on dark surfaces — it's more readable than pure Signal Green
+- Keep heading line-heights compressed (1.0–1.11) with negative letter-spacing for dense, authoritative text blocks
+- Use the warm gray palette (`#3d3a39`, `#8b949e`, `#b8b3b0`) for borders and secondary text — warmth prevents the dark theme from feeling sterile
+- Present code snippets as primary content — they're hero elements, not supporting illustrations
+- Use border weight (1px → 2px → 3px) and color shifts (`#3d3a39` → `#00d992`) to communicate depth and importance, rather than relying on shadows
+- Pair system-ui for headings with Inter for body text — the speed/authority of native fonts combined with the precision of a geometric sans
+- Use SFMono-Regular for all code content — it's the developer credibility signal
+- Apply `"calt"` and `"rlig"` OpenType features across all text
+
+### Don't
+- Don't use bright or light backgrounds as primary surfaces — the entire identity lives on near-black
+- Don't introduce warm colors (orange, red, yellow) as decorative accents — the palette is strictly green + warm neutrals on black. Warm colors are reserved for semantic states (warning, error) only
+- Don't use Emerald Signal Green (`#00d992`) on large surfaces or as background fills — it's an accent, never a surface
+- Don't increase heading line-heights beyond 1.33 — the compressed density is core to the engineering-platform identity
+- Don't use heavy shadows generously — depth comes from border treatment, not box-shadow. Shadows are reserved for Level 4–5 elevation only
+- Don't use pure white (`#ffffff`) as default body text — Snow White (`#f2f2f2`) is the standard. Pure white is reserved for maximum-emphasis headings and button text
+- Don't mix in serif or decorative fonts — the entire system is geometric sans + monospace
+- Don't use border-radius larger than 8px on content cards — 9999px (pill) is only for small tags and badges
+- Don't skip the warm-gray border system — cards without `#3d3a39` borders lose their containment and float ambiguously on the dark canvas
+- Don't animate aggressively — animations are slow and subtle (25–100s durations for marquee, gentle glow pulses). Fast motion contradicts the "engineering precision" atmosphere
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Small Mobile | <420px | Minimum layout, stacked everything, reduced hero text to ~24px |
+| Mobile | 420–767px | Single column, hamburger nav, full-width cards, hero text ~36px |
+| Tablet | 768–1024px | 2-column grids begin, condensed nav, medium hero text |
+| Desktop | 1025–1440px | Full multi-column layout, expanded nav with dropdowns, large hero (60px) |
+| Large Desktop | >1440px | Max-width container centered (est. 1280–1440px), generous horizontal margins |
+
+*23 breakpoints detected in total, ranging from 360px to 1992px — indicating a fluid, heavily responsive grid system rather than fixed breakpoint snapping.*
+
+### Touch Targets
+- Buttons use comfortable padding (12px 16px minimum) ensuring adequate touch area
+- Navigation links spaced with sufficient gap for thumb navigation
+- Interactive card surfaces are large enough to serve as full touch targets
+- Minimum recommended touch target: 44x44px
+
+### Collapsing Strategy
+- **Navigation**: Full horizontal nav with dropdowns collapses to hamburger menu on mobile
+- **Feature grids**: 3-column → 2-column → single-column vertical stacking
+- **Hero text**: 60px → 36px → 24px progressive scaling with maintained compression ratios
+- **Logo marquee**: Adjusts scroll speed and item sizing; maintains infinite loop
+- **Code blocks**: Horizontal scroll on smaller viewports rather than wrapping — preserving code readability
+- **Section padding**: Reduces proportionally but maintains generous vertical rhythm between chapters
+- **Cards**: Stack vertically on mobile with full-width treatment and maintained internal padding
+
+### Image Behavior
+- Dark-themed screenshots and diagrams scale proportionally within containers
+- Agent flow diagrams simplify or scroll horizontally on narrow viewports
+- Dot-pattern decorative backgrounds scale with viewport
+- No visible art direction changes between breakpoints — same crops, proportional scaling
+- Lazy loading for below-fold images (Docusaurus default behavior)
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Brand Accent: "Emerald Signal Green (#00d992)"
+- Button Text: "VoltAgent Mint (#2fd6a1)"
+- Page Background: "Abyss Black (#050507)"
+- Card Surface: "Carbon Surface (#101010)"
+- Border / Containment: "Warm Charcoal (#3d3a39)"
+- Primary Text: "Snow White (#f2f2f2)"
+- Secondary Text: "Warm Parchment (#b8b3b0)"
+- Tertiary Text: "Steel Slate (#8b949e)"
+
+### Example Component Prompts
+- "Create a feature card on Carbon Surface (#101010) with a 1px solid Warm Charcoal (#3d3a39) border, comfortably rounded corners (8px). Use Snow White (#f2f2f2) for the title in system-ui at 24px weight 700, and Warm Parchment (#b8b3b0) for the description in Inter at 16px. Add a subtle Warm Ambient shadow (rgba(92, 88, 85, 0.2) 0px 0px 15px)."
+- "Design a ghost button with transparent background, Snow White (#f2f2f2) text in Inter at 16px, a 1px solid Warm Charcoal (#3d3a39) border, and subtly rounded corners (6px). Padding: 12px vertical, 16px horizontal. On hover, background shifts to rgba(0, 0, 0, 0.2)."
+- "Build a hero section on Abyss Black (#050507) with a massive heading at 60px system-ui, line-height 1.0, letter-spacing -0.65px. The word 'Platform' should be colored in Emerald Signal Green (#00d992). Below the heading, place a code block showing 'npm create voltagent-app@latest' in SFMono-Regular at 14px on Carbon Surface (#101010) with a copy button."
+- "Create a highlighted feature card using a 2px solid Emerald Signal Green (#00d992) border instead of the standard Warm Charcoal. Keep Carbon Surface background, comfortably rounded corners (8px), and include a code snippet on the left with feature description text on the right."
+- "Design a navigation bar on Abyss Black (#050507) with the VoltAgent logo (bolt icon with animated green glow) on the left, nav links in Inter at 14px weight 500 in Snow White, and a green CTA button (Carbon Surface bg, VoltAgent Mint text) on the right. Add a 1px solid Warm Charcoal bottom border."
+
+### Iteration Guide
+When refining existing screens generated with this design system:
+1. Focus on ONE component at a time
+2. Reference specific color names and hex codes — "use Warm Parchment (#b8b3b0)" not "make it lighter"
+3. Use border treatment to communicate elevation: "change the border to 2px solid Emerald Signal Green (#00d992)" for emphasis
+4. Describe the desired "feel" alongside measurements — "compressed and authoritative heading at 36px with line-height 1.11 and -0.9px letter-spacing"
+5. For glow effects, specify "Emerald Signal Green (#00d992) as a drop-shadow with 2–8px blur radius"
+6. Always specify which font — system-ui for headings, Inter for body/UI, SFMono-Regular for code
+7. Keep animations slow and subtle — marquee scrolls at 25–80s, glow pulses gently

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ csgclaw serve
 
 Open the printed URL (e.g. `http://127.0.0.1:18080/`) in your browser to enter the IM workspace.
 On first start, CSGClaw auto-detects an agent profile for the Manager from CSGHub Lite, Codex, or Claude Code. If detection fails, the Web UI stays available and opens the Manager profile setup panel so you can choose a provider and model there.
+For Codex and Claude Code, CSGClaw reuses local CLI auth where possible: Codex from `~/.codex/auth.json`, Claude Code from macOS Keychain, or `csgclaw auth login codex|claude-code` when manual OAuth is needed.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ csgclaw serve
 
 Open the printed URL (e.g. `http://127.0.0.1:18080/`) in your browser to enter the IM workspace.
 On first start, CSGClaw auto-detects an agent profile for the Manager from CSGHub Lite, Codex, or Claude Code. If detection fails, the Web UI stays available and opens the Manager profile setup panel so you can choose a provider and model there.
-For Codex and Claude Code, CSGClaw reuses local CLI auth where possible: Codex from `~/.codex/auth.json`, Claude Code from macOS Keychain, or `csgclaw auth login codex|claude-code` when manual OAuth is needed.
+For Codex and Claude Code, CSGClaw reuses local CLI auth where possible: Codex from `~/.codex/auth.json`, Claude Code from macOS Keychain, or `csgclaw model auth login codex|claude-code` when manual OAuth is needed.
 
 ## Configuration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,6 +39,7 @@ csgclaw serve
 
 执行后 CLI 会打印访问地址（例如 `http://127.0.0.1:18080/`），在浏览器中打开即可进入 IM 工作区。
 首次启动时，CSGClaw 会从 CSGHub Lite、Codex 或 Claude Code 自动检测 Manager 的 agent profile。如果检测失败，Web UI 仍然可用，并会打开 Manager profile 设置面板，让你在那里选择 provider 和模型。
+对于 Codex 和 Claude Code，CSGClaw 会尽量复用本地 CLI 鉴权：Codex 来自 `~/.codex/auth.json`，Claude Code 来自 macOS Keychain；需要手动 OAuth 时可运行 `csgclaw auth login codex|claude-code`。
 
 ## 配置
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	agentcmd "csgclaw/cli/agent"
+	authcmd "csgclaw/cli/auth"
 	"csgclaw/cli/bot"
 	"csgclaw/cli/command"
 	"csgclaw/cli/member"
@@ -72,6 +73,7 @@ func (a *App) registerDefaultCommands() {
 		servecmd.NewServeCmd(),
 		servecmd.NewStopCmd(),
 		agentcmd.NewCmd(),
+		authcmd.NewCmd(),
 		usercmd.NewCmd(),
 		bot.NewCmd(),
 		room.NewCmd(),

--- a/cli/app.go
+++ b/cli/app.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 
 	agentcmd "csgclaw/cli/agent"
-	authcmd "csgclaw/cli/auth"
 	"csgclaw/cli/bot"
 	"csgclaw/cli/command"
+	completioncmd "csgclaw/cli/completion"
 	"csgclaw/cli/member"
 	"csgclaw/cli/message"
+	modelcmd "csgclaw/cli/model"
 	onboardcmd "csgclaw/cli/onboard"
 	"csgclaw/cli/room"
 	servecmd "csgclaw/cli/serve"
@@ -73,12 +74,14 @@ func (a *App) registerDefaultCommands() {
 		servecmd.NewServeCmd(),
 		servecmd.NewStopCmd(),
 		agentcmd.NewCmd(),
-		authcmd.NewCmd(),
+		modelcmd.NewCmd(),
 		usercmd.NewCmd(),
 		bot.NewCmd(),
 		room.NewCmd(),
 		member.NewCmd(),
 		message.NewCmd(),
+		completioncmd.NewCmd("csgclaw", completioncmd.FullSpec()),
+		completioncmd.NewCompleteCmd("csgclaw", completioncmd.FullSpec()),
 		servecmd.NewInternalServeCmd(),
 	)
 }

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -1703,6 +1703,7 @@ func TestUsageIncludesTopLevelCommandIndex(t *testing.T) {
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
 		"user     Manage IM users",
+		"completion Generate shell completion scripts.",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("usage = %q, want substring %q", got, want)
@@ -1732,6 +1733,7 @@ func TestRootHelpIncludesAvailableCommands(t *testing.T) {
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
 		"user     Manage IM users",
+		"completion Generate shell completion scripts.",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help = %q, want substring %q", got, want)
@@ -1750,6 +1752,48 @@ func TestExecuteDoesNotRegisterTopLevelAuthAliases(t *testing.T) {
 		err := app.Execute(context.Background(), args)
 		if err == nil || !strings.Contains(err.Error(), "unknown command") {
 			t.Fatalf("Execute(%v) error = %v, want unknown command", args, err)
+		}
+	}
+}
+
+func TestExecuteCompletionBash(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &App{
+		stdout:     &stdout,
+		stderr:     &stderr,
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil }),
+	}
+
+	if err := app.Execute(context.Background(), []string{"completion", "bash"}); err != nil {
+		t.Fatalf("Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{`"${COMP_WORDS[0]}" __complete`, "complete -F _csgclaw_completion csgclaw"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want substring %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestExecuteHiddenCompleteUsesFullCommandSet(t *testing.T) {
+	var stdout bytes.Buffer
+	app := &App{
+		stdout:     &stdout,
+		stderr:     &bytes.Buffer{},
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil }),
+	}
+
+	if err := app.Execute(context.Background(), []string{"__complete", "csgclaw", ""}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{"agent\n", "model\n", "completion\n"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want substring %q", got, want)
+		}
+	}
+	for _, notWant := range []string{"_serve\n", "__complete\n"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("stdout = %q, should not include %q", got, notWant)
 		}
 	}
 }

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -1698,7 +1698,7 @@ func TestUsageIncludesTopLevelCommandIndex(t *testing.T) {
 	for _, want := range []string{
 		"Available Commands:",
 		"agent    Manage agents",
-		"auth     Manage local provider authentication.",
+		"model    Manage model providers.",
 		"bot      Manage bots",
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
@@ -1727,7 +1727,7 @@ func TestRootHelpIncludesAvailableCommands(t *testing.T) {
 	for _, want := range []string{
 		"Available Commands:",
 		"agent    Manage agents",
-		"auth     Manage local provider authentication.",
+		"model    Manage model providers.",
 		"bot      Manage bots",
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
@@ -1740,7 +1740,7 @@ func TestRootHelpIncludesAvailableCommands(t *testing.T) {
 }
 
 func TestExecuteDoesNotRegisterTopLevelAuthAliases(t *testing.T) {
-	for _, args := range [][]string{{"codex-login"}, {"claude-login"}} {
+	for _, args := range [][]string{{"auth", "login", "codex"}, {"codex-login"}, {"claude-login"}} {
 		var stderr bytes.Buffer
 		app := &App{
 			stdout:     &bytes.Buffer{},

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -1698,6 +1698,7 @@ func TestUsageIncludesTopLevelCommandIndex(t *testing.T) {
 	for _, want := range []string{
 		"Available Commands:",
 		"agent    Manage agents",
+		"auth     Manage local provider authentication.",
 		"bot      Manage bots",
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
@@ -1726,6 +1727,7 @@ func TestRootHelpIncludesAvailableCommands(t *testing.T) {
 	for _, want := range []string{
 		"Available Commands:",
 		"agent    Manage agents",
+		"auth     Manage local provider authentication.",
 		"bot      Manage bots",
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
@@ -1733,6 +1735,21 @@ func TestRootHelpIncludesAvailableCommands(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestExecuteDoesNotRegisterTopLevelAuthAliases(t *testing.T) {
+	for _, args := range [][]string{{"codex-login"}, {"claude-login"}} {
+		var stderr bytes.Buffer
+		app := &App{
+			stdout:     &bytes.Buffer{},
+			stderr:     &stderr,
+			httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil }),
+		}
+		err := app.Execute(context.Background(), args)
+		if err == nil || !strings.Contains(err.Error(), "unknown command") {
+			t.Fatalf("Execute(%v) error = %v, want unknown command", args, err)
 		}
 	}
 }

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -21,6 +22,11 @@ type loginResult struct {
 	Message       string `json:"message,omitempty"`
 }
 
+type loginProviderResult struct {
+	status cliproxy.AuthStatus
+	err    error
+}
+
 var loginProvider = func(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
 	return cliproxy.Default().Login(ctx, provider, opts)
 }
@@ -30,11 +36,11 @@ func NewCmd() command.Command {
 }
 
 func (cmd) Name() string {
-	return "auth"
+	return "model"
 }
 
 func (cmd) Summary() string {
-	return "Manage local provider authentication."
+	return "Manage model providers."
 }
 
 func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
@@ -48,22 +54,52 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 	}
 
 	switch args[0] {
-	case "login":
-		return c.runLogin(ctx, run, args[1:], globals)
+	case "auth":
+		return c.runAuth(ctx, run, args[1:], globals)
 	default:
 		c.usage(run)
-		return fmt.Errorf("unknown auth subcommand %q", args[0])
+		return fmt.Errorf("unknown model subcommand %q", args[0])
 	}
 }
 
 func (c cmd) usage(run *command.Context) {
-	run.UsageCommandGroup(c, run.Program+" auth <subcommand> [flags]", []string{
-		"login <provider>    Login to codex or claude-code",
+	run.UsageCommandGroup(c, run.Program+" model <subcommand> [flags]", []string{
+		"auth login <provider>    Login to codex or claude-code",
 	})
 }
 
+func (c cmd) runAuth(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
+	if len(args) == 0 {
+		c.usageAuth(run)
+		return flag.ErrHelp
+	}
+	if command.IsHelpArg(args[0]) {
+		c.usageAuth(run)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "login":
+		return c.runLogin(ctx, run, args[1:], globals)
+	default:
+		c.usageAuth(run)
+		return fmt.Errorf("unknown model auth subcommand %q", args[0])
+	}
+}
+
+func (c cmd) usageAuth(run *command.Context) {
+	fmt.Fprintln(run.Stderr, "Manage local model provider authentication.")
+	fmt.Fprintln(run.Stderr)
+	fmt.Fprintln(run.Stderr, "Usage:")
+	fmt.Fprintf(run.Stderr, "  %s model auth <subcommand> [flags]\n\n", run.Program)
+	fmt.Fprintln(run.Stderr, "Available Subcommands:")
+	fmt.Fprintln(run.Stderr, "  login <provider>    Login to codex or claude-code")
+	fmt.Fprintln(run.Stderr)
+	fmt.Fprintf(run.Stderr, "Run `%s model auth <subcommand> -h` for subcommand details.\n", run.Program)
+}
+
 func (c cmd) runLogin(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
-	fs := run.NewFlagSet("auth login", run.Program+" auth login <provider> [flags]", "Login to a local CLIProxy provider.")
+	fs := run.NewFlagSet("model auth login", run.Program+" model auth login <provider> [flags]", "Login to a local CLIProxy provider.")
 	noBrowserDefault, args := extractNoBrowserFlag(args)
 	noBrowser := fs.Bool("no-browser", noBrowserDefault, "print the OAuth URL instead of opening a browser")
 	if err := fs.Parse(args); err != nil {
@@ -71,18 +107,21 @@ func (c cmd) runLogin(ctx context.Context, run *command.Context, args []string, 
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		return fmt.Errorf("auth login requires exactly one provider")
+		return fmt.Errorf("model auth login requires exactly one provider")
 	}
 
 	provider := normalizeLoginProvider(rest[0])
 	if provider == "" {
 		return fmt.Errorf("unsupported auth provider %q", rest[0])
 	}
-	status, err := loginProvider(ctx, provider, cliproxy.LoginOptions{
+	status, err := cancellableLoginProvider(ctx, provider, cliproxy.LoginOptions{
 		NoBrowser: *noBrowser,
 		Prompt:    promptFunc(run.Stdin, run.Stdout),
 	})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("login canceled")
+		}
 		return err
 	}
 	return renderLogin(globals.Output, run.Stdout, loginResult{
@@ -91,6 +130,24 @@ func (c cmd) runLogin(ctx context.Context, run *command.Context, args []string, 
 		Source:        status.Source,
 		Message:       loginMessage(status),
 	})
+}
+
+func cancellableLoginProvider(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resultCh := make(chan loginProviderResult, 1)
+	go func() {
+		status, err := loginProvider(ctx, provider, opts)
+		resultCh <- loginProviderResult{status: status, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result.status, result.err
+	case <-ctx.Done():
+		return cliproxy.AuthStatus{}, ctx.Err()
+	}
 }
 
 func extractNoBrowserFlag(args []string) (bool, []string) {

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"csgclaw/cli/command"
+	"csgclaw/internal/cliproxy"
+)
+
+type cmd struct{}
+
+type loginResult struct {
+	Provider      string `json:"provider"`
+	Authenticated bool   `json:"authenticated"`
+	Source        string `json:"source,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+var loginProvider = func(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
+	return cliproxy.Default().Login(ctx, provider, opts)
+}
+
+func NewCmd() command.Command {
+	return cmd{}
+}
+
+func (cmd) Name() string {
+	return "auth"
+}
+
+func (cmd) Summary() string {
+	return "Manage local provider authentication."
+}
+
+func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
+	if len(args) == 0 {
+		c.usage(run)
+		return flag.ErrHelp
+	}
+	if command.IsHelpArg(args[0]) {
+		c.usage(run)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "login":
+		return c.runLogin(ctx, run, args[1:], globals)
+	default:
+		c.usage(run)
+		return fmt.Errorf("unknown auth subcommand %q", args[0])
+	}
+}
+
+func (c cmd) usage(run *command.Context) {
+	run.UsageCommandGroup(c, run.Program+" auth <subcommand> [flags]", []string{
+		"login <provider>    Login to codex or claude-code",
+	})
+}
+
+func (c cmd) runLogin(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
+	fs := run.NewFlagSet("auth login", run.Program+" auth login <provider> [flags]", "Login to a local CLIProxy provider.")
+	noBrowserDefault, args := extractNoBrowserFlag(args)
+	noBrowser := fs.Bool("no-browser", noBrowserDefault, "print the OAuth URL instead of opening a browser")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		return fmt.Errorf("auth login requires exactly one provider")
+	}
+
+	provider := normalizeLoginProvider(rest[0])
+	if provider == "" {
+		return fmt.Errorf("unsupported auth provider %q", rest[0])
+	}
+	status, err := loginProvider(ctx, provider, cliproxy.LoginOptions{
+		NoBrowser: *noBrowser,
+		Prompt:    promptFunc(run.Stdin, run.Stdout),
+	})
+	if err != nil {
+		return err
+	}
+	return renderLogin(globals.Output, run.Stdout, loginResult{
+		Provider:      status.Provider,
+		Authenticated: status.Authenticated,
+		Source:        status.Source,
+		Message:       loginMessage(status),
+	})
+}
+
+func extractNoBrowserFlag(args []string) (bool, []string) {
+	filtered := make([]string, 0, len(args))
+	noBrowser := false
+	for _, arg := range args {
+		switch arg {
+		case "--no-browser", "-no-browser":
+			noBrowser = true
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+	return noBrowser, filtered
+}
+
+func normalizeLoginProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex":
+		return "codex"
+	case "claude", "claude-code", "claude_code":
+		return "claude_code"
+	default:
+		return ""
+	}
+}
+
+func promptFunc(r io.Reader, w io.Writer) func(string) (string, error) {
+	reader := bufio.NewReader(r)
+	return func(prompt string) (string, error) {
+		if strings.TrimSpace(prompt) != "" {
+			if _, err := fmt.Fprint(w, prompt); err != nil {
+				return "", err
+			}
+		}
+		line, err := reader.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			return "", err
+		}
+		return strings.TrimSpace(line), nil
+	}
+}
+
+func loginMessage(status cliproxy.AuthStatus) string {
+	if status.Authenticated {
+		if status.Source != "" {
+			return fmt.Sprintf("%s auth ready (%s)", status.Provider, status.Source)
+		}
+		return fmt.Sprintf("%s auth ready", status.Provider)
+	}
+	if status.Message != "" {
+		return status.Message
+	}
+	return fmt.Sprintf("%s auth is not configured", status.Provider)
+}
+
+func renderLogin(output string, w io.Writer, result loginResult) error {
+	output, err := command.NormalizeOutput(output)
+	if err != nil {
+		return err
+	}
+	if output == "json" {
+		return command.WriteJSON(w, result)
+	}
+	_, err = fmt.Fprintln(w, result.Message)
+	return err
+}

--- a/cli/auth/auth_test.go
+++ b/cli/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestRunLoginCodex(t *testing.T) {
 
 	var out bytes.Buffer
 	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &out, Stderr: &bytes.Buffer{}}
-	if err := NewCmd().Run(context.Background(), run, []string{"login", "codex"}, command.GlobalOptions{Output: "table"}); err != nil {
+	if err := NewCmd().Run(context.Background(), run, []string{"auth", "login", "codex"}, command.GlobalOptions{Output: "table"}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got := out.String(); !strings.Contains(got, "codex auth ready (codex-home)") {
@@ -46,7 +47,7 @@ func TestRunLoginClaudeCodeNoBrowser(t *testing.T) {
 
 	var out bytes.Buffer
 	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &out, Stderr: &bytes.Buffer{}}
-	if err := NewCmd().Run(context.Background(), run, []string{"login", "claude-code", "--no-browser"}, command.GlobalOptions{Output: "json"}); err != nil {
+	if err := NewCmd().Run(context.Background(), run, []string{"auth", "login", "claude-code", "--no-browser"}, command.GlobalOptions{Output: "json"}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got := out.String(); !strings.Contains(got, `"provider": "claude_code"`) || !strings.Contains(got, `"source": "oauth"`) {
@@ -56,9 +57,36 @@ func TestRunLoginClaudeCodeNoBrowser(t *testing.T) {
 
 func TestRunLoginRejectsUnsupportedProvider(t *testing.T) {
 	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
-	err := NewCmd().Run(context.Background(), run, []string{"login", "gemini"}, command.GlobalOptions{})
+	err := NewCmd().Run(context.Background(), run, []string{"auth", "login", "gemini"}, command.GlobalOptions{})
 	if err == nil || !strings.Contains(err.Error(), "unsupported auth provider") {
 		t.Fatalf("Run() error = %v, want unsupported provider", err)
+	}
+}
+
+func TestRunLoginCancelsWhileProviderIsWaiting(t *testing.T) {
+	for _, provider := range []string{"codex", "claude-code"} {
+		t.Run(provider, func(t *testing.T) {
+			release := make(chan struct{})
+			restore := stubLoginProvider(func(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
+				<-release
+				return cliproxy.AuthStatus{}, nil
+			})
+			defer restore()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+			err := NewCmd().Run(ctx, run, []string{"auth", "login", provider}, command.GlobalOptions{})
+			close(release)
+
+			if err == nil || !strings.Contains(err.Error(), "login canceled") {
+				t.Fatalf("Run() error = %v, want login canceled", err)
+			}
+			if errors.Is(err, context.Canceled) {
+				t.Fatalf("Run() error = %v, want user-facing cancellation error", err)
+			}
+		})
 	}
 }
 

--- a/cli/auth/auth_test.go
+++ b/cli/auth/auth_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"csgclaw/cli/command"
+	"csgclaw/internal/cliproxy"
+)
+
+func TestRunLoginCodex(t *testing.T) {
+	restore := stubLoginProvider(func(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
+		if provider != "codex" {
+			t.Fatalf("provider = %q, want codex", provider)
+		}
+		if opts.NoBrowser {
+			t.Fatalf("NoBrowser = true, want false")
+		}
+		return cliproxy.AuthStatus{Provider: "codex", Authenticated: true, Source: "codex-home"}, nil
+	})
+	defer restore()
+
+	var out bytes.Buffer
+	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &out, Stderr: &bytes.Buffer{}}
+	if err := NewCmd().Run(context.Background(), run, []string{"login", "codex"}, command.GlobalOptions{Output: "table"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "codex auth ready (codex-home)") {
+		t.Fatalf("output = %q, want codex ready message", got)
+	}
+}
+
+func TestRunLoginClaudeCodeNoBrowser(t *testing.T) {
+	restore := stubLoginProvider(func(ctx context.Context, provider string, opts cliproxy.LoginOptions) (cliproxy.AuthStatus, error) {
+		if provider != "claude_code" {
+			t.Fatalf("provider = %q, want claude_code", provider)
+		}
+		if !opts.NoBrowser {
+			t.Fatalf("NoBrowser = false, want true")
+		}
+		return cliproxy.AuthStatus{Provider: "claude_code", Authenticated: true, Source: "oauth"}, nil
+	})
+	defer restore()
+
+	var out bytes.Buffer
+	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &out, Stderr: &bytes.Buffer{}}
+	if err := NewCmd().Run(context.Background(), run, []string{"login", "claude-code", "--no-browser"}, command.GlobalOptions{Output: "json"}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, `"provider": "claude_code"`) || !strings.Contains(got, `"source": "oauth"`) {
+		t.Fatalf("output = %q, want claude_code oauth json", got)
+	}
+}
+
+func TestRunLoginRejectsUnsupportedProvider(t *testing.T) {
+	run := &command.Context{Program: "csgclaw", Stdin: strings.NewReader(""), Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	err := NewCmd().Run(context.Background(), run, []string{"login", "gemini"}, command.GlobalOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unsupported auth provider") {
+		t.Fatalf("Run() error = %v, want unsupported provider", err)
+	}
+}
+
+func stubLoginProvider(fn func(context.Context, string, cliproxy.LoginOptions) (cliproxy.AuthStatus, error)) func() {
+	previous := loginProvider
+	loginProvider = fn
+	return func() { loginProvider = previous }
+}

--- a/cli/completion/completion.go
+++ b/cli/completion/completion.go
@@ -1,0 +1,662 @@
+package completion
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"csgclaw/cli/command"
+)
+
+const (
+	CommandName       = "completion"
+	hiddenCommandName = "__complete"
+)
+
+var supportedShells = []string{"bash", "zsh", "fish"}
+
+type FlagSpec struct {
+	Name       string
+	Short      string
+	TakesValue bool
+	Values     []string
+}
+
+type CommandSpec struct {
+	Name     string
+	Summary  string
+	Hidden   bool
+	Flags    []FlagSpec
+	Children []CommandSpec
+	Values   []string
+}
+
+type cmd struct {
+	program string
+	root    CommandSpec
+}
+
+type completeCmd struct {
+	program string
+	root    CommandSpec
+}
+
+func NewCmd(program string, root CommandSpec) command.Command {
+	return cmd{program: program, root: root}
+}
+
+func NewCompleteCmd(program string, root CommandSpec) command.Command {
+	return completeCmd{program: program, root: root}
+}
+
+func FullSpec() CommandSpec {
+	return CommandSpec{
+		Name:  "csgclaw",
+		Flags: fullGlobalFlags(),
+		Children: []CommandSpec{
+			{
+				Name:    "onboard",
+				Summary: "Initialize local config and bootstrap state.",
+				Flags: []FlagSpec{
+					{Name: "debian-registries", TakesValue: true},
+					{Name: "log-level", TakesValue: true, Values: logLevelValues()},
+				},
+			},
+			{
+				Name:    "serve",
+				Summary: "Start the local HTTP server.",
+				Flags: []FlagSpec{
+					{Name: "daemon", Short: "d"},
+					{Name: "log-level", TakesValue: true, Values: logLevelValues()},
+					{Name: "log", TakesValue: true},
+					{Name: "pid", TakesValue: true},
+				},
+			},
+			{
+				Name:    "stop",
+				Summary: "Stop the local HTTP server.",
+				Flags:   []FlagSpec{{Name: "pid", TakesValue: true}},
+			},
+			agentSpec(),
+			modelSpec(),
+			userSpec(),
+			botSpec(),
+			roomSpec(),
+			memberSpec(),
+			messageSpec(),
+			completionSpec(),
+		},
+	}
+}
+
+func LiteSpec() CommandSpec {
+	return CommandSpec{
+		Name:  "csgclaw-cli",
+		Flags: liteGlobalFlags(),
+		Children: []CommandSpec{
+			botSpec(),
+			roomSpec(),
+			memberSpec(),
+			messageSpec(),
+			completionSpec(),
+		},
+	}
+}
+
+func (cmd) Name() string {
+	return CommandName
+}
+
+func (cmd) Summary() string {
+	return "Generate shell completion scripts."
+}
+
+func (c cmd) Run(_ context.Context, run *command.Context, args []string, _ command.GlobalOptions) error {
+	if len(args) == 0 || command.IsHelpArg(args[0]) {
+		c.usage(run)
+		return flag.ErrHelp
+	}
+	if len(args) != 1 {
+		c.usage(run)
+		return fmt.Errorf("%s completion requires exactly one shell", c.program)
+	}
+
+	shell := strings.ToLower(strings.TrimSpace(args[0]))
+	if !isSupportedShell(shell) {
+		c.usage(run)
+		return fmt.Errorf("unsupported shell %q", args[0])
+	}
+	return Generate(run.Stdout, c.program, shell)
+}
+
+func (c cmd) usage(run *command.Context) {
+	fmt.Fprintln(run.Stderr, "Generate shell completion scripts.")
+	fmt.Fprintln(run.Stderr)
+	fmt.Fprintln(run.Stderr, "Usage:")
+	fmt.Fprintf(run.Stderr, "  %s completion <bash|zsh|fish>\n", c.program)
+	fmt.Fprintln(run.Stderr)
+	fmt.Fprintln(run.Stderr, "Examples:")
+	fmt.Fprintf(run.Stderr, "  %s completion bash > /etc/bash_completion.d/%s\n", c.program, c.program)
+	fmt.Fprintf(run.Stderr, "  %s completion zsh > \"${fpath[1]}/_%s\"\n", c.program, c.program)
+	fmt.Fprintf(run.Stderr, "  %s completion fish > ~/.config/fish/completions/%s.fish\n", c.program, c.program)
+}
+
+func (completeCmd) Name() string {
+	return hiddenCommandName
+}
+
+func (completeCmd) Summary() string {
+	return "Complete shell words."
+}
+
+func (completeCmd) Hidden() bool {
+	return true
+}
+
+func (c completeCmd) Run(_ context.Context, run *command.Context, args []string, _ command.GlobalOptions) error {
+	for _, suggestion := range Complete(c.root, c.program, args) {
+		fmt.Fprintln(run.Stdout, suggestion)
+	}
+	return nil
+}
+
+func Generate(w io.Writer, program, shell string) error {
+	switch shell {
+	case "bash":
+		return generateBash(w, program)
+	case "zsh":
+		return generateZsh(w, program)
+	case "fish":
+		return generateFish(w, program)
+	default:
+		return fmt.Errorf("unsupported shell %q", shell)
+	}
+}
+
+func Complete(root CommandSpec, program string, rawArgs []string) []string {
+	args := stripProgram(rawArgs, program)
+	if len(args) == 0 {
+		return filterSuggestions(rootSuggestions(root), "")
+	}
+
+	current := args[len(args)-1]
+	previous := args[:len(args)-1]
+	node, valueFlag := resolveNode(root, previous)
+	if valueFlag != nil {
+		return filterSuggestions(valueFlag.Values, current)
+	}
+	if flag, prefix, ok := currentFlagValue(node, current); ok {
+		return filterSuggestions(formatFlagValues(flag, prefix), current)
+	}
+	if strings.HasPrefix(current, "-") && current != "-" {
+		return filterSuggestions(formatFlags(flagsForNode(node)), current)
+	}
+
+	return filterSuggestions(nodeSuggestions(node, current == ""), current)
+}
+
+func fullGlobalFlags() []FlagSpec {
+	return append(liteGlobalFlags(), FlagSpec{Name: "config", TakesValue: true})
+}
+
+func liteGlobalFlags() []FlagSpec {
+	return []FlagSpec{
+		{Name: "endpoint", TakesValue: true},
+		{Name: "token", TakesValue: true},
+		{Name: "output", TakesValue: true, Values: []string{"table", "json"}},
+		{Name: "version", Short: "V"},
+	}
+}
+
+func agentSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "agent",
+		Summary: "Manage agents.",
+		Children: []CommandSpec{
+			{
+				Name:    "list",
+				Summary: "List agents",
+				Flags: []FlagSpec{
+					{Name: "filter", TakesValue: true, Values: []string{"running", "stopped"}},
+				},
+			},
+			{
+				Name:    "create",
+				Summary: "Create an agent",
+				Flags: []FlagSpec{
+					{Name: "replace", Short: "r"},
+					{Name: "force", Short: "f"},
+					{Name: "id", TakesValue: true},
+					{Name: "name", TakesValue: true},
+					{Name: "description", TakesValue: true},
+					{Name: "image", TakesValue: true},
+					{Name: "profile", TakesValue: true},
+				},
+			},
+			{Name: "start", Summary: "Start an agent"},
+			{Name: "stop", Summary: "Stop an agent"},
+			{
+				Name:    "delete",
+				Summary: "Delete agents",
+				Flags: []FlagSpec{
+					{Name: "all", Short: "a"},
+					{Name: "force", Short: "f"},
+				},
+			},
+			{
+				Name:    "logs",
+				Summary: "Show agent logs",
+				Flags: []FlagSpec{
+					{Name: "follow", Short: "f"},
+					{Short: "n", TakesValue: true},
+				},
+			},
+		},
+	}
+}
+
+func modelSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "model",
+		Summary: "Manage model providers.",
+		Children: []CommandSpec{
+			{
+				Name:    "auth",
+				Summary: "Manage local model provider authentication",
+				Children: []CommandSpec{
+					{
+						Name:    "login",
+						Summary: "Login to codex or claude-code",
+						Flags:   []FlagSpec{{Name: "no-browser"}},
+						Values:  []string{"codex", "claude-code"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func userSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "user",
+		Summary: "Manage IM users.",
+		Children: []CommandSpec{
+			{Name: "list", Summary: "List users", Flags: channelFlags()},
+			{
+				Name:    "create",
+				Summary: "Create a user",
+				Flags: append(channelFlags(),
+					FlagSpec{Name: "id", TakesValue: true},
+					FlagSpec{Name: "name", TakesValue: true},
+					FlagSpec{Name: "handle", TakesValue: true},
+					FlagSpec{Name: "role", TakesValue: true},
+					FlagSpec{Name: "avatar", TakesValue: true},
+				),
+			},
+			{Name: "delete", Summary: "Remove a user", Flags: channelFlags()},
+		},
+	}
+}
+
+func botSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "bot",
+		Summary: "Manage bots.",
+		Children: []CommandSpec{
+			{
+				Name:    "list",
+				Summary: "List bots",
+				Flags:   append(channelFlags(), FlagSpec{Name: "role", TakesValue: true, Values: roleValues()}),
+			},
+			{
+				Name:    "create",
+				Summary: "Create a bot",
+				Flags: append(channelFlags(),
+					FlagSpec{Name: "id", TakesValue: true},
+					FlagSpec{Name: "name", TakesValue: true},
+					FlagSpec{Name: "description", TakesValue: true},
+					FlagSpec{Name: "role", TakesValue: true, Values: roleValues()},
+					FlagSpec{Name: "model-id", TakesValue: true},
+				),
+			},
+			{Name: "delete", Summary: "Delete a bot", Flags: channelFlags()},
+		},
+	}
+}
+
+func roomSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "room",
+		Summary: "Manage IM rooms.",
+		Children: []CommandSpec{
+			{Name: "list", Summary: "List rooms", Flags: channelFlags()},
+			{
+				Name:    "create",
+				Summary: "Create a room",
+				Flags: append(channelFlags(),
+					FlagSpec{Name: "title", TakesValue: true},
+					FlagSpec{Name: "description", TakesValue: true},
+					FlagSpec{Name: "creator-id", TakesValue: true},
+					FlagSpec{Name: "member-ids", TakesValue: true},
+					FlagSpec{Name: "locale", TakesValue: true},
+				),
+			},
+			{Name: "delete", Summary: "Delete a room", Flags: channelFlags()},
+		},
+	}
+}
+
+func memberSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "member",
+		Summary: "Manage IM room members.",
+		Children: []CommandSpec{
+			{
+				Name:    "list",
+				Summary: "List room members",
+				Flags:   append(channelFlags(), FlagSpec{Name: "room-id", TakesValue: true}),
+			},
+			{
+				Name:    "create",
+				Summary: "Add a member to a room",
+				Flags: append(channelFlags(),
+					FlagSpec{Name: "room-id", TakesValue: true},
+					FlagSpec{Name: "user-id", TakesValue: true},
+					FlagSpec{Name: "inviter-id", TakesValue: true},
+					FlagSpec{Name: "locale", TakesValue: true},
+				),
+			},
+		},
+	}
+}
+
+func messageSpec() CommandSpec {
+	return CommandSpec{
+		Name:    "message",
+		Summary: "Manage IM messages.",
+		Children: []CommandSpec{
+			{
+				Name:    "list",
+				Summary: "List messages",
+				Flags:   append(channelFlags(), FlagSpec{Name: "room-id", TakesValue: true}),
+			},
+			{
+				Name:    "create",
+				Summary: "Create a message",
+				Flags: append(channelFlags(),
+					FlagSpec{Name: "room-id", TakesValue: true},
+					FlagSpec{Name: "sender-id", TakesValue: true},
+					FlagSpec{Name: "content", TakesValue: true},
+					FlagSpec{Name: "mention-id", TakesValue: true},
+				),
+			},
+		},
+	}
+}
+
+func completionSpec() CommandSpec {
+	return CommandSpec{
+		Name:    CommandName,
+		Summary: "Generate shell completion scripts.",
+		Values:  supportedShells,
+	}
+}
+
+func channelFlags() []FlagSpec {
+	return []FlagSpec{{Name: "channel", TakesValue: true, Values: []string{"csgclaw", "feishu"}}}
+}
+
+func logLevelValues() []string {
+	return []string{"debug", "info", "warn", "error"}
+}
+
+func roleValues() []string {
+	return []string{"manager", "worker"}
+}
+
+func isSupportedShell(shell string) bool {
+	for _, supported := range supportedShells {
+		if shell == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func generateBash(w io.Writer, program string) error {
+	name := safeFunctionName(program)
+	_, err := fmt.Fprintf(w, `# bash completion for %[1]s
+
+_%[2]s_completion() {
+    COMPREPLY=()
+    local suggestion
+    while IFS= read -r suggestion; do
+        COMPREPLY+=("$suggestion")
+    done < <("${COMP_WORDS[0]}" __complete "${COMP_WORDS[@]}")
+}
+
+complete -F _%[2]s_completion %[1]s
+`, program, name)
+	return err
+}
+
+func generateZsh(w io.Writer, program string) error {
+	name := safeFunctionName(program)
+	_, err := fmt.Fprintf(w, `#compdef %[1]s
+# zsh completion for %[1]s
+
+_%[2]s_completion() {
+    local -a completions
+    local cmd="${words[1]}"
+    completions=("${(@f)$("${cmd}" __complete "${words[@]}")}")
+    compadd -- "${completions[@]}"
+}
+
+compdef _%[2]s_completion %[1]s
+`, program, name)
+	return err
+}
+
+func generateFish(w io.Writer, program string) error {
+	name := safeFunctionName(program)
+	_, err := fmt.Fprintf(w, `# fish completion for %[1]s
+
+function __%[2]s_completion
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+    if test -z "$current"; or test (count $tokens) -eq 0; or test "$tokens[-1]" != "$current"
+        set -a tokens "$current"
+    end
+    command %[1]s __complete $tokens
+end
+
+complete -c %[1]s -f -a "(__%[2]s_completion)"
+`, program, name)
+	return err
+}
+
+func stripProgram(args []string, program string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	if isProgramToken(args[0], program) {
+		return args[1:]
+	}
+	return args
+}
+
+func isProgramToken(token, program string) bool {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return false
+	}
+	return token == program || filepath.Base(token) == program
+}
+
+func resolveNode(root CommandSpec, args []string) (CommandSpec, *FlagSpec) {
+	node := root
+	var expecting *FlagSpec
+	for _, arg := range args {
+		if expecting != nil {
+			expecting = nil
+			continue
+		}
+		if isFlagToken(arg) {
+			flag, hasValue := findFlag(node, arg)
+			if flag != nil && flag.TakesValue && !hasValue {
+				expecting = flag
+			}
+			continue
+		}
+		if child, ok := childByName(node, arg); ok {
+			node = child
+		}
+	}
+	return node, expecting
+}
+
+func currentFlagValue(node CommandSpec, current string) (*FlagSpec, string, bool) {
+	if !isFlagToken(current) || !strings.Contains(current, "=") {
+		return nil, "", false
+	}
+	flag, _ := findFlag(node, current)
+	if flag == nil || !flag.TakesValue || len(flag.Values) == 0 {
+		return nil, "", false
+	}
+	_, value, _ := strings.Cut(current, "=")
+	return flag, value, true
+}
+
+func findFlag(node CommandSpec, token string) (*FlagSpec, bool) {
+	name, hasValue, ok := flagName(token)
+	if !ok {
+		return nil, false
+	}
+	flags := flagsForNode(node)
+	for i := range flags {
+		flag := &flags[i]
+		if flag.Name == name || flag.Short == name {
+			return flag, hasValue
+		}
+	}
+	return nil, hasValue
+}
+
+func flagName(token string) (string, bool, bool) {
+	if !isFlagToken(token) {
+		return "", false, false
+	}
+	name := strings.TrimLeft(token, "-")
+	if name == "" {
+		return "", false, false
+	}
+	name, _, hasValue := strings.Cut(name, "=")
+	return name, hasValue, true
+}
+
+func isFlagToken(token string) bool {
+	return strings.HasPrefix(token, "-") && token != "-"
+}
+
+func childByName(node CommandSpec, name string) (CommandSpec, bool) {
+	for _, child := range node.Children {
+		if child.Name == name {
+			return child, true
+		}
+	}
+	return CommandSpec{}, false
+}
+
+func rootSuggestions(root CommandSpec) []string {
+	return nodeSuggestions(root, true)
+}
+
+func nodeSuggestions(node CommandSpec, includeFlags bool) []string {
+	out := make([]string, 0, len(node.Children)+len(node.Values)+len(node.Flags)+2)
+	for _, child := range node.Children {
+		if child.Hidden {
+			continue
+		}
+		out = append(out, child.Name)
+	}
+	out = append(out, node.Values...)
+	if includeFlags {
+		out = append(out, formatFlags(flagsForNode(node))...)
+	}
+	return out
+}
+
+func flagsForNode(node CommandSpec) []FlagSpec {
+	flags := make([]FlagSpec, 0, len(node.Flags)+1)
+	flags = append(flags, node.Flags...)
+	flags = append(flags, FlagSpec{Name: "help", Short: "h"})
+	return flags
+}
+
+func formatFlags(flags []FlagSpec) []string {
+	out := make([]string, 0, len(flags)*2)
+	for _, flag := range flags {
+		if flag.Name != "" {
+			out = append(out, "--"+flag.Name)
+		}
+		if flag.Short != "" {
+			out = append(out, "-"+flag.Short)
+		}
+	}
+	return out
+}
+
+func formatFlagValues(flag *FlagSpec, prefix string) []string {
+	name := flag.Name
+	if name == "" {
+		name = flag.Short
+	}
+	marker := "--" + name + "="
+	if flag.Name == "" {
+		marker = "-" + name + "="
+	}
+	values := make([]string, 0, len(flag.Values))
+	for _, value := range flag.Values {
+		if strings.HasPrefix(value, prefix) {
+			values = append(values, marker+value)
+		}
+	}
+	return values
+}
+
+func filterSuggestions(suggestions []string, prefix string) []string {
+	seen := make(map[string]bool, len(suggestions))
+	out := make([]string, 0, len(suggestions))
+	for _, suggestion := range suggestions {
+		if seen[suggestion] || !strings.HasPrefix(suggestion, prefix) {
+			continue
+		}
+		seen[suggestion] = true
+		out = append(out, suggestion)
+	}
+	return out
+}
+
+func safeFunctionName(program string) string {
+	program = strings.TrimSpace(program)
+	if program == "" {
+		return "csgclaw"
+	}
+	var b strings.Builder
+	for _, r := range program {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	name := strings.Trim(b.String(), "_")
+	if name == "" {
+		return "csgclaw"
+	}
+	return name
+}

--- a/cli/completion/completion_test.go
+++ b/cli/completion/completion_test.go
@@ -1,0 +1,121 @@
+package completion
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompleteFullTopLevel(t *testing.T) {
+	got := Complete(FullSpec(), "csgclaw", []string{"csgclaw", ""})
+
+	assertContainsAll(t, got, "onboard", "serve", "agent", "model", "bot", "completion", "--endpoint", "--config", "-V")
+	assertContainsNone(t, got, "_serve", "__complete")
+}
+
+func TestCompleteLiteTopLevel(t *testing.T) {
+	got := Complete(LiteSpec(), "csgclaw-cli", []string{"csgclaw-cli", ""})
+
+	assertContainsAll(t, got, "bot", "room", "member", "message", "completion", "--endpoint", "-V")
+	assertContainsNone(t, got, "onboard", "serve", "agent", "model", "user", "_serve", "__complete")
+}
+
+func TestCompleteSubcommandsAndFlags(t *testing.T) {
+	got := Complete(FullSpec(), "csgclaw", []string{"csgclaw", "agent", ""})
+	assertContainsAll(t, got, "list", "create", "start", "stop", "delete", "logs", "--help")
+
+	got = Complete(FullSpec(), "csgclaw", []string{"csgclaw", "agent", "create", "--"})
+	assertContainsAll(t, got, "--replace", "--force", "--id", "--name", "--description", "--image", "--profile")
+}
+
+func TestCompleteFlagValues(t *testing.T) {
+	got := Complete(FullSpec(), "csgclaw", []string{"csgclaw", "bot", "list", "--channel", ""})
+	assertEqual(t, got, []string{"csgclaw", "feishu"})
+
+	got = Complete(FullSpec(), "csgclaw", []string{"csgclaw", "bot", "list", "--channel=f"})
+	assertEqual(t, got, []string{"--channel=feishu"})
+
+	got = Complete(FullSpec(), "csgclaw", []string{"csgclaw", "model", "auth", "login", "c"})
+	assertEqual(t, got, []string{"codex", "claude-code"})
+}
+
+func TestGenerateScripts(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+		shell   string
+		want    []string
+	}{
+		{
+			name:    "bash",
+			program: "csgclaw",
+			shell:   "bash",
+			want:    []string{`"${COMP_WORDS[0]}" __complete`, "complete -F _csgclaw_completion csgclaw"},
+		},
+		{
+			name:    "zsh",
+			program: "csgclaw-cli",
+			shell:   "zsh",
+			want:    []string{"#compdef csgclaw-cli", "compdef _csgclaw_cli_completion csgclaw-cli"},
+		},
+		{
+			name:    "fish",
+			program: "csgclaw-cli",
+			shell:   "fish",
+			want:    []string{"command csgclaw-cli __complete", "complete -c csgclaw-cli"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := Generate(&out, tt.program, tt.shell); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("script = %q, want substring %q", out.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func assertContainsAll(t *testing.T, got []string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		found := false
+		for _, item := range got {
+			if item == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("suggestions = %#v, want %q", got, want)
+		}
+	}
+}
+
+func assertContainsNone(t *testing.T, got []string, notWants ...string) {
+	t.Helper()
+	for _, notWant := range notWants {
+		for _, item := range got {
+			if item == notWant {
+				t.Fatalf("suggestions = %#v, should not include %q", got, notWant)
+			}
+		}
+	}
+}
+
+func assertEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("suggestions = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("suggestions = %#v, want %#v", got, want)
+		}
+	}
+}

--- a/cli/csgclawcli/app.go
+++ b/cli/csgclawcli/app.go
@@ -11,6 +11,7 @@ import (
 
 	"csgclaw/cli/bot"
 	"csgclaw/cli/command"
+	completioncmd "csgclaw/cli/completion"
 	"csgclaw/cli/member"
 	"csgclaw/cli/message"
 	"csgclaw/cli/room"
@@ -68,6 +69,8 @@ func (a *App) registerDefaultCommands() {
 		room.NewCmd(),
 		member.NewCmd(),
 		message.NewCmd(),
+		completioncmd.NewCmd("csgclaw-cli", completioncmd.LiteSpec()),
+		completioncmd.NewCompleteCmd("csgclaw-cli", completioncmd.LiteSpec()),
 	)
 }
 

--- a/cli/csgclawcli/app_test.go
+++ b/cli/csgclawcli/app_test.go
@@ -34,6 +34,7 @@ func TestExecuteExposesOnlyLiteCommands(t *testing.T) {
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
 		"message  Manage IM messages.",
+		"completion Generate shell completion scripts.",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("usage = %q, want substring %q", got, want)
@@ -42,6 +43,48 @@ func TestExecuteExposesOnlyLiteCommands(t *testing.T) {
 	for _, notWant := range []string{"  agent", "  serve", "  onboard", "  user"} {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("usage = %q, should not include %q", got, notWant)
+		}
+	}
+}
+
+func TestExecuteCompletionFish(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &App{
+		stdout:     &stdout,
+		stderr:     &stderr,
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil }),
+	}
+
+	if err := app.Execute(context.Background(), []string{"completion", "fish"}); err != nil {
+		t.Fatalf("Execute() error = %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"command csgclaw-cli __complete", "complete -c csgclaw-cli"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want substring %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestExecuteHiddenCompleteUsesLiteCommandSet(t *testing.T) {
+	var stdout bytes.Buffer
+	app := &App{
+		stdout:     &stdout,
+		stderr:     &bytes.Buffer{},
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil }),
+	}
+
+	if err := app.Execute(context.Background(), []string{"__complete", "csgclaw-cli", ""}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{"bot\n", "room\n", "member\n", "message\n", "completion\n"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want substring %q", got, want)
+		}
+	}
+	for _, notWant := range []string{"agent\n", "serve\n", "onboard\n", "user\n", "__complete\n"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("stdout = %q, should not include %q", got, notWant)
 		}
 	}
 }

--- a/cli/model/model.go
+++ b/cli/model/model.go
@@ -1,4 +1,4 @@
-package auth
+package model
 
 import (
 	"bufio"

--- a/cli/model/model_test.go
+++ b/cli/model/model_test.go
@@ -1,4 +1,4 @@
-package auth
+package model
 
 import (
 	"bytes"

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -379,14 +379,6 @@ func startServer(ctx context.Context, cfg config.Config, svc *agent.Service, bot
 		defer cancel()
 		_ = ShutdownCLIProxy(shutdownCtx)
 	}()
-	if err := EnsureBootstrapManager(ctx, svc, false); err != nil {
-		return err
-	}
-	go func() {
-		if err := StartConfiguredAgents(ctx, svc); err != nil {
-			slog.Warn("some configured agents failed to start", "error", err)
-		}
-	}()
 	if botSvc != nil {
 		botSvc.SetDependencies(svc, imSvc, feishuSvc)
 	}
@@ -406,7 +398,31 @@ func startServer(ctx context.Context, cfg config.Config, svc *agent.Service, bot
 		AccessToken: cfg.Server.AccessToken,
 		NoAuth:      cfg.Server.NoAuth,
 		Context:     ctx,
+		OnReady: func() {
+			recreateManager := shouldRecreateBootstrapManagerOnServeStart(svc)
+			if recreateManager {
+				if _, err := svc.Recreate(ctx, agent.ManagerUserID); err != nil {
+					slog.Warn("bootstrap manager failed to reconnect", "error", err)
+				}
+			} else if err := EnsureBootstrapManager(ctx, svc, false); err != nil {
+				slog.Warn("bootstrap manager failed to start", "error", err)
+			}
+			if err := StartConfiguredAgents(ctx, svc); err != nil {
+				slog.Warn("some configured agents failed to start", "error", err)
+			}
+		},
 	})
+}
+
+func shouldRecreateBootstrapManagerOnServeStart(svc *agent.Service) bool {
+	if svc == nil {
+		return false
+	}
+	manager, ok := svc.Agent(agent.ManagerUserID)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(manager.Status), "running")
 }
 
 func preflightDefaultModelProvider(ctx context.Context, cfg config.Config) error {

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -399,12 +399,7 @@ func startServer(ctx context.Context, cfg config.Config, svc *agent.Service, bot
 		NoAuth:      cfg.Server.NoAuth,
 		Context:     ctx,
 		OnReady: func() {
-			recreateManager := shouldRecreateBootstrapManagerOnServeStart(svc)
-			if recreateManager {
-				if _, err := svc.Recreate(ctx, agent.ManagerUserID); err != nil {
-					slog.Warn("bootstrap manager failed to reconnect", "error", err)
-				}
-			} else if err := EnsureBootstrapManager(ctx, svc, false); err != nil {
+			if err := EnsureBootstrapManager(ctx, svc, false); err != nil {
 				slog.Warn("bootstrap manager failed to start", "error", err)
 			}
 			if err := StartConfiguredAgents(ctx, svc); err != nil {
@@ -412,17 +407,6 @@ func startServer(ctx context.Context, cfg config.Config, svc *agent.Service, bot
 			}
 		},
 	})
-}
-
-func shouldRecreateBootstrapManagerOnServeStart(svc *agent.Service) bool {
-	if svc == nil {
-		return false
-	}
-	manager, ok := svc.Agent(agent.ManagerUserID)
-	if !ok {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(manager.Status), "running")
 }
 
 func preflightDefaultModelProvider(ctx context.Context, cfg config.Config) error {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -144,9 +144,6 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 	}
 	RunServer = func(opts server.Options) error {
 		called = true
-		if !bootstrapped {
-			return fmt.Errorf("RunServer called before EnsureBootstrapManager")
-		}
 		if opts.Context != ctx {
 			return fmt.Errorf("Context = %v, want %v", opts.Context, ctx)
 		}
@@ -156,6 +153,10 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 		if !opts.NoAuth {
 			return fmt.Errorf("NoAuth = false, want true")
 		}
+		if opts.OnReady == nil {
+			return fmt.Errorf("OnReady is nil")
+		}
+		go opts.OnReady()
 		return nil
 	}
 	releasedStart := false
@@ -297,6 +298,36 @@ func TestConfigureServeLoggerSetsDebugLevel(t *testing.T) {
 
 	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		t.Fatal("default logger debug level is disabled, want enabled")
+	}
+}
+
+func TestServeForegroundStartsConfiguredAgentsWhenBootstrapFails(t *testing.T) {
+	restore := stubServeDependencies(t)
+	defer restore()
+
+	started := make(chan struct{})
+	EnsureBootstrapManager = func(context.Context, *agent.Service, bool) error {
+		return fmt.Errorf("runtime lock")
+	}
+	StartConfiguredAgents = func(context.Context, *agent.Service) error {
+		close(started)
+		return nil
+	}
+	RunServer = func(opts server.Options) error {
+		if opts.OnReady == nil {
+			return fmt.Errorf("OnReady is nil")
+		}
+		opts.OnReady()
+		return nil
+	}
+
+	if err := serveForeground(context.Background(), testContext(), config.Config{Server: config.ServerConfig{ListenAddr: "127.0.0.1:18080"}}, "json"); err != nil {
+		t.Fatalf("serveForeground() error = %v", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("StartConfiguredAgents was not called after bootstrap failure")
 	}
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状
   "provider": "claude_code",
   "authenticated": false,
   "login_required": true,
-  "message": "Auth required. Run csgclaw auth login claude-code or connect this provider in the CSGClaw UI.",
+  "message": "Auth required. Run csgclaw model auth login claude-code or connect this provider in the CSGClaw UI.",
   "supports_login": true,
   "supports_keychain": true
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@
 - 内容类型：除 SSE 接口外，请求和响应均为 `application/json`
 - 时间格式：使用 RFC3339 / ISO8601，例如 `2026-03-28T12:00:00Z`
 - 认证：大部分接口当前不需要认证；`/api/bots/*` 和 `GET /api/v1/channels/feishu/bots/{id}/events` 需要 `Authorization: Bearer <token>`
-- 错误返回：失败时通常返回纯文本错误信息，不是统一 JSON 结构
+- 错误返回：失败时通常返回纯文本错误信息；LLM 鉴权缺失等少量场景会返回 JSON error payload
 
 ## 1. 基础接口
 
@@ -21,7 +21,55 @@
 ok
 ```
 
-## 2. Agent 接口
+## 2. CLIProxy Auth 接口
+
+Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状态可通过以下接口查询和触发登录。
+
+### `GET /api/v1/cliproxy/auth/status?provider=codex|claude_code`
+
+查询本地鉴权状态。服务端会在安全可读的情况下自动导入现有凭据：Codex 来自 `~/.codex/auth.json`，Claude Code 在 macOS 上来自 Keychain。
+
+响应示例：
+
+```json
+{
+  "provider": "codex",
+  "authenticated": true,
+  "login_required": false,
+  "source": "codex-home",
+  "supports_login": true
+}
+```
+
+未登录时：
+
+```json
+{
+  "provider": "claude_code",
+  "authenticated": false,
+  "login_required": true,
+  "message": "Auth required. Run csgclaw auth login claude-code or connect this provider in the CSGClaw UI.",
+  "supports_login": true,
+  "supports_keychain": true
+}
+```
+
+### `POST /api/v1/cliproxy/auth/login`
+
+触发 Provider 登录。Claude Code 会先尝试 macOS Keychain 导入，再进入 OAuth。
+
+请求体：
+
+```json
+{
+  "provider": "claude_code",
+  "no_browser": true
+}
+```
+
+响应同 status 接口。
+
+## 3. Agent 接口
 
 统一后的 `worker` 对象字段如下。除 PicoClaw Bot 兼容接口外，`bot / worker / agent` 在 API 和内部结构里都按这一套字段表达：
 
@@ -111,7 +159,7 @@ ok
 - 若 IM 服务可用，会自动创建对应 IM 用户，并创建 `Admin & <Worker>` 私聊
 - 校验失败通常返回 `400 Bad Request`
 
-## 3. IM 接口
+## 4. IM 接口
 
 ### `GET /api/v1/im/bootstrap`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ Top-level commands:
 - `serve`
 - `stop`
 - `agent`
-- `auth`
+- `model`
 - `user`
 - `bot`
 - `room`
@@ -166,14 +166,14 @@ Behavior:
 - Sends `SIGTERM` to the PID stored in the PID file.
 - If the process is already gone, it removes the stale PID file and reports that state.
 
-### `csgclaw auth`
+### `csgclaw model auth`
 
-Manages local Codex and Claude Code authentication for the embedded CLIProxyAPI.
+Manages local Codex and Claude Code authentication for model providers through the embedded CLIProxyAPI.
 
 Usage:
 
 ```bash
-csgclaw auth login <provider> [flags]
+csgclaw model auth login <provider> [flags]
 ```
 
 Providers:
@@ -190,13 +190,13 @@ Behavior:
 - `codex` first reuses `~/.codex/auth.json` when available, then starts OAuth if needed.
 - `claude-code` first probes macOS Keychain when available, then starts OAuth if needed.
 - Auth is stored in the CLIProxy auth directory, defaulting to `~/.cli-proxy-api`.
-- No top-level aliases such as `csgclaw codex-login` or `csgclaw claude-login` are registered.
+- Model provider auth is scoped under `csgclaw model auth`, not the server's own API authentication.
 
 Examples:
 
 ```bash
-csgclaw auth login codex
-csgclaw auth login claude-code --no-browser
+csgclaw model auth login codex
+csgclaw model auth login claude-code --no-browser
 ```
 
 ### `csgclaw agent`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,6 +77,7 @@ Top-level commands:
 - `serve`
 - `stop`
 - `agent`
+- `auth`
 - `user`
 - `bot`
 - `room`
@@ -164,6 +165,39 @@ Behavior:
 
 - Sends `SIGTERM` to the PID stored in the PID file.
 - If the process is already gone, it removes the stale PID file and reports that state.
+
+### `csgclaw auth`
+
+Manages local Codex and Claude Code authentication for the embedded CLIProxyAPI.
+
+Usage:
+
+```bash
+csgclaw auth login <provider> [flags]
+```
+
+Providers:
+
+- `codex`
+- `claude-code`
+
+Flags:
+
+- `--no-browser`: print the OAuth URL instead of opening a browser.
+
+Behavior:
+
+- `codex` first reuses `~/.codex/auth.json` when available, then starts OAuth if needed.
+- `claude-code` first probes macOS Keychain when available, then starts OAuth if needed.
+- Auth is stored in the CLIProxy auth directory, defaulting to `~/.cli-proxy-api`.
+- No top-level aliases such as `csgclaw codex-login` or `csgclaw claude-login` are registered.
+
+Examples:
+
+```bash
+csgclaw auth login codex
+csgclaw auth login claude-code --no-browser
+```
 
 ### `csgclaw agent`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,19 @@ Top-level commands:
 - `room`
 - `member`
 - `message`
+- `completion`
+
+### Shell completion
+
+Both CLIs can generate shell completion scripts for `bash`, `zsh`, and `fish`.
+
+Examples:
+
+```bash
+csgclaw completion bash
+csgclaw completion zsh
+csgclaw completion fish
+```
 
 ### `csgclaw onboard`
 
@@ -570,6 +583,17 @@ Top-level commands:
 - `room`
 - `member`
 - `message`
+- `completion`
+
+### Shell completion
+
+Examples:
+
+```bash
+csgclaw-cli completion bash
+csgclaw-cli completion zsh
+csgclaw-cli completion fish
+```
 
 ### Command groups
 

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -83,6 +83,19 @@ csgclaw [global-flags] <command> [args]
 - `room`
 - `member`
 - `message`
+- `completion`
+
+### Shell 补全
+
+两个 CLI 都可以生成 `bash`、`zsh` 和 `fish` 的 shell 补全脚本。
+
+示例：
+
+```bash
+csgclaw completion bash
+csgclaw completion zsh
+csgclaw completion fish
+```
 
 ### `csgclaw onboard`
 
@@ -578,6 +591,17 @@ csgclaw-cli [global-flags] <command> [args]
 - `room`
 - `member`
 - `message`
+- `completion`
+
+### Shell 补全
+
+示例：
+
+```bash
+csgclaw-cli completion bash
+csgclaw-cli completion zsh
+csgclaw-cli completion fish
+```
 
 ### 命令组
 

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -77,6 +77,7 @@ csgclaw [global-flags] <command> [args]
 - `serve`
 - `stop`
 - `agent`
+- `auth`
 - `user`
 - `bot`
 - `room`
@@ -172,6 +173,39 @@ csgclaw stop [flags]
 
 - 从 PID 文件读取进程号并发送 `SIGTERM`。
 - 如果进程已经不存在，会删除失效的 PID 文件并返回对应状态。
+
+### `csgclaw auth`
+
+管理嵌入式 CLIProxyAPI 使用的本地 Codex 和 Claude Code 鉴权。
+
+用法：
+
+```bash
+csgclaw auth login <provider> [flags]
+```
+
+Provider：
+
+- `codex`
+- `claude-code`
+
+参数：
+
+- `--no-browser`：打印 OAuth URL，而不是自动打开浏览器。
+
+行为说明：
+
+- `codex` 会优先复用 `~/.codex/auth.json`，没有可用 token 时再启动 OAuth。
+- `claude-code` 会在 macOS 上优先探测 Keychain，没有可用 token 时再启动 OAuth。
+- 鉴权文件会写入 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
+- 不注册 `csgclaw codex-login` 或 `csgclaw claude-login` 这类顶层别名。
+
+示例：
+
+```bash
+csgclaw auth login codex
+csgclaw auth login claude-code --no-browser
+```
 
 ### `csgclaw agent`
 

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -77,7 +77,7 @@ csgclaw [global-flags] <command> [args]
 - `serve`
 - `stop`
 - `agent`
-- `auth`
+- `model`
 - `user`
 - `bot`
 - `room`
@@ -174,14 +174,14 @@ csgclaw stop [flags]
 - 从 PID 文件读取进程号并发送 `SIGTERM`。
 - 如果进程已经不存在，会删除失效的 PID 文件并返回对应状态。
 
-### `csgclaw auth`
+### `csgclaw model auth`
 
-管理嵌入式 CLIProxyAPI 使用的本地 Codex 和 Claude Code 鉴权。
+管理模型 Provider 通过嵌入式 CLIProxyAPI 使用的本地 Codex 和 Claude Code 鉴权。
 
 用法：
 
 ```bash
-csgclaw auth login <provider> [flags]
+csgclaw model auth login <provider> [flags]
 ```
 
 Provider：
@@ -198,13 +198,13 @@ Provider：
 - `codex` 会优先复用 `~/.codex/auth.json`，没有可用 token 时再启动 OAuth。
 - `claude-code` 会在 macOS 上优先探测 Keychain，没有可用 token 时再启动 OAuth。
 - 鉴权文件会写入 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
-- 不注册 `csgclaw codex-login` 或 `csgclaw claude-login` 这类顶层别名。
+- 模型 Provider 鉴权放在 `csgclaw model auth` 下，不和服务端自身 API 鉴权混在一起。
 
 示例：
 
 ```bash
-csgclaw auth login codex
-csgclaw auth login claude-code --no-browser
+csgclaw model auth login codex
+csgclaw model auth login claude-code --no-browser
 ```
 
 ### `csgclaw agent`

--- a/docs/config.md
+++ b/docs/config.md
@@ -102,6 +102,16 @@ Codex and Claude Code profiles are configured in agent state through the Web UI.
 
 Leave `[bootstrap].manager_image_override` empty to use the built-in default manager image. Set it only when you need to override that default.
 
+Auth is also managed locally:
+
+- Codex auth is imported from `~/.codex/auth.json` when available.
+- Claude Code auth is probed from macOS Keychain when available, then falls back to OAuth.
+- Manual login commands are `csgclaw auth login codex` and `csgclaw auth login claude-code`.
+- `CSGCLAW_CLIPROXY_AUTH_DIR` overrides the CLIProxy auth directory; the default is `~/.cli-proxy-api`.
+- `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` disables automatic import/probing.
+- `CSGCLAW_CLIPROXY_NO_BROWSER=1` prints OAuth URLs instead of opening a browser.
+- `CSGCLAW_CLIPROXY_DISABLE_KEYCHAIN=1` disables Claude Keychain probing.
+
 ## Sandbox Providers
 
 CSGClaw runs Workers through the configured sandbox provider. The default build shape uses `boxlite-cli`, which runs BoxLite through the external CLI process. SDK-enabled builds still default to `boxlite-sdk`, which uses the vendored BoxLite Go SDK.

--- a/docs/config.md
+++ b/docs/config.md
@@ -106,7 +106,7 @@ Auth is also managed locally:
 
 - Codex auth is imported from `~/.codex/auth.json` when available.
 - Claude Code auth is probed from macOS Keychain when available, then falls back to OAuth.
-- Manual login commands are `csgclaw auth login codex` and `csgclaw auth login claude-code`.
+- Manual login commands are `csgclaw model auth login codex` and `csgclaw model auth login claude-code`.
 - `CSGCLAW_CLIPROXY_AUTH_DIR` overrides the CLIProxy auth directory; the default is `~/.cli-proxy-api`.
 - `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` disables automatic import/probing.
 - `CSGCLAW_CLIPROXY_NO_BROWSER=1` prints OAuth URLs instead of opening a browser.

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -106,7 +106,7 @@ Codex 和 Claude Code Profile 通过 Web UI 写入 agent state。CSGClaw 在 `se
 
 - Codex 会优先从 `~/.codex/auth.json` 自动导入。
 - Claude Code 会在 macOS 上优先探测 Keychain，未找到时再走 OAuth。
-- 手动登录命令是 `csgclaw auth login codex` 和 `csgclaw auth login claude-code`。
+- 手动登录命令是 `csgclaw model auth login codex` 和 `csgclaw model auth login claude-code`。
 - `CSGCLAW_CLIPROXY_AUTH_DIR` 可覆盖 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
 - `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` 可关闭自动导入和探测。
 - `CSGCLAW_CLIPROXY_NO_BROWSER=1` 会打印 OAuth URL，而不是自动打开浏览器。

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -102,6 +102,16 @@ Codex 和 Claude Code Profile 通过 Web UI 写入 agent state。CSGClaw 在 `se
 
 `[bootstrap].manager_image_override` 留空时会使用代码内置的默认 manager image；只有在需要覆盖默认值时才设置它。
 
+本地鉴权由 CSGClaw 统一管理：
+
+- Codex 会优先从 `~/.codex/auth.json` 自动导入。
+- Claude Code 会在 macOS 上优先探测 Keychain，未找到时再走 OAuth。
+- 手动登录命令是 `csgclaw auth login codex` 和 `csgclaw auth login claude-code`。
+- `CSGCLAW_CLIPROXY_AUTH_DIR` 可覆盖 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
+- `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` 可关闭自动导入和探测。
+- `CSGCLAW_CLIPROXY_NO_BROWSER=1` 会打印 OAuth URL，而不是自动打开浏览器。
+- `CSGCLAW_CLIPROXY_DISABLE_KEYCHAIN=1` 可关闭 Claude Keychain 探测。
+
 ## Sandbox Provider
 
 CSGClaw 通过配置的 sandbox provider 隔离 Worker 执行环境。默认构建形态使用 `boxlite-cli`，通过外部 CLI 进程运行 BoxLite；启用 SDK 的构建形态仍默认使用 `boxlite-sdk`，对应仓库内 vendored BoxLite Go SDK。

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require github.com/RussellLuo/boxlite/sdks/go v0.7.6
 require github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 
 require (
+	github.com/gin-gonic/gin v1.10.1
 	github.com/router-for-me/CLIProxyAPI/v6 v6.9.40
 	golang.org/x/term v0.37.0
 )
@@ -22,7 +23,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/gin-gonic/gin v1.10.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -53,7 +53,10 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 	modelID := profile.ModelID
 	managerBaseURL := resolveManagerBaseURL(s.server)
 	llmBaseURL := llmBridgeBaseURL(managerBaseURL, botID)
-	hostConfigRoot, err := ensureAgentPicoClawConfig(name, botID, s.server, config.ModelConfig{ModelID: modelID})
+	if _, err := ensureAgentPicoClawConfig(name, botID, s.server, config.ModelConfig{ModelID: modelID}); err != nil {
+		return sandbox.CreateSpec{}, err
+	}
+	hostWorkspaceRoot, err := ensureAgentWorkspace(name, workspaceTemplateForAgent(name, botID))
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
@@ -70,18 +73,11 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 		Cmd: []string{
 			"/bin/sh",
 			"-c",
-			"/usr/local/bin/picoclaw gateway -d 1>" + boxGatewayLogPath + " 2>/dev/null",
+			gatewayRunCommand(),
 		},
 	}
 
-	if _, err := ensureAgentWorkspace(name, workspaceTemplateForAgent(name, botID)); err != nil {
-		return sandbox.CreateSpec{}, err
-	}
-	projectsRoot, err := ensureAgentProjectsRoot()
-	if err != nil {
-		return sandbox.CreateSpec{}, err
-	}
-	for _, mount := range gatewayVolumeMounts(hostConfigRoot, projectsRoot) {
+	for _, mount := range gatewayVolumeMounts(hostWorkspaceRoot) {
 		spec.Mounts = append(spec.Mounts, sandbox.Mount{
 			HostPath:  mount.hostPath,
 			GuestPath: mount.guestPath,
@@ -117,17 +113,26 @@ type gatewayVolumeMount struct {
 	guestPath string
 }
 
-func gatewayVolumeMounts(hostConfigRoot, projectsRoot string) []gatewayVolumeMount {
+func gatewayVolumeMounts(hostWorkspaceRoot string) []gatewayVolumeMount {
 	return []gatewayVolumeMount{
 		{
-			hostPath:  hostConfigRoot,
-			guestPath: boxPicoClawDir,
-		},
-		{
-			hostPath:  projectsRoot,
-			guestPath: boxProjectsDir,
+			hostPath:  hostWorkspaceRoot,
+			guestPath: boxWorkspaceDir,
 		},
 	}
+}
+
+func gatewayRunCommand() string {
+	configPath := boxWorkspaceConfigPath(hostPicoClawConfig)
+	securityPath := boxWorkspaceConfigPath(hostPicoClawSecurity)
+	return "mkdir -p " + boxPicoClawDir +
+		" && cp " + configPath + " " + filepath.Join(boxPicoClawDir, hostPicoClawConfig) +
+		" && cp " + securityPath + " " + filepath.Join(boxPicoClawDir, hostPicoClawSecurity) +
+		" && /usr/local/bin/picoclaw gateway -d 1>" + boxGatewayLogPath + " 2>/dev/null"
+}
+
+func boxWorkspaceConfigPath(name string) string {
+	return filepath.Join(boxWorkspaceDir, filepath.FromSlash(hostPicoClawStateDir), name)
 }
 
 func gatewayStartCommand(debug bool) ([]string, []string) {

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -70,19 +70,18 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 		Cmd: []string{
 			"/bin/sh",
 			"-c",
-			"/usr/local/bin/picoclaw gateway -d 1>~/.picoclaw/gateway.log 2>/dev/null",
+			"/usr/local/bin/picoclaw gateway -d 1>" + boxGatewayLogPath + " 2>/dev/null",
 		},
 	}
 
-	hostWorkspaceRoot, err := ensureAgentWorkspace(name, workspaceTemplateForAgent(name, botID))
-	if err != nil {
+	if _, err := ensureAgentWorkspace(name, workspaceTemplateForAgent(name, botID)); err != nil {
 		return sandbox.CreateSpec{}, err
 	}
 	projectsRoot, err := ensureAgentProjectsRoot()
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
-	for _, mount := range gatewayVolumeMounts(hostConfigRoot, hostWorkspaceRoot, projectsRoot) {
+	for _, mount := range gatewayVolumeMounts(hostConfigRoot, projectsRoot) {
 		spec.Mounts = append(spec.Mounts, sandbox.Mount{
 			HostPath:  mount.hostPath,
 			GuestPath: mount.guestPath,
@@ -118,15 +117,11 @@ type gatewayVolumeMount struct {
 	guestPath string
 }
 
-func gatewayVolumeMounts(hostConfigRoot, hostWorkspaceRoot, projectsRoot string) []gatewayVolumeMount {
+func gatewayVolumeMounts(hostConfigRoot, projectsRoot string) []gatewayVolumeMount {
 	return []gatewayVolumeMount{
 		{
 			hostPath:  hostConfigRoot,
 			guestPath: boxPicoClawDir,
-		},
-		{
-			hostPath:  hostWorkspaceRoot,
-			guestPath: boxWorkspaceDir,
 		},
 		{
 			hostPath:  projectsRoot,

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -53,6 +53,10 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 	modelID := profile.ModelID
 	managerBaseURL := resolveManagerBaseURL(s.server)
 	llmBaseURL := llmBridgeBaseURL(managerBaseURL, botID)
+	hostConfigRoot, err := ensureAgentPicoClawConfig(name, botID, s.server, config.ModelConfig{ModelID: modelID})
+	if err != nil {
+		return sandbox.CreateSpec{}, err
+	}
 	envVars := picoclawBoxEnvVars(managerBaseURL, s.server.AccessToken, botID, llmBaseURL, modelID)
 	addFeishuBoxEnvVars(envVars, botID, s.channels)
 	addProfileEnvVars(envVars, profile.Env)
@@ -78,7 +82,7 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
-	for _, mount := range gatewayVolumeMounts(hostWorkspaceRoot, projectsRoot) {
+	for _, mount := range gatewayVolumeMounts(hostConfigRoot, hostWorkspaceRoot, projectsRoot) {
 		spec.Mounts = append(spec.Mounts, sandbox.Mount{
 			HostPath:  mount.hostPath,
 			GuestPath: mount.guestPath,
@@ -114,8 +118,12 @@ type gatewayVolumeMount struct {
 	guestPath string
 }
 
-func gatewayVolumeMounts(hostWorkspaceRoot, projectsRoot string) []gatewayVolumeMount {
+func gatewayVolumeMounts(hostConfigRoot, hostWorkspaceRoot, projectsRoot string) []gatewayVolumeMount {
 	return []gatewayVolumeMount{
+		{
+			hostPath:  hostConfigRoot,
+			guestPath: boxPicoClawDir,
+		},
 		{
 			hostPath:  hostWorkspaceRoot,
 			guestPath: boxWorkspaceDir,

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -41,17 +41,7 @@ func (s *Service) forceRemoveBox(ctx context.Context, rt sandbox.Runtime, idOrNa
 	if rt == nil {
 		return fmt.Errorf("invalid sandbox runtime")
 	}
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		err = rt.Remove(ctx, idOrName, sandbox.RemoveOptions{Force: true})
-		if err == nil || sandbox.IsNotFound(err) || !isSandboxRuntimeLockError(err) || attempt == sandboxRuntimeLockRetryAttempts-1 {
-			return err
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return err
-		}
-	}
-	return err
+	return rt.Remove(ctx, idOrName, sandbox.RemoveOptions{Force: true})
 }
 
 func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProfile) (sandbox.CreateSpec, error) {

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -60,6 +60,10 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
+	projectsRoot, err := ensureAgentProjectsRoot()
+	if err != nil {
+		return sandbox.CreateSpec{}, err
+	}
 	envVars := picoclawBoxEnvVars(managerBaseURL, s.server.AccessToken, botID, llmBaseURL, modelID)
 	addFeishuBoxEnvVars(envVars, botID, s.channels)
 	addProfileEnvVars(envVars, profile.Env)
@@ -77,7 +81,7 @@ func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProf
 		},
 	}
 
-	for _, mount := range gatewayVolumeMounts(hostWorkspaceRoot) {
+	for _, mount := range gatewayVolumeMounts(hostWorkspaceRoot, projectsRoot) {
 		spec.Mounts = append(spec.Mounts, sandbox.Mount{
 			HostPath:  mount.hostPath,
 			GuestPath: mount.guestPath,
@@ -113,11 +117,15 @@ type gatewayVolumeMount struct {
 	guestPath string
 }
 
-func gatewayVolumeMounts(hostWorkspaceRoot string) []gatewayVolumeMount {
+func gatewayVolumeMounts(hostWorkspaceRoot, projectsRoot string) []gatewayVolumeMount {
 	return []gatewayVolumeMount{
 		{
 			hostPath:  hostWorkspaceRoot,
 			guestPath: boxWorkspaceDir,
+		},
+		{
+			hostPath:  projectsRoot,
+			guestPath: boxProjectsDir,
 		},
 	}
 }

--- a/internal/agent/box.go
+++ b/internal/agent/box.go
@@ -22,11 +22,11 @@ func (s *Service) createGatewayBox(ctx context.Context, rt sandbox.Runtime, imag
 	if err != nil {
 		return nil, sandbox.Info{}, err
 	}
-	box, err := rt.Create(ctx, spec)
+	box, err := s.createBox(ctx, rt, spec)
 	if err != nil {
 		return nil, sandbox.Info{}, fmt.Errorf("create gateway box: %w", err)
 	}
-	info, err := box.Info(ctx)
+	info, err := s.boxInfo(ctx, box)
 	if err != nil {
 		_ = s.closeBox(box)
 		return nil, sandbox.Info{}, fmt.Errorf("read gateway box info: %w", err)
@@ -41,7 +41,17 @@ func (s *Service) forceRemoveBox(ctx context.Context, rt sandbox.Runtime, idOrNa
 	if rt == nil {
 		return fmt.Errorf("invalid sandbox runtime")
 	}
-	return rt.Remove(ctx, idOrName, sandbox.RemoveOptions{Force: true})
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		err = rt.Remove(ctx, idOrName, sandbox.RemoveOptions{Force: true})
+		if err == nil || sandbox.IsNotFound(err) || !isSandboxRuntimeLockError(err) || attempt == sandboxRuntimeLockRetryAttempts-1 {
+			return err
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return err
+		}
+	}
+	return err
 }
 
 func (s *Service) gatewayCreateSpec(image, name, botID string, profile AgentProfile) (sandbox.CreateSpec, error) {

--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -25,13 +25,6 @@ func ensureManagerPicoClawConfig(server config.ServerConfig, model config.ModelC
 }
 
 func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConfig, model config.ModelConfig) (string, error) {
-	workspaceRoot, err := agentWorkspaceRoot(agentName)
-	if err != nil {
-		return "", err
-	}
-	if err := migrateNestedPicoClawWorkspace(agentName, workspaceRoot); err != nil {
-		return "", err
-	}
 	hostRoot, err := agentWorkspacePicoClawConfigRoot(agentName)
 	if err != nil {
 		return "", err

--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -25,12 +25,19 @@ func ensureManagerPicoClawConfig(server config.ServerConfig, model config.ModelC
 }
 
 func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConfig, model config.ModelConfig) (string, error) {
-	hostRoot, err := agentPicoClawRoot(agentName)
+	workspaceRoot, err := agentWorkspaceRoot(agentName)
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(filepath.Join(hostRoot, hostPicoClawLogs), 0o755); err != nil {
-		return "", fmt.Errorf("create manager picoclaw logs dir: %w", err)
+	if err := migrateNestedPicoClawWorkspace(agentName, workspaceRoot); err != nil {
+		return "", err
+	}
+	hostRoot, err := agentWorkspacePicoClawConfigRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
+		return "", fmt.Errorf("create picoclaw config dir: %w", err)
 	}
 
 	data, err := renderAgentPicoClawConfig(botID, server, model)
@@ -42,7 +49,7 @@ func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConf
 		return "", fmt.Errorf("write manager picoclaw config: %w", err)
 	}
 	securityData := renderManagerSecurityConfig(server, model)
-	securityPath := filepath.Join(hostRoot, ".security.yml")
+	securityPath := filepath.Join(hostRoot, hostPicoClawSecurity)
 	if err := os.WriteFile(securityPath, []byte(securityData), 0o600); err != nil {
 		return "", fmt.Errorf("write manager security config: %w", err)
 	}
@@ -51,6 +58,14 @@ func ensureAgentPicoClawConfig(agentName, botID string, server config.ServerConf
 
 func managerPicoClawRoot() (string, error) {
 	return agentPicoClawRoot(ManagerName)
+}
+
+func agentWorkspacePicoClawConfigRoot(agentName string) (string, error) {
+	workspaceRoot, err := agentWorkspaceRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(workspaceRoot, filepath.FromSlash(hostPicoClawStateDir)), nil
 }
 
 func agentPicoClawRoot(agentName string) (string, error) {

--- a/internal/agent/manager_config_test.go
+++ b/internal/agent/manager_config_test.go
@@ -76,7 +76,7 @@ func TestPicoclawBridgeModelIDPrefixesOpenAIForSlashModelNames(t *testing.T) {
 	}
 }
 
-func TestEnsureAgentPicoClawConfigUsesDirectoryMountRoot(t *testing.T) {
+func TestEnsureAgentPicoClawConfigUsesWorkspaceStateDir(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
@@ -90,6 +90,10 @@ func TestEnsureAgentPicoClawConfigUsesDirectoryMountRoot(t *testing.T) {
 		t.Fatalf("ensureAgentPicoClawConfig() error = %v", err)
 	}
 
+	wantRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "ux", hostWorkspaceDir, filepath.FromSlash(hostPicoClawStateDir))
+	if root != wantRoot {
+		t.Fatalf("ensureAgentPicoClawConfig() = %q, want %q", root, wantRoot)
+	}
 	if info, err := os.Stat(root); err != nil {
 		t.Fatalf("os.Stat(root) error = %v", err)
 	} else if !info.IsDir() {
@@ -97,7 +101,7 @@ func TestEnsureAgentPicoClawConfigUsesDirectoryMountRoot(t *testing.T) {
 	}
 	for _, path := range []string{
 		filepath.Join(root, hostPicoClawConfig),
-		filepath.Join(root, ".security.yml"),
+		filepath.Join(root, hostPicoClawSecurity),
 	} {
 		if info, err := os.Stat(path); err != nil {
 			t.Fatalf("os.Stat(%q) error = %v", path, err)

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -7,15 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"csgclaw/internal/config"
 	"csgclaw/internal/sandbox"
 )
-
-const sandboxRuntimeLockRetryAttempts = 8
-
-var sandboxRuntimeLockRetryDelay = 50 * time.Millisecond
 
 func (s *Service) ensureRuntime(agentName string) (sandbox.Runtime, error) {
 	if testEnsureRuntimeHook != nil {
@@ -81,114 +76,38 @@ func (s *Service) lookupBootstrapManager(ctx context.Context) (sandbox.Runtime, 
 }
 
 func (s *Service) getBox(ctx context.Context, rt sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
-	var box sandbox.Instance
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		if testGetBoxHook != nil {
-			box, err = testGetBoxHook(s, ctx, rt, idOrName)
-		} else {
-			box, err = rt.Get(ctx, idOrName)
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return box, err
-		}
+	if testGetBoxHook != nil {
+		return testGetBoxHook(s, ctx, rt, idOrName)
 	}
-	return box, err
+	return rt.Get(ctx, idOrName)
 }
 
 func (s *Service) startBox(ctx context.Context, box sandbox.Instance) error {
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		if testStartBoxHook != nil {
-			err = testStartBoxHook(s, ctx, box)
-		} else {
-			err = box.Start(ctx)
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return err
-		}
+	if testStartBoxHook != nil {
+		return testStartBoxHook(s, ctx, box)
 	}
-	return err
+	return box.Start(ctx)
 }
 
 func (s *Service) stopBox(ctx context.Context, box sandbox.Instance, opts sandbox.StopOptions) error {
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		if testStopBoxHook != nil {
-			err = testStopBoxHook(s, ctx, box, opts)
-		} else {
-			err = box.Stop(ctx, opts)
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return err
-		}
+	if testStopBoxHook != nil {
+		return testStopBoxHook(s, ctx, box, opts)
 	}
-	return err
+	return box.Stop(ctx, opts)
 }
 
 func (s *Service) boxInfo(ctx context.Context, box sandbox.Instance) (sandbox.Info, error) {
-	var info sandbox.Info
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		if testBoxInfoHook != nil {
-			info, err = testBoxInfoHook(s, ctx, box)
-		} else {
-			info, err = box.Info(ctx)
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return info, err
-		}
+	if testBoxInfoHook != nil {
+		return testBoxInfoHook(s, ctx, box)
 	}
-	return info, err
-}
-
-func isSandboxRuntimeLockError(err error) bool {
-	if err == nil {
-		return false
-	}
-	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "runtime lock") || strings.Contains(text, "another boxliteruntime")
-}
-
-func shouldRetrySandboxRuntimeLock(ctx context.Context, err error, attempt int) bool {
-	if err == nil || !isSandboxRuntimeLockError(err) || attempt == sandboxRuntimeLockRetryAttempts-1 {
-		return false
-	}
-	return waitSandboxRuntimeLockRetry(ctx, attempt) == nil
-}
-
-func waitSandboxRuntimeLockRetry(ctx context.Context, attempt int) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	delay := sandboxRuntimeLockRetryDelay * time.Duration(attempt+1)
-	if delay <= 0 {
-		return nil
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+	return box.Info(ctx)
 }
 
 func (s *Service) createBox(ctx context.Context, rt sandbox.Runtime, spec sandbox.CreateSpec) (sandbox.Instance, error) {
-	var box sandbox.Instance
-	var err error
-	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
-		if testCreateBoxHook != nil {
-			box, err = testCreateBoxHook(s, ctx, rt, spec)
-		} else {
-			box, err = rt.Create(ctx, spec)
-		}
-		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
-			return box, err
-		}
+	if testCreateBoxHook != nil {
+		return testCreateBoxHook(s, ctx, rt, spec)
 	}
-	return box, err
+	return rt.Create(ctx, spec)
 }
 
 func (s *Service) runBoxCommand(ctx context.Context, box sandbox.Instance, name string, args []string, w io.Writer) (int, error) {

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -7,10 +7,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"csgclaw/internal/config"
 	"csgclaw/internal/sandbox"
 )
+
+const sandboxRuntimeLockRetryAttempts = 8
+
+var sandboxRuntimeLockRetryDelay = 50 * time.Millisecond
 
 func (s *Service) ensureRuntime(agentName string) (sandbox.Runtime, error) {
 	if testEnsureRuntimeHook != nil {
@@ -76,38 +81,114 @@ func (s *Service) lookupBootstrapManager(ctx context.Context) (sandbox.Runtime, 
 }
 
 func (s *Service) getBox(ctx context.Context, rt sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
-	if testGetBoxHook != nil {
-		return testGetBoxHook(s, ctx, rt, idOrName)
+	var box sandbox.Instance
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		if testGetBoxHook != nil {
+			box, err = testGetBoxHook(s, ctx, rt, idOrName)
+		} else {
+			box, err = rt.Get(ctx, idOrName)
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return box, err
+		}
 	}
-	return rt.Get(ctx, idOrName)
+	return box, err
 }
 
 func (s *Service) startBox(ctx context.Context, box sandbox.Instance) error {
-	if testStartBoxHook != nil {
-		return testStartBoxHook(s, ctx, box)
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		if testStartBoxHook != nil {
+			err = testStartBoxHook(s, ctx, box)
+		} else {
+			err = box.Start(ctx)
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return err
+		}
 	}
-	return box.Start(ctx)
+	return err
 }
 
 func (s *Service) stopBox(ctx context.Context, box sandbox.Instance, opts sandbox.StopOptions) error {
-	if testStopBoxHook != nil {
-		return testStopBoxHook(s, ctx, box, opts)
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		if testStopBoxHook != nil {
+			err = testStopBoxHook(s, ctx, box, opts)
+		} else {
+			err = box.Stop(ctx, opts)
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return err
+		}
 	}
-	return box.Stop(ctx, opts)
+	return err
 }
 
 func (s *Service) boxInfo(ctx context.Context, box sandbox.Instance) (sandbox.Info, error) {
-	if testBoxInfoHook != nil {
-		return testBoxInfoHook(s, ctx, box)
+	var info sandbox.Info
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		if testBoxInfoHook != nil {
+			info, err = testBoxInfoHook(s, ctx, box)
+		} else {
+			info, err = box.Info(ctx)
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return info, err
+		}
 	}
-	return box.Info(ctx)
+	return info, err
+}
+
+func isSandboxRuntimeLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "runtime lock") || strings.Contains(text, "another boxliteruntime")
+}
+
+func shouldRetrySandboxRuntimeLock(ctx context.Context, err error, attempt int) bool {
+	if err == nil || !isSandboxRuntimeLockError(err) || attempt == sandboxRuntimeLockRetryAttempts-1 {
+		return false
+	}
+	return waitSandboxRuntimeLockRetry(ctx, attempt) == nil
+}
+
+func waitSandboxRuntimeLockRetry(ctx context.Context, attempt int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	delay := sandboxRuntimeLockRetryDelay * time.Duration(attempt+1)
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (s *Service) createBox(ctx context.Context, rt sandbox.Runtime, spec sandbox.CreateSpec) (sandbox.Instance, error) {
-	if testCreateBoxHook != nil {
-		return testCreateBoxHook(s, ctx, rt, spec)
+	var box sandbox.Instance
+	var err error
+	for attempt := 0; attempt < sandboxRuntimeLockRetryAttempts; attempt++ {
+		if testCreateBoxHook != nil {
+			box, err = testCreateBoxHook(s, ctx, rt, spec)
+		} else {
+			box, err = rt.Create(ctx, spec)
+		}
+		if !shouldRetrySandboxRuntimeLock(ctx, err, attempt) {
+			return box, err
+		}
 	}
-	return rt.Create(ctx, spec)
+	return box, err
 }
 
 func (s *Service) runBoxCommand(ctx context.Context, box sandbox.Instance, name string, args []string, w io.Writer) (int, error) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -826,7 +826,9 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 	box, resolvedKey, err := s.resolveAgentBox(ctx, rt, got)
 	if err != nil {
 		if sandbox.IsNotFound(err) {
-			return Agent{}, fmt.Errorf("agent %q not found", id)
+			_ = s.closeRuntime(runtimeHome, rt)
+			rt = nil
+			return s.Recreate(ctx, id)
 		}
 		return Agent{}, err
 	}
@@ -1056,6 +1058,12 @@ func (s *Service) StartConfiguredAgents(ctx context.Context) error {
 		}
 		live := s.hydrateAgentStatus(ctx, a)
 		if isAgentRuntimeRunning(live) {
+			// A running sandbox can still hold a stale PicoClaw event stream after
+			// csgclaw serve restarts. Recreate the worker gateway so it subscribes
+			// to the current server instance.
+			if _, err := s.Recreate(ctx, live.ID); err != nil {
+				startErr = errors.Join(startErr, fmt.Errorf("%s: %w", live.Name, err))
+			}
 			continue
 		}
 		if _, err := s.Start(ctx, live.ID); err != nil {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -31,6 +33,7 @@ const (
 	boxPicoClawDir     = "/home/picoclaw/.picoclaw"
 	boxWorkspaceDir    = boxPicoClawDir + "/workspace"
 	boxProjectsDir     = "/home/picoclaw/.picoclaw/workspace/projects"
+	gatewayLogPoll     = 200 * time.Millisecond
 )
 
 var localIPv4Resolver = localIPv4
@@ -728,13 +731,24 @@ func normalizeCreateID(id string) string {
 }
 
 func (s *Service) Agent(id string) (Agent, bool) {
+	a, ok := s.agentSnapshot(id)
+	if !ok {
+		return Agent{}, false
+	}
+	return s.hydrateAgentStatus(context.Background(), a), true
+}
+
+func (s *Service) agentSnapshot(id string) (Agent, bool) {
+	if s == nil {
+		return Agent{}, false
+	}
 	s.mu.RLock()
 	a, ok := s.agents[strings.TrimSpace(id)]
 	s.mu.RUnlock()
 	if !ok {
 		return Agent{}, false
 	}
-	return s.hydrateAgentStatus(context.Background(), a), true
+	return *cloneAgent(&a), true
 }
 
 func (s *Service) resolveAgentBox(ctx context.Context, rt sandbox.Runtime, got Agent) (sandbox.Instance, string, error) {
@@ -810,6 +824,9 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 	if got.AgentProfile.EnvRestartRequired {
 		return s.Recreate(ctx, id)
 	}
+	if err := s.ensureWorkerGatewayConfig(got); err != nil {
+		return Agent{}, err
+	}
 
 	rt, err := s.ensureRuntime(got.Name)
 	if err != nil {
@@ -872,6 +889,27 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 		return Agent{}, fmt.Errorf("agent %q not found", id)
 	}
 	return started, nil
+}
+
+func (s *Service) ensureWorkerGatewayConfig(got Agent) error {
+	if s == nil || !strings.EqualFold(strings.TrimSpace(got.Role), RoleWorker) || !isAgentProfileComplete(got) {
+		return nil
+	}
+	name := strings.TrimSpace(got.Name)
+	botID := strings.TrimSpace(got.ID)
+	if name == "" || botID == "" {
+		return fmt.Errorf("agent name and id are required")
+	}
+	profile := normalizeProfile(got.AgentProfile, name, got.Description)
+	modelID := strings.TrimSpace(profile.ModelID)
+	if modelID == "" {
+		modelID = strings.TrimSpace(got.ModelID)
+	}
+	if modelID == "" {
+		modelID = s.model.Resolved().ModelID
+	}
+	_, err := ensureAgentPicoClawConfig(name, botID, s.server, config.ModelConfig{ModelID: modelID})
+	return err
 }
 
 func (s *Service) Stop(ctx context.Context, id string) (Agent, error) {
@@ -1201,9 +1239,14 @@ func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines 
 		lines = 20
 	}
 
-	got, ok := s.Agent(id)
+	got, ok := s.agentSnapshot(id)
 	if !ok {
 		return fmt.Errorf("agent %q not found", id)
+	}
+	if err := streamHostGatewayLog(ctx, got.Name, follow, lines, w); err == nil {
+		return nil
+	} else if follow || !errors.Is(err, os.ErrNotExist) {
+		return err
 	}
 
 	rt, err := s.ensureRuntime(got.Name)
@@ -1252,6 +1295,159 @@ func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines 
 	return nil
 }
 
+func streamHostGatewayLog(ctx context.Context, agentName string, follow bool, lines int, w io.Writer) error {
+	logPath, err := agentGatewayLogPath(agentName)
+	if err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := streamGatewayLogFile(ctx, logPath, follow, lines, w); err != nil {
+		if follow && errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func agentGatewayLogPath(agentName string) (string, error) {
+	root, err := agentPicoClawRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "gateway.log"), nil
+}
+
+func streamGatewayLogFile(ctx context.Context, logPath string, follow bool, lines int, w io.Writer) error {
+	file, err := openGatewayLogFile(ctx, logPath, follow)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	offset, err := writeLastGatewayLogLines(file, lines, w)
+	if err != nil || !follow {
+		return err
+	}
+	return followGatewayLogFile(ctx, file, offset, w)
+}
+
+func openGatewayLogFile(ctx context.Context, logPath string, follow bool) (*os.File, error) {
+	for {
+		file, err := os.Open(logPath)
+		if err == nil {
+			return file, nil
+		}
+		if !follow || !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(gatewayLogPoll):
+		}
+	}
+}
+
+func writeLastGatewayLogLines(file *os.File, lines int, w io.Writer) (int64, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	if size <= 0 {
+		return 0, nil
+	}
+	data, err := readLastGatewayLogLines(file, size, lines)
+	if err != nil {
+		return 0, err
+	}
+	if len(data) > 0 {
+		if _, err := w.Write(data); err != nil {
+			return 0, err
+		}
+	}
+	return size, nil
+}
+
+func readLastGatewayLogLines(file *os.File, size int64, lines int) ([]byte, error) {
+	const chunkSize int64 = 4096
+
+	var data []byte
+	var newlineCount int
+	pos := size
+	for pos > 0 && (lines <= 0 || newlineCount <= lines) {
+		readSize := chunkSize
+		if pos < readSize {
+			readSize = pos
+		}
+		pos -= readSize
+		chunk := make([]byte, int(readSize))
+		if _, err := file.ReadAt(chunk, pos); err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+		data = append(chunk, data...)
+		newlineCount += bytes.Count(chunk, []byte{'\n'})
+	}
+	return trimLastGatewayLogLines(data, lines), nil
+}
+
+func trimLastGatewayLogLines(data []byte, lines int) []byte {
+	if lines <= 0 || len(data) == 0 {
+		return data
+	}
+	seen := 0
+	for idx := len(data) - 1; idx >= 0; idx-- {
+		if data[idx] != '\n' {
+			continue
+		}
+		if idx == len(data)-1 {
+			continue
+		}
+		seen++
+		if seen == lines {
+			return data[idx+1:]
+		}
+	}
+	return data
+}
+
+func followGatewayLogFile(ctx context.Context, file *os.File, offset int64, w io.Writer) error {
+	ticker := time.NewTicker(gatewayLogPoll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		info, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		size := info.Size()
+		if size < offset {
+			offset = 0
+		}
+		if size == offset {
+			continue
+		}
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return err
+		}
+		n, err := io.CopyN(w, file, size-offset)
+		offset += n
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+}
+
 func (s *Service) hydrateAgentStatus(ctx context.Context, a Agent) Agent {
 	a = *cloneAgent(&a)
 	if strings.TrimSpace(a.Name) == "" {
@@ -1262,15 +1458,11 @@ func (s *Service) hydrateAgentStatus(ctx context.Context, a Agent) Agent {
 
 	rt, err := s.ensureRuntime(a.Name)
 	if err != nil {
-		logHydrateUnknownStatus(a, "ensure_runtime", err)
-		a.Status = string(sandbox.StateUnknown)
-		return a
+		return statusAfterHydrateFailure(a, "ensure_runtime", err)
 	}
 	runtimeHome, err := s.sandboxRuntimeHome(a.Name)
 	if err != nil {
-		logHydrateUnknownStatus(a, "resolve_runtime_home", err)
-		a.Status = string(sandbox.StateUnknown)
-		return a
+		return statusAfterHydrateFailure(a, "resolve_runtime_home", err)
 	}
 	defer func() {
 		_ = s.closeRuntime(runtimeHome, rt)
@@ -1278,9 +1470,7 @@ func (s *Service) hydrateAgentStatus(ctx context.Context, a Agent) Agent {
 
 	box, _, err := s.resolveAgentBox(ctx, rt, a)
 	if err != nil {
-		logHydrateUnknownStatus(a, "resolve_agent_box", err)
-		a.Status = string(sandbox.StateUnknown)
-		return a
+		return statusAfterHydrateFailure(a, "resolve_agent_box", err)
 	}
 	defer func() {
 		_ = s.closeBox(box)
@@ -1288,15 +1478,53 @@ func (s *Service) hydrateAgentStatus(ctx context.Context, a Agent) Agent {
 
 	info, err := s.boxInfo(ctx, box)
 	if err != nil {
-		logHydrateUnknownStatus(a, "read_box_info", err)
-		a.Status = string(sandbox.StateUnknown)
-		return a
+		return statusAfterHydrateFailure(a, "read_box_info", err)
 	}
 	if strings.TrimSpace(info.ID) != "" {
 		a.BoxID = info.ID
 	}
 	a.Status = string(info.State)
 	return a
+}
+
+func statusAfterHydrateFailure(a Agent, stage string, err error) Agent {
+	if strings.TrimSpace(a.Status) != "" && !sandbox.IsNotFound(err) {
+		logHydrateStaleStatus(a, stage, err)
+		return a
+	}
+	logHydrateUnknownStatus(a, stage, err)
+	a.Status = string(sandbox.StateUnknown)
+	return a
+}
+
+func logHydrateStaleStatus(a Agent, stage string, err error) {
+	if strings.TrimSpace(stage) == "" {
+		stage = "unknown_stage"
+	}
+	attrs := []any{
+		"agent_id", strings.TrimSpace(a.ID),
+		"agent_name", strings.TrimSpace(a.Name),
+		"agent_box_id", strings.TrimSpace(a.BoxID),
+		"agent_status", strings.TrimSpace(a.Status),
+		"stage", stage,
+		"error", err,
+	}
+	if isSandboxRuntimeContention(err) {
+		slog.Debug("agent status refresh skipped; sandbox runtime is busy", attrs...)
+		return
+	}
+	slog.Warn("agent status refresh failed; keeping last known status",
+		attrs...,
+	)
+}
+
+func isSandboxRuntimeContention(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "failed to acquire runtime lock") ||
+		strings.Contains(msg, "another boxliteruntime is already using directory")
 }
 
 func logHydrateUnknownStatus(a Agent, stage string, err error) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -33,6 +33,7 @@ const (
 	boxPicoClawDir     = "/home/picoclaw/.picoclaw"
 	boxWorkspaceDir    = boxPicoClawDir + "/workspace"
 	boxProjectsDir     = "/home/picoclaw/.picoclaw/workspace/projects"
+	boxGatewayLogPath  = boxWorkspaceDir + "/gateway.log"
 	gatewayLogPoll     = 200 * time.Millisecond
 )
 
@@ -1283,7 +1284,7 @@ func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines 
 	if follow {
 		args = append(args, "-f")
 	}
-	args = append(args, boxPicoClawDir+"/gateway.log")
+	args = append(args, boxGatewayLogPath)
 
 	exitCode, err := s.runBoxCommand(ctx, box, "tail", args, w)
 	if err != nil {
@@ -1296,14 +1297,14 @@ func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines 
 }
 
 func streamHostGatewayLog(ctx context.Context, agentName string, follow bool, lines int, w io.Writer) error {
-	logPath, err := agentGatewayLogPath(agentName)
+	logPaths, err := agentGatewayLogPaths(agentName)
 	if err != nil {
 		return err
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := streamGatewayLogFile(ctx, logPath, follow, lines, w); err != nil {
+	if err := streamGatewayLogFile(ctx, logPaths, follow, lines, w); err != nil {
 		if follow && errors.Is(err, context.Canceled) {
 			return nil
 		}
@@ -1313,6 +1314,29 @@ func streamHostGatewayLog(ctx context.Context, agentName string, follow bool, li
 }
 
 func agentGatewayLogPath(agentName string) (string, error) {
+	root, err := agentWorkspaceRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "gateway.log"), nil
+}
+
+func agentGatewayLogPaths(agentName string) ([]string, error) {
+	primary, err := agentGatewayLogPath(agentName)
+	if err != nil {
+		return nil, err
+	}
+	legacy, err := legacyAgentGatewayLogPath(agentName)
+	if err != nil {
+		return nil, err
+	}
+	if legacy == primary {
+		return []string{primary}, nil
+	}
+	return []string{primary, legacy}, nil
+}
+
+func legacyAgentGatewayLogPath(agentName string) (string, error) {
 	root, err := agentPicoClawRoot(agentName)
 	if err != nil {
 		return "", err
@@ -1320,8 +1344,8 @@ func agentGatewayLogPath(agentName string) (string, error) {
 	return filepath.Join(root, "gateway.log"), nil
 }
 
-func streamGatewayLogFile(ctx context.Context, logPath string, follow bool, lines int, w io.Writer) error {
-	file, err := openGatewayLogFile(ctx, logPath, follow)
+func streamGatewayLogFile(ctx context.Context, logPaths []string, follow bool, lines int, w io.Writer) error {
+	file, err := openGatewayLogFile(ctx, logPaths, follow)
 	if err != nil {
 		return err
 	}
@@ -1336,14 +1360,29 @@ func streamGatewayLogFile(ctx context.Context, logPath string, follow bool, line
 	return followGatewayLogFile(ctx, file, offset, w)
 }
 
-func openGatewayLogFile(ctx context.Context, logPath string, follow bool) (*os.File, error) {
+func openGatewayLogFile(ctx context.Context, logPaths []string, follow bool) (*os.File, error) {
+	if len(logPaths) == 0 {
+		return nil, os.ErrNotExist
+	}
 	for {
-		file, err := os.Open(logPath)
-		if err == nil {
-			return file, nil
+		var notFound error
+		for _, logPath := range logPaths {
+			file, err := os.Open(logPath)
+			if err == nil {
+				return file, nil
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
+			if notFound == nil {
+				notFound = err
+			}
 		}
-		if !follow || !errors.Is(err, os.ErrNotExist) {
-			return nil, err
+		if !follow {
+			if notFound != nil {
+				return nil, notFound
+			}
+			return nil, os.ErrNotExist
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -20,21 +20,22 @@ import (
 )
 
 const (
-	ManagerName        = "manager"
-	ManagerUserID      = "u-manager"
-	managerHostPort    = 18790
-	managerGuestPort   = 18790
-	managerDebugMode   = true
-	hostPicoClawDir    = ".picoclaw"
-	hostWorkspaceDir   = "workspace"
-	hostProjectsDir    = "projects"
-	hostPicoClawConfig = "config.json"
-	hostPicoClawLogs   = "logs"
-	boxPicoClawDir     = "/home/picoclaw/.picoclaw"
-	boxWorkspaceDir    = boxPicoClawDir + "/workspace"
-	boxProjectsDir     = "/home/picoclaw/.picoclaw/workspace/projects"
-	boxGatewayLogPath  = boxWorkspaceDir + "/gateway.log"
-	gatewayLogPoll     = 200 * time.Millisecond
+	ManagerName          = "manager"
+	ManagerUserID        = "u-manager"
+	managerHostPort      = 18790
+	managerGuestPort     = 18790
+	managerDebugMode     = true
+	hostPicoClawDir      = ".picoclaw"
+	hostWorkspaceDir     = "workspace"
+	hostProjectsDir      = "projects"
+	hostPicoClawConfig   = "config.json"
+	hostPicoClawSecurity = ".security.yml"
+	hostPicoClawStateDir = ".csgclaw/picoclaw"
+	boxPicoClawDir       = "/home/picoclaw/.picoclaw"
+	boxWorkspaceDir      = boxPicoClawDir + "/workspace"
+	boxProjectsDir       = "/home/picoclaw/.picoclaw/workspace/projects"
+	boxGatewayLogPath    = boxWorkspaceDir + "/gateway.log"
+	gatewayLogPoll       = 200 * time.Millisecond
 )
 
 var localIPv4Resolver = localIPv4

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -397,10 +397,10 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 	if got, want := countBoxliteCLICommand(runner.requests, "start"), 0; got != want {
 		t.Fatalf("start command count = %d, want %d", got, want)
 	}
-	if !hasBoxliteCLICommandArgs(runner.requests, "run", "/bin/sh", "-c", "/usr/local/bin/picoclaw gateway -d 1>~/.picoclaw/gateway.log 2>/dev/null") {
+	if !hasBoxliteCLICommandArgs(runner.requests, "run", "/bin/sh", "-c", "/usr/local/bin/picoclaw gateway -d 1>"+boxGatewayLogPath+" 2>/dev/null") {
 		t.Fatalf("boxlite-cli gateway run command not found in requests: %#v", requestArgs(runner.requests))
 	}
-	if hasBoxliteCLIExec(runner.requests, "tail", "-n", "1", "-f", boxPicoClawDir+"/gateway.log") {
+	if hasBoxliteCLIExec(runner.requests, "tail", "-n", "1", "-f", boxGatewayLogPath) {
 		t.Fatalf("boxlite-cli tail exec should not be used for mounted gateway logs: %#v", requestArgs(runner.requests))
 	}
 	if !hasBoxliteCLICommandArgs(runner.requests, "rm", "-f", "box-alice") {
@@ -1473,7 +1473,7 @@ func TestStreamLogsFallsBackToSandboxTailWhenHostLogIsMissing(t *testing.T) {
 	if gotName != "tail" {
 		t.Fatalf("runBoxCommand() name = %q, want %q", gotName, "tail")
 	}
-	if strings.Join(gotArgs, " ") != "-n 50 /home/picoclaw/.picoclaw/gateway.log" {
+	if strings.Join(gotArgs, " ") != "-n 50 "+boxGatewayLogPath {
 		t.Fatalf("runBoxCommand() args = %q", gotArgs)
 	}
 	if out.String() != "line-1\n" {
@@ -2663,7 +2663,7 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	if spec.AutoRemove {
 		t.Fatal("gatewayCreateSpec() auto_remove = true, want false")
 	}
-	wantCmd := "/bin/sh -c /usr/local/bin/picoclaw gateway -d 1>~/.picoclaw/gateway.log 2>/dev/null"
+	wantCmd := "/bin/sh -c /usr/local/bin/picoclaw gateway -d 1>" + boxGatewayLogPath + " 2>/dev/null"
 	if strings.Join(spec.Cmd, " ") != wantCmd {
 		t.Fatalf("gatewayCreateSpec() cmd = %q, want %q", spec.Cmd, wantCmd)
 	}
@@ -2681,22 +2681,71 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	}
 
 	wantConfigRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir)
-	wantWorkspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)
+	wantWorkspaceRoot := filepath.Join(wantConfigRoot, hostWorkspaceDir)
 	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
-	if len(spec.Mounts) != 3 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 3 mounts", spec.Mounts)
+	if len(spec.Mounts) != 2 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
 	}
 	if spec.Mounts[0].HostPath != wantConfigRoot || spec.Mounts[0].GuestPath != boxPicoClawDir {
 		t.Fatalf("config mount = %+v, want host %q guest %q", spec.Mounts[0], wantConfigRoot, boxPicoClawDir)
 	}
-	if spec.Mounts[1].HostPath != wantWorkspaceRoot || spec.Mounts[1].GuestPath != boxWorkspaceDir {
-		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[1], wantWorkspaceRoot, boxWorkspaceDir)
-	}
-	if spec.Mounts[2].HostPath != wantProjectsRoot || spec.Mounts[2].GuestPath != boxProjectsDir {
-		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[2], wantProjectsRoot, boxProjectsDir)
+	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
+		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
 	}
 	if _, err := os.Stat(filepath.Join(wantConfigRoot, hostPicoClawConfig)); err != nil {
 		t.Fatalf("worker PicoClaw config was not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wantWorkspaceRoot, "AGENT.md")); err != nil {
+		t.Fatalf("worker workspace was not written under .picoclaw: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)); !os.IsNotExist(err) {
+		t.Fatalf("legacy workspace stat error = %v, want not exist", err)
+	}
+}
+
+func TestGatewayCreateSpecMigratesLegacyWorkspaceDir(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	workspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(workspaceRoot) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "local.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(local workspace file) error = %v", err)
+	}
+
+	spec, err := svc.gatewayCreateSpec("picoclaw:latest", "alice", "u-worker-1", AgentProfile{
+		Name:     "alice",
+		Provider: ProviderAPI,
+		ModelID:  "gpt-5.5",
+	})
+	if err != nil {
+		t.Fatalf("gatewayCreateSpec() error = %v", err)
+	}
+
+	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
+	if len(spec.Mounts) != 2 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
+	}
+	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
+		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
+	}
+	if _, err := os.Stat(workspaceRoot); !os.IsNotExist(err) {
+		t.Fatalf("legacy workspace stat error = %v, want not exist", err)
+	}
+	newWorkspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir, hostWorkspaceDir)
+	if data, err := os.ReadFile(filepath.Join(newWorkspaceRoot, "local.txt")); err != nil {
+		t.Fatalf("read migrated workspace file: %v", err)
+	} else if string(data) != "keep" {
+		t.Fatalf("migrated workspace file = %q, want keep", data)
+	}
+	if _, err := os.Stat(filepath.Join(newWorkspaceRoot, "AGENT.md")); err != nil {
+		t.Fatalf("worker workspace template was not written after migration: %v", err)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -66,6 +66,19 @@ func (f *fakeInfoInstance) Info(context.Context) (sandbox.Info, error) {
 	return f.info, nil
 }
 
+type cancelOnWrite struct {
+	writer io.Writer
+	cancel context.CancelFunc
+}
+
+func (w cancelOnWrite) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if n > 0 && w.cancel != nil {
+		w.cancel()
+	}
+	return n, err
+}
+
 type agentBoxliteCLIRunner struct {
 	requests []boxlitecli.CommandRequest
 	boxes    map[string]agentBoxliteCLIBox
@@ -356,8 +369,18 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 		t.Fatalf("CreateWorker() = %+v, want running box-alice", worker)
 	}
 
+	logPath, err := agentGatewayLogPath("alice")
+	if err != nil {
+		t.Fatalf("agentGatewayLogPath() error = %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("old line\nnew line\ngateway line\n"), 0o600); err != nil {
+		t.Fatalf("write gateway log: %v", err)
+	}
+
 	var logs strings.Builder
-	if err := svc.StreamLogs(context.Background(), worker.ID, true, 3, &logs); err != nil {
+	logCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StreamLogs(logCtx, worker.ID, true, 1, cancelOnWrite{writer: &logs, cancel: cancel}); err != nil {
 		t.Fatalf("StreamLogs() error = %v", err)
 	}
 	if got := logs.String(); got != "gateway line\n" {
@@ -377,8 +400,8 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 	if !hasBoxliteCLICommandArgs(runner.requests, "run", "/bin/sh", "-c", "/usr/local/bin/picoclaw gateway -d 1>~/.picoclaw/gateway.log 2>/dev/null") {
 		t.Fatalf("boxlite-cli gateway run command not found in requests: %#v", requestArgs(runner.requests))
 	}
-	if !hasBoxliteCLIExec(runner.requests, "tail", "-n", "3", "-f", boxPicoClawDir+"/gateway.log") {
-		t.Fatalf("boxlite-cli tail exec not found in requests: %#v", requestArgs(runner.requests))
+	if hasBoxliteCLIExec(runner.requests, "tail", "-n", "1", "-f", boxPicoClawDir+"/gateway.log") {
+		t.Fatalf("boxlite-cli tail exec should not be used for mounted gateway logs: %#v", requestArgs(runner.requests))
 	}
 	if !hasBoxliteCLICommandArgs(runner.requests, "rm", "-f", "box-alice") {
 		t.Fatalf("boxlite-cli remove command not found in requests: %#v", requestArgs(runner.requests))
@@ -827,7 +850,7 @@ func TestDeleteRemovesAgentFromState(t *testing.T) {
 	}
 }
 
-func TestSaveLockedOmitsPersistedAgentStatus(t *testing.T) {
+func TestSaveLockedPersistsLastKnownAgentStatus(t *testing.T) {
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "agents.json")
 
@@ -852,8 +875,118 @@ func TestSaveLockedOmitsPersistedAgentStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile() error = %v", err)
 	}
-	if strings.Contains(string(data), `"status"`) {
-		t.Fatalf("saved state should not contain status: %s", data)
+	if !strings.Contains(string(data), `"status": "running"`) {
+		t.Fatalf("saved state should contain last known status: %s", data)
+	}
+}
+
+func TestListKeepsLastKnownStatusWhenHydrationFails(t *testing.T) {
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) {
+			return nil, fmt.Errorf("runtime lock")
+		},
+		nil,
+	)
+	defer ResetTestHooks()
+
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:        "u-alice",
+		Name:      "alice",
+		Role:      RoleWorker,
+		BoxID:     "box-alice",
+		Status:    string(sandbox.StateRunning),
+		CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	}
+
+	got := svc.List()
+	if len(got) != 1 {
+		t.Fatalf("List() len = %d, want 1", len(got))
+	}
+	if got[0].Status != string(sandbox.StateRunning) {
+		t.Fatalf("List()[0].Status = %q, want running", got[0].Status)
+	}
+}
+
+func TestIsSandboxRuntimeContentionRecognizesBoxLiteLockErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "failed acquire runtime lock",
+			err:  fmt.Errorf("inspect boxlite cli box: Error: internal error: Failed to acquire runtime lock at /tmp/boxlite"),
+			want: true,
+		},
+		{
+			name: "runtime already using directory",
+			err:  fmt.Errorf("get agent box: internal error: Another BoxliteRuntime is already using directory: /tmp/boxlite"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("network down"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSandboxRuntimeContention(tc.err); got != tc.want {
+				t.Fatalf("isSandboxRuntimeContention(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadLegacyAgentWithBoxIDInfersRunningUntilHydrated(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "agents.json")
+	data, err := json.Marshal(persistedState{
+		Agents: []persistedAgent{
+			{
+				ID:        "u-alice",
+				Name:      "alice",
+				Role:      RoleWorker,
+				BoxID:     "box-alice",
+				CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) {
+			return nil, fmt.Errorf("runtime lock")
+		},
+		nil,
+	)
+	defer ResetTestHooks()
+
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", statePath)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	got, ok := svc.Agent("u-alice")
+	if !ok {
+		t.Fatal("Agent() ok = false, want true")
+	}
+	if got.Status != string(sandbox.StateRunning) {
+		t.Fatalf("Agent().Status = %q, want running fallback", got.Status)
 	}
 }
 
@@ -1294,7 +1427,7 @@ func TestCreateWorkerClosesBoxHandleAfterCreate(t *testing.T) {
 	}
 }
 
-func TestStreamLogsUsesStoredBoxIDAndTailArgs(t *testing.T) {
+func TestStreamLogsFallsBackToSandboxTailWhenHostLogIsMissing(t *testing.T) {
 	rt := &fakeRuntime{}
 	SetTestHooks(func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil }, nil)
 	defer ResetTestHooks()
@@ -1331,7 +1464,7 @@ func TestStreamLogsUsesStoredBoxIDAndTailArgs(t *testing.T) {
 	}
 
 	var out strings.Builder
-	if err := svc.StreamLogs(context.Background(), "u-alice", true, 50, &out); err != nil {
+	if err := svc.StreamLogs(context.Background(), "u-alice", false, 50, &out); err != nil {
 		t.Fatalf("StreamLogs() error = %v", err)
 	}
 	if gotBoxID != "box-123" {
@@ -1340,11 +1473,55 @@ func TestStreamLogsUsesStoredBoxIDAndTailArgs(t *testing.T) {
 	if gotName != "tail" {
 		t.Fatalf("runBoxCommand() name = %q, want %q", gotName, "tail")
 	}
-	if strings.Join(gotArgs, " ") != "-n 50 -f /home/picoclaw/.picoclaw/gateway.log" {
+	if strings.Join(gotArgs, " ") != "-n 50 /home/picoclaw/.picoclaw/gateway.log" {
 		t.Fatalf("runBoxCommand() args = %q", gotArgs)
 	}
 	if out.String() != "line-1\n" {
 		t.Fatalf("output = %q, want streamed log line", out.String())
+	}
+}
+
+func TestStreamLogsFollowUsesHostGatewayLogWithoutSandboxRuntime(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:        "u-alice",
+		Name:      "alice",
+		BoxID:     "box-123",
+		Role:      RoleWorker,
+		Status:    "running",
+		CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	}
+	logPath, err := agentGatewayLogPath("alice")
+	if err != nil {
+		t.Fatalf("agentGatewayLogPath() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("older\nready\n"), 0o600); err != nil {
+		t.Fatalf("write gateway log: %v", err)
+	}
+
+	testEnsureRuntimeHook = func(*Service, string) (sandbox.Runtime, error) {
+		t.Fatal("StreamLogs follow opened sandbox runtime; want host log streaming")
+		return nil, nil
+	}
+	defer func() { testEnsureRuntimeHook = nil }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out strings.Builder
+	if err := svc.StreamLogs(ctx, "u-alice", true, 1, cancelOnWrite{writer: &out, cancel: cancel}); err != nil {
+		t.Fatalf("StreamLogs() error = %v", err)
+	}
+	if out.String() != "ready\n" {
+		t.Fatalf("output = %q, want last host log line", out.String())
 	}
 }
 
@@ -1477,7 +1654,73 @@ func TestStartFallsBackToNameAndRefreshesStoredAgentState(t *testing.T) {
 	}
 }
 
+func TestStartRefreshesCompleteWorkerGatewayConfig(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	orig := localIPv4Resolver
+	localIPv4Resolver = func() string { return "10.0.0.8" }
+	defer func() { localIPv4Resolver = orig }()
+
+	rt := &fakeRuntime{}
+	SetTestHooks(func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil }, nil)
+	defer ResetTestHooks()
+
+	testGetBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
+		if idOrName != "box-alice" {
+			t.Fatalf("getBox() idOrName = %q, want box-alice", idOrName)
+		}
+		return &fakeInfoInstance{info: sandbox.Info{
+			ID:        "box-alice",
+			Name:      "alice",
+			State:     sandbox.StateRunning,
+			CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		}}, nil
+	}
+	testStartBoxHook = func(_ *Service, _ context.Context, _ sandbox.Instance) error {
+		return nil
+	}
+	testBoxInfoHook = func(_ *Service, _ context.Context, box sandbox.Instance) (sandbox.Info, error) {
+		return box.Info(context.Background())
+	}
+	defer func() {
+		testGetBoxHook = nil
+		testStartBoxHook = nil
+		testBoxInfoHook = nil
+	}()
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{ListenAddr: ":18080", AccessToken: "token"}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:              "u-alice",
+		Name:            "alice",
+		Role:            RoleWorker,
+		BoxID:           "box-alice",
+		Status:          string(sandbox.StateRunning),
+		AgentProfile:    AgentProfile{Name: "alice", Provider: ProviderCodex, ModelID: "gpt-5.5", ProfileComplete: true},
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	}
+
+	if _, err := svc.Start(context.Background(), "u-alice"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir, hostPicoClawConfig)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(worker config) error = %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{`"bot_id": "u-alice"`, `"model_name": "gpt-5.5"`, `"api_base": "http://10.0.0.8:18080/api/bots/u-alice/llm"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("worker config missing %q in:\n%s", want, text)
+		}
+	}
+}
+
 func TestStartConfiguredAgentsRecreatesMissingCompleteWorkerBoxes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	rt := &fakeRuntime{}
 	boxes := map[string]sandbox.Info{}
 	var created []string
@@ -1581,6 +1824,7 @@ func TestStartConfiguredAgentsRecreatesMissingCompleteWorkerBoxes(t *testing.T) 
 }
 
 func TestStartConfiguredAgentsStartsStoppedAndRecreatesRunningCompleteWorkers(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	rt := &fakeRuntime{}
 	infos := map[string]sandbox.Info{
 		"box-alice": {
@@ -1699,6 +1943,7 @@ func TestStartConfiguredAgentsStartsStoppedAndRecreatesRunningCompleteWorkers(t 
 		Name:            "carol",
 		Role:            RoleWorker,
 		BoxID:           "box-carol",
+		Status:          string(sandbox.StateRunning),
 		AgentProfile:    completeCarol,
 		ProfileComplete: true,
 		CreatedAt:       time.Date(2026, 4, 1, 13, 0, 0, 0, time.UTC),
@@ -2435,16 +2680,23 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 		t.Fatalf("PICOCLAW_CHANNELS_FEISHU_APP_ID = %q, want %q", got, want)
 	}
 
+	wantConfigRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir)
 	wantWorkspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)
 	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
-	if len(spec.Mounts) != 2 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
+	if len(spec.Mounts) != 3 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 3 mounts", spec.Mounts)
 	}
-	if spec.Mounts[0].HostPath != wantWorkspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
-		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], wantWorkspaceRoot, boxWorkspaceDir)
+	if spec.Mounts[0].HostPath != wantConfigRoot || spec.Mounts[0].GuestPath != boxPicoClawDir {
+		t.Fatalf("config mount = %+v, want host %q guest %q", spec.Mounts[0], wantConfigRoot, boxPicoClawDir)
 	}
-	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
-		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
+	if spec.Mounts[1].HostPath != wantWorkspaceRoot || spec.Mounts[1].GuestPath != boxWorkspaceDir {
+		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[1], wantWorkspaceRoot, boxWorkspaceDir)
+	}
+	if spec.Mounts[2].HostPath != wantProjectsRoot || spec.Mounts[2].GuestPath != boxProjectsDir {
+		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[2], wantProjectsRoot, boxProjectsDir)
+	}
+	if _, err := os.Stat(filepath.Join(wantConfigRoot, hostPicoClawConfig)); err != nil {
+		t.Fatalf("worker PicoClaw config was not written: %v", err)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -397,7 +397,7 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 	if got, want := countBoxliteCLICommand(runner.requests, "start"), 0; got != want {
 		t.Fatalf("start command count = %d, want %d", got, want)
 	}
-	if !hasBoxliteCLICommandArgs(runner.requests, "run", "/bin/sh", "-c", "/usr/local/bin/picoclaw gateway -d 1>"+boxGatewayLogPath+" 2>/dev/null") {
+	if !hasBoxliteCLICommandArgs(runner.requests, "run", "/bin/sh", "-c", gatewayRunCommand()) {
 		t.Fatalf("boxlite-cli gateway run command not found in requests: %#v", requestArgs(runner.requests))
 	}
 	if hasBoxliteCLIExec(runner.requests, "tail", "-n", "1", "-f", boxGatewayLogPath) {
@@ -1706,7 +1706,7 @@ func TestStartRefreshesCompleteWorkerGatewayConfig(t *testing.T) {
 	if _, err := svc.Start(context.Background(), "u-alice"); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir, hostPicoClawConfig)
+	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir, filepath.FromSlash(hostPicoClawStateDir), hostPicoClawConfig)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("ReadFile(worker config) error = %v", err)
@@ -2663,7 +2663,7 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	if spec.AutoRemove {
 		t.Fatal("gatewayCreateSpec() auto_remove = true, want false")
 	}
-	wantCmd := "/bin/sh -c /usr/local/bin/picoclaw gateway -d 1>" + boxGatewayLogPath + " 2>/dev/null"
+	wantCmd := "/bin/sh -c " + gatewayRunCommand()
 	if strings.Join(spec.Cmd, " ") != wantCmd {
 		t.Fatalf("gatewayCreateSpec() cmd = %q, want %q", spec.Cmd, wantCmd)
 	}
@@ -2680,30 +2680,27 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 		t.Fatalf("PICOCLAW_CHANNELS_FEISHU_APP_ID = %q, want %q", got, want)
 	}
 
-	wantConfigRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir)
-	wantWorkspaceRoot := filepath.Join(wantConfigRoot, hostWorkspaceDir)
-	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
-	if len(spec.Mounts) != 2 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
+	wantAgentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
+	wantWorkspaceRoot := filepath.Join(wantAgentHome, hostWorkspaceDir)
+	wantConfigRoot := filepath.Join(wantWorkspaceRoot, filepath.FromSlash(hostPicoClawStateDir))
+	if len(spec.Mounts) != 1 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 1 mount", spec.Mounts)
 	}
-	if spec.Mounts[0].HostPath != wantConfigRoot || spec.Mounts[0].GuestPath != boxPicoClawDir {
-		t.Fatalf("config mount = %+v, want host %q guest %q", spec.Mounts[0], wantConfigRoot, boxPicoClawDir)
-	}
-	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
-		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
+	if spec.Mounts[0].HostPath != wantWorkspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
+		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], wantWorkspaceRoot, boxWorkspaceDir)
 	}
 	if _, err := os.Stat(filepath.Join(wantConfigRoot, hostPicoClawConfig)); err != nil {
 		t.Fatalf("worker PicoClaw config was not written: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(wantWorkspaceRoot, "AGENT.md")); err != nil {
-		t.Fatalf("worker workspace was not written under .picoclaw: %v", err)
+		t.Fatalf("worker workspace was not written: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)); !os.IsNotExist(err) {
-		t.Fatalf("legacy workspace stat error = %v, want not exist", err)
+	if _, err := os.Stat(filepath.Join(wantAgentHome, hostPicoClawDir)); !os.IsNotExist(err) {
+		t.Fatalf("picoclaw host dir stat error = %v, want not exist", err)
 	}
 }
 
-func TestGatewayCreateSpecMigratesLegacyWorkspaceDir(t *testing.T) {
+func TestGatewayCreateSpecMigratesNestedPicoClawWorkspaceDir(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
@@ -2711,11 +2708,12 @@ func TestGatewayCreateSpecMigratesLegacyWorkspaceDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
-	workspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir)
-	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
-		t.Fatalf("os.MkdirAll(workspaceRoot) error = %v", err)
+	agentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
+	nestedWorkspaceRoot := filepath.Join(agentHome, hostPicoClawDir, hostWorkspaceDir)
+	if err := os.MkdirAll(nestedWorkspaceRoot, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(nestedWorkspaceRoot) error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceRoot, "local.txt"), []byte("keep"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(nestedWorkspaceRoot, "local.txt"), []byte("keep"), 0o600); err != nil {
 		t.Fatalf("os.WriteFile(local workspace file) error = %v", err)
 	}
 
@@ -2728,23 +2726,22 @@ func TestGatewayCreateSpecMigratesLegacyWorkspaceDir(t *testing.T) {
 		t.Fatalf("gatewayCreateSpec() error = %v", err)
 	}
 
-	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
-	if len(spec.Mounts) != 2 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
+	if len(spec.Mounts) != 1 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 1 mount", spec.Mounts)
 	}
-	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
-		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
+	workspaceRoot := filepath.Join(agentHome, hostWorkspaceDir)
+	if spec.Mounts[0].HostPath != workspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
+		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], workspaceRoot, boxWorkspaceDir)
 	}
-	if _, err := os.Stat(workspaceRoot); !os.IsNotExist(err) {
-		t.Fatalf("legacy workspace stat error = %v, want not exist", err)
+	if _, err := os.Stat(nestedWorkspaceRoot); !os.IsNotExist(err) {
+		t.Fatalf("nested workspace stat error = %v, want not exist", err)
 	}
-	newWorkspaceRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostPicoClawDir, hostWorkspaceDir)
-	if data, err := os.ReadFile(filepath.Join(newWorkspaceRoot, "local.txt")); err != nil {
+	if data, err := os.ReadFile(filepath.Join(workspaceRoot, "local.txt")); err != nil {
 		t.Fatalf("read migrated workspace file: %v", err)
 	} else if string(data) != "keep" {
 		t.Fatalf("migrated workspace file = %q, want keep", data)
 	}
-	if _, err := os.Stat(filepath.Join(newWorkspaceRoot, "AGENT.md")); err != nil {
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "AGENT.md")); err != nil {
 		t.Fatalf("worker workspace template was not written after migration: %v", err)
 	}
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -2704,56 +2704,6 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	}
 }
 
-func TestGatewayCreateSpecMigratesNestedPicoClawWorkspaceDir(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
-	agentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
-	nestedWorkspaceRoot := filepath.Join(agentHome, hostPicoClawDir, hostWorkspaceDir)
-	if err := os.MkdirAll(nestedWorkspaceRoot, 0o755); err != nil {
-		t.Fatalf("os.MkdirAll(nestedWorkspaceRoot) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(nestedWorkspaceRoot, "local.txt"), []byte("keep"), 0o600); err != nil {
-		t.Fatalf("os.WriteFile(local workspace file) error = %v", err)
-	}
-
-	spec, err := svc.gatewayCreateSpec("picoclaw:latest", "alice", "u-worker-1", AgentProfile{
-		Name:     "alice",
-		Provider: ProviderAPI,
-		ModelID:  "gpt-5.5",
-	})
-	if err != nil {
-		t.Fatalf("gatewayCreateSpec() error = %v", err)
-	}
-
-	if len(spec.Mounts) != 2 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
-	}
-	workspaceRoot := filepath.Join(agentHome, hostWorkspaceDir)
-	if spec.Mounts[0].HostPath != workspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
-		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], workspaceRoot, boxWorkspaceDir)
-	}
-	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
-	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
-		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
-	}
-	if _, err := os.Stat(nestedWorkspaceRoot); !os.IsNotExist(err) {
-		t.Fatalf("nested workspace stat error = %v, want not exist", err)
-	}
-	if data, err := os.ReadFile(filepath.Join(workspaceRoot, "local.txt")); err != nil {
-		t.Fatalf("read migrated workspace file: %v", err)
-	} else if string(data) != "keep" {
-		t.Fatalf("migrated workspace file = %q, want keep", data)
-	}
-	if _, err := os.Stat(filepath.Join(workspaceRoot, "AGENT.md")); err != nil {
-		t.Fatalf("worker workspace template was not written after migration: %v", err)
-	}
-}
-
 func TestGatewayStartCommandUsesTiniForNormalMode(t *testing.T) {
 	entrypoint, cmd := gatewayStartCommand(false)
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -66,6 +66,41 @@ func (f *fakeInfoInstance) Info(context.Context) (sandbox.Info, error) {
 	return f.info, nil
 }
 
+type transientInfoInstance struct {
+	fakeInstance
+	failures int
+	calls    int
+	info     sandbox.Info
+}
+
+func (f *transientInfoInstance) Info(context.Context) (sandbox.Info, error) {
+	f.calls++
+	if f.calls <= f.failures {
+		return sandbox.Info{}, fmt.Errorf("inspect boxlite cli box: boxlite cli exited with code 1: Failed to acquire runtime lock: Another BoxliteRuntime is already using directory")
+	}
+	return f.info, nil
+}
+
+type singleInstanceRuntime struct {
+	instance sandbox.Instance
+}
+
+func (r *singleInstanceRuntime) Create(context.Context, sandbox.CreateSpec) (sandbox.Instance, error) {
+	return r.instance, nil
+}
+
+func (r *singleInstanceRuntime) Get(context.Context, string) (sandbox.Instance, error) {
+	return r.instance, nil
+}
+
+func (r *singleInstanceRuntime) Remove(context.Context, string, sandbox.RemoveOptions) error {
+	return nil
+}
+
+func (r *singleInstanceRuntime) Close() error {
+	return nil
+}
+
 type agentBoxliteCLIRunner struct {
 	requests []boxlitecli.CommandRequest
 	boxes    map[string]agentBoxliteCLIBox
@@ -387,6 +422,47 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 		if len(req.Args) > 2 && req.Args[2] == "run" && !containsAny(req.Args, "/bin/sh", "/usr/local/bin/picoclaw") {
 			t.Fatalf("boxlite-cli run args missing gateway command: %q", req.Args)
 		}
+	}
+}
+
+func TestCreateGatewayBoxRetriesTransientRuntimeLockInfo(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	origDelay := sandboxRuntimeLockRetryDelay
+	sandboxRuntimeLockRetryDelay = time.Millisecond
+	t.Cleanup(func() {
+		sandboxRuntimeLockRetryDelay = origDelay
+	})
+
+	inst := &transientInfoInstance{
+		failures: 2,
+		info: sandbox.Info{
+			ID:        "box-alice",
+			Name:      "alice",
+			State:     sandbox.StateRunning,
+			CreatedAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+		},
+	}
+	svc, err := NewService(testModelConfig(), config.ServerConfig{ListenAddr: ":18080", AccessToken: "token"}, "picoclaw:latest", filepath.Join(homeDir, "agents.json"))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	box, info, err := svc.createGatewayBox(context.Background(), &singleInstanceRuntime{instance: inst}, "picoclaw:latest", "alice", "u-alice", AgentProfile{
+		Provider:        ProviderCodex,
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("createGatewayBox() error = %v", err)
+	}
+	if box != inst {
+		t.Fatalf("createGatewayBox() box = %T, want transientInfoInstance", box)
+	}
+	if info.ID != "box-alice" || info.State != sandbox.StateRunning {
+		t.Fatalf("createGatewayBox() info = %+v, want running box-alice", info)
+	}
+	if inst.calls != 3 {
+		t.Fatalf("Info() calls = %d, want 3", inst.calls)
 	}
 }
 
@@ -1477,30 +1553,154 @@ func TestStartFallsBackToNameAndRefreshesStoredAgentState(t *testing.T) {
 	}
 }
 
-func TestStartConfiguredAgentsStartsStoppedCompleteWorkers(t *testing.T) {
+func TestStartConfiguredAgentsRecreatesMissingCompleteWorkerBoxes(t *testing.T) {
 	rt := &fakeRuntime{}
-	SetTestHooks(func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil }, nil)
+	boxes := map[string]sandbox.Info{}
+	var created []string
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil },
+		func(_ *Service, _ context.Context, _ sandbox.Runtime, image, name, botID string, profile AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+			if image != "worker-image:1" {
+				t.Fatalf("createGatewayBox() image = %q, want %q", image, "worker-image:1")
+			}
+			if botID != "u-alice" {
+				t.Fatalf("createGatewayBox() botID = %q, want %q", botID, "u-alice")
+			}
+			if !profile.ProfileComplete || profile.Provider != ProviderCodex || profile.ModelID != "gpt-5.5" {
+				t.Fatalf("createGatewayBox() profile = %+v, want complete codex gpt-5.5", profile)
+			}
+			created = append(created, name)
+			info := sandbox.Info{
+				ID:        "box-alice-new",
+				Name:      name,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			}
+			boxes[info.ID] = info
+			boxes[name] = info
+			return &fakeInfoInstance{info: info}, info, nil
+		},
+	)
 	defer ResetTestHooks()
 
-	states := map[string]sandbox.State{
-		"box-alice": sandbox.StateStopped,
-		"box-carol": sandbox.StateRunning,
-	}
-	names := map[string]string{
-		"box-alice": "alice",
-		"box-carol": "carol",
-	}
+	var gotKeys []string
 	testGetBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
-		state, ok := states[idOrName]
+		gotKeys = append(gotKeys, idOrName)
+		info, ok := boxes[idOrName]
 		if !ok {
 			return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
 		}
-		return &fakeInfoInstance{info: sandbox.Info{
-			ID:        idOrName,
-			Name:      names[idOrName],
-			State:     state,
+		return &fakeInfoInstance{info: info}, nil
+	}
+	testBoxInfoHook = func(_ *Service, _ context.Context, box sandbox.Instance) (sandbox.Info, error) {
+		return box.Info(context.Background())
+	}
+	var removed []string
+	testForceRemoveBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) error {
+		removed = append(removed, idOrName)
+		return fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+	}
+
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "agents.json")
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:1", statePath)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	completeAlice := AgentProfile{Name: "alice", Provider: ProviderCodex, ModelID: "gpt-5.5", ProfileComplete: true}
+	svc.agents["u-alice"] = Agent{
+		ID:              "u-alice",
+		Name:            "alice",
+		Role:            RoleWorker,
+		Image:           "worker-image:1",
+		BoxID:           "box-alice-stale",
+		Status:          string(sandbox.StateRunning),
+		AgentProfile:    completeAlice,
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	}
+
+	if err := svc.StartConfiguredAgents(context.Background()); err != nil {
+		t.Fatalf("StartConfiguredAgents() error = %v", err)
+	}
+	if strings.Join(created, ",") != "alice" {
+		t.Fatalf("created boxes = %q, want alice", created)
+	}
+	if strings.Join(removed, ",") != "box-alice-stale" {
+		t.Fatalf("removed boxes = %q, want stale box id", removed)
+	}
+	if len(gotKeys) < 2 || gotKeys[0] != "box-alice-stale" || gotKeys[1] != "alice" {
+		t.Fatalf("getBox() leading keys = %q, want stale box id then name", gotKeys)
+	}
+	got, ok := svc.Agent("u-alice")
+	if !ok {
+		t.Fatal("Agent() missing u-alice")
+	}
+	if got.BoxID != "box-alice-new" {
+		t.Fatalf("Agent().BoxID = %q, want %q", got.BoxID, "box-alice-new")
+	}
+	if got.Status != string(sandbox.StateRunning) {
+		t.Fatalf("Agent().Status = %q, want running", got.Status)
+	}
+
+	reloaded, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:1", statePath)
+	if err != nil {
+		t.Fatalf("NewService(reload) error = %v", err)
+	}
+	persisted, ok := reloaded.Agent("u-alice")
+	if !ok {
+		t.Fatal("reloaded Agent() missing u-alice")
+	}
+	if persisted.BoxID != "box-alice-new" {
+		t.Fatalf("reloaded Agent().BoxID = %q, want %q", persisted.BoxID, "box-alice-new")
+	}
+}
+
+func TestStartConfiguredAgentsStartsStoppedAndRecreatesRunningCompleteWorkers(t *testing.T) {
+	rt := &fakeRuntime{}
+	infos := map[string]sandbox.Info{
+		"box-alice": {
+			ID:        "box-alice",
+			Name:      "alice",
+			State:     sandbox.StateStopped,
 			CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
-		}}, nil
+		},
+		"box-carol": {
+			ID:        "box-carol",
+			Name:      "carol",
+			State:     sandbox.StateRunning,
+			CreatedAt: time.Date(2026, 4, 1, 13, 0, 0, 0, time.UTC),
+		},
+	}
+	var recreated []string
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil },
+		func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string, name, botID string, profile AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+			recreated = append(recreated, name)
+			if name != "carol" || botID != "u-carol" {
+				t.Fatalf("createGatewayBox() got name=%q botID=%q, want carol/u-carol", name, botID)
+			}
+			if !profile.ProfileComplete || profile.Provider != ProviderCodex || profile.ModelID != "gpt-5.5" {
+				t.Fatalf("createGatewayBox() profile = %+v, want complete codex gpt-5.5", profile)
+			}
+			info := sandbox.Info{
+				ID:        "box-carol-new",
+				Name:      name,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+			}
+			infos[info.ID] = info
+			infos[name] = info
+			return &fakeInfoInstance{info: info}, info, nil
+		},
+	)
+	defer ResetTestHooks()
+	testGetBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
+		info, ok := infos[idOrName]
+		if !ok {
+			return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+		}
+		return &fakeInfoInstance{info: info}, nil
 	}
 	var started []string
 	testStartBoxHook = func(_ *Service, _ context.Context, box sandbox.Instance) error {
@@ -1509,7 +1709,9 @@ func TestStartConfiguredAgentsStartsStoppedCompleteWorkers(t *testing.T) {
 			return err
 		}
 		started = append(started, info.ID)
-		states[info.ID] = sandbox.StateRunning
+		info.State = sandbox.StateRunning
+		infos[info.ID] = info
+		infos[info.Name] = info
 		return nil
 	}
 	testBoxInfoHook = func(_ *Service, _ context.Context, box sandbox.Instance) (sandbox.Info, error) {
@@ -1517,8 +1719,20 @@ func TestStartConfiguredAgentsStartsStoppedCompleteWorkers(t *testing.T) {
 		if err != nil {
 			return sandbox.Info{}, err
 		}
-		info.State = states[info.ID]
+		if current, ok := infos[info.ID]; ok {
+			return current, nil
+		}
 		return info, nil
+	}
+	var removed []string
+	testForceRemoveBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) error {
+		removed = append(removed, idOrName)
+		if info, ok := infos[idOrName]; ok {
+			delete(infos, info.ID)
+			delete(infos, info.Name)
+			return nil
+		}
+		return fmt.Errorf("%w: missing", sandbox.ErrNotFound)
 	}
 
 	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
@@ -1572,12 +1786,28 @@ func TestStartConfiguredAgentsStartsStoppedCompleteWorkers(t *testing.T) {
 	if strings.Join(started, ",") != "box-alice" {
 		t.Fatalf("started boxes = %q, want only box-alice", started)
 	}
+	if strings.Join(recreated, ",") != "carol" {
+		t.Fatalf("recreated boxes = %q, want carol", recreated)
+	}
+	if strings.Join(removed, ",") != "box-carol" {
+		t.Fatalf("removed boxes = %q, want box-carol", removed)
+	}
 	got, ok := svc.Agent("u-alice")
 	if !ok {
 		t.Fatal("Agent() missing u-alice")
 	}
 	if got.Status != string(sandbox.StateRunning) {
 		t.Fatalf("Agent().Status = %q, want running", got.Status)
+	}
+	carol, ok := svc.Agent("u-carol")
+	if !ok {
+		t.Fatal("Agent() missing u-carol")
+	}
+	if carol.BoxID != "box-carol-new" {
+		t.Fatalf("Agent(u-carol).BoxID = %q, want box-carol-new", carol.BoxID)
+	}
+	if carol.Status != string(sandbox.StateRunning) {
+		t.Fatalf("Agent(u-carol).Status = %q, want running", carol.Status)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -66,41 +66,6 @@ func (f *fakeInfoInstance) Info(context.Context) (sandbox.Info, error) {
 	return f.info, nil
 }
 
-type transientInfoInstance struct {
-	fakeInstance
-	failures int
-	calls    int
-	info     sandbox.Info
-}
-
-func (f *transientInfoInstance) Info(context.Context) (sandbox.Info, error) {
-	f.calls++
-	if f.calls <= f.failures {
-		return sandbox.Info{}, fmt.Errorf("inspect boxlite cli box: boxlite cli exited with code 1: Failed to acquire runtime lock: Another BoxliteRuntime is already using directory")
-	}
-	return f.info, nil
-}
-
-type singleInstanceRuntime struct {
-	instance sandbox.Instance
-}
-
-func (r *singleInstanceRuntime) Create(context.Context, sandbox.CreateSpec) (sandbox.Instance, error) {
-	return r.instance, nil
-}
-
-func (r *singleInstanceRuntime) Get(context.Context, string) (sandbox.Instance, error) {
-	return r.instance, nil
-}
-
-func (r *singleInstanceRuntime) Remove(context.Context, string, sandbox.RemoveOptions) error {
-	return nil
-}
-
-func (r *singleInstanceRuntime) Close() error {
-	return nil
-}
-
 type agentBoxliteCLIRunner struct {
 	requests []boxlitecli.CommandRequest
 	boxes    map[string]agentBoxliteCLIBox
@@ -422,47 +387,6 @@ func TestBoxLiteCLIProviderGatewayLifecycle(t *testing.T) {
 		if len(req.Args) > 2 && req.Args[2] == "run" && !containsAny(req.Args, "/bin/sh", "/usr/local/bin/picoclaw") {
 			t.Fatalf("boxlite-cli run args missing gateway command: %q", req.Args)
 		}
-	}
-}
-
-func TestCreateGatewayBoxRetriesTransientRuntimeLockInfo(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-	origDelay := sandboxRuntimeLockRetryDelay
-	sandboxRuntimeLockRetryDelay = time.Millisecond
-	t.Cleanup(func() {
-		sandboxRuntimeLockRetryDelay = origDelay
-	})
-
-	inst := &transientInfoInstance{
-		failures: 2,
-		info: sandbox.Info{
-			ID:        "box-alice",
-			Name:      "alice",
-			State:     sandbox.StateRunning,
-			CreatedAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
-		},
-	}
-	svc, err := NewService(testModelConfig(), config.ServerConfig{ListenAddr: ":18080", AccessToken: "token"}, "picoclaw:latest", filepath.Join(homeDir, "agents.json"))
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
-	box, info, err := svc.createGatewayBox(context.Background(), &singleInstanceRuntime{instance: inst}, "picoclaw:latest", "alice", "u-alice", AgentProfile{
-		Provider:        ProviderCodex,
-		ModelID:         "gpt-5.5",
-		ProfileComplete: true,
-	})
-	if err != nil {
-		t.Fatalf("createGatewayBox() error = %v", err)
-	}
-	if box != inst {
-		t.Fatalf("createGatewayBox() box = %T, want transientInfoInstance", box)
-	}
-	if info.ID != "box-alice" || info.State != sandbox.StateRunning {
-		t.Fatalf("createGatewayBox() info = %+v, want running box-alice", info)
-	}
-	if inst.calls != 3 {
-		t.Fatalf("Info() calls = %d, want 3", inst.calls)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -2683,11 +2683,15 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	wantAgentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
 	wantWorkspaceRoot := filepath.Join(wantAgentHome, hostWorkspaceDir)
 	wantConfigRoot := filepath.Join(wantWorkspaceRoot, filepath.FromSlash(hostPicoClawStateDir))
-	if len(spec.Mounts) != 1 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 1 mount", spec.Mounts)
+	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
+	if len(spec.Mounts) != 2 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
 	}
 	if spec.Mounts[0].HostPath != wantWorkspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
 		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], wantWorkspaceRoot, boxWorkspaceDir)
+	}
+	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
+		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
 	}
 	if _, err := os.Stat(filepath.Join(wantConfigRoot, hostPicoClawConfig)); err != nil {
 		t.Fatalf("worker PicoClaw config was not written: %v", err)
@@ -2726,12 +2730,16 @@ func TestGatewayCreateSpecMigratesNestedPicoClawWorkspaceDir(t *testing.T) {
 		t.Fatalf("gatewayCreateSpec() error = %v", err)
 	}
 
-	if len(spec.Mounts) != 1 {
-		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 1 mount", spec.Mounts)
+	if len(spec.Mounts) != 2 {
+		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
 	}
 	workspaceRoot := filepath.Join(agentHome, hostWorkspaceDir)
 	if spec.Mounts[0].HostPath != workspaceRoot || spec.Mounts[0].GuestPath != boxWorkspaceDir {
 		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], workspaceRoot, boxWorkspaceDir)
+	}
+	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
+	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != boxProjectsDir {
+		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, boxProjectsDir)
 	}
 	if _, err := os.Stat(nestedWorkspaceRoot); !os.IsNotExist(err) {
 		t.Fatalf("nested workspace stat error = %v, want not exist", err)

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"csgclaw/internal/sandbox"
 )
 
 type persistedState struct {
@@ -36,6 +38,7 @@ type persistedAgent struct {
 	Image            string                   `json:"image,omitempty"`
 	BoxID            string                   `json:"box_id,omitempty"`
 	Role             string                   `json:"role"`
+	Status           string                   `json:"status,omitempty"`
 	CreatedAt        time.Time                `json:"created_at"`
 	Profile          string                   `json:"profile,omitempty"`
 	Provider         string                   `json:"provider,omitempty"`
@@ -54,6 +57,7 @@ func newPersistedAgent(a Agent) persistedAgent {
 		Image:            a.Image,
 		BoxID:            a.BoxID,
 		Role:             a.Role,
+		Status:           a.Status,
 		CreatedAt:        a.CreatedAt,
 		Profile:          a.Profile,
 		Provider:         a.Provider,
@@ -73,6 +77,7 @@ func (a persistedAgent) toAgent() Agent {
 		Image:            a.Image,
 		BoxID:            a.BoxID,
 		Role:             a.Role,
+		Status:           a.Status,
 		CreatedAt:        a.CreatedAt,
 		Profile:          a.Profile,
 		Provider:         a.Provider,
@@ -213,6 +218,9 @@ func (s *Service) normalizeLoadedAgent(a Agent) Agent {
 		if strings.TrimSpace(a.Image) == "" {
 			a.Image = s.managerImage
 		}
+	}
+	if strings.TrimSpace(a.Status) == "" && strings.TrimSpace(a.BoxID) != "" {
+		a.Status = string(sandbox.StateRunning)
 	}
 	return a
 }

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -28,9 +28,6 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		return "", fmt.Errorf("workspace template is required")
 	}
-	if err := migrateNestedPicoClawWorkspace(agentName, hostRoot); err != nil {
-		return "", err
-	}
 	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
 		return "", fmt.Errorf("create agent workspace dir: %w", err)
 	}
@@ -46,87 +43,6 @@ func agentWorkspaceRoot(agentName string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(agentHome, hostWorkspaceDir), nil
-}
-
-func nestedPicoClawWorkspaceRoot(agentName string) (string, error) {
-	picoClawRoot, err := agentPicoClawRoot(agentName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(picoClawRoot, hostWorkspaceDir), nil
-}
-
-func migrateNestedPicoClawWorkspace(agentName, dstRoot string) error {
-	srcRoot, err := nestedPicoClawWorkspaceRoot(agentName)
-	if err != nil {
-		return err
-	}
-	if srcRoot == dstRoot {
-		return nil
-	}
-	if _, err := os.Lstat(srcRoot); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("inspect legacy agent workspace: %w", err)
-	}
-	if _, err := os.Lstat(dstRoot); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect agent workspace: %w", err)
-		}
-		if err := os.MkdirAll(filepath.Dir(dstRoot), 0o755); err != nil {
-			return fmt.Errorf("create agent workspace parent: %w", err)
-		}
-		if err := os.Rename(srcRoot, dstRoot); err != nil {
-			return fmt.Errorf("move nested picoclaw workspace: %w", err)
-		}
-		return nil
-	}
-	if err := mergeLegacyWorkspace(srcRoot, dstRoot); err != nil {
-		return err
-	}
-	return nil
-}
-
-func mergeLegacyWorkspace(srcRoot, dstRoot string) error {
-	entries, err := os.ReadDir(srcRoot)
-	if err != nil {
-		return fmt.Errorf("read legacy workspace: %w", err)
-	}
-	if err := os.MkdirAll(dstRoot, 0o755); err != nil {
-		return fmt.Errorf("create merged workspace: %w", err)
-	}
-	for _, entry := range entries {
-		srcPath := filepath.Join(srcRoot, entry.Name())
-		dstPath := filepath.Join(dstRoot, entry.Name())
-		dstInfo, err := os.Lstat(dstPath)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("inspect merged workspace path: %w", err)
-			}
-			if err := os.Rename(srcPath, dstPath); err != nil {
-				return fmt.Errorf("move legacy workspace path: %w", err)
-			}
-			continue
-		}
-		if entry.IsDir() && dstInfo.IsDir() {
-			if err := mergeLegacyWorkspace(srcPath, dstPath); err != nil {
-				return err
-			}
-			continue
-		}
-		legacyPath := filepath.Join(dstRoot, ".legacy-workspace", entry.Name())
-		if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
-			return fmt.Errorf("create legacy workspace archive: %w", err)
-		}
-		if err := os.Rename(srcPath, legacyPath); err != nil {
-			return fmt.Errorf("archive legacy workspace path: %w", err)
-		}
-	}
-	if err := os.Remove(srcRoot); err != nil {
-		return fmt.Errorf("remove legacy workspace dir: %w", err)
-	}
-	return nil
 }
 
 func copyEmbeddedWorkspace(template, dstRoot string) error {

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -28,6 +28,9 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		return "", fmt.Errorf("workspace template is required")
 	}
+	if err := migrateLegacyAgentWorkspace(agentName, hostRoot); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
 		return "", fmt.Errorf("create agent workspace dir: %w", err)
 	}
@@ -38,11 +41,92 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 }
 
 func agentWorkspaceRoot(agentName string) (string, error) {
+	picoClawRoot, err := agentPicoClawRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(picoClawRoot, hostWorkspaceDir), nil
+}
+
+func legacyAgentWorkspaceRoot(agentName string) (string, error) {
 	agentHome, err := agentHomeDir(agentName)
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(agentHome, hostWorkspaceDir), nil
+}
+
+func migrateLegacyAgentWorkspace(agentName, dstRoot string) error {
+	srcRoot, err := legacyAgentWorkspaceRoot(agentName)
+	if err != nil {
+		return err
+	}
+	if srcRoot == dstRoot {
+		return nil
+	}
+	if _, err := os.Lstat(srcRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect legacy agent workspace: %w", err)
+	}
+	if _, err := os.Lstat(dstRoot); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect agent workspace: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dstRoot), 0o755); err != nil {
+			return fmt.Errorf("create agent workspace parent: %w", err)
+		}
+		if err := os.Rename(srcRoot, dstRoot); err != nil {
+			return fmt.Errorf("move legacy agent workspace: %w", err)
+		}
+		return nil
+	}
+	if err := mergeLegacyWorkspace(srcRoot, dstRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mergeLegacyWorkspace(srcRoot, dstRoot string) error {
+	entries, err := os.ReadDir(srcRoot)
+	if err != nil {
+		return fmt.Errorf("read legacy workspace: %w", err)
+	}
+	if err := os.MkdirAll(dstRoot, 0o755); err != nil {
+		return fmt.Errorf("create merged workspace: %w", err)
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcRoot, entry.Name())
+		dstPath := filepath.Join(dstRoot, entry.Name())
+		dstInfo, err := os.Lstat(dstPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("inspect merged workspace path: %w", err)
+			}
+			if err := os.Rename(srcPath, dstPath); err != nil {
+				return fmt.Errorf("move legacy workspace path: %w", err)
+			}
+			continue
+		}
+		if entry.IsDir() && dstInfo.IsDir() {
+			if err := mergeLegacyWorkspace(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		legacyPath := filepath.Join(dstRoot, ".legacy-workspace", entry.Name())
+		if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+			return fmt.Errorf("create legacy workspace archive: %w", err)
+		}
+		if err := os.Rename(srcPath, legacyPath); err != nil {
+			return fmt.Errorf("archive legacy workspace path: %w", err)
+		}
+	}
+	if err := os.Remove(srcRoot); err != nil {
+		return fmt.Errorf("remove legacy workspace dir: %w", err)
+	}
+	return nil
 }
 
 func copyEmbeddedWorkspace(template, dstRoot string) error {

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -28,7 +28,7 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 	if strings.TrimSpace(template) == "" {
 		return "", fmt.Errorf("workspace template is required")
 	}
-	if err := migrateLegacyAgentWorkspace(agentName, hostRoot); err != nil {
+	if err := migrateNestedPicoClawWorkspace(agentName, hostRoot); err != nil {
 		return "", err
 	}
 	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
@@ -41,14 +41,6 @@ func ensureAgentWorkspace(agentName, template string) (string, error) {
 }
 
 func agentWorkspaceRoot(agentName string) (string, error) {
-	picoClawRoot, err := agentPicoClawRoot(agentName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(picoClawRoot, hostWorkspaceDir), nil
-}
-
-func legacyAgentWorkspaceRoot(agentName string) (string, error) {
 	agentHome, err := agentHomeDir(agentName)
 	if err != nil {
 		return "", err
@@ -56,8 +48,16 @@ func legacyAgentWorkspaceRoot(agentName string) (string, error) {
 	return filepath.Join(agentHome, hostWorkspaceDir), nil
 }
 
-func migrateLegacyAgentWorkspace(agentName, dstRoot string) error {
-	srcRoot, err := legacyAgentWorkspaceRoot(agentName)
+func nestedPicoClawWorkspaceRoot(agentName string) (string, error) {
+	picoClawRoot, err := agentPicoClawRoot(agentName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(picoClawRoot, hostWorkspaceDir), nil
+}
+
+func migrateNestedPicoClawWorkspace(agentName, dstRoot string) error {
+	srcRoot, err := nestedPicoClawWorkspaceRoot(agentName)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func migrateLegacyAgentWorkspace(agentName, dstRoot string) error {
 			return fmt.Errorf("create agent workspace parent: %w", err)
 		}
 		if err := os.Rename(srcRoot, dstRoot); err != nil {
-			return fmt.Errorf("move legacy agent workspace: %w", err)
+			return fmt.Errorf("move nested picoclaw workspace: %w", err)
 		}
 		return nil
 	}

--- a/internal/api/cliproxy_auth.go
+++ b/internal/api/cliproxy_auth.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"csgclaw/internal/cliproxy"
+)
+
+type cliproxyAuthLoginRequest struct {
+	Provider  string `json:"provider"`
+	NoBrowser bool   `json:"no_browser,omitempty"`
+}
+
+var cliproxyAuthStatus = func(r *http.Request, provider string) (cliproxy.AuthStatus, error) {
+	return cliproxy.Default().AuthStatus(r.Context(), provider)
+}
+
+var cliproxyAuthLogin = func(r *http.Request, req cliproxyAuthLoginRequest) (cliproxy.AuthStatus, error) {
+	return cliproxy.Default().Login(r.Context(), req.Provider, cliproxy.LoginOptions{NoBrowser: req.NoBrowser})
+}
+
+func (h *Handler) handleCLIProxyAuthStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	provider := strings.TrimSpace(r.URL.Query().Get("provider"))
+	if provider == "" {
+		http.Error(w, "provider is required", http.StatusBadRequest)
+		return
+	}
+	status, err := cliproxyAuthStatus(r, provider)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+func (h *Handler) handleCLIProxyAuthLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req cliproxyAuthLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Provider) == "" {
+		http.Error(w, "provider is required", http.StatusBadRequest)
+		return
+	}
+	status, err := cliproxyAuthLogin(r, req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}

--- a/internal/api/cliproxy_auth_test.go
+++ b/internal/api/cliproxy_auth_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/cliproxy"
+)
+
+func TestHandleCLIProxyAuthStatus(t *testing.T) {
+	restoreStatus := stubCLIProxyAuthStatus(func(r *http.Request, provider string) (cliproxy.AuthStatus, error) {
+		if provider != "codex" {
+			t.Fatalf("provider = %q, want codex", provider)
+		}
+		return cliproxy.AuthStatus{Provider: "codex", Authenticated: true, Source: "cli-proxy", SupportsLogin: true}, nil
+	})
+	defer restoreStatus()
+
+	rec := httptest.NewRecorder()
+	(&Handler{}).Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/cliproxy/auth/status?provider=codex", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var got cliproxy.AuthStatus
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Authenticated || got.Source != "cli-proxy" {
+		t.Fatalf("response = %+v, want authenticated cli-proxy", got)
+	}
+}
+
+func TestHandleCLIProxyAuthStatusRequiresProvider(t *testing.T) {
+	rec := httptest.NewRecorder()
+	(&Handler{}).Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/cliproxy/auth/status", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCLIProxyAuthLogin(t *testing.T) {
+	restoreLogin := stubCLIProxyAuthLogin(func(r *http.Request, req cliproxyAuthLoginRequest) (cliproxy.AuthStatus, error) {
+		if req.Provider != "claude_code" || !req.NoBrowser {
+			t.Fatalf("request = %+v, want claude_code no_browser", req)
+		}
+		return cliproxy.AuthStatus{Provider: "claude_code", Authenticated: true, Source: "oauth", SupportsLogin: true}, nil
+	})
+	defer restoreLogin()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cliproxy/auth/login", strings.NewReader(`{"provider":"claude_code","no_browser":true}`))
+	(&Handler{}).Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var got cliproxy.AuthStatus
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Authenticated || got.Source != "oauth" {
+		t.Fatalf("response = %+v, want authenticated oauth", got)
+	}
+}
+
+func TestHandleCLIProxyAuthLoginRequiresProvider(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cliproxy/auth/login", strings.NewReader(`{"no_browser":true}`))
+	(&Handler{}).Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func stubCLIProxyAuthStatus(fn func(*http.Request, string) (cliproxy.AuthStatus, error)) func() {
+	previous := cliproxyAuthStatus
+	cliproxyAuthStatus = fn
+	return func() { cliproxyAuthStatus = previous }
+}
+
+func stubCLIProxyAuthLogin(fn func(*http.Request, cliproxyAuthLoginRequest) (cliproxy.AuthStatus, error)) func() {
+	previous := cliproxyAuthLogin
+	cliproxyAuthLogin = fn
+	return func() { cliproxyAuthLogin = previous }
+}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2423,7 +2423,7 @@ func TestReplayRecentPicoClawMessagesReplaysUnansweredHumanMessage(t *testing.T)
 	defer cancel()
 
 	srv := &Handler{im: imSvc, picoclaw: bridge}
-	srv.replayRecentPicoClawMessages("u-manager")
+	srv.replayRecentPicoClawMessages("u-manager", "")
 
 	select {
 	case evt := <-events:
@@ -2470,11 +2470,121 @@ func TestReplayRecentPicoClawMessagesSkipsAnsweredMessage(t *testing.T) {
 	defer cancel()
 
 	srv := &Handler{im: imSvc, picoclaw: bridge}
-	srv.replayRecentPicoClawMessages("u-manager")
+	srv.replayRecentPicoClawMessages("u-manager", "")
 
 	select {
 	case evt := <-events:
 		t.Fatalf("replayed event = %+v, want no replay for answered message", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestReplayRecentPicoClawMessagesDoesNotDuplicateDeliveredMessage(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-delivered",
+						SenderID:  "u-admin",
+						Content:   "please reply",
+						CreatedAt: now,
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+
+	room, ok := imSvc.Room("room-1")
+	if !ok {
+		t.Fatal("Room(room-1) = false, want room")
+	}
+	sender, ok := imSvc.User("u-admin")
+	if !ok {
+		t.Fatal("User(u-admin) = false, want user")
+	}
+	bridge.PublishMessageEvent(room, sender, room.Messages[0])
+
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-delivered" {
+			t.Fatalf("live event = %+v, want msg-delivered", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("PublishMessageEvent() timed out waiting for event")
+	}
+
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+	srv.replayRecentPicoClawMessages("u-manager", "")
+
+	select {
+	case evt := <-events:
+		t.Fatalf("replayed event = %+v, want no duplicate for delivered message", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestReplayRecentPicoClawMessagesHonorsLastEventID(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-seen",
+						SenderID:  "u-admin",
+						Content:   "already delivered",
+						CreatedAt: now,
+					},
+					{
+						ID:        "msg-new",
+						SenderID:  "u-admin",
+						Content:   "new after reconnect",
+						CreatedAt: now.Add(time.Second),
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+	srv.replayRecentPicoClawMessages("u-manager", "msg-seen")
+
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-new" || evt.Text != "new after reconnect" {
+			t.Fatalf("replayed event = %+v, want msg-new new after reconnect", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replayRecentPicoClawMessages() timed out waiting for event")
+	}
+
+	select {
+	case evt := <-events:
+		t.Fatalf("extra replayed event = %+v, want only messages after Last-Event-ID", evt)
 	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -977,7 +979,7 @@ func TestHandleAgentLogsStreamsGatewayLog(t *testing.T) {
 	}()
 
 	srv := &Handler{svc: agentSvc}
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/u-alice/logs?follow=true&lines=80", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/u-alice/logs?lines=80", nil)
 	rec := httptest.NewRecorder()
 
 	srv.Routes().ServeHTTP(rec, req)
@@ -991,14 +993,11 @@ func TestHandleAgentLogsStreamsGatewayLog(t *testing.T) {
 	if gotCmd != "tail" {
 		t.Fatalf("command = %q, want %q", gotCmd, "tail")
 	}
-	if strings.Join(gotArgs, " ") != "-n 80 -f /home/picoclaw/.picoclaw/gateway.log" {
+	if strings.Join(gotArgs, " ") != "-n 80 /home/picoclaw/.picoclaw/gateway.log" {
 		t.Fatalf("args = %q", gotArgs)
 	}
 	if rec.Body.String() != "hello\nworld\n" {
 		t.Fatalf("body = %q, want streamed logs", rec.Body.String())
-	}
-	if !rec.Flushed {
-		t.Fatal("response was not flushed for follow=true")
 	}
 }
 
@@ -2394,6 +2393,225 @@ func TestHandlePicoClawSendMessageRequiresIMService(t *testing.T) {
 	}
 }
 
+func TestPublishPicoClawEventQueuesUntilBotSubscribes(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-pending",
+						SenderID:  "u-admin",
+						Content:   "queued while disconnected",
+						CreatedAt: now,
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+
+	sender, ok := imSvc.User("u-admin")
+	if !ok {
+		t.Fatal("missing sender")
+	}
+	room, ok := imSvc.Room("room-1")
+	if !ok || len(room.Messages) != 1 {
+		t.Fatalf("room = %+v, want one message", room)
+	}
+
+	srv.PublishPicoClawEvent(im.Event{
+		Type:    im.EventTypeMessageCreated,
+		RoomID:  "room-1",
+		Sender:  &sender,
+		Message: &room.Messages[0],
+	})
+
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-pending" || evt.Text != "queued while disconnected" {
+			t.Fatalf("queued event = %+v, want msg-pending queued while disconnected", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe() timed out waiting for queued PicoClaw event")
+	}
+}
+
+func TestPublishPicoClawEventReconnectsMissedWorker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	created := make(chan sandbox.CreateSpec, 1)
+	provider := &sandboxtest.Provider{
+		NameValue: "fake",
+		OpenFunc: func(context.Context, string) (sandbox.Runtime, error) {
+			return &sandboxtest.Runtime{
+				GetFunc: func(context.Context, string) (sandbox.Instance, error) {
+					return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+				},
+				RemoveFunc: func(context.Context, string, sandbox.RemoveOptions) error {
+					return fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+				},
+				CreateFunc: func(_ context.Context, spec sandbox.CreateSpec) (sandbox.Instance, error) {
+					created <- spec
+					return sandboxtest.NewInstance(sandbox.Info{
+						ID:        "box-" + spec.Name,
+						Name:      spec.Name,
+						State:     sandbox.StateRunning,
+						CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+					}), nil
+				},
+			}, nil
+		},
+	}
+	t.Cleanup(agent.TestOnlySetSandboxProvider(provider))
+
+	statePath := filepath.Join(t.TempDir(), "agents.json")
+	if err := writeSeededAgents(statePath, []agent.Agent{
+		{
+			ID:              "u-worker",
+			Name:            "worker",
+			Role:            agent.RoleWorker,
+			BoxID:           "box-stale",
+			Status:          string(sandbox.StateRunning),
+			AgentProfile:    agent.AgentProfile{Name: "worker", Provider: agent.ProviderCodex, ModelID: "gpt-5.5", ProfileComplete: true},
+			ProfileComplete: true,
+			CreatedAt:       time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		},
+	}); err != nil {
+		t.Fatalf("writeSeededAgents() error = %v", err)
+	}
+	svc, err := agent.NewService(
+		config.ModelConfig{ModelID: "gpt-5.5"},
+		config.ServerConfig{ListenAddr: ":18080", AccessToken: "token"},
+		"",
+		statePath,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-worker", Name: "worker", Handle: "worker"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				Members:  []string{"u-admin", "u-worker"},
+				Messages: []im.Message{{ID: "msg-1", SenderID: "u-admin", Content: "please handle this", CreatedAt: time.Now().UTC()}},
+			},
+		},
+	})
+	sender, ok := imSvc.User("u-admin")
+	if !ok {
+		t.Fatal("missing sender")
+	}
+	room, ok := imSvc.Room("room-1")
+	if !ok || len(room.Messages) != 1 {
+		t.Fatalf("room = %+v, want one message", room)
+	}
+
+	srv := &Handler{svc: svc, im: imSvc, picoclaw: im.NewPicoClawBridge("")}
+	srv.PublishPicoClawEvent(im.Event{
+		Type:    im.EventTypeMessageCreated,
+		RoomID:  "room-1",
+		Sender:  &sender,
+		Message: &room.Messages[0],
+	})
+
+	select {
+	case spec := <-created:
+		if spec.Name != "worker" {
+			t.Fatalf("recreated spec.Name = %q, want worker", spec.Name)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for missed worker reconnect")
+	}
+}
+
+func TestHandlePicoClawEventsRequeuesWhenSSEWriteFails(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-retry",
+						SenderID:  "u-admin",
+						Content:   "retry after broken stream",
+						CreatedAt: now,
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	room, ok := imSvc.Room("room-1")
+	if !ok {
+		t.Fatal("Room(room-1) = false, want room")
+	}
+	sender, ok := imSvc.User("u-admin")
+	if !ok {
+		t.Fatal("User(u-admin) = false, want user")
+	}
+	bridge.PublishMessageEvent(room, sender, room.Messages[0])
+
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+	req := httptest.NewRequest(http.MethodGet, "/api/bots/u-manager/events", nil)
+	srv.handlePicoClawEvents(&failingPicoClawEventWriter{header: make(http.Header)}, req, "u-manager")
+
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-retry" || evt.Text != "retry after broken stream" {
+			t.Fatalf("requeued event = %+v, want msg-retry retry after broken stream", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe() timed out waiting for requeued event")
+	}
+}
+
+type failingPicoClawEventWriter struct {
+	header http.Header
+}
+
+func (w *failingPicoClawEventWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingPicoClawEventWriter) Write(data []byte) (int, error) {
+	text := string(data)
+	if strings.HasPrefix(text, "id: ") || strings.HasPrefix(text, "event: message") {
+		return 0, errors.New("broken stream")
+	}
+	return len(data), nil
+}
+
+func (w *failingPicoClawEventWriter) WriteHeader(int) {}
+
+func (w *failingPicoClawEventWriter) Flush() {}
+
 func TestReplayRecentPicoClawMessagesReplaysUnansweredHumanMessage(t *testing.T) {
 	now := time.Now().UTC()
 	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
@@ -2522,6 +2740,7 @@ func TestReplayRecentPicoClawMessagesDoesNotDuplicateDeliveredMessage(t *testing
 		if evt.MessageID != "msg-delivered" {
 			t.Fatalf("live event = %+v, want msg-delivered", evt)
 		}
+		bridge.Ack("u-manager", evt.MessageID)
 	case <-time.After(time.Second):
 		t.Fatal("PublishMessageEvent() timed out waiting for event")
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2394,6 +2394,91 @@ func TestHandlePicoClawSendMessageRequiresIMService(t *testing.T) {
 	}
 }
 
+func TestReplayRecentPicoClawMessagesReplaysUnansweredHumanMessage(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-missed",
+						SenderID:  "u-admin",
+						Content:   "please reply",
+						CreatedAt: now,
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+	srv.replayRecentPicoClawMessages("u-manager")
+
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-missed" || evt.Text != "please reply" {
+			t.Fatalf("replayed event = %+v, want msg-missed please reply", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replayRecentPicoClawMessages() timed out waiting for event")
+	}
+}
+
+func TestReplayRecentPicoClawMessagesSkipsAnsweredMessage(t *testing.T) {
+	now := time.Now().UTC()
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []im.User{
+			{ID: "u-admin", Name: "admin", Handle: "admin"},
+			{ID: "u-manager", Name: "manager", Handle: "manager"},
+		},
+		Rooms: []im.Room{
+			{
+				ID:       "room-1",
+				IsDirect: true,
+				Members:  []string{"u-admin", "u-manager"},
+				Messages: []im.Message{
+					{
+						ID:        "msg-answered",
+						SenderID:  "u-admin",
+						Content:   "please reply",
+						CreatedAt: now,
+					},
+					{
+						ID:        "msg-reply",
+						SenderID:  "u-manager",
+						Content:   "done",
+						CreatedAt: now.Add(time.Second),
+					},
+				},
+			},
+		},
+	})
+	bridge := im.NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-manager")
+	defer cancel()
+
+	srv := &Handler{im: imSvc, picoclaw: bridge}
+	srv.replayRecentPicoClawMessages("u-manager")
+
+	select {
+	case evt := <-events:
+		t.Fatalf("replayed event = %+v, want no replay for answered message", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestHandlePicoClawModelsReturnsBridgeCatalog(t *testing.T) {
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "agents.json")

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -993,7 +993,7 @@ func TestHandleAgentLogsStreamsGatewayLog(t *testing.T) {
 	if gotCmd != "tail" {
 		t.Fatalf("command = %q, want %q", gotCmd, "tail")
 	}
-	if strings.Join(gotArgs, " ") != "-n 80 /home/picoclaw/.picoclaw/gateway.log" {
+	if strings.Join(gotArgs, " ") != "-n 80 /home/picoclaw/.picoclaw/workspace/gateway.log" {
 		t.Fatalf("args = %q", gotArgs)
 	}
 	if rec.Body.String() != "hello\nworld\n" {

--- a/internal/api/llm.go
+++ b/internal/api/llm.go
@@ -44,6 +44,16 @@ func (h *Handler) handlePicoClawChatCompletions(w http.ResponseWriter, r *http.R
 
 func writeLLMError(w http.ResponseWriter, err error) {
 	if httpErr, ok := err.(*llm.HTTPError); ok {
+		if httpErr.Code != "" {
+			writeJSON(w, httpErr.Status, map[string]any{
+				"error": map[string]any{
+					"code":     httpErr.Code,
+					"message":  httpErr.Message,
+					"provider": httpErr.Provider,
+				},
+			})
+			return
+		}
 		http.Error(w, httpErr.Message, httpErr.Status)
 		return
 	}

--- a/internal/api/picoclaw.go
+++ b/internal/api/picoclaw.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,7 +14,10 @@ import (
 	"csgclaw/internal/im"
 )
 
-const picoClawReplayWindow = 30 * time.Minute
+const (
+	picoClawReplayWindow      = 30 * time.Minute
+	picoClawHeartbeatInterval = 15 * time.Second
+)
 
 func (h *Handler) registerPicoClawRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/bots/", h.handlePicoClawBotRoutes)
@@ -76,27 +80,87 @@ func (h *Handler) handlePicoClawEvents(w http.ResponseWriter, r *http.Request, b
 	w.Header().Set("Connection", "keep-alive")
 
 	events, cancel := h.picoclaw.Subscribe(botID)
-	defer cancel()
+	defer func() {
+		cancel()
+		h.requeuePicoClawBufferedEvents(botID, events)
+	}()
+	controller := http.NewResponseController(w)
 
-	_, _ = io.WriteString(w, ": connected\n\n")
-	flusher.Flush()
+	if _, err := io.WriteString(w, ": connected\n\n"); err != nil {
+		return
+	}
+	if err := flushPicoClawSSE(controller, flusher); err != nil {
+		return
+	}
 	h.replayRecentPicoClawMessages(botID, r.Header.Get("Last-Event-ID"))
+	heartbeat := time.NewTicker(picoClawHeartbeatInterval)
+	defer heartbeat.Stop()
 
 	for {
 		select {
 		case <-r.Context().Done():
 			return
-		case evt := <-events:
-			data, err := evt.MarshalJSONLine()
-			if err != nil {
+		case <-heartbeat.C:
+			if err := writePicoClawSSEComment(w, controller, flusher, "heartbeat"); err != nil {
 				return
 			}
-			if id := picoClawSSEID(evt.MessageID); id != "" {
-				_, _ = fmt.Fprintf(w, "id: %s\n", id)
+		case evt, ok := <-events:
+			if !ok {
+				return
 			}
-			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
-			flusher.Flush()
+			if err := writePicoClawSSEEvent(w, controller, flusher, evt); err != nil {
+				h.picoclaw.Requeue(botID, evt)
+				return
+			}
+			h.picoclaw.Ack(botID, evt.MessageID)
 		}
+	}
+}
+
+func writePicoClawSSEEvent(w http.ResponseWriter, controller *http.ResponseController, fallback http.Flusher, evt im.PicoClawEvent) error {
+	data, err := evt.MarshalJSONLine()
+	if err != nil {
+		return err
+	}
+	if id := picoClawSSEID(evt.MessageID); id != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", id); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil {
+		return err
+	}
+	return flushPicoClawSSE(controller, fallback)
+}
+
+func writePicoClawSSEComment(w http.ResponseWriter, controller *http.ResponseController, fallback http.Flusher, comment string) error {
+	if _, err := fmt.Fprintf(w, ": %s\n\n", comment); err != nil {
+		return err
+	}
+	return flushPicoClawSSE(controller, fallback)
+}
+
+func flushPicoClawSSE(controller *http.ResponseController, fallback http.Flusher) error {
+	if controller != nil {
+		if err := controller.Flush(); err == nil {
+			return nil
+		} else if !errors.Is(err, http.ErrNotSupported) {
+			return err
+		}
+	}
+	if fallback == nil {
+		return nil
+	}
+	fallback.Flush()
+	return nil
+}
+
+func (h *Handler) requeuePicoClawBufferedEvents(botID string, events <-chan im.PicoClawEvent) {
+	if h == nil || h.picoclaw == nil {
+		return
+	}
+	for evt := range events {
+		h.picoclaw.Requeue(botID, evt)
 	}
 }
 

--- a/internal/api/picoclaw.go
+++ b/internal/api/picoclaw.go
@@ -1,14 +1,19 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"csgclaw/internal/im"
 )
+
+const picoClawReplayWindow = 30 * time.Minute
 
 func (h *Handler) registerPicoClawRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/bots/", h.handlePicoClawBotRoutes)
@@ -26,7 +31,8 @@ func (h *Handler) PublishPicoClawEvent(evt im.Event) {
 	if !ok {
 		return
 	}
-	h.picoclaw.PublishMessageEvent(room, *evt.Sender, *evt.Message)
+	missed := h.picoclaw.PublishMessageEvent(room, *evt.Sender, *evt.Message)
+	h.reconnectMissedPicoClawAgents(evt.Sender.ID, missed)
 }
 
 func (h *Handler) handlePicoClawBotRoutes(w http.ResponseWriter, r *http.Request) {
@@ -74,6 +80,7 @@ func (h *Handler) handlePicoClawEvents(w http.ResponseWriter, r *http.Request, b
 
 	_, _ = io.WriteString(w, ": connected\n\n")
 	flusher.Flush()
+	h.replayRecentPicoClawMessages(botID)
 
 	for {
 		select {
@@ -88,6 +95,79 @@ func (h *Handler) handlePicoClawEvents(w http.ResponseWriter, r *http.Request, b
 			flusher.Flush()
 		}
 	}
+}
+
+func (h *Handler) replayRecentPicoClawMessages(botID string) {
+	if h == nil || h.im == nil || h.picoclaw == nil {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-picoClawReplayWindow)
+	for _, room := range h.im.ListRooms() {
+		for idx, message := range room.Messages {
+			if !message.CreatedAt.IsZero() && message.CreatedAt.Before(cutoff) {
+				continue
+			}
+			if h.isAgentSender(message.SenderID) {
+				continue
+			}
+			if hasLaterMessageFrom(room.Messages[idx+1:], botID) {
+				continue
+			}
+			sender, ok := h.im.User(message.SenderID)
+			if !ok {
+				continue
+			}
+			h.picoclaw.EnqueueMessageEvent(room, sender, message, botID)
+		}
+	}
+}
+
+func (h *Handler) reconnectMissedPicoClawAgents(senderID string, botIDs []string) {
+	if h == nil || h.svc == nil || h.isAgentSender(senderID) || len(botIDs) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(botIDs))
+	for _, botID := range botIDs {
+		botID = strings.TrimSpace(botID)
+		if botID == "" {
+			continue
+		}
+		if _, ok := seen[botID]; ok {
+			continue
+		}
+		seen[botID] = struct{}{}
+		if _, ok := h.svc.Agent(botID); !ok {
+			continue
+		}
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			if _, err := h.svc.Recreate(ctx, botID); err != nil {
+				slog.Warn("picoclaw agent reconnect failed", "agent_id", botID, "error", err)
+			}
+		}()
+	}
+}
+
+func (h *Handler) isAgentSender(senderID string) bool {
+	if h == nil || h.svc == nil {
+		return false
+	}
+	_, ok := h.svc.Agent(senderID)
+	return ok
+}
+
+func hasLaterMessageFrom(messages []im.Message, senderID string) bool {
+	senderID = strings.TrimSpace(senderID)
+	if senderID == "" {
+		return false
+	}
+	for _, message := range messages {
+		if message.SenderID == senderID {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) handlePicoClawSendMessage(w http.ResponseWriter, r *http.Request, botID string) {

--- a/internal/api/picoclaw.go
+++ b/internal/api/picoclaw.go
@@ -80,7 +80,7 @@ func (h *Handler) handlePicoClawEvents(w http.ResponseWriter, r *http.Request, b
 
 	_, _ = io.WriteString(w, ": connected\n\n")
 	flusher.Flush()
-	h.replayRecentPicoClawMessages(botID)
+	h.replayRecentPicoClawMessages(botID, r.Header.Get("Last-Event-ID"))
 
 	for {
 		select {
@@ -91,20 +91,28 @@ func (h *Handler) handlePicoClawEvents(w http.ResponseWriter, r *http.Request, b
 			if err != nil {
 				return
 			}
+			if id := picoClawSSEID(evt.MessageID); id != "" {
+				_, _ = fmt.Fprintf(w, "id: %s\n", id)
+			}
 			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
 			flusher.Flush()
 		}
 	}
 }
 
-func (h *Handler) replayRecentPicoClawMessages(botID string) {
+func (h *Handler) replayRecentPicoClawMessages(botID, lastEventID string) {
 	if h == nil || h.im == nil || h.picoclaw == nil {
 		return
 	}
+	rooms := h.im.ListRooms()
 	cutoff := time.Now().UTC().Add(-picoClawReplayWindow)
-	for _, room := range h.im.ListRooms() {
+	replayAfter, hasReplayCursor := replayCursor(rooms, lastEventID)
+	for _, room := range rooms {
 		for idx, message := range room.Messages {
 			if !message.CreatedAt.IsZero() && message.CreatedAt.Before(cutoff) {
+				continue
+			}
+			if hasReplayCursor && isAtOrBeforeReplayCursor(message, lastEventID, replayAfter) {
 				continue
 			}
 			if h.isAgentSender(message.SenderID) {
@@ -117,9 +125,43 @@ func (h *Handler) replayRecentPicoClawMessages(botID string) {
 			if !ok {
 				continue
 			}
+			// Route replay through the bridge so the stable message ID remains the
+			// dedupe key for events already delivered live or drained from pending.
 			h.picoclaw.EnqueueMessageEvent(room, sender, message, botID)
 		}
 	}
+}
+
+func replayCursor(rooms []im.Room, lastEventID string) (time.Time, bool) {
+	lastEventID = strings.TrimSpace(lastEventID)
+	if lastEventID == "" {
+		return time.Time{}, false
+	}
+	for _, room := range rooms {
+		for _, message := range room.Messages {
+			if message.ID == lastEventID {
+				return message.CreatedAt, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func isAtOrBeforeReplayCursor(message im.Message, lastEventID string, replayAfter time.Time) bool {
+	if message.ID == strings.TrimSpace(lastEventID) {
+		return true
+	}
+	if replayAfter.IsZero() || message.CreatedAt.IsZero() {
+		return false
+	}
+	return !message.CreatedAt.After(replayAfter)
+}
+
+func picoClawSSEID(messageID string) string {
+	messageID = strings.TrimSpace(messageID)
+	messageID = strings.ReplaceAll(messageID, "\r", "")
+	messageID = strings.ReplaceAll(messageID, "\n", "")
+	return messageID
 }
 
 func (h *Handler) reconnectMissedPicoClawAgents(senderID string, botIDs []string) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -16,6 +16,8 @@ func (h *Handler) registerCoreRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/bots/", h.handleBotByID)
 	mux.HandleFunc("/api/v1/agents", h.handleAgents)
 	mux.HandleFunc("/api/v1/agents/", h.handleAgentByID)
+	mux.HandleFunc("/api/v1/cliproxy/auth/status", h.handleCLIProxyAuthStatus)
+	mux.HandleFunc("/api/v1/cliproxy/auth/login", h.handleCLIProxyAuthLogin)
 	mux.HandleFunc("/api/v1/agent-profiles/models", h.handleAgentProfileModels)
 	mux.HandleFunc("/api/v1/agent-profile-defaults", h.handleAgentProfileDefaults)
 	mux.HandleFunc("/api/v1/bootstrap", h.handleIMBootstrap)

--- a/internal/cliproxy/auth.go
+++ b/internal/cliproxy/auth.go
@@ -1,0 +1,578 @@
+package cliproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+const (
+	autoLoginEnv       = "CSGCLAW_CLIPROXY_AUTO_LOGIN"
+	noBrowserEnv       = "CSGCLAW_CLIPROXY_NO_BROWSER"
+	disableKeychainEnv = "CSGCLAW_CLIPROXY_DISABLE_KEYCHAIN"
+
+	authProviderClaude = "claude"
+)
+
+type AuthStatus struct {
+	Provider         string `json:"provider"`
+	Authenticated    bool   `json:"authenticated"`
+	LoginRequired    bool   `json:"login_required"`
+	Source           string `json:"source,omitempty"`
+	Message          string `json:"message,omitempty"`
+	SupportsLogin    bool   `json:"supports_login"`
+	SupportsKeychain bool   `json:"supports_keychain,omitempty"`
+}
+
+type LoginOptions struct {
+	NoBrowser bool
+	Prompt    func(prompt string) (string, error)
+}
+
+type authImportResult struct {
+	imported bool
+	source   string
+	message  string
+}
+
+type keychainCandidate struct {
+	service string
+	account string
+}
+
+var (
+	errAuthNotFound      = errors.New("cliproxy auth not found")
+	errAuthNotImportable = errors.New("cliproxy auth not importable")
+
+	currentGOOS              = runtime.GOOS
+	claudeKeychainReader     = securityFindGenericPassword
+	claudeKeychainCandidates = []keychainCandidate{
+		{service: "com.anthropic.claude-code"},
+		{service: "Claude Code"},
+		{service: "Claude"},
+		{service: "Anthropic"},
+	}
+)
+
+func (s *Service) AuthStatus(ctx context.Context, provider string) (AuthStatus, error) {
+	return s.authStatus(ctx, provider, true)
+}
+
+func (s *Service) Login(ctx context.Context, provider string, opts LoginOptions) (AuthStatus, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	authProvider, statusProvider, err := normalizeAuthProvider(provider)
+	if err != nil {
+		return AuthStatus{}, err
+	}
+	cfg, err := authConfig()
+	if err != nil {
+		return AuthStatus{}, err
+	}
+
+	if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
+		return authenticatedStatus(statusProvider, "cli-proxy", authProvider), nil
+	}
+
+	if authProvider == authProviderClaude && keychainImportEnabled() {
+		if imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider); imported.imported {
+			_ = s.Shutdown(context.Background())
+			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
+		}
+	}
+
+	noBrowser := opts.NoBrowser || envBool(noBrowserEnv)
+	manager := sdkauth.NewManager(
+		sdkauth.NewFileTokenStore(),
+		sdkauth.NewCodexAuthenticator(),
+		sdkauth.NewClaudeAuthenticator(),
+	)
+	if _, _, err = manager.Login(ctx, authProvider, cfg, &sdkauth.LoginOptions{
+		NoBrowser: noBrowser,
+		Prompt:    opts.Prompt,
+	}); err != nil {
+		return AuthStatus{}, err
+	}
+	_ = s.Shutdown(context.Background())
+	return authenticatedStatus(statusProvider, "oauth", authProvider), nil
+}
+
+func (s *Service) HasAuth(ctx context.Context, provider string) (bool, error) {
+	status, err := s.AuthStatus(ctx, provider)
+	if err != nil {
+		return false, err
+	}
+	return status.Authenticated, nil
+}
+
+func (s *Service) authStatus(ctx context.Context, provider string, allowImport bool) (AuthStatus, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	authProvider, statusProvider, err := normalizeAuthProvider(provider)
+	if err != nil {
+		return AuthStatus{}, err
+	}
+	cfg, err := authConfig()
+	if err != nil {
+		return AuthStatus{}, err
+	}
+
+	if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
+		return authenticatedStatus(statusProvider, "cli-proxy", authProvider), nil
+	}
+
+	var importMessage string
+	if allowImport && autoAuthImportEnabled() {
+		imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider)
+		importMessage = imported.message
+		if imported.imported {
+			_ = s.Shutdown(context.Background())
+			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
+		}
+		if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
+			return authenticatedStatus(statusProvider, "cli-proxy", authProvider), nil
+		}
+	}
+
+	status := unauthenticatedStatus(statusProvider, authProvider)
+	if importMessage != "" {
+		status.Message = importMessage
+	}
+	return status, nil
+}
+
+func importExistingAuth(ctx context.Context, authDir string) {
+	if !autoAuthImportEnabled() {
+		return
+	}
+	for _, provider := range []string{ProviderCodex, authProviderClaude} {
+		if existing, err := findAuth(ctx, authDir, provider); err == nil && existing != nil {
+			continue
+		}
+		_, _ = importExternalAuth(ctx, authDir, provider)
+	}
+}
+
+func importExternalAuth(ctx context.Context, authDir, provider string) (authImportResult, error) {
+	switch provider {
+	case ProviderCodex:
+		return importCodexHomeAuth(ctx, authDir)
+	case authProviderClaude:
+		return importClaudeKeychainAuth(ctx, authDir)
+	default:
+		return authImportResult{}, fmt.Errorf("unsupported cliproxy auth provider %q", provider)
+	}
+}
+
+func importCodexHomeAuth(ctx context.Context, authDir string) (authImportResult, error) {
+	path, err := codexHomeAuthPath()
+	if err != nil {
+		return authImportResult{message: "Codex auth was not found. Run csgclaw auth login codex."}, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return authImportResult{message: "Codex auth was not found. Run csgclaw auth login codex."}, nil
+		}
+		return authImportResult{message: "Codex auth could not be read. Run csgclaw auth login codex."}, nil
+	}
+	metadata, err := codexMetadataFromAuthJSON(raw)
+	if err != nil {
+		return authImportResult{message: "Codex auth is not importable. Run csgclaw auth login codex."}, nil
+	}
+	fileName := authFileName(ProviderCodex, metadata, "codex-imported")
+	if _, err = saveMetadataAuth(ctx, authDir, ProviderCodex, fileName, metadata); err != nil {
+		return authImportResult{}, err
+	}
+	return authImportResult{imported: true, source: "codex-home"}, nil
+}
+
+func importClaudeKeychainAuth(ctx context.Context, authDir string) (authImportResult, error) {
+	if currentGOOS != "darwin" {
+		return authImportResult{message: "Claude Code auth is required. Run csgclaw auth login claude-code."}, nil
+	}
+	if !keychainImportEnabled() {
+		return authImportResult{message: "Claude Keychain probing is disabled. Run csgclaw auth login claude-code."}, nil
+	}
+	for _, candidate := range claudeKeychainCandidates {
+		raw, err := claudeKeychainReader(ctx, candidate.service, candidate.account)
+		if err != nil || len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		metadata, err := claudeMetadataFromKeychain(raw)
+		if err != nil {
+			continue
+		}
+		fileName := authFileName(authProviderClaude, metadata, "claude-keychain-"+shortHash(candidate.service+":"+candidate.account))
+		if _, err = saveMetadataAuth(ctx, authDir, authProviderClaude, fileName, metadata); err != nil {
+			return authImportResult{}, err
+		}
+		return authImportResult{imported: true, source: "macos-keychain"}, nil
+	}
+	return authImportResult{message: "Claude Code auth was not found in macOS Keychain. Run csgclaw auth login claude-code."}, nil
+}
+
+func securityFindGenericPassword(ctx context.Context, service, account string) ([]byte, error) {
+	args := []string{"find-generic-password", "-s", service, "-w"}
+	if strings.TrimSpace(account) != "" {
+		args = []string{"find-generic-password", "-s", service, "-a", account, "-w"}
+	}
+	cmd := exec.CommandContext(ctx, "security", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errAuthNotFound
+	}
+	return out, nil
+}
+
+func codexHomeAuthPath() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return filepath.Join(home, "auth.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "auth.json"), nil
+}
+
+func codexMetadataFromAuthJSON(raw []byte) (map[string]any, error) {
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, err
+	}
+	tokenMap := root
+	if nested, ok := mapValue(root, "tokens"); ok {
+		tokenMap = nested
+	}
+	accessToken := stringFromMap(tokenMap, "access_token", "accessToken")
+	refreshToken := stringFromMap(tokenMap, "refresh_token", "refreshToken")
+	if accessToken == "" || refreshToken == "" {
+		return nil, errAuthNotImportable
+	}
+	metadata := map[string]any{
+		"type":          ProviderCodex,
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+		"disabled":      false,
+	}
+	copyString(metadata, tokenMap, "id_token", "idToken")
+	copyString(metadata, tokenMap, "account_id", "accountID", "accountId")
+	copyString(metadata, root, "last_refresh", "lastRefresh")
+	copyString(metadata, tokenMap, "last_refresh", "lastRefresh")
+	if email := findFirstString(root, "email", "emailAddress"); email != "" {
+		metadata["email"] = email
+	} else if email = emailFromJWT(stringFromMap(tokenMap, "id_token", "idToken")); email != "" {
+		metadata["email"] = email
+	}
+	if expired := expiryFromValue(firstValue(tokenMap, "expired", "expires_at", "expiresAt", "expiry", "expiration")); expired != "" {
+		metadata["expired"] = expired
+	}
+	return metadata, nil
+}
+
+func claudeMetadataFromKeychain(raw []byte) (map[string]any, error) {
+	var root any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, err
+	}
+	for _, candidate := range collectMaps(root) {
+		accessToken := stringFromMap(candidate, "access_token", "accessToken")
+		refreshToken := stringFromMap(candidate, "refresh_token", "refreshToken")
+		if accessToken == "" || refreshToken == "" {
+			continue
+		}
+		metadata := map[string]any{
+			"type":          authProviderClaude,
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"disabled":      false,
+		}
+		copyString(metadata, candidate, "id_token", "idToken")
+		if email := findFirstString(root, "email", "emailAddress", "accountEmail"); email != "" {
+			metadata["email"] = email
+		}
+		if expired := expiryFromValue(firstValue(candidate, "expired", "expires_at", "expiresAt", "expiry", "expiration")); expired != "" {
+			metadata["expired"] = expired
+		}
+		if lastRefresh := stringFromMap(candidate, "last_refresh", "lastRefresh"); lastRefresh != "" {
+			metadata["last_refresh"] = lastRefresh
+		}
+		return metadata, nil
+	}
+	return nil, errAuthNotImportable
+}
+
+func saveMetadataAuth(ctx context.Context, authDir, provider, fileName string, metadata map[string]any) (string, error) {
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	return store.Save(ctx, &cliproxyauth.Auth{
+		ID:       fileName,
+		Provider: provider,
+		FileName: fileName,
+		Metadata: metadata,
+	})
+}
+
+func findAuth(ctx context.Context, authDir, provider string) (*cliproxyauth.Auth, error) {
+	store := sdkauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	records, err := store.List(ctx)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	for _, record := range records {
+		if record == nil || record.Disabled {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(record.Provider), provider) {
+			return record, nil
+		}
+	}
+	return nil, nil
+}
+
+func authConfig() (*sdkconfig.Config, error) {
+	authDir, err := configuredAuthDir()
+	if err != nil {
+		return nil, err
+	}
+	return &sdkconfig.Config{AuthDir: authDir}, nil
+}
+
+func normalizeAuthProvider(provider string) (authProvider, statusProvider string, err error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case ProviderCodex:
+		return ProviderCodex, ProviderCodex, nil
+	case "claude_code", "claude-code", "claude", ProviderAnthropic:
+		return authProviderClaude, "claude_code", nil
+	default:
+		return "", "", fmt.Errorf("unsupported cliproxy auth provider %q", provider)
+	}
+}
+
+func authenticatedStatus(statusProvider, source, authProvider string) AuthStatus {
+	status := AuthStatus{
+		Provider:      statusProvider,
+		Authenticated: true,
+		Source:        source,
+		SupportsLogin: true,
+	}
+	if authProvider == authProviderClaude && currentGOOS == "darwin" {
+		status.SupportsKeychain = true
+	}
+	return status
+}
+
+func unauthenticatedStatus(statusProvider, authProvider string) AuthStatus {
+	command := "csgclaw auth login " + statusProvider
+	if statusProvider == "claude_code" {
+		command = "csgclaw auth login claude-code"
+	}
+	status := AuthStatus{
+		Provider:      statusProvider,
+		LoginRequired: true,
+		SupportsLogin: true,
+		Message:       "Auth required. Run " + command + " or connect this provider in the CSGClaw UI.",
+	}
+	if authProvider == authProviderClaude && currentGOOS == "darwin" {
+		status.SupportsKeychain = true
+	}
+	return status
+}
+
+func autoAuthImportEnabled() bool {
+	return !envIsFalse(autoLoginEnv)
+}
+
+func keychainImportEnabled() bool {
+	return !envBool(disableKeychainEnv)
+}
+
+func envBool(name string) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(name)))
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
+func envIsFalse(name string) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(name)))
+	return value == "0" || value == "false" || value == "no" || value == "off"
+}
+
+func authFileName(provider string, metadata map[string]any, fallback string) string {
+	base := fallback
+	if email, _ := metadata["email"].(string); strings.TrimSpace(email) != "" {
+		base = provider + "-" + sanitizeFileSegment(email)
+	} else if accountID, _ := metadata["account_id"].(string); strings.TrimSpace(accountID) != "" {
+		base = provider + "-" + shortHash(accountID)
+	}
+	if !strings.HasSuffix(strings.ToLower(base), ".json") {
+		base += ".json"
+	}
+	return base
+}
+
+func sanitizeFileSegment(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "account"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.', r == '_', r == '-', r == '@':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), ".-")
+	if out == "" {
+		return "account"
+	}
+	return out
+}
+
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+func mapValue(values map[string]any, keys ...string) (map[string]any, bool) {
+	for _, key := range keys {
+		if v, ok := values[key].(map[string]any); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func stringFromMap(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := values[key].(string); ok {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func copyString(dst map[string]any, src map[string]any, canonical string, aliases ...string) {
+	keys := append([]string{canonical}, aliases...)
+	if value := stringFromMap(src, keys...); value != "" {
+		dst[canonical] = value
+	}
+}
+
+func firstValue(values map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func collectMaps(root any) []map[string]any {
+	var out []map[string]any
+	var walk func(any)
+	walk = func(value any) {
+		switch typed := value.(type) {
+		case map[string]any:
+			out = append(out, typed)
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(root)
+	return out
+}
+
+func findFirstString(root any, keys ...string) string {
+	for _, candidate := range collectMaps(root) {
+		if value := stringFromMap(candidate, keys...); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func expiryFromValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case float64:
+		return unixExpiry(typed)
+	case int64:
+		return unixExpiry(float64(typed))
+	case json.Number:
+		n, err := strconv.ParseFloat(string(typed), 64)
+		if err != nil {
+			return ""
+		}
+		return unixExpiry(n)
+	default:
+		return ""
+	}
+}
+
+func unixExpiry(value float64) string {
+	if value <= 0 {
+		return ""
+	}
+	if value > 1_000_000_000_000 {
+		return time.UnixMilli(int64(value)).UTC().Format(time.RFC3339)
+	}
+	return time.Unix(int64(value), 0).UTC().Format(time.RFC3339)
+}
+
+func emailFromJWT(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err = json.Unmarshal(raw, &claims); err != nil {
+		return ""
+	}
+	if email, _ := claims["email"].(string); strings.TrimSpace(email) != "" {
+		return strings.TrimSpace(email)
+	}
+	return ""
+}

--- a/internal/cliproxy/auth.go
+++ b/internal/cliproxy/auth.go
@@ -184,18 +184,18 @@ func importExternalAuth(ctx context.Context, authDir, provider string) (authImpo
 func importCodexHomeAuth(ctx context.Context, authDir string) (authImportResult, error) {
 	path, err := codexHomeAuthPath()
 	if err != nil {
-		return authImportResult{message: "Codex auth was not found. Run csgclaw auth login codex."}, nil
+		return authImportResult{message: "Codex auth was not found. Run csgclaw model auth login codex."}, nil
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return authImportResult{message: "Codex auth was not found. Run csgclaw auth login codex."}, nil
+			return authImportResult{message: "Codex auth was not found. Run csgclaw model auth login codex."}, nil
 		}
-		return authImportResult{message: "Codex auth could not be read. Run csgclaw auth login codex."}, nil
+		return authImportResult{message: "Codex auth could not be read. Run csgclaw model auth login codex."}, nil
 	}
 	metadata, err := codexMetadataFromAuthJSON(raw)
 	if err != nil {
-		return authImportResult{message: "Codex auth is not importable. Run csgclaw auth login codex."}, nil
+		return authImportResult{message: "Codex auth is not importable. Run csgclaw model auth login codex."}, nil
 	}
 	fileName := authFileName(ProviderCodex, metadata, "codex-imported")
 	if _, err = saveMetadataAuth(ctx, authDir, ProviderCodex, fileName, metadata); err != nil {
@@ -206,10 +206,10 @@ func importCodexHomeAuth(ctx context.Context, authDir string) (authImportResult,
 
 func importClaudeKeychainAuth(ctx context.Context, authDir string) (authImportResult, error) {
 	if currentGOOS != "darwin" {
-		return authImportResult{message: "Claude Code auth is required. Run csgclaw auth login claude-code."}, nil
+		return authImportResult{message: "Claude Code auth is required. Run csgclaw model auth login claude-code."}, nil
 	}
 	if !keychainImportEnabled() {
-		return authImportResult{message: "Claude Keychain probing is disabled. Run csgclaw auth login claude-code."}, nil
+		return authImportResult{message: "Claude Keychain probing is disabled. Run csgclaw model auth login claude-code."}, nil
 	}
 	for _, candidate := range claudeKeychainCandidates {
 		raw, err := claudeKeychainReader(ctx, candidate.service, candidate.account)
@@ -226,7 +226,7 @@ func importClaudeKeychainAuth(ctx context.Context, authDir string) (authImportRe
 		}
 		return authImportResult{imported: true, source: "macos-keychain"}, nil
 	}
-	return authImportResult{message: "Claude Code auth was not found in macOS Keychain. Run csgclaw auth login claude-code."}, nil
+	return authImportResult{message: "Claude Code auth was not found in macOS Keychain. Run csgclaw model auth login claude-code."}, nil
 }
 
 func securityFindGenericPassword(ctx context.Context, service, account string) ([]byte, error) {
@@ -385,9 +385,9 @@ func authenticatedStatus(statusProvider, source, authProvider string) AuthStatus
 }
 
 func unauthenticatedStatus(statusProvider, authProvider string) AuthStatus {
-	command := "csgclaw auth login " + statusProvider
+	command := "csgclaw model auth login " + statusProvider
 	if statusProvider == "claude_code" {
-		command = "csgclaw auth login claude-code"
+		command = "csgclaw model auth login claude-code"
 	}
 	status := AuthStatus{
 		Provider:      statusProvider,

--- a/internal/cliproxy/auth_test.go
+++ b/internal/cliproxy/auth_test.go
@@ -1,0 +1,154 @@
+package cliproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthStatusImportsCodexHomeAuth(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"last_refresh": "2026-04-29T00:00:00Z",
+		"tokens": {
+			"access_token": "access",
+			"refresh_token": "refresh",
+			"id_token": "id",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := (&Service{}).AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if !status.Authenticated || status.Source != "codex-home" {
+		t.Fatalf("status = %+v, want authenticated codex-home", status)
+	}
+
+	files, err := filepath.Glob(filepath.Join(authDir, "codex-*.json"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("imported files = %v, %v; want one codex file", files, err)
+	}
+	var metadata map[string]any
+	raw, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["type"] != "codex" || metadata["access_token"] != "access" || metadata["refresh_token"] != "refresh" {
+		t.Fatalf("metadata = %#v, want codex tokens", metadata)
+	}
+}
+
+func TestAuthStatusImportsClaudeKeychainToken(t *testing.T) {
+	authDir := t.TempDir()
+	t.Setenv(authDirEnv, authDir)
+	restore := stubKeychain(t, func(context.Context, string, string) ([]byte, error) {
+		return []byte(`{
+			"oauthAccount": {"emailAddress": "dev@example.test"},
+			"claudeAiOauth": {
+				"accessToken": "access",
+				"refreshToken": "refresh",
+				"expiresAt": 1777392000000
+			}
+		}`), nil
+	})
+	defer restore()
+
+	status, err := (&Service{}).AuthStatus(context.Background(), "claude_code")
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if !status.Authenticated || status.Source != "macos-keychain" {
+		t.Fatalf("status = %+v, want authenticated macos-keychain", status)
+	}
+
+	files, err := filepath.Glob(filepath.Join(authDir, "claude-*.json"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("imported files = %v, %v; want one claude file", files, err)
+	}
+	var metadata map[string]any
+	raw, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["type"] != "claude" || metadata["email"] != "dev@example.test" || metadata["access_token"] != "access" || metadata["refresh_token"] != "refresh" {
+		t.Fatalf("metadata = %#v, want claude keychain tokens", metadata)
+	}
+	if metadata["expired"] == "" {
+		t.Fatalf("metadata missing normalized expiry: %#v", metadata)
+	}
+}
+
+func TestAuthStatusClaudeKeychainMissingDoesNotFail(t *testing.T) {
+	authDir := t.TempDir()
+	t.Setenv(authDirEnv, authDir)
+	restore := stubKeychain(t, func(context.Context, string, string) ([]byte, error) {
+		return nil, errors.New("not found")
+	})
+	defer restore()
+
+	status, err := (&Service{}).AuthStatus(context.Background(), "claude_code")
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if status.Authenticated || !status.LoginRequired {
+		t.Fatalf("status = %+v, want login required", status)
+	}
+	files, err := filepath.Glob(filepath.Join(authDir, "*.json"))
+	if err != nil || len(files) != 0 {
+		t.Fatalf("files = %v, %v; want no auth files", files, err)
+	}
+}
+
+func TestAuthStatusClaudeMalformedKeychainDoesNotWrite(t *testing.T) {
+	authDir := t.TempDir()
+	t.Setenv(authDirEnv, authDir)
+	restore := stubKeychain(t, func(context.Context, string, string) ([]byte, error) {
+		return []byte(`{"claudeAiOauth":{"accessToken":"access-only"}}`), nil
+	})
+	defer restore()
+
+	status, err := (&Service{}).AuthStatus(context.Background(), "claude_code")
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if status.Authenticated || !status.LoginRequired {
+		t.Fatalf("status = %+v, want login required", status)
+	}
+	files, err := filepath.Glob(filepath.Join(authDir, "*.json"))
+	if err != nil || len(files) != 0 {
+		t.Fatalf("files = %v, %v; want no auth files", files, err)
+	}
+}
+
+func stubKeychain(t *testing.T, reader func(context.Context, string, string) ([]byte, error)) func() {
+	t.Helper()
+	previousGOOS := currentGOOS
+	previousReader := claudeKeychainReader
+	currentGOOS = "darwin"
+	claudeKeychainReader = reader
+	return func() {
+		currentGOOS = previousGOOS
+		claudeKeychainReader = previousReader
+	}
+}

--- a/internal/cliproxy/service.go
+++ b/internal/cliproxy/service.go
@@ -77,6 +77,7 @@ func (s *Service) EnsureStarted(ctx context.Context) error {
 		s.mu.Unlock()
 		return err
 	}
+	importExistingAuth(ctx, cfg.AuthDir)
 
 	svc, err := cliproxysdk.NewBuilder().
 		WithConfig(cfg).

--- a/internal/cliproxy/service.go
+++ b/internal/cliproxy/service.go
@@ -16,6 +16,8 @@ import (
 
 	"csgclaw/internal/config"
 
+	"github.com/gin-gonic/gin"
+	cliproxyapi "github.com/router-for-me/CLIProxyAPI/v6/sdk/api"
 	cliproxysdk "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator/builtin"
@@ -33,6 +35,8 @@ const (
 
 	configDirEnv = "CSGCLAW_CLIPROXY_CONFIG_DIR"
 	authDirEnv   = "CSGCLAW_CLIPROXY_AUTH_DIR"
+
+	embeddedCLIProxySkipGinLogKey = "__gin_skip_request_logging__"
 )
 
 type Service struct {
@@ -82,6 +86,7 @@ func (s *Service) EnsureStarted(ctx context.Context) error {
 	svc, err := cliproxysdk.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(cfgPath).
+		WithServerOptions(cliproxyapi.WithMiddleware(skipEmbeddedHealthzAccessLog())).
 		Build()
 	if err != nil {
 		s.mu.Unlock()
@@ -240,6 +245,15 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func skipEmbeddedHealthzAccessLog() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c != nil && c.Request != nil && c.Request.URL != nil && c.Request.URL.Path == "/healthz" {
+			c.Set(embeddedCLIProxySkipGinLogKey, true)
+		}
+		c.Next()
 	}
 }
 

--- a/internal/cliproxy/service_test.go
+++ b/internal/cliproxy/service_test.go
@@ -1,12 +1,15 @@
 package cliproxy
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	cliproxysdk "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
@@ -133,6 +136,42 @@ func TestBuildConfigUsesPrivateNonReservedPortAndWritesConfig(t *testing.T) {
 	if strings.Contains(text, strconv.Itoa(reservedLegacyCLIProxyPort)) {
 		t.Fatalf("generated config contains reserved fixed port:\n%s", text)
 	}
+}
+
+func TestSkipEmbeddedHealthzAccessLogMarksOnlyHealthz(t *testing.T) {
+	mode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(mode) })
+
+	router := gin.New()
+	router.Use(skipEmbeddedHealthzAccessLog())
+	router.GET("/healthz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"skip": ginContextBool(c, embeddedCLIProxySkipGinLogKey)})
+	})
+	router.GET("/v1/models", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"skip": ginContextBool(c, embeddedCLIProxySkipGinLogKey)})
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"skip":true}` {
+		t.Fatalf("healthz skip response = %s, want true", got)
+	}
+
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"skip":false}` {
+		t.Fatalf("api skip response = %s, want false", got)
+	}
+}
+
+func ginContextBool(c *gin.Context, key string) bool {
+	value, ok := c.Get(key)
+	if !ok {
+		return false
+	}
+	flag, ok := value.(bool)
+	return ok && flag
 }
 
 func TestConfiguredAuthDirExpandsHome(t *testing.T) {

--- a/internal/im/picoclaw.go
+++ b/internal/im/picoclaw.go
@@ -3,6 +3,7 @@ package im
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -10,6 +11,7 @@ type PicoClawBridge struct {
 	mu          sync.Mutex
 	subscribers map[string]map[chan PicoClawEvent]struct{}
 	pending     map[string][]PicoClawEvent
+	inflight    map[string]map[string]PicoClawEvent
 	seen        map[string]map[string]struct{}
 }
 
@@ -40,6 +42,7 @@ func NewPicoClawBridge(string) *PicoClawBridge {
 	return &PicoClawBridge{
 		subscribers: make(map[string]map[chan PicoClawEvent]struct{}),
 		pending:     make(map[string][]PicoClawEvent),
+		inflight:    make(map[string]map[string]PicoClawEvent),
 		seen:        make(map[string]map[string]struct{}),
 	}
 }
@@ -54,39 +57,30 @@ func (b *PicoClawBridge) Subscribe(botID string) (<-chan PicoClawEvent, func()) 
 	b.subscribers[botID][ch] = struct{}{}
 	pending := append([]PicoClawEvent(nil), b.pending[botID]...)
 	delete(b.pending, botID)
-	b.mu.Unlock()
 
-	var unsent []PicoClawEvent
-	var sent []PicoClawEvent
 	for _, evt := range pending {
 		select {
 		case ch <- evt:
-			sent = append(sent, evt)
+			b.markInflightLocked(botID, evt)
 		default:
-			unsent = append(unsent, evt)
-		}
-	}
-	if len(sent) > 0 || len(unsent) > 0 {
-		b.mu.Lock()
-		for _, evt := range sent {
-			b.markSeenLocked(botID, evt.MessageID)
-		}
-		for _, evt := range unsent {
 			b.addPendingLocked(botID, evt)
 		}
-		b.mu.Unlock()
 	}
+	b.mu.Unlock()
 
+	var cancelOnce sync.Once
 	cancel := func() {
-		b.mu.Lock()
-		if subs, ok := b.subscribers[botID]; ok {
-			delete(subs, ch)
-			if len(subs) == 0 {
-				delete(b.subscribers, botID)
+		cancelOnce.Do(func() {
+			b.mu.Lock()
+			if subs, ok := b.subscribers[botID]; ok {
+				delete(subs, ch)
+				if len(subs) == 0 {
+					delete(b.subscribers, botID)
+				}
 			}
-		}
-		b.mu.Unlock()
-		close(ch)
+			b.mu.Unlock()
+			close(ch)
+		})
 	}
 	return ch, cancel
 }
@@ -119,46 +113,132 @@ func (b *PicoClawBridge) EnqueueMessageEvent(room Room, sender User, message Mes
 
 func (b *PicoClawBridge) enqueue(botID string, evt PicoClawEvent) bool {
 	b.mu.Lock()
-	if b.hasSeenLocked(botID, evt.MessageID) {
-		b.mu.Unlock()
+	defer b.mu.Unlock()
+	if b.hasSeenOrInflightLocked(botID, evt.MessageID) {
 		return true
 	}
-	subs := make([]chan PicoClawEvent, 0, len(b.subscribers[botID]))
-	for ch := range b.subscribers[botID] {
-		subs = append(subs, ch)
-	}
+	subs := b.subscribers[botID]
 	if len(subs) == 0 {
 		b.addPendingLocked(botID, evt)
-		b.mu.Unlock()
 		return false
 	}
-	b.mu.Unlock()
 
 	sent := false
-	for _, ch := range subs {
+	for ch := range subs {
 		select {
 		case ch <- evt:
 			sent = true
 		default:
 		}
 	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
 	if sent {
-		b.markSeenLocked(botID, evt.MessageID)
+		b.markInflightLocked(botID, evt)
 		return true
 	}
 	b.addPendingLocked(botID, evt)
 	return false
 }
 
+func (b *PicoClawBridge) Ack(botID, messageID string) {
+	botID = strings.TrimSpace(botID)
+	messageID = strings.TrimSpace(messageID)
+	if botID == "" || messageID == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if inflight := b.inflight[botID]; inflight != nil {
+		delete(inflight, messageID)
+		if len(inflight) == 0 {
+			delete(b.inflight, botID)
+		}
+	}
+	b.removePendingLocked(botID, messageID)
+	b.markSeenLocked(botID, messageID)
+}
+
+func (b *PicoClawBridge) Requeue(botID string, evt PicoClawEvent) {
+	botID = strings.TrimSpace(botID)
+	if botID == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if messageID := strings.TrimSpace(evt.MessageID); messageID != "" {
+		if inflight := b.inflight[botID]; inflight != nil {
+			delete(inflight, messageID)
+			if len(inflight) == 0 {
+				delete(b.inflight, botID)
+			}
+		}
+	}
+	b.addPendingLocked(botID, evt)
+}
+
 func (b *PicoClawBridge) addPendingLocked(botID string, evt PicoClawEvent) {
-	if b.hasSeenLocked(botID, evt.MessageID) {
+	if b.hasSeenOrInflightLocked(botID, evt.MessageID) || b.hasPendingLocked(botID, evt.MessageID) {
 		return
 	}
 	pending := append(b.pending[botID], evt)
 	if len(pending) > maxPendingPicoClawEventsPerBot {
 		pending = pending[len(pending)-maxPendingPicoClawEventsPerBot:]
+	}
+	b.pending[botID] = pending
+}
+
+func (b *PicoClawBridge) markInflightLocked(botID string, evt PicoClawEvent) {
+	messageID := strings.TrimSpace(evt.MessageID)
+	if messageID == "" || b.hasSeenLocked(botID, messageID) {
+		return
+	}
+	if b.inflight[botID] == nil {
+		b.inflight[botID] = make(map[string]PicoClawEvent)
+	}
+	b.inflight[botID][messageID] = evt
+	b.removePendingLocked(botID, messageID)
+}
+
+func (b *PicoClawBridge) hasSeenOrInflightLocked(botID, messageID string) bool {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return false
+	}
+	if b.hasSeenLocked(botID, messageID) {
+		return true
+	}
+	_, ok := b.inflight[botID][messageID]
+	return ok
+}
+
+func (b *PicoClawBridge) hasPendingLocked(botID, messageID string) bool {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return false
+	}
+	for _, evt := range b.pending[botID] {
+		if strings.TrimSpace(evt.MessageID) == messageID {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *PicoClawBridge) removePendingLocked(botID, messageID string) {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return
+	}
+	pending := b.pending[botID]
+	for idx := 0; idx < len(pending); {
+		if strings.TrimSpace(pending[idx].MessageID) == messageID {
+			pending = append(pending[:idx], pending[idx+1:]...)
+			continue
+		}
+		idx++
+	}
+	if len(pending) == 0 {
+		delete(b.pending, botID)
+		return
 	}
 	b.pending[botID] = pending
 }

--- a/internal/im/picoclaw.go
+++ b/internal/im/picoclaw.go
@@ -9,7 +9,11 @@ import (
 type PicoClawBridge struct {
 	mu          sync.Mutex
 	subscribers map[string]map[chan PicoClawEvent]struct{}
+	pending     map[string][]PicoClawEvent
+	seen        map[string]map[string]struct{}
 }
+
+const maxPendingPicoClawEventsPerBot = 64
 
 type PicoClawEvent struct {
 	MessageID string         `json:"message_id"`
@@ -35,6 +39,8 @@ type PicoClawSendMessageRequest struct {
 func NewPicoClawBridge(string) *PicoClawBridge {
 	return &PicoClawBridge{
 		subscribers: make(map[string]map[chan PicoClawEvent]struct{}),
+		pending:     make(map[string][]PicoClawEvent),
+		seen:        make(map[string]map[string]struct{}),
 	}
 }
 
@@ -46,7 +52,30 @@ func (b *PicoClawBridge) Subscribe(botID string) (<-chan PicoClawEvent, func()) 
 		b.subscribers[botID] = make(map[chan PicoClawEvent]struct{})
 	}
 	b.subscribers[botID][ch] = struct{}{}
+	pending := append([]PicoClawEvent(nil), b.pending[botID]...)
+	delete(b.pending, botID)
 	b.mu.Unlock()
+
+	var unsent []PicoClawEvent
+	var sent []PicoClawEvent
+	for _, evt := range pending {
+		select {
+		case ch <- evt:
+			sent = append(sent, evt)
+		default:
+			unsent = append(unsent, evt)
+		}
+	}
+	if len(sent) > 0 || len(unsent) > 0 {
+		b.mu.Lock()
+		for _, evt := range sent {
+			b.markSeenLocked(botID, evt.MessageID)
+		}
+		for _, evt := range unsent {
+			b.addPendingLocked(botID, evt)
+		}
+		b.mu.Unlock()
+	}
 
 	cancel := func() {
 		b.mu.Lock()
@@ -62,39 +91,109 @@ func (b *PicoClawBridge) Subscribe(botID string) (<-chan PicoClawEvent, func()) 
 	return ch, cancel
 }
 
-func (b *PicoClawBridge) PublishMessageEvent(room Room, sender User, message Message) {
+func (b *PicoClawBridge) SubscriberCount(botID string) int {
 	b.mu.Lock()
-	targets := make(map[string][]chan PicoClawEvent, len(b.subscribers))
-	for botID, subs := range b.subscribers {
+	defer b.mu.Unlock()
+	return len(b.subscribers[botID])
+}
+
+func (b *PicoClawBridge) PublishMessageEvent(room Room, sender User, message Message) []string {
+	var missed []string
+	for _, botID := range room.Members {
 		if !shouldNotifyBot(room, message, botID) {
 			continue
 		}
-		for ch := range subs {
-			targets[botID] = append(targets[botID], ch)
+		if !b.EnqueueMessageEvent(room, sender, message, botID) {
+			missed = append(missed, botID)
 		}
+	}
+	return missed
+}
+
+func (b *PicoClawBridge) EnqueueMessageEvent(room Room, sender User, message Message, botID string) bool {
+	if !shouldNotifyBot(room, message, botID) {
+		return true
+	}
+	return b.enqueue(botID, messageEventForBot(room, sender, message, botID))
+}
+
+func (b *PicoClawBridge) enqueue(botID string, evt PicoClawEvent) bool {
+	b.mu.Lock()
+	if b.hasSeenLocked(botID, evt.MessageID) {
+		b.mu.Unlock()
+		return true
+	}
+	subs := make([]chan PicoClawEvent, 0, len(b.subscribers[botID]))
+	for ch := range b.subscribers[botID] {
+		subs = append(subs, ch)
+	}
+	if len(subs) == 0 {
+		b.addPendingLocked(botID, evt)
+		b.mu.Unlock()
+		return false
 	}
 	b.mu.Unlock()
 
-	for botID, subs := range targets {
-		evt := PicoClawEvent{
-			MessageID: message.ID,
-			RoomID:    room.ID,
-			ChatType:  chatTypeForRoom(room),
-			Sender: PicoClawSender{
-				ID:          sender.ID,
-				Username:    sender.Handle,
-				DisplayName: sender.Name,
-			},
-			Text:      message.Content,
-			Timestamp: fmt.Sprintf("%d", message.CreatedAt.UnixMilli()),
-			Mentions:  mentionsForBot(message.Mentions, botID),
+	sent := false
+	for _, ch := range subs {
+		select {
+		case ch <- evt:
+			sent = true
+		default:
 		}
-		for _, ch := range subs {
-			select {
-			case ch <- evt:
-			default:
-			}
-		}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if sent {
+		b.markSeenLocked(botID, evt.MessageID)
+		return true
+	}
+	b.addPendingLocked(botID, evt)
+	return false
+}
+
+func (b *PicoClawBridge) addPendingLocked(botID string, evt PicoClawEvent) {
+	if b.hasSeenLocked(botID, evt.MessageID) {
+		return
+	}
+	pending := append(b.pending[botID], evt)
+	if len(pending) > maxPendingPicoClawEventsPerBot {
+		pending = pending[len(pending)-maxPendingPicoClawEventsPerBot:]
+	}
+	b.pending[botID] = pending
+}
+
+func (b *PicoClawBridge) hasSeenLocked(botID, messageID string) bool {
+	if messageID == "" {
+		return false
+	}
+	_, ok := b.seen[botID][messageID]
+	return ok
+}
+
+func (b *PicoClawBridge) markSeenLocked(botID, messageID string) {
+	if messageID == "" {
+		return
+	}
+	if b.seen[botID] == nil {
+		b.seen[botID] = make(map[string]struct{})
+	}
+	b.seen[botID][messageID] = struct{}{}
+}
+
+func messageEventForBot(room Room, sender User, message Message, botID string) PicoClawEvent {
+	return PicoClawEvent{
+		MessageID: message.ID,
+		RoomID:    room.ID,
+		ChatType:  chatTypeForRoom(room),
+		Sender: PicoClawSender{
+			ID:          sender.ID,
+			Username:    sender.Handle,
+			DisplayName: sender.Name,
+		},
+		Text:      message.Content,
+		Timestamp: fmt.Sprintf("%d", message.CreatedAt.UnixMilli()),
+		Mentions:  mentionsForBot(message.Mentions, botID),
 	}
 }
 

--- a/internal/im/picoclaw_test.go
+++ b/internal/im/picoclaw_test.go
@@ -121,3 +121,76 @@ func TestPublishMessageEventQueuesUntilBotSubscribes(t *testing.T) {
 		t.Fatal("Subscribe() timed out waiting for queued event")
 	}
 }
+
+func TestPicoClawBridgeAckPreventsDuplicateReplay(t *testing.T) {
+	bridge := NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-bot")
+	defer cancel()
+
+	room := Room{
+		ID:       "room-direct",
+		IsDirect: true,
+		Members:  []string{"u-admin", "u-bot"},
+	}
+	sender := User{ID: "u-admin", Name: "Admin", Handle: "admin"}
+	message := Message{
+		ID:        "msg-acked",
+		SenderID:  "u-admin",
+		Content:   "acked hello",
+		CreatedAt: time.Now().UTC(),
+	}
+
+	bridge.PublishMessageEvent(room, sender, message)
+	select {
+	case evt := <-events:
+		bridge.Ack("u-bot", evt.MessageID)
+	case <-time.After(time.Second):
+		t.Fatal("PublishMessageEvent() timed out waiting for event")
+	}
+
+	bridge.EnqueueMessageEvent(room, sender, message, "u-bot")
+	select {
+	case evt := <-events:
+		t.Fatalf("duplicate event = %+v, want none after ack", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPicoClawBridgeRequeueDeliversUnackedEventAgain(t *testing.T) {
+	bridge := NewPicoClawBridge("")
+	events, cancel := bridge.Subscribe("u-bot")
+
+	room := Room{
+		ID:       "room-direct",
+		IsDirect: true,
+		Members:  []string{"u-admin", "u-bot"},
+	}
+	sender := User{ID: "u-admin", Name: "Admin", Handle: "admin"}
+	message := Message{
+		ID:        "msg-requeue",
+		SenderID:  "u-admin",
+		Content:   "retry hello",
+		CreatedAt: time.Now().UTC(),
+	}
+
+	bridge.PublishMessageEvent(room, sender, message)
+	var got PicoClawEvent
+	select {
+	case got = <-events:
+	case <-time.After(time.Second):
+		t.Fatal("PublishMessageEvent() timed out waiting for event")
+	}
+	bridge.Requeue("u-bot", got)
+	cancel()
+
+	events, cancel = bridge.Subscribe("u-bot")
+	defer cancel()
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-requeue" || evt.Text != "retry hello" {
+			t.Fatalf("requeued event = %+v, want msg-requeue retry hello", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe() timed out waiting for requeued event")
+	}
+}

--- a/internal/im/picoclaw_test.go
+++ b/internal/im/picoclaw_test.go
@@ -88,3 +88,36 @@ func TestPublishMessageEventUsesGroupChatTypeForTwoMemberGroup(t *testing.T) {
 		t.Fatal("PublishMessageEvent() timed out waiting for event")
 	}
 }
+
+func TestPublishMessageEventQueuesUntilBotSubscribes(t *testing.T) {
+	bridge := NewPicoClawBridge("")
+	room := Room{
+		ID:       "room-direct",
+		IsDirect: true,
+		Members:  []string{"u-admin", "u-bot"},
+	}
+	sender := User{ID: "u-admin", Name: "Admin", Handle: "admin"}
+	message := Message{
+		ID:        "msg-queued",
+		SenderID:  "u-admin",
+		Content:   "queued hello",
+		CreatedAt: time.Now().UTC(),
+	}
+
+	missed := bridge.PublishMessageEvent(room, sender, message)
+	if len(missed) != 1 || missed[0] != "u-bot" {
+		t.Fatalf("PublishMessageEvent() missed = %v, want [u-bot]", missed)
+	}
+
+	events, cancel := bridge.Subscribe("u-bot")
+	defer cancel()
+
+	select {
+	case evt := <-events:
+		if evt.MessageID != "msg-queued" || evt.Text != "queued hello" {
+			t.Fatalf("queued event = %+v, want msg-queued queued hello", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe() timed out waiting for queued event")
+	}
+}

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -22,12 +22,18 @@ type Service struct {
 }
 
 type HTTPError struct {
-	Status  int
-	Message string
+	Status   int
+	Message  string
+	Code     string
+	Provider string
 }
 
 var embeddedCLIProxyProviderBaseURL = func(ctx context.Context, provider string) (string, error) {
 	return cliproxy.Default().ProviderBaseURL(ctx, provider)
+}
+
+var embeddedCLIProxyAuthStatus = func(ctx context.Context, provider string) (cliproxy.AuthStatus, error) {
+	return cliproxy.Default().AuthStatus(ctx, provider)
 }
 
 func (e *HTTPError) Error() string {
@@ -198,6 +204,22 @@ func applyProviderPayloadConstraints(payload map[string]any, profile agent.Agent
 func (s *Service) agentProfileTarget(ctx context.Context, profile agent.AgentProfile) (string, string, error) {
 	switch profile.Provider {
 	case agent.ProviderCodex, agent.ProviderClaudeCode:
+		status, err := embeddedCLIProxyAuthStatus(ctx, profile.Provider)
+		if err != nil {
+			return "", "", &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("embedded cliproxy auth unavailable: %v", err)}
+		}
+		if !status.Authenticated {
+			message := strings.TrimSpace(status.Message)
+			if message == "" {
+				message = fmt.Sprintf("%s auth is required. Connect this provider in the CSGClaw UI.", profile.Provider)
+			}
+			return "", "", &HTTPError{
+				Status:   http.StatusConflict,
+				Code:     "auth_required",
+				Provider: profile.Provider,
+				Message:  message,
+			}
+		}
 		baseURL, err := embeddedCLIProxyProviderBaseURL(ctx, profile.Provider)
 		if err != nil {
 			return "", "", &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("embedded cliproxy unavailable: %v", err)}

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"csgclaw/internal/agent"
+	"csgclaw/internal/cliproxy"
 	"csgclaw/internal/config"
 )
 
@@ -186,7 +187,11 @@ func TestChatCompletionsCodexRoutesThroughEmbeddedCLIProxy(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	previous := embeddedCLIProxyProviderBaseURL
-	defer func() { embeddedCLIProxyProviderBaseURL = previous }()
+	previousAuthStatus := embeddedCLIProxyAuthStatus
+	defer func() {
+		embeddedCLIProxyProviderBaseURL = previous
+		embeddedCLIProxyAuthStatus = previousAuthStatus
+	}()
 
 	var payload map[string]any
 	var gotAuth string
@@ -206,6 +211,12 @@ func TestChatCompletionsCodexRoutesThroughEmbeddedCLIProxy(t *testing.T) {
 			t.Fatalf("provider = %q, want codex", provider)
 		}
 		return upstream.URL + "/api/provider/codex/v1", nil
+	}
+	embeddedCLIProxyAuthStatus = func(_ context.Context, provider string) (cliproxy.AuthStatus, error) {
+		if provider != agent.ProviderCodex {
+			t.Fatalf("auth provider = %q, want codex", provider)
+		}
+		return cliproxy.AuthStatus{Provider: "codex", Authenticated: true}, nil
 	}
 
 	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
@@ -244,6 +255,49 @@ func TestChatCompletionsCodexRoutesThroughEmbeddedCLIProxy(t *testing.T) {
 	}
 	if payload["store"] != false {
 		t.Fatalf("store = %#v, want false", payload["store"])
+	}
+}
+
+func TestChatCompletionsCodexRequiresAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	previousAuthStatus := embeddedCLIProxyAuthStatus
+	defer func() { embeddedCLIProxyAuthStatus = previousAuthStatus }()
+	embeddedCLIProxyAuthStatus = func(_ context.Context, provider string) (cliproxy.AuthStatus, error) {
+		if provider != agent.ProviderCodex {
+			t.Fatalf("auth provider = %q, want codex", provider)
+		}
+		return cliproxy.AuthStatus{
+			Provider:      "codex",
+			LoginRequired: true,
+			Message:       "Auth required. Run csgclaw auth login codex.",
+		}, nil
+	}
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderCodex,
+				ModelID:         "gpt-5.4",
+				ReasoningEffort: "medium",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	_, _, _, err := svc.ChatCompletions(context.Background(), agent.ManagerUserID, []byte(`{"messages":[]}`))
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("error = %T %v, want *HTTPError", err, err)
+	}
+	if httpErr.Status != http.StatusConflict || httpErr.Code != "auth_required" || httpErr.Provider != agent.ProviderCodex {
+		t.Fatalf("HTTPError = %+v, want auth_required conflict", httpErr)
 	}
 }
 

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -270,7 +270,7 @@ func TestChatCompletionsCodexRequiresAuth(t *testing.T) {
 		return cliproxy.AuthStatus{
 			Provider:      "codex",
 			LoginRequired: true,
-			Message:       "Auth required. Run csgclaw auth login codex.",
+			Message:       "Auth required. Run csgclaw model auth login codex.",
 		}, nil
 	}
 

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -55,11 +55,11 @@ func accessLogShouldSkip(r *http.Request) bool {
 	if r == nil || r.URL == nil {
 		return false
 	}
-	if r.Method != http.MethodGet {
-		return false
-	}
 	if r.URL.Path == "/healthz" {
 		return true
+	}
+	if r.Method != http.MethodGet {
+		return false
 	}
 	return r.URL.Path == "/api/v1/agents" && r.URL.Query().Get("poll") == "1"
 }

--- a/internal/server/accesslog_test.go
+++ b/internal/server/accesslog_test.go
@@ -86,14 +86,17 @@ func TestAccessLogSkipsHealthzPolling(t *testing.T) {
 		_, _ = w.Write([]byte("ok"))
 	}))
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz?ready=1", nil))
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost} {
+		buf.Reset()
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(method, "/healthz?ready=1", nil))
 
-	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
-		t.Fatalf("response = %d %q, want 200 ok", rec.Code, rec.Body.String())
-	}
-	if got := buf.String(); got != "" {
-		t.Fatalf("healthz request was logged: %q", got)
+		if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+			t.Fatalf("%s response = %d %q, want 200 ok", method, rec.Code, rec.Body.String())
+		}
+		if got := buf.String(); got != "" {
+			t.Fatalf("%s healthz request was logged: %q", method, got)
+		}
 	}
 }
 

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -26,6 +27,7 @@ type Options struct {
 	AccessToken string
 	NoAuth      bool
 	Context     context.Context
+	OnReady     func()
 }
 
 func Run(opts Options) error {
@@ -69,7 +71,15 @@ func Run(opts Options) error {
 		_ = httpServer.Shutdown(shutdownCtx)
 	}()
 
-	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	listener, err := net.Listen("tcp", opts.ListenAddr)
+	if err != nil {
+		return err
+	}
+	if opts.OnReady != nil {
+		go opts.OnReady()
+	}
+
+	if err := httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 		errCh <- err
 	}
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -144,6 +144,7 @@ const messages = {
     roomDescription: "说明",
     roomDescriptionPlaceholder: "简单说明这个房间的用途",
     initialMembers: "初始成员",
+    allMembers: "全部成员",
     cancel: "取消",
     create: "创建",
     inviteTitle: "添加成员",
@@ -300,6 +301,7 @@ const messages = {
     roomDescription: "Details",
     roomDescriptionPlaceholder: "Briefly describe what this room is for",
     initialMembers: "Initial Members",
+    allMembers: "All members",
     cancel: "Cancel",
     create: "Create",
     inviteTitle: "Add Members",
@@ -1376,6 +1378,7 @@ function App() {
       return;
     }
     setSubmitError("");
+    setInviteUserIDs([]);
     setShowInvite(true);
   }
 
@@ -1525,9 +1528,16 @@ function App() {
   }
 
   const createRoomCandidates = data.users;
+  const createRoomCandidateIDs = createRoomCandidates.map((user) => user.id).filter(Boolean);
+  const createRoomSelectableMemberIDs = createRoomCandidateIDs.filter((id) => !lockedRoomMemberIDs.includes(id));
+  const allCreateRoomMembersSelected = createRoomCandidateIDs.length > 0 && createRoomCandidateIDs.every((id) => roomMemberIDs.includes(id));
+  const createRoomSelectedMemberCount = createRoomCandidateIDs.filter((id) => roomMemberIDs.includes(id)).length;
   const inviteCandidates = activeConversation
     ? data.users.filter((user) => !activeConversation.members.includes(user.id))
     : [];
+  const inviteCandidateIDs = inviteCandidates.map((user) => user.id).filter(Boolean);
+  const allInviteCandidatesSelected = inviteCandidateIDs.length > 0 && inviteCandidateIDs.every((id) => inviteUserIDs.includes(id));
+  const inviteSelectedMemberCount = inviteCandidateIDs.filter((id) => inviteUserIDs.includes(id)).length;
   const activeConversationMembers = activeConversation
     ? activeConversation.members.map((id) => usersById.get(id)).filter(Boolean)
     : [];
@@ -2702,6 +2712,24 @@ function App() {
                 <div className="field">
                   <span>${t("initialMembers")}</span>
                   <div className="selection-list">
+                    <label className="selection-item selection-all-item">
+                      <input
+                        type="checkbox"
+                        checked=${allCreateRoomMembersSelected}
+                        disabled=${createRoomSelectableMemberIDs.length === 0}
+                        onChange=${() => {
+                          setRoomMemberIDs((current) => {
+                            const allSelected = createRoomCandidateIDs.length > 0 && createRoomCandidateIDs.every((id) => current.includes(id));
+                            if (allSelected) {
+                              return current.filter((id) => !createRoomSelectableMemberIDs.includes(id));
+                            }
+                            return Array.from(new Set([...current, ...createRoomSelectableMemberIDs]));
+                          });
+                        }}
+                      />
+                      <span>${t("allMembers")}</span>
+                      <small>${createRoomSelectedMemberCount}/${createRoomCandidateIDs.length}</small>
+                    </label>
                     ${createRoomCandidates.map((user) => html`
                       <label key=${user.id} className="selection-item">
                         <input
@@ -2741,17 +2769,36 @@ function App() {
                   <span>${t("inviteCandidates")}</span>
                   <div className="selection-list">
                     ${inviteCandidates.length > 0
-                      ? inviteCandidates.map((user) => html`
-                          <label key=${user.id} className="selection-item">
+                      ? html`
+                          <label className="selection-item selection-all-item">
                             <input
                               type="checkbox"
-                              checked=${inviteUserIDs.includes(user.id)}
-                              onChange=${() => setInviteUserIDs((current) => toggleSelection(current, user.id))}
+                              checked=${allInviteCandidatesSelected}
+                              onChange=${() => {
+                                setInviteUserIDs((current) => {
+                                  const allSelected = inviteCandidateIDs.length > 0 && inviteCandidateIDs.every((id) => current.includes(id));
+                                  if (allSelected) {
+                                    return current.filter((id) => !inviteCandidateIDs.includes(id));
+                                  }
+                                  return Array.from(new Set([...current, ...inviteCandidateIDs]));
+                                });
+                              }}
                             />
-                            <span>${user.name}</span>
-                            <small>@${user.handle}</small>
+                            <span>${t("allMembers")}</span>
+                            <small>${inviteSelectedMemberCount}/${inviteCandidateIDs.length}</small>
                           </label>
-                        `)
+                          ${inviteCandidates.map((user) => html`
+                            <label key=${user.id} className="selection-item">
+                              <input
+                                type="checkbox"
+                                checked=${inviteUserIDs.includes(user.id)}
+                                onChange=${() => setInviteUserIDs((current) => toggleSelection(current, user.id))}
+                              />
+                              <span>${user.name}</span>
+                              <small>@${user.handle}</small>
+                            </label>
+                          `)}
+                        `
                       : html`<div className="selection-empty">${t("noInviteCandidates")}</div>`}
                   </div>
                 </div>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -14,6 +14,7 @@ const WORKSPACE_GROUPS_COLLAPSED_STORAGE_KEY = "csgclaw.im.workspaceGroupsCollap
 const MESSAGE_LIST_BOTTOM_THRESHOLD = 24;
 const AGENT_STATUS_REFRESH_INTERVAL_MS = 2000;
 const PROVIDERS = ["csghub_lite", "codex", "claude_code", "api"];
+const CLIPROXY_AUTH_PROVIDERS = new Set(["codex", "claude_code"]);
 const REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
 const WORKSPACE_TAB_MESSAGES = "messages";
 const WORKSPACE_TAB_AGENTS = "agents";
@@ -127,6 +128,11 @@ const messages = {
     noChannels: "还没有房间。",
     noDirectMessages: "还没有私信。",
     modelLoadFailed: "模型加载失败",
+    authConnected: "已连接",
+    authMissing: "需要登录",
+    authConnect: "连接",
+    authConnecting: "连接中...",
+    authRequired: "请先连接当前 Provider 后再发送消息。",
     detectionResults: "自动检测结果",
     createRoomTitle: "创建房间",
     createRoomSubtitle: "为一个新主题建立房间，并预先邀请成员。",
@@ -277,6 +283,11 @@ const messages = {
     noChannels: "No rooms yet.",
     noDirectMessages: "No direct messages yet.",
     modelLoadFailed: "Failed to load models",
+    authConnected: "Connected",
+    authMissing: "Login required",
+    authConnect: "Connect",
+    authConnecting: "Connecting...",
+    authRequired: "Connect the current provider before sending messages.",
     detectionResults: "Auto-detection",
     createRoomTitle: "New Room",
     createRoomSubtitle: "Create a new room and invite members in advance.",
@@ -742,6 +753,8 @@ function App() {
   const [profileError, setProfileError] = useState("");
   const [profileBusy, setProfileBusy] = useState(false);
   const [profileModelBusy, setProfileModelBusy] = useState(false);
+  const [cliproxyAuthStatuses, setCLIProxyAuthStatuses] = useState({});
+  const [cliproxyAuthBusy, setCLIProxyAuthBusy] = useState("");
   const [agents, setAgents] = useState([]);
   const [agentsLoaded, setAgentsLoaded] = useState(false);
   const [agentsError, setAgentsError] = useState("");
@@ -767,6 +780,7 @@ function App() {
   const profilePreviewRef = useRef(null);
   const agentRefreshTimerRef = useRef(null);
   const shouldAutoScrollRef = useRef(true);
+  const autoScrollConversationRef = useRef(activeConversationId);
 
   useEffect(() => {
     refreshBootstrap();
@@ -1101,6 +1115,22 @@ function App() {
   }, [managerProfileIncomplete, profileDraft?.provider, profileDraft?.base_url, profileDraft?.api_key, profileDraft?.headersText]);
 
   useEffect(() => {
+    refreshCLIProxyAuthStatus(managerProfile?.provider);
+  }, [managerProfile?.provider]);
+
+  useEffect(() => {
+    refreshCLIProxyAuthStatus(profileDraft?.provider);
+  }, [profileDraft?.provider]);
+
+  useEffect(() => {
+    refreshCLIProxyAuthStatus(agentDraft?.provider);
+  }, [agentDraft?.provider]);
+
+  useEffect(() => {
+    refreshCLIProxyAuthStatus(agentPageDraft?.provider);
+  }, [agentPageDraft?.provider]);
+
+  useEffect(() => {
     const el = messageListRef.current;
     if (!el) {
       return;
@@ -1114,17 +1144,26 @@ function App() {
     return () => el.removeEventListener("scroll", updateAutoScrollState);
   }, [activeConversationId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (activePane.type !== "conversation") {
+      return;
+    }
     const el = messageListRef.current;
     if (!el) {
       return;
     }
-    shouldAutoScrollRef.current = true;
+    autoScrollConversationRef.current = activeConversationId;
     el.scrollTop = el.scrollHeight;
-  }, [activeConversationId]);
+    shouldAutoScrollRef.current = true;
+  }, [activePane.type, activeConversationId]);
 
   useEffect(() => {
     const el = messageListRef.current;
+    if (autoScrollConversationRef.current !== activeConversationId) {
+      autoScrollConversationRef.current = activeConversationId;
+      shouldAutoScrollRef.current = false;
+      return;
+    }
     if (!el || !shouldAutoScrollRef.current) {
       return;
     }
@@ -1187,6 +1226,11 @@ function App() {
   async function sendMessage() {
     if (managerProfileIncomplete) {
       setComposerError(t("profileIncomplete"));
+      return;
+    }
+    const managerProvider = normalizeAuthProviderName(managerProfile?.provider);
+    if (providerNeedsAuth(managerProvider) && cliproxyAuthStatuses[managerProvider]?.authenticated === false) {
+      setComposerError(t("authRequired"));
       return;
     }
     if (!data || !activeConversation || !draftText.trim()) {
@@ -1498,6 +1542,72 @@ function App() {
       setProfileDraft(profileToDraft(profile));
     } catch (_) {
       // The manager may not exist during the first bootstrap milliseconds.
+    }
+  }
+
+  async function refreshCLIProxyAuthStatus(provider) {
+    const normalized = normalizeAuthProviderName(provider);
+    if (!providerNeedsAuth(normalized)) {
+      return;
+    }
+    try {
+      const resp = await fetch(`api/v1/cliproxy/auth/status?provider=${encodeURIComponent(normalized)}`);
+      if (!resp.ok) {
+        throw new Error((await resp.text()).trim() || t("authMissing"));
+      }
+      const status = await resp.json();
+      setCLIProxyAuthStatuses((current) => ({ ...current, [normalized]: status }));
+      setComposerError("");
+    } catch (err) {
+      setCLIProxyAuthStatuses((current) => ({
+        ...current,
+        [normalized]: {
+          provider: normalized,
+          authenticated: false,
+          login_required: true,
+          message: err.message || t("authMissing"),
+        },
+      }));
+    }
+  }
+
+  async function loginCLIProxyProvider(provider) {
+    const normalized = normalizeAuthProviderName(provider);
+    if (!providerNeedsAuth(normalized) || cliproxyAuthBusy) {
+      return;
+    }
+    setCLIProxyAuthBusy(normalized);
+    setCLIProxyAuthStatuses((current) => ({
+      ...current,
+      [normalized]: {
+        ...(current[normalized] || {}),
+        provider: normalized,
+        message: t("authConnecting"),
+      },
+    }));
+    try {
+      const resp = await fetch("api/v1/cliproxy/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: normalized }),
+      });
+      if (!resp.ok) {
+        throw new Error((await resp.text()).trim() || t("authMissing"));
+      }
+      const status = await resp.json();
+      setCLIProxyAuthStatuses((current) => ({ ...current, [normalized]: status }));
+    } catch (err) {
+      setCLIProxyAuthStatuses((current) => ({
+        ...current,
+        [normalized]: {
+          provider: normalized,
+          authenticated: false,
+          login_required: true,
+          message: err.message || t("authMissing"),
+        },
+      }));
+    } finally {
+      setCLIProxyAuthBusy("");
     }
   }
 
@@ -2220,8 +2330,11 @@ function App() {
                   modelBusy=${agentPageModelBusy}
                   saving=${agentPageBusy}
                   saveError=${agentPageError}
+                  authStatuses=${cliproxyAuthStatuses}
+                  authBusyProvider=${cliproxyAuthBusy}
                   onDraftChange=${setAgentPageDraft}
                   onSave=${saveAgentPage}
+                  onProviderLogin=${loginCLIProxyProvider}
                   onStart=${(item) => runAgentAction(item, "start")}
                   onStop=${(item) => runAgentAction(item, "stop")}
                   onRecreate=${(item) => runAgentAction(item, "recreate")}
@@ -2412,6 +2525,15 @@ function App() {
                           `)}
                         </div>
                       `
+                    : null}
+                  ${managerProfile && providerNeedsAuth(managerProfile.provider) && cliproxyAuthStatuses[normalizeAuthProviderName(managerProfile.provider)]?.authenticated === false
+                    ? html`<${CLIProxyAuthControl}
+                        provider=${managerProfile.provider}
+                        t=${t}
+                        status=${cliproxyAuthStatuses[normalizeAuthProviderName(managerProfile.provider)]}
+                        busy=${cliproxyAuthBusy === normalizeAuthProviderName(managerProfile.provider)}
+                        onLogin=${loginCLIProxyProvider}
+                      />`
                     : null}
                   <div className="composer-box">
                     <div className="composer-input-wrap">
@@ -2642,6 +2764,13 @@ function App() {
                         <span>${t("profileFastMode")}</span>
                       </label>
                     </div>
+                    <${CLIProxyAuthControl}
+                      provider=${agentDraft.provider}
+                      t=${t}
+                      status=${cliproxyAuthStatuses[normalizeAuthProviderName(agentDraft.provider)]}
+                      busy=${cliproxyAuthBusy === normalizeAuthProviderName(agentDraft.provider)}
+                      onLogin=${loginCLIProxyProvider}
+                    />
                   </section>
                   ${agentDraft.provider === "api"
                     ? html`
@@ -2767,6 +2896,13 @@ function App() {
                         <span>${t("profileFastMode")}</span>
                       </label>
                     </div>
+                    <${CLIProxyAuthControl}
+                      provider=${profileDraft.provider}
+                      t=${t}
+                      status=${cliproxyAuthStatuses[normalizeAuthProviderName(profileDraft.provider)]}
+                      busy=${cliproxyAuthBusy === normalizeAuthProviderName(profileDraft.provider)}
+                      onLogin=${loginCLIProxyProvider}
+                    />
                   </section>
                   ${profileDraft.provider === "api"
                     ? html`
@@ -3076,7 +3212,7 @@ function WorkspaceConversationRow({ conversation, active, currentUserID, usersBy
   `;
 }
 
-function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, modelBusy, saving, saveError, onDraftChange, onSave, onStart, onStop, onRecreate, onDelete, onInvite, onOpenDM }) {
+function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, modelBusy, saving, saveError, authStatuses, authBusyProvider, onDraftChange, onSave, onProviderLogin, onStart, onStop, onRecreate, onDelete, onInvite, onOpenDM }) {
   const isManager = item.role === "manager" || item.id === "u-manager";
   const running = isAgentRunning(item);
   const incomplete = isAgentIncomplete(item);
@@ -3105,9 +3241,7 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
         ${activeRoom && !isManager
           ? html`<button className="preview-action-button" disabled=${busyKey.startsWith(busyPrefix)} onClick=${() => onInvite(item)}>${t("inviteToRoom")}</button>`
           : null}
-        ${!isManager
-          ? html`<button className="preview-action-button" onClick=${() => onOpenDM(item)}>${t("openDM")}</button>`
-          : null}
+        <button className="preview-action-button" onClick=${() => onOpenDM(item)}>${t("openDM")}</button>
         ${!isManager
           ? html`<button className="preview-action-button preview-action-button-danger" disabled=${busyKey.startsWith(busyPrefix)} onClick=${() => onDelete(item)}>${t("agentDelete")}</button>`
           : null}
@@ -3194,6 +3328,13 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                     <span>${t("profileFastMode")}</span>
                   </label>
                 </div>
+                <${CLIProxyAuthControl}
+                  provider=${draft.provider}
+                  t=${t}
+                  status=${authStatuses?.[normalizeAuthProviderName(draft.provider)]}
+                  busy=${authBusyProvider === normalizeAuthProviderName(draft.provider)}
+                  onLogin=${onProviderLogin}
+                />
               </section>
 
               ${draft.provider === "api"
@@ -3880,6 +4021,42 @@ function parseJSONMap(text) {
     throw new Error("Expected a JSON object");
   }
   return parsed;
+}
+
+function normalizeAuthProviderName(provider) {
+  const value = String(provider ?? "").trim().toLowerCase();
+  if (value === "claude" || value === "claude-code") {
+    return "claude_code";
+  }
+  return value;
+}
+
+function providerNeedsAuth(provider) {
+  return CLIPROXY_AUTH_PROVIDERS.has(normalizeAuthProviderName(provider));
+}
+
+function CLIProxyAuthControl({ provider, t, status, busy, onLogin }) {
+  const normalized = normalizeAuthProviderName(provider);
+  if (!providerNeedsAuth(normalized)) {
+    return null;
+  }
+  const connected = Boolean(status?.authenticated);
+  const message = connected
+    ? `${formatProviderLabel(normalized)} ${t("authConnected")}`
+    : (status?.message || `${formatProviderLabel(normalized)} ${t("authMissing")}`);
+  return html`
+    <div className=${`auth-status-row ${connected ? "connected" : "missing"}`}>
+      <span className="auth-status-dot" aria-hidden="true"></span>
+      <span className="auth-status-message">${message}</span>
+      ${connected
+        ? null
+        : html`
+            <button type="button" className="secondary-button compact" disabled=${busy || !onLogin} onClick=${() => onLogin?.(normalized)}>
+              ${busy ? t("authConnecting") : `${t("authConnect")} ${formatProviderLabel(normalized)}`}
+            </button>
+          `}
+    </div>
+  `;
 }
 
 function formatProviderLabel(provider) {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -343,6 +343,23 @@ const messages = {
   },
 };
 
+function requiredFieldLabel(label) {
+  return html`
+    <span className="field-label">
+      ${label}
+      <span className="field-required-star" aria-hidden="true">*</span>
+    </span>
+  `;
+}
+
+function isBlank(value) {
+  return !String(value ?? "").trim();
+}
+
+function profileBaseURLMissing(draft) {
+  return draft?.provider === "api" && isBlank(draft.base_url);
+}
+
 function GlobeIcon() {
   return html`
     <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -2615,8 +2632,14 @@ function App() {
                   <button className="modal-close" onClick=${() => setShowCreateRoom(false)}>${t("close")}</button>
                 </div>
                 <label className="field">
-                  <span>${t("roomName")}</span>
-                  <input value=${roomTitle} onInput=${(event) => setRoomTitle(event.target.value)} placeholder=${t("roomNamePlaceholder")} />
+                  ${requiredFieldLabel(t("roomName"))}
+                  <input
+                    value=${roomTitle}
+                    required
+                    aria-required="true"
+                    onInput=${(event) => setRoomTitle(event.target.value)}
+                    placeholder=${t("roomNamePlaceholder")}
+                  />
                 </label>
                 <label className="field">
                   <span>${t("roomDescription")}</span>
@@ -2642,7 +2665,7 @@ function App() {
                 ${submitError ? html`<div className="form-error">${submitError}</div>` : null}
                 <div className="modal-actions">
                   <button className="secondary-button" onClick=${() => setShowCreateRoom(false)}>${t("cancel")}</button>
-                  <button className="send-button" disabled=${!roomTitle.trim()} onClick=${createRoom}>${t("create")}</button>
+                  <button className="send-button" disabled=${isBlank(roomTitle)} onClick=${createRoom}>${t("create")}</button>
                 </div>
               </div>
             </div>
@@ -2704,10 +2727,12 @@ function App() {
                     <div className="profile-section-title">${t("profileBasics")}</div>
                     <div className="profile-grid profile-grid-compact">
                       <label className="field">
-                        <span>${t("agentName")}</span>
+                        ${requiredFieldLabel(t("agentName"))}
                         <input
                           value=${agentDraft.name}
                           disabled=${agentModalMode === "edit" && editingAgent?.id === "u-manager"}
+                          required
+                          aria-required="true"
                           onInput=${(event) => setAgentDraft({ ...agentDraft, name: event.target.value })}
                           placeholder=${t("agentNamePlaceholder")}
                         />
@@ -2741,8 +2766,13 @@ function App() {
                         </select>
                       </label>
                       <label className="field">
-                        <span>${t("profileModel")}</span>
-                        <select value=${agentDraft.model_id} onChange=${(event) => setAgentDraft({ ...agentDraft, model_id: event.target.value })}>
+                        ${requiredFieldLabel(t("profileModel"))}
+                        <select
+                          value=${agentDraft.model_id}
+                          required
+                          aria-required="true"
+                          onChange=${(event) => setAgentDraft({ ...agentDraft, model_id: event.target.value })}
+                        >
                           <option value="">${agentModelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
                           ${agentModels.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
                           ${agentDraft.model_id && !agentModels.includes(agentDraft.model_id)
@@ -2778,8 +2808,14 @@ function App() {
                           <div className="profile-section-title">${t("profileAPIProvider")}</div>
                           <div className="profile-api-grid">
                             <label className="field">
-                              <span>${t("profileBaseURL")}</span>
-                              <input value=${agentDraft.base_url} onInput=${(event) => setAgentDraft({ ...agentDraft, base_url: event.target.value })} placeholder="https://api.openai.com/v1" />
+                              ${requiredFieldLabel(t("profileBaseURL"))}
+                              <input
+                                value=${agentDraft.base_url}
+                                required
+                                aria-required="true"
+                                onInput=${(event) => setAgentDraft({ ...agentDraft, base_url: event.target.value })}
+                                placeholder="https://api.openai.com/v1"
+                              />
                             </label>
                             <label className="field">
                               <span>${t("profileAPIKey")}</span>
@@ -2814,7 +2850,7 @@ function App() {
                 ${agentError ? html`<div className="form-error">${agentError}</div>` : null}
                 <div className="modal-actions">
                   <button className="secondary-button" onClick=${() => setShowAgentModal(false)}>${t("cancel")}</button>
-                  <button className="send-button" disabled=${agentBusy || !agentDraft.name.trim() || !agentDraft.model_id} onClick=${saveAgent}>
+                  <button className="send-button" disabled=${agentBusy || isBlank(agentDraft.name) || !agentDraft.model_id || profileBaseURLMissing(agentDraft)} onClick=${saveAgent}>
                     ${agentBusy ? "..." : agentModalMode === "create" ? t("agentCreateSave") : t("agentUpdateSave")}
                   </button>
                 </div>
@@ -2866,9 +2902,11 @@ function App() {
                         </select>
                       </label>
                       <label className="field">
-                        <span>${t("profileModel")}</span>
+                        ${requiredFieldLabel(t("profileModel"))}
                         <select
                           value=${profileDraft.model_id}
+                          required
+                          aria-required="true"
                           onChange=${(event) => setProfileDraft({ ...profileDraft, model_id: event.target.value })}
                         >
                           <option value="">${profileModelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
@@ -2910,8 +2948,14 @@ function App() {
                           <div className="profile-section-title">${t("profileAPIProvider")}</div>
                           <div className="profile-api-grid">
                             <label className="field">
-                              <span>${t("profileBaseURL")}</span>
-                              <input value=${profileDraft.base_url} onInput=${(event) => setProfileDraft({ ...profileDraft, base_url: event.target.value })} placeholder="https://api.openai.com/v1" />
+                              ${requiredFieldLabel(t("profileBaseURL"))}
+                              <input
+                                value=${profileDraft.base_url}
+                                required
+                                aria-required="true"
+                                onInput=${(event) => setProfileDraft({ ...profileDraft, base_url: event.target.value })}
+                                placeholder="https://api.openai.com/v1"
+                              />
                             </label>
                             <label className="field">
                               <span>${t("profileAPIKey")}</span>
@@ -2945,7 +2989,7 @@ function App() {
                 </div>
                 ${profileError ? html`<div className="form-error">${profileError}</div>` : null}
                 <div className="modal-actions">
-                  <button className="send-button" disabled=${profileBusy || !profileDraft.model_id} onClick=${saveManagerProfile}>
+                  <button className="send-button" disabled=${profileBusy || !profileDraft.model_id || profileBaseURLMissing(profileDraft)} onClick=${saveManagerProfile}>
                     ${profileBusy ? "..." : t("profileSave")}
                   </button>
                 </div>
@@ -3233,7 +3277,13 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
         </div>
       </header>
       <div className="entity-toolbar">
-        <button className="preview-action-button preview-action-button-primary" disabled=${saving || !draft?.name?.trim() || !draft?.model_id} onClick=${onSave}>${saving ? t("profileLoadingModels") : t("agentUpdateSave")}</button>
+        <button
+          className="preview-action-button preview-action-button-primary"
+          disabled=${saving || isBlank(draft?.name) || !draft?.model_id || profileBaseURLMissing(draft)}
+          onClick=${onSave}
+        >
+          ${saving ? t("profileLoadingModels") : t("agentUpdateSave")}
+        </button>
         <button className="preview-action-button" disabled=${busyKey.startsWith(busyPrefix) || incomplete} onClick=${() => running ? onStop(item) : onStart(item)}>
           ${running ? t("agentStop") : t("agentStart")}
         </button>
@@ -3281,8 +3331,14 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                 <div className="profile-section-title">${t("profileBasics")}</div>
                 <div className="profile-grid-compact">
                   <label className="field">
-                    <span>${t("agentName")}</span>
-                    <input value=${draft.name} onInput=${(event) => updateDraft({ name: event.target.value })} placeholder=${t("agentNamePlaceholder")} />
+                    ${requiredFieldLabel(t("agentName"))}
+                    <input
+                      value=${draft.name}
+                      required
+                      aria-required="true"
+                      onInput=${(event) => updateDraft({ name: event.target.value })}
+                      placeholder=${t("agentNamePlaceholder")}
+                    />
                   </label>
                   <label className="field">
                     <span>${t("agentImage")}</span>
@@ -3308,8 +3364,13 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                     </select>
                   </label>
                   <label className="field">
-                    <span>${t("profileModel")}</span>
-                    <select value=${draft.model_id} onChange=${(event) => updateDraft({ model_id: event.target.value })}>
+                    ${requiredFieldLabel(t("profileModel"))}
+                    <select
+                      value=${draft.model_id}
+                      required
+                      aria-required="true"
+                      onChange=${(event) => updateDraft({ model_id: event.target.value })}
+                    >
                       <option value="">${modelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
                       ${models.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
                       ${draft.model_id && !models.includes(draft.model_id)
@@ -3343,8 +3404,14 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                       <div className="profile-section-title">${t("profileAPIProvider")}</div>
                       <div className="profile-api-grid">
                         <label className="field">
-                          <span>${t("profileBaseURL")}</span>
-                          <input value=${draft.base_url} onInput=${(event) => updateDraft({ base_url: event.target.value })} placeholder="https://api.openai.com/v1" />
+                          ${requiredFieldLabel(t("profileBaseURL"))}
+                          <input
+                            value=${draft.base_url}
+                            required
+                            aria-required="true"
+                            onInput=${(event) => updateDraft({ base_url: event.target.value })}
+                            placeholder="https://api.openai.com/v1"
+                          />
                         </label>
                         <label className="field">
                           <span>${t("profileAPIKey")}</span>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -33,6 +33,7 @@ mermaid.initialize({
 const messages = {
   zh: {
     pageTitle: "CSGClaw IM",
+    localAgentConsole: "本地 Agent 控制台",
     loading: "正在加载 IM 工作区...",
     loadingFailed: "加载失败，请稍后重试。",
     emptyConversation: "请选择一个房间或私信",
@@ -188,6 +189,7 @@ const messages = {
   },
   en: {
     pageTitle: "CSGClaw IM",
+    localAgentConsole: "Local agent console",
     loading: "Loading IM workspace...",
     loadingFailed: "Failed to load the workspace. Please try again.",
     emptyConversation: "Select a room or DM",
@@ -1536,9 +1538,16 @@ function App() {
   const managerAgent = agents.find((item) => item.role === "manager" || item.id === "u-manager");
   const workerAgents = agents.filter((item) => item.id !== managerAgent?.id);
   const agentItems = [managerAgent, ...workerAgents].filter(Boolean);
+  const runningAgentCount = agentItems.filter(isAgentRunning).length;
   const selectedAgent = selectedAgentForPage;
   const selectedConversation = activePane.type === "conversation" ? activeConversation : null;
   const activeChannel = selectedConversation && !isDirectConversation(selectedConversation) ? selectedConversation : null;
+  const selectedMessageCount = selectedConversation?.messages?.length ?? 0;
+  const currentWorkspaceLabel = activePane.type === "agent"
+    ? t("agentOverview")
+    : activePane.type === "computer"
+      ? t("computerOverview")
+      : t("conversationOverview");
   const previewUser = profilePreview?.type === "user"
     ? usersById.get(profilePreview.id) ?? null
     : profilePreview?.type === "agent"
@@ -2147,7 +2156,9 @@ function App() {
           >
             <div className="sidebar-header workspace-header">
               <div className="sidebar-brand-row">
-                <div className="sidebar-brand">CSGClaw</div>
+                <div className="sidebar-brand-lockup" aria-label="CSGClaw">
+                  <div className="sidebar-brand-mark sidebar-brand-wordmark" aria-hidden="true">CSGClaw</div>
+                </div>
                 <div className="sidebar-controls">
                   <div className="theme-switch" role="group" aria-label=${t("themeSwitcher")}>
                     <div className=${`theme-switch-track ${theme === "dark" ? "is-dark" : "is-light"}`}>
@@ -2190,6 +2201,17 @@ function App() {
                   </button>
                 </div>
               </div>
+              <div className="workspace-signal-panel" aria-label=${currentWorkspaceLabel}>
+                <div className="workspace-signal-copy">
+                  <span>${currentWorkspaceLabel}</span>
+                  <strong>${runningAgentCount}/${agentItems.length || 0} ${t("activeNow")}</strong>
+                </div>
+                <div className="workspace-signal-meter" aria-hidden="true">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
+              </div>
             </div>
             <nav className="workspace-nav" aria-label="Workspace">
               <div className="workspace-tabbar" role="tablist" aria-label="Workspace sections">
@@ -2202,6 +2224,10 @@ function App() {
                   onClick=${() => setWorkspaceTab(WORKSPACE_TAB_MESSAGES)}
                 >
                   <span className="workspace-tab-icon" aria-hidden="true"><${RoomsIcon} /></span>
+                  <span className="workspace-tab-copy">
+                    <strong>${t("messagesTab")}</strong>
+                    <small>${roomCount}</small>
+                  </span>
                 </button>
                 <button
                   className=${`workspace-tab ${workspaceTab === WORKSPACE_TAB_AGENTS ? "active" : ""}`}
@@ -2212,6 +2238,10 @@ function App() {
                   onClick=${() => setWorkspaceTab(WORKSPACE_TAB_AGENTS)}
                 >
                   <span className="workspace-tab-icon" aria-hidden="true"><${UsersIcon} /></span>
+                  <span className="workspace-tab-copy">
+                    <strong>${t("agentsTab")}</strong>
+                    <small>${agentItems.length}</small>
+                  </span>
                 </button>
               </div>
               ${workspaceTab === WORKSPACE_TAB_MESSAGES
@@ -2323,10 +2353,10 @@ function App() {
               <button className=${`sidebar-rail-button ${activePane.type === "computer" ? "active" : ""}`} aria-label=${t("localComputer")} title=${t("localComputer")} onClick=${selectComputer}>
                 <span className="sidebar-rail-icon" aria-hidden="true"><${ComputerIcon} /></span>
               </button>
-              <button className="sidebar-rail-button" aria-label=${t("createAgent")} title=${t("createAgent")} onClick=${openCreateAgentModal}>
+              <button type="button" className="sidebar-rail-button" aria-label=${t("createAgent")} title=${t("createAgent")} onClick=${openCreateAgentModal}>
                 <span className="sidebar-rail-icon" aria-hidden="true"><${AgentIcon} /></span>
               </button>
-              <button className="sidebar-rail-button" aria-label=${t("createRoom")} title=${t("createRoom")} onClick=${() => openCreateRoomModal()}>
+              <button type="button" className="sidebar-rail-button" aria-label=${t("createRoom")} title=${t("createRoom")} onClick=${() => openCreateRoomModal()}>
                 <span className="sidebar-rail-icon" aria-hidden="true"><${RoomPlusIcon} /></span>
               </button>
             </nav>
@@ -2381,6 +2411,10 @@ function App() {
                     <div className="chat-title-bar">
                       <div className="chat-title-row">
                         <div className="chat-title-group">
+                          <div className="chat-kicker">
+                            <span>${isDirectConversation(activeConversation) ? t("directMessagesSection") : t("conversationLabel")}</span>
+                            <strong>${selectedMessageCount}</strong>
+                          </div>
                           <div className="chat-title truncate">${activeConversation.title}</div>
                           <div ref=${memberMenuRef} className="header-menu">
                             <button
@@ -2464,10 +2498,15 @@ function App() {
                             : null}
                         </div>
                         <button
+                          type="button"
                           className="icon-button"
                           aria-label=${inviteActionLabel}
                           title=${inviteActionLabel}
-                          onClick=${handleInviteAction}
+                          onClick=${(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            handleInviteAction();
+                          }}
                         >
                           <span className="icon-button-mark"><${AddUserIcon} /></span>
                         </button>
@@ -2481,9 +2520,19 @@ function App() {
 
                 <section ref=${messageListRef} className="messages">
                   ${activeConversation.messages.length === 0
-                    ? html`<div className="messages-empty">${t("noMessages")}</div>`
+                    ? html`
+                        <div className="messages-empty rich-empty">
+                          <span aria-hidden="true" className="rich-empty-mark">></span>
+                          <strong>${t("noMessages")}</strong>
+                        </div>
+                      `
                     : visibleMessages.length === 0
-                      ? html`<div className="messages-empty">${t("noVisibleMessages")}</div>`
+                      ? html`
+                          <div className="messages-empty rich-empty">
+                            <span aria-hidden="true" className="rich-empty-mark">#</span>
+                            <strong>${t("noVisibleMessages")}</strong>
+                          </div>
+                        `
                       : null}
                   ${visibleMessages.map((message) => {
                     if (isEventMessage(message)) {
@@ -2595,7 +2644,12 @@ function App() {
                   <div className="composer-tip">${t("composerTip")}</div>
                 </footer>
               `
-            : html`<div className="empty-state">${t("emptyConversation")}</div>`}
+            : html`
+                <div className="empty-state shell-empty-state">
+                  <span className="rich-empty-mark" aria-hidden="true">></span>
+                  <strong>${t("emptyConversation")}</strong>
+                </div>
+              `}
         </main>
       </div>
 
@@ -3156,7 +3210,17 @@ function WorkspaceGroup({ id, title, count, collapsed, onToggle, onAdd, addLabel
         </button>
         ${onAdd
           ? html`
-              <button className="workspace-add-button" aria-label=${addLabel || title} title=${addLabel || title} onClick=${onAdd}>
+              <button
+                type="button"
+                className="workspace-add-button"
+                aria-label=${addLabel || title}
+                title=${addLabel || title}
+                onClick=${(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onAdd?.();
+                }}
+              >
                 <span aria-hidden="true">+</span>
               </button>
             `

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -19,6 +19,7 @@
         }
       })();
     </script>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23050507'/%3E%3Cpath d='M9 10h10M9 22h10M20 7v18' stroke='%2300d992' stroke-width='3' stroke-linecap='round'/%3E%3C/svg%3E" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1896,6 +1896,13 @@ body::after {
   border: 1px solid var(--line);
 }
 
+.selection-all-item {
+  border-color: color-mix(in oklab, var(--primary) 34%, var(--line));
+  background:
+    linear-gradient(90deg, color-mix(in oklab, var(--primary) 13%, transparent), transparent 72%),
+    var(--field);
+}
+
 .selection-empty,
 .form-error {
   margin-top: 14px;
@@ -3962,6 +3969,13 @@ body::after {
   border-color: var(--line);
   border-radius: 8px;
   background: var(--field);
+}
+
+.selection-item.selection-all-item {
+  border-color: color-mix(in oklab, var(--primary) 34%, var(--line));
+  background:
+    linear-gradient(90deg, color-mix(in oklab, var(--primary) 13%, transparent), transparent 72%),
+    var(--field);
 }
 
 .selection-item.compact-toggle-row {

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1258,9 +1258,15 @@ body::after {
 }
 
 .message-card {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
+  max-width: min(720px, 100%);
   display: grid;
+  justify-items: start;
+}
+
+.message-row.own .message-card {
+  justify-items: end;
 }
 
 .message-meta {
@@ -1276,6 +1282,7 @@ body::after {
 }
 
 .message-bubble {
+  width: fit-content;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -1701,6 +1708,12 @@ body::after {
   background: var(--field);
 }
 
+.secondary-button.compact {
+  min-height: 32px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
 .modal-actions .send-button {
   height: 34px;
   padding: 0 14px;
@@ -1955,6 +1968,37 @@ body::after {
   grid-template-columns: minmax(150px, 0.9fr) minmax(220px, 1.3fr) minmax(116px, 0.7fr) minmax(120px, 0.6fr);
   gap: 10px;
   align-items: end;
+}
+
+.auth-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--field);
+}
+
+.auth-status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #d69321;
+}
+
+.auth-status-row.connected .auth-status-dot {
+  background: #2f9e60;
+}
+
+.auth-status-message {
+  min-width: 0;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
 }
 
 .span-2 {

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -457,6 +457,8 @@ body::after {
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
+  position: relative;
+  z-index: 3;
 }
 
 .member-badge-button {
@@ -1791,6 +1793,7 @@ body::after {
 
 .modal-backdrop {
   position: fixed;
+  z-index: 60;
   inset: 0;
   display: grid;
   place-items: center;
@@ -1799,6 +1802,8 @@ body::after {
 }
 
 .modal-card {
+  position: relative;
+  z-index: 1;
   width: min(560px, 100%);
   max-height: calc(100vh - 40px);
   overflow: auto;
@@ -2973,5 +2978,1280 @@ body::after {
   .entity-avatar {
     width: 52px;
     height: 52px;
+  }
+}
+
+/* DESIGN.md inspired product refactor: carbon console, emerald signal, warm containment. */
+:root {
+  --bg: oklch(0.13 0.012 82);
+  --sidebar: oklch(0.165 0.014 82);
+  --panel: oklch(0.155 0.012 82);
+  --panel-strong: oklch(0.205 0.015 82);
+  --panel-soft: oklch(0.255 0.018 82);
+  --surface: oklch(0.118 0.01 82);
+  --field: oklch(0.205 0.013 82);
+  --text: oklch(0.94 0.006 82);
+  --muted: oklch(0.69 0.018 78);
+  --line: oklch(0.36 0.022 72 / 0.72);
+  --grid-line: oklch(0.36 0.025 72 / 0.16);
+  --primary: oklch(0.77 0.16 164);
+  --primary-soft: oklch(0.77 0.16 164 / 0.14);
+  --primary-strong: oklch(0.86 0.15 164);
+  --on-primary: oklch(0.13 0.014 82);
+  --mention-on-primary: oklch(0.2 0.095 164);
+  --mention: oklch(0.83 0.15 164);
+  --avatar-text: oklch(0.96 0.005 82);
+  --message-border: oklch(0.39 0.021 72 / 0.72);
+  --admin-bubble: oklch(0.91 0.033 92);
+  --admin-text: oklch(0.2 0.016 82);
+  --admin-mention: oklch(0.42 0.13 164);
+  --danger: oklch(0.65 0.17 29);
+  --warning: oklch(0.79 0.14 73);
+  --shadow: 0 24px 70px oklch(0.06 0.01 82 / 0.5);
+  --shadow-soft: 0 14px 32px oklch(0.06 0.01 82 / 0.3);
+  --focus-ring: 0 0 0 3px oklch(0.77 0.16 164 / 0.22);
+  --font-sans: "Avenir Next", "Segoe UI", "PingFang SC", system-ui, sans-serif;
+  --font-display: system-ui, -apple-system, "Segoe UI", "PingFang SC", sans-serif;
+  --font-mono: "SFMono-Regular", "SF Mono", Menlo, Monaco, Consolas, monospace;
+}
+
+:root[data-theme="light"] {
+  --bg: oklch(0.94 0.012 82);
+  --sidebar: oklch(0.985 0.006 82);
+  --panel: oklch(0.978 0.006 82);
+  --panel-strong: oklch(0.94 0.012 82);
+  --panel-soft: oklch(0.9 0.017 82);
+  --surface: oklch(0.965 0.008 82);
+  --field: oklch(0.93 0.011 82);
+  --text: oklch(0.22 0.015 82);
+  --muted: oklch(0.48 0.021 78);
+  --line: oklch(0.78 0.025 72 / 0.82);
+  --grid-line: oklch(0.58 0.045 72 / 0.14);
+  --primary: oklch(0.59 0.14 164);
+  --primary-soft: oklch(0.59 0.14 164 / 0.12);
+  --primary-strong: oklch(0.48 0.13 164);
+  --on-primary: oklch(0.97 0.006 82);
+  --mention-on-primary: oklch(0.92 0.07 164);
+  --mention: oklch(0.43 0.13 164);
+  --message-border: oklch(0.79 0.025 72 / 0.9);
+  --admin-bubble: oklch(0.9 0.035 92);
+  --admin-text: oklch(0.23 0.015 82);
+  --shadow: 0 24px 70px oklch(0.38 0.03 72 / 0.16);
+  --shadow-soft: 0 14px 32px oklch(0.38 0.03 72 / 0.11);
+}
+
+html {
+  background: var(--bg);
+}
+
+body {
+  position: relative;
+  background:
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(0deg, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(135deg, oklch(0.155 0.014 82), var(--bg) 48%, oklch(0.105 0.011 82));
+  background-size: 44px 44px, 44px 44px, auto;
+  letter-spacing: 0;
+}
+
+:root[data-theme="light"] body {
+  background:
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(0deg, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(135deg, oklch(0.97 0.008 82), var(--bg) 55%, oklch(0.92 0.014 82));
+  background-size: 44px 44px, 44px 44px, auto;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, transparent 0 36%, oklch(0.77 0.16 164 / 0.08) 36% 36.2%, transparent 36.2% 100%),
+    linear-gradient(150deg, transparent 0 68%, oklch(0.6 0.035 72 / 0.16) 68% 68.2%, transparent 68.2% 100%);
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(0deg, oklch(1 0 0 / 0.018) 0 1px, transparent 1px 4px);
+  mix-blend-mode: soft-light;
+}
+
+.app-shell {
+  position: relative;
+  z-index: 1;
+  --sidebar-slot-width: 326px;
+  gap: 12px;
+  padding: 12px;
+  transition: grid-template-columns 280ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.app-shell.sidebar-collapsed {
+  --sidebar-slot-width: 74px;
+}
+
+.sidebar-slot {
+  overflow: visible;
+}
+
+.sidebar,
+.sidebar-rail,
+.chat-panel {
+  border-color: var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  animation: rise-in 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.sidebar,
+.sidebar-rail {
+  background:
+    linear-gradient(180deg, oklch(0.19 0.016 82 / 0.96), var(--sidebar)),
+    var(--sidebar);
+}
+
+.chat-panel {
+  background:
+    linear-gradient(180deg, oklch(0.19 0.016 82 / 0.78), var(--panel) 34%, var(--surface)),
+    var(--panel);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+:root[data-theme="light"] .sidebar,
+:root[data-theme="light"] .sidebar-rail,
+:root[data-theme="light"] .chat-panel {
+  background: var(--panel);
+}
+
+.sidebar.collapsed {
+  transform: translateX(-16px) scale(0.98);
+}
+
+.sidebar-rail {
+  gap: 22px;
+  padding: 18px 10px;
+}
+
+.sidebar-header,
+.chat-header,
+.composer {
+  padding: 18px;
+}
+
+.sidebar-header {
+  border-bottom-color: var(--line);
+  background:
+    linear-gradient(135deg, oklch(0.77 0.16 164 / 0.08), transparent 42%),
+    linear-gradient(180deg, oklch(1 0 0 / 0.035), transparent);
+}
+
+.sidebar-brand-row {
+  align-items: center;
+  gap: 14px;
+  margin: 0;
+}
+
+.sidebar-brand-lockup {
+  min-width: 0;
+  flex: 0 0 auto;
+  display: inline-grid;
+  place-items: center;
+}
+
+.sidebar-brand-mark {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border: 1px solid oklch(0.77 0.16 164 / 0.62);
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, oklch(0.77 0.16 164 / 0.18), transparent 48%),
+    var(--surface);
+  box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.045), 0 0 18px oklch(0.77 0.16 164 / 0.12);
+}
+
+.sidebar-brand-mark::before,
+.sidebar-brand-mark::after,
+.sidebar-brand-mark span {
+  content: "";
+  position: absolute;
+  background: var(--primary);
+  border-radius: 999px;
+  box-shadow: 0 0 10px oklch(0.77 0.16 164 / 0.38);
+}
+
+.sidebar-brand-mark::before {
+  width: 18px;
+  height: 2px;
+  transform: translate(-3px, -8px);
+}
+
+.sidebar-brand-mark::after {
+  width: 2px;
+  height: 24px;
+  transform: translate(7px, 0);
+}
+
+.sidebar-brand-mark span {
+  width: 19px;
+  height: 2px;
+  transform: translate(-3px, 8px);
+}
+
+.sidebar-brand-wordmark {
+  width: 112px;
+  padding: 0 12px;
+  justify-content: center;
+  color: var(--primary-strong);
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 780;
+  line-height: 1;
+  letter-spacing: 0;
+  text-shadow: 0 0 12px oklch(0.77 0.16 164 / 0.28);
+}
+
+.sidebar-brand-wordmark::before,
+.sidebar-brand-wordmark::after,
+.sidebar-brand-wordmark span {
+  content: none;
+  display: none;
+}
+
+.sidebar-brand {
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 680;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.sidebar-brand-subtitle {
+  margin-top: 5px;
+  color: var(--muted);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.sidebar-controls {
+  gap: 6px;
+  flex: 0 0 auto;
+  align-items: center;
+  align-self: center;
+}
+
+.sidebar-toggle-button,
+.sidebar-expand-button,
+.theme-switch-track,
+.language-switch-track,
+.icon-button,
+.member-badge-button,
+.ghost-button,
+.secondary-button,
+.modal-close,
+.agent-add-button,
+.agent-icon-button,
+.agent-action-text,
+.preview-action-button,
+.workspace-add-button,
+.env-remove-button,
+.tool-menu-row {
+  transition:
+    color 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease,
+    opacity 180ms ease,
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 180ms ease;
+}
+
+.sidebar-toggle-button,
+.sidebar-expand-button {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--muted);
+}
+
+.sidebar-toggle-button:hover,
+.sidebar-expand-button:hover {
+  border-color: var(--line);
+  background: var(--field);
+  color: var(--primary-strong);
+}
+
+.sidebar-toggle-button:active,
+.sidebar-expand-button:active,
+.icon-button:active,
+.member-badge-button:active,
+.send-button:active,
+.composer-send-button:active,
+.preview-action-button:active,
+.secondary-button:active,
+.workspace-row:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.sidebar-toggle-button:focus-visible,
+.sidebar-expand-button:focus-visible,
+.workspace-tab:focus-visible,
+.workspace-group-toggle:focus-visible,
+.sidebar-rail-button:focus-visible,
+.composer-send-button:focus-visible,
+.language-toggle:focus-visible,
+.theme-toggle:focus-visible,
+.field input:focus,
+.field textarea:focus,
+.field select:focus,
+.composer-editor:focus,
+.preview-action-button:focus-visible,
+.send-button:focus-visible,
+.secondary-button:focus-visible,
+.modal-close:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.theme-switch-track,
+.language-switch-track {
+  border-color: var(--line);
+  background: var(--surface);
+}
+
+.theme-switch-thumb,
+.language-switch-thumb {
+  background: var(--primary);
+  box-shadow: 0 0 12px oklch(0.77 0.16 164 / 0.22);
+}
+
+.theme-toggle.active,
+.language-toggle.active {
+  color: var(--on-primary);
+}
+
+.workspace-signal-panel {
+  margin-top: 18px;
+  display: grid;
+  gap: 12px;
+  padding: 13px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, oklch(0.77 0.16 164 / 0.09), transparent 52%),
+    var(--surface);
+}
+
+.workspace-signal-copy {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.workspace-signal-copy span {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.workspace-signal-copy strong {
+  color: var(--primary-strong);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.workspace-signal-meter {
+  display: grid;
+  grid-template-columns: 1.2fr 0.7fr 1.8fr;
+  gap: 5px;
+  height: 5px;
+}
+
+.workspace-signal-meter span {
+  border-radius: 999px;
+  background: var(--primary);
+  opacity: 0.35;
+}
+
+.workspace-signal-meter span:nth-child(2) {
+  opacity: 0.72;
+}
+
+.workspace-signal-meter span:nth-child(3) {
+  opacity: 0.5;
+}
+
+.workspace-nav {
+  padding: 0 12px 18px;
+  gap: 18px;
+  scrollbar-gutter: stable;
+}
+
+.workspace-tabbar {
+  gap: 8px;
+  margin: 0 -2px;
+  padding: 12px 0 4px;
+  border-bottom: 0;
+}
+
+.workspace-tab {
+  height: 54px;
+  justify-content: flex-start;
+  gap: 10px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--muted);
+}
+
+.workspace-tab:hover {
+  border-color: oklch(0.77 0.16 164 / 0.38);
+  background: var(--field);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.workspace-tab.active {
+  border-color: oklch(0.77 0.16 164 / 0.56);
+  background:
+    linear-gradient(135deg, oklch(0.77 0.16 164 / 0.18), transparent 58%),
+    var(--field);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.035);
+}
+
+.workspace-tab-icon,
+.workspace-tab-icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.workspace-tab-icon {
+  color: var(--primary-strong);
+}
+
+.workspace-tab-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.workspace-tab-copy strong {
+  color: currentColor;
+  font-size: 12px;
+  font-weight: 720;
+  line-height: 1.1;
+}
+
+.workspace-tab-copy small {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.workspace-tab-panel,
+.workspace-group {
+  gap: 14px;
+}
+
+.workspace-group-head {
+  position: relative;
+  z-index: 2;
+  padding: 0 2px;
+}
+
+.workspace-group-title {
+  letter-spacing: 0.1em;
+}
+
+.workspace-add-button,
+.env-remove-button {
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
+  border-color: var(--line);
+  background: var(--surface);
+}
+
+.workspace-add-button:hover,
+.env-remove-button:hover {
+  border-color: oklch(0.77 0.16 164 / 0.42);
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+.workspace-group-items {
+  gap: 4px;
+}
+
+.workspace-row {
+  min-height: 46px;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  gap: 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 8px 9px;
+}
+
+.workspace-row:hover {
+  border-color: var(--line);
+  background: oklch(1 0 0 / 0.045);
+  transform: translateX(2px);
+}
+
+.workspace-row.active {
+  border-color: oklch(0.77 0.16 164 / 0.46);
+  background:
+    linear-gradient(90deg, oklch(0.77 0.16 164 / 0.18), transparent 72%),
+    var(--field);
+}
+
+.workspace-row-icon {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.workspace-row-title,
+.agent-name,
+.conversation-name,
+.message-author {
+  font-weight: 680;
+}
+
+.workspace-status-dot.online {
+  box-shadow: 0 0 0 3px var(--primary-soft), 0 0 14px oklch(0.77 0.16 164 / 0.28);
+}
+
+.mini-badge,
+.agent-badge,
+.agent-status,
+.status-pill {
+  border: 1px solid var(--line);
+  font-family: var(--font-mono);
+}
+
+.chat-header {
+  border-bottom-color: var(--line);
+  background:
+    linear-gradient(90deg, oklch(0.77 0.16 164 / 0.08), transparent 35%),
+    var(--surface);
+}
+
+.chat-title-bar {
+  gap: 16px;
+}
+
+.chat-title-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "kicker member"
+    "title member";
+  gap: 4px 12px;
+  align-items: center;
+}
+
+.chat-title-group .header-menu {
+  grid-area: member;
+}
+
+.chat-kicker {
+  grid-area: kicker;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.chat-kicker strong {
+  color: var(--primary-strong);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.chat-title {
+  grid-area: title;
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 650;
+  line-height: 1.03;
+}
+
+.chat-subtitle {
+  max-width: 76ch;
+  margin-top: 10px;
+  font-size: 13px;
+}
+
+.icon-button,
+.member-badge-button,
+.ghost-button,
+.secondary-button,
+.modal-close,
+.tool-menu-row,
+.agent-add-button,
+.agent-icon-button,
+.agent-action-text,
+.preview-action-button,
+.danger-button {
+  border-color: var(--line);
+  background: var(--field);
+  color: var(--text);
+  border-radius: 8px;
+}
+
+.icon-button:hover,
+.member-badge-button:hover,
+.secondary-button:hover,
+.modal-close:hover,
+.tool-menu-row:hover,
+.agent-add-button:hover,
+.agent-icon-button:hover,
+.agent-action-text:hover,
+.preview-action-button:hover:not(:disabled) {
+  border-color: oklch(0.77 0.16 164 / 0.42);
+  background: color-mix(in oklab, var(--field) 82%, var(--primary-soft));
+  color: var(--text);
+}
+
+.icon-button.active,
+.member-badge-button.active {
+  border-color: oklch(0.77 0.16 164 / 0.52);
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+}
+
+.header-popover,
+.mention-picker,
+.profile-preview-popover,
+.modal-card {
+  border-radius: 8px;
+  border-color: var(--line);
+  background:
+    linear-gradient(180deg, oklch(1 0 0 / 0.04), transparent),
+    color-mix(in oklab, var(--panel) 94%, oklch(0.04 0.006 82));
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+:root[data-theme="light"] .header-popover,
+:root[data-theme="light"] .mention-picker,
+:root[data-theme="light"] .profile-preview-popover,
+:root[data-theme="light"] .modal-card {
+  background: color-mix(in oklab, var(--panel) 96%, oklch(1 0 0));
+}
+
+.members-popover-list {
+  gap: 8px;
+}
+
+.member-row {
+  padding: 6px;
+  border-radius: 8px;
+}
+
+.member-row:hover {
+  background: var(--field);
+}
+
+.messages {
+  padding: 28px;
+  gap: 20px;
+  background:
+    linear-gradient(90deg, oklch(1 0 0 / 0.022) 1px, transparent 1px),
+    linear-gradient(0deg, oklch(1 0 0 / 0.018) 1px, transparent 1px),
+    linear-gradient(180deg, oklch(0.77 0.16 164 / 0.04), transparent 34%),
+    var(--panel);
+  background-size: 36px 36px, 36px 36px, auto, auto;
+}
+
+:root[data-theme="light"] .messages {
+  background:
+    linear-gradient(90deg, oklch(0.58 0.045 72 / 0.08) 1px, transparent 1px),
+    linear-gradient(0deg, oklch(0.58 0.045 72 / 0.07) 1px, transparent 1px),
+    var(--panel);
+  background-size: 36px 36px, 36px 36px, auto;
+}
+
+.message-row {
+  max-width: min(78%, 920px);
+}
+
+.message-meta {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.message-bubble {
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, oklch(1 0 0 / 0.035), transparent),
+    var(--panel-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.message-row.own .message-bubble {
+  border-color: oklch(0.77 0.16 164 / 0.45);
+  background:
+    linear-gradient(180deg, oklch(0.86 0.15 164), var(--primary));
+  color: var(--on-primary);
+}
+
+.message-row.admin .message-bubble {
+  border-color: color-mix(in oklab, var(--admin-bubble) 70%, var(--line));
+}
+
+.message-content code,
+.structured-message-code code,
+.structured-message-json code,
+.message-content pre {
+  font-family: var(--font-mono);
+}
+
+.message-content :not(pre) > code {
+  border-radius: 6px;
+  background: oklch(1 0 0 / 0.07);
+  color: var(--primary-strong);
+}
+
+.message-content pre,
+.structured-message-code,
+.structured-message-json {
+  border-color: var(--line);
+  border-radius: 8px;
+  background: oklch(0.105 0.011 82);
+  color: oklch(0.91 0.012 82);
+}
+
+.structured-message-details {
+  border-color: var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.message-content blockquote {
+  border-left-width: 1px;
+  border-left-color: oklch(0.77 0.16 164 / 0.5);
+}
+
+.composer {
+  border-top-color: var(--line);
+  background:
+    linear-gradient(180deg, oklch(0.77 0.16 164 / 0.035), transparent),
+    var(--surface);
+}
+
+.composer-box {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--field);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
+}
+
+.composer-input-wrap {
+  min-height: 74px;
+}
+
+.composer-editor {
+  min-height: 74px;
+  padding: 19px 84px 18px 18px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.composer-editor:focus {
+  box-shadow: inset 0 0 0 1px oklch(0.77 0.16 164 / 0.42), var(--focus-ring);
+}
+
+.composer-placeholder {
+  top: 19px;
+  left: 18px;
+}
+
+.composer-send-button,
+.send-button,
+.preview-action-button-primary {
+  border: 1px solid oklch(0.77 0.16 164 / 0.48);
+  background:
+    linear-gradient(180deg, oklch(0.86 0.15 164), var(--primary));
+  color: var(--on-primary);
+  box-shadow: 0 14px 28px oklch(0.08 0.07 164 / 0.26);
+}
+
+.composer-send-button {
+  right: 12px;
+  bottom: 12px;
+  border-radius: 8px;
+}
+
+.composer-send-button:hover:not(:disabled),
+.send-button:hover:not(:disabled),
+.preview-action-button-primary:hover:not(:disabled) {
+  border-color: oklch(0.86 0.15 164 / 0.62);
+  box-shadow: 0 18px 34px oklch(0.08 0.07 164 / 0.32);
+}
+
+.send-button,
+.secondary-button,
+.preview-action-button,
+.modal-close {
+  font-weight: 650;
+}
+
+.composer-tip {
+  color: color-mix(in oklab, var(--muted) 84%, var(--primary));
+  font-size: 12px;
+}
+
+.empty-state,
+.messages-empty {
+  color: var(--muted);
+}
+
+.messages-empty,
+.rich-empty {
+  display: grid;
+  place-items: center;
+  gap: 10px;
+  max-width: min(440px, 100%);
+  margin: auto;
+  padding: 24px;
+  border-radius: 8px;
+  border: 1px dashed oklch(0.77 0.16 164 / 0.34);
+  background:
+    linear-gradient(135deg, oklch(0.77 0.16 164 / 0.08), transparent 60%),
+    var(--surface);
+  text-align: center;
+}
+
+.rich-empty strong,
+.shell-empty-state strong {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 640;
+  line-height: 1.5;
+}
+
+.rich-empty-mark {
+  width: 36px;
+  height: 36px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid oklch(0.77 0.16 164 / 0.42);
+  border-radius: 8px;
+  color: var(--primary-strong);
+  background: var(--field);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.shell-empty-state {
+  gap: 12px;
+  background:
+    linear-gradient(90deg, oklch(1 0 0 / 0.02) 1px, transparent 1px),
+    linear-gradient(0deg, oklch(1 0 0 / 0.018) 1px, transparent 1px);
+  background-size: 36px 36px;
+}
+
+.modal-backdrop {
+  background: oklch(0.1 0.012 82 / 0.78);
+  backdrop-filter: blur(6px);
+}
+
+.modal-card {
+  padding: 26px;
+}
+
+.modal-actions {
+  border-top-color: var(--line);
+  background: transparent;
+}
+
+.modal-title {
+  color: var(--text);
+  font-size: 22px;
+  line-height: 1.08;
+}
+
+.field {
+  gap: 8px;
+}
+
+.field .field-label,
+.field span,
+.profile-section .field span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+}
+
+.field input,
+.field textarea,
+.field select,
+.profile-section .field input,
+.profile-section .field textarea,
+.profile-section .field select,
+.env-row input {
+  border-color: var(--line);
+  border-radius: 8px;
+  background: var(--field);
+  color: var(--text);
+}
+
+.field input:hover,
+.field textarea:hover,
+.field select:hover,
+.profile-section .field input:hover,
+.profile-section .field textarea:hover,
+.profile-section .field select:hover,
+.env-row input:hover {
+  border-color: oklch(0.77 0.16 164 / 0.38);
+}
+
+.selection-list,
+.profile-section,
+.entity-field,
+.metric,
+.entity-list-row,
+.agent-row,
+.auth-status-row,
+.detection-row {
+  border-color: var(--line);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, oklch(1 0 0 / 0.025), transparent),
+    var(--surface);
+}
+
+.selection-item {
+  border-color: var(--line);
+  border-radius: 8px;
+  background: var(--field);
+}
+
+.selection-item.compact-toggle-row {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 14px;
+}
+
+.selection-item.compact-toggle-row span {
+  white-space: nowrap;
+}
+
+.selection-item:hover {
+  border-color: oklch(0.77 0.16 164 / 0.38);
+}
+
+.form-error {
+  border: 1px solid color-mix(in oklab, var(--danger) 42%, var(--line));
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: color-mix(in oklab, var(--danger) 12%, var(--surface));
+  color: color-mix(in oklab, var(--danger) 86%, var(--text));
+}
+
+.entity-pane {
+  padding: 34px;
+  gap: 24px;
+  background:
+    linear-gradient(90deg, oklch(1 0 0 / 0.02) 1px, transparent 1px),
+    linear-gradient(0deg, oklch(1 0 0 / 0.016) 1px, transparent 1px);
+  background-size: 40px 40px;
+}
+
+.entity-header {
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 18px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.entity-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 8px;
+  border-color: oklch(0.77 0.16 164 / 0.36);
+  background:
+    linear-gradient(135deg, oklch(0.77 0.16 164 / 0.16), transparent 60%),
+    var(--field);
+  color: var(--primary-strong);
+}
+
+.entity-title-row h1 {
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 650;
+  line-height: 1.04;
+}
+
+.entity-heading p {
+  color: var(--muted);
+}
+
+.status-pill.online {
+  border-color: oklch(0.77 0.16 164 / 0.42);
+  color: var(--primary-strong);
+}
+
+.metric-row {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.entity-field,
+.metric {
+  padding: 14px;
+}
+
+.entity-field span,
+.metric span {
+  letter-spacing: 0.09em;
+}
+
+.metric strong {
+  font-family: var(--font-mono);
+  font-size: 26px;
+  font-weight: 640;
+}
+
+.profile-editor-shell {
+  gap: 16px;
+}
+
+.profile-section {
+  padding: 18px;
+}
+
+.profile-section-title,
+.preview-title,
+.header-popover-title,
+.section-label {
+  color: var(--muted);
+  letter-spacing: 0.1em;
+}
+
+.profile-preview-popover {
+  border-radius: 8px;
+}
+
+.preview-hero {
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.preview-name {
+  font-size: 21px;
+  line-height: 1.05;
+}
+
+.preview-fields {
+  gap: 10px;
+}
+
+.entity-list-main-button:hover {
+  color: var(--primary-strong);
+}
+
+.danger-button,
+.preview-action-button-danger,
+.agent-icon-button.danger {
+  border-color: color-mix(in oklab, var(--danger) 46%, var(--line));
+  background: color-mix(in oklab, var(--danger) 10%, var(--field));
+  color: color-mix(in oklab, var(--danger) 88%, var(--text));
+}
+
+@keyframes signal-pulse {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleX(0.82);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+.workspace-signal-meter span {
+  transform-origin: left center;
+  animation: signal-pulse 3200ms cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.workspace-signal-meter span:nth-child(2) {
+  animation-delay: 420ms;
+}
+
+.workspace-signal-meter span:nth-child(3) {
+  animation-delay: 840ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    --sidebar-slot-width: 300px;
+  }
+
+  .chat-title {
+    font-size: 24px;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    --sidebar-slot-width: 100%;
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .app-shell.sidebar-collapsed {
+    --sidebar-slot-width: 74px;
+  }
+
+  .sidebar-brand-row {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .sidebar-controls {
+    width: auto;
+    justify-content: flex-end;
+  }
+
+  .workspace-signal-panel {
+    margin-top: 14px;
+  }
+
+  .chat-header,
+  .modal-header,
+  .modal-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .chat-title-bar {
+    align-items: flex-start;
+  }
+
+  .chat-title-actions {
+    align-self: flex-start;
+  }
+
+  .entity-pane {
+    padding: 24px 18px;
+  }
+
+  .entity-header {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  .entity-avatar {
+    width: 56px;
+    height: 56px;
+  }
+
+  .entity-title-row h1 {
+    font-size: 24px;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-shell,
+  .app-shell.sidebar-collapsed {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(260px, 40dvh) minmax(0, 1fr);
+  }
+
+  .sidebar-slot {
+    min-height: 260px;
+  }
+
+  .sidebar-rail.visible {
+    min-height: 100%;
+  }
+
+  .chat-panel {
+    min-height: 0;
+  }
+
+  .workspace-tab {
+    justify-content: center;
+  }
+
+  .workspace-tab-copy {
+    display: none;
+  }
+
+  .chat-title-group {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "kicker"
+      "title"
+      "member";
+  }
+
+  .chat-title-group .header-menu {
+    justify-self: start;
+  }
+
+  .messages {
+    padding: 18px;
+  }
+
+  .message-row {
+    max-width: 94%;
+  }
+
+  .composer {
+    padding: 14px;
   }
 }

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1842,6 +1842,21 @@ body::after {
   font-weight: 650;
 }
 
+.field .field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  width: fit-content;
+}
+
+.field .field-required-star,
+.profile-section .field .field-required-star {
+  color: var(--danger);
+  font-weight: 800;
+  line-height: 1;
+}
+
 .field input,
 .field textarea,
 .field select {


### PR DESCRIPTION
### Summary

- Added CLIProxy auth bridge for Codex and Claude Code, including Codex auth import, macOS Claude Keychain probing, auth status/login APIs, CLI auth commands, and UI auth states.
- Fixed agent reply loss after `csgclaw serve` restart by reconnecting/recreating agent gateways, retrying transient BoxLite runtime-lock failures, and replaying missed PicoClaw messages.
- Updated docs and tests for auth flows, restart recovery, and PicoClaw delivery.
