### PR TITLE
Fix stale Codex auth reuse in embedded CLIProxy

### DIFF
--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -225,6 +226,8 @@ func TestServeForegroundPrintsManualIMURLWhenBrowserNotAllowed(t *testing.T) {
 	}
 
 	run := testContext()
+	stdout := newNotifyingBuffer("Open this URL in your browser after startup.")
+	run.Stdout = stdout
 	cfg := config.Config{
 		Server: config.ServerConfig{
 			AdvertiseBaseURL: "http://example.test/base",
@@ -238,7 +241,12 @@ func TestServeForegroundPrintsManualIMURLWhenBrowserNotAllowed(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("OpenBrowser fallback path was not reached after server readiness")
 	}
-	got := run.Stdout.(*bytes.Buffer).String()
+	select {
+	case <-stdout.Seen():
+	case <-time.After(time.Second):
+		t.Fatal("manual-open hint was not printed after browser fallback")
+	}
+	got := stdout.String()
 	if !strings.Contains(got, "CSGClaw IM is available at: http://example.test/base/") {
 		t.Fatalf("stdout missing IM URL:\n%s", got)
 	}
@@ -1135,6 +1143,41 @@ func testContext() *command.Context {
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},
 	}
+}
+
+type notifyingBuffer struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	needle string
+	seen   chan struct{}
+	once   sync.Once
+}
+
+func newNotifyingBuffer(needle string) *notifyingBuffer {
+	return &notifyingBuffer{
+		needle: needle,
+		seen:   make(chan struct{}),
+	}
+}
+
+func (b *notifyingBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if strings.Contains(b.buf.String(), b.needle) {
+		b.once.Do(func() { close(b.seen) })
+	}
+	return n, err
+}
+
+func (b *notifyingBuffer) Seen() <-chan struct{} {
+	return b.seen
+}
+
+func (b *notifyingBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 type fakeCodexBridgeManager struct {

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,7 @@ Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状
 
 ### `GET /api/v1/cliproxy/auth/status?provider=codex|claude_code`
 
-查询本地鉴权状态。服务端会在安全可读的情况下自动导入现有凭据：Codex 来自 `~/.codex/auth.json`，Claude Code 在 macOS 上来自 Keychain。
+查询本地鉴权状态。服务端会在安全可读的情况下自动导入现有凭据：Codex 来自 `~/.codex/auth.json`，Claude Code 在 macOS 上来自 Keychain。导入后的鉴权文件统一写入 CSGClaw 管理的 CLIProxy auth 目录，默认是 `~/.csgclaw/auth`。
 
 响应示例：
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,7 +212,7 @@ Behavior:
 
 - `codex` first reuses `~/.codex/auth.json` when available, then starts OAuth if needed.
 - `claude-code` first probes macOS Keychain when available, then starts OAuth if needed.
-- Auth is stored in the CLIProxy auth directory, defaulting to `~/.cli-proxy-api`.
+- Auth is stored in the CSGClaw-managed CLIProxy auth directory, defaulting to `~/.csgclaw/auth`.
 - Model provider auth is scoped under `csgclaw model auth`, not the server's own API authentication.
 
 Examples:

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -212,7 +212,7 @@ Provider：
 
 - `codex` 会优先复用 `~/.codex/auth.json`，没有可用 token 时再启动 OAuth。
 - `claude-code` 会在 macOS 上优先探测 Keychain，没有可用 token 时再启动 OAuth。
-- 鉴权文件会写入 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
+- 鉴权文件会写入 CSGClaw 管理的 CLIProxy auth 目录，默认是 `~/.csgclaw/auth`。
 - 模型 Provider 鉴权放在 `csgclaw model auth` 下，不和服务端自身 API 鉴权混在一起。
 
 示例：

--- a/docs/config.md
+++ b/docs/config.md
@@ -105,8 +105,9 @@ Auth is also managed locally:
 
 - Codex auth is imported from `~/.codex/auth.json` when available.
 - Claude Code auth is probed from macOS Keychain when available, then falls back to OAuth.
+- At server startup, Codex and Claude Code auth are imported or refreshed into the CSGClaw-managed CLIProxy auth directory using CLIProxy-compatible JSON.
 - Manual login commands are `csgclaw model auth login codex` and `csgclaw model auth login claude-code`.
-- `CSGCLAW_CLIPROXY_AUTH_DIR` overrides the CLIProxy auth directory; the default is `~/.cli-proxy-api`.
+- `CSGCLAW_CLIPROXY_AUTH_DIR` overrides the CLIProxy auth directory; the default is `~/.csgclaw/auth`.
 - `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` disables automatic import/probing.
 - `CSGCLAW_CLIPROXY_NO_BROWSER=1` prints OAuth URLs instead of opening a browser.
 - `CSGCLAW_CLIPROXY_DISABLE_KEYCHAIN=1` disables Claude Keychain probing.

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -105,8 +105,9 @@ Worker 在创建时也可以显式选择 runtime kind。默认值是 `picoclaw-s
 
 - Codex 会优先从 `~/.codex/auth.json` 自动导入。
 - Claude Code 会在 macOS 上优先探测 Keychain，未找到时再走 OAuth。
+- 服务启动时会把 Codex 和 Claude Code auth 导入或刷新到 CSGClaw 管理的 CLIProxy auth 目录中，并统一写成 CLIProxy 兼容 JSON。
 - 手动登录命令是 `csgclaw model auth login codex` 和 `csgclaw model auth login claude-code`。
-- `CSGCLAW_CLIPROXY_AUTH_DIR` 可覆盖 CLIProxy auth 目录，默认是 `~/.cli-proxy-api`。
+- `CSGCLAW_CLIPROXY_AUTH_DIR` 可覆盖 CLIProxy auth 目录，默认是 `~/.csgclaw/auth`。
 - `CSGCLAW_CLIPROXY_AUTO_LOGIN=0` 可关闭自动导入和探测。
 - `CSGCLAW_CLIPROXY_NO_BROWSER=1` 会打印 OAuth URL，而不是自动打开浏览器。
 - `CSGCLAW_CLIPROXY_DISABLE_KEYCHAIN=1` 可关闭 Claude Keychain 探测。

--- a/internal/cliproxy/auth.go
+++ b/internal/cliproxy/auth.go
@@ -86,6 +86,13 @@ func (s *Service) Login(ctx context.Context, provider string, opts LoginOptions)
 		return AuthStatus{}, err
 	}
 
+	if authProvider == ProviderCodex {
+		if imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider); imported.imported {
+			_ = s.Shutdown(context.Background())
+			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
+		}
+	}
+
 	if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
 		return authenticatedStatus(statusProvider, "cli-proxy", authProvider), nil
 	}
@@ -134,12 +141,21 @@ func (s *Service) authStatus(ctx context.Context, provider string, allowImport b
 		return AuthStatus{}, err
 	}
 
+	var importMessage string
+	if allowImport && autoAuthImportEnabled() && authProvider == ProviderCodex {
+		imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider)
+		importMessage = imported.message
+		if imported.imported {
+			_ = s.Shutdown(context.Background())
+			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
+		}
+	}
+
 	if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
 		return authenticatedStatus(statusProvider, "cli-proxy", authProvider), nil
 	}
 
-	var importMessage string
-	if allowImport && autoAuthImportEnabled() {
+	if allowImport && autoAuthImportEnabled() && authProvider != ProviderCodex {
 		imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider)
 		importMessage = imported.message
 		if imported.imported {
@@ -163,6 +179,10 @@ func importExistingAuth(ctx context.Context, authDir string) {
 		return
 	}
 	for _, provider := range []string{ProviderCodex, authProviderClaude} {
+		if provider == ProviderCodex {
+			_, _ = importExternalAuth(ctx, authDir, provider)
+			continue
+		}
 		if existing, err := findAuth(ctx, authDir, provider); err == nil && existing != nil {
 			continue
 		}
@@ -198,6 +218,9 @@ func importCodexHomeAuth(ctx context.Context, authDir string) (authImportResult,
 		return authImportResult{message: "Codex auth is not importable. Run csgclaw model auth login codex."}, nil
 	}
 	fileName := authFileName(ProviderCodex, metadata, "codex-imported")
+	if shouldKeepExistingAuth(filepath.Join(authDir, fileName), metadata) {
+		return authImportResult{}, nil
+	}
 	if _, err = saveMetadataAuth(ctx, authDir, ProviderCodex, fileName, metadata); err != nil {
 		return authImportResult{}, err
 	}
@@ -283,6 +306,10 @@ func codexMetadataFromAuthJSON(raw []byte) (map[string]any, error) {
 		metadata["email"] = email
 	}
 	if expired := expiryFromValue(firstValue(tokenMap, "expired", "expires_at", "expiresAt", "expiry", "expiration")); expired != "" {
+		metadata["expired"] = expired
+	} else if expired = expiryFromJWT(accessToken); expired != "" {
+		metadata["expired"] = expired
+	} else if expired = expiryFromJWT(stringFromMap(tokenMap, "id_token", "idToken")); expired != "" {
 		metadata["expired"] = expired
 	}
 	return metadata, nil
@@ -559,20 +586,94 @@ func unixExpiry(value float64) string {
 }
 
 func emailFromJWT(token string) string {
-	parts := strings.Split(token, ".")
-	if len(parts) < 2 {
-		return ""
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return ""
-	}
-	var claims map[string]any
-	if err = json.Unmarshal(raw, &claims); err != nil {
+	claims := jwtClaims(token)
+	if claims == nil {
 		return ""
 	}
 	if email, _ := claims["email"].(string); strings.TrimSpace(email) != "" {
 		return strings.TrimSpace(email)
 	}
 	return ""
+}
+
+func expiryFromJWT(token string) string {
+	claims := jwtClaims(token)
+	if claims == nil {
+		return ""
+	}
+	if expired := expiryFromValue(claims["exp"]); expired != "" {
+		return expired
+	}
+	return ""
+}
+
+func shouldKeepExistingAuth(path string, incoming map[string]any) bool {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var existing map[string]any
+	if err = json.Unmarshal(raw, &existing); err != nil {
+		return false
+	}
+	if disabled, _ := existing["disabled"].(bool); disabled {
+		return false
+	}
+	existingTime, existingOK := authFreshnessTime(existing)
+	incomingTime, incomingOK := authFreshnessTime(incoming)
+	if !existingOK {
+		return false
+	}
+	if !incomingOK {
+		return true
+	}
+	return existingTime.After(incomingTime)
+}
+
+func authFreshnessTime(metadata map[string]any) (time.Time, bool) {
+	var freshest time.Time
+	var ok bool
+	for _, key := range []string{"expired", "expires_at", "expiresAt", "expiry", "expiration", "last_refresh", "lastRefresh"} {
+		if value, exists := metadata[key]; exists {
+			if candidate, parsed := timeFromAuthValue(value); parsed && (!ok || candidate.After(freshest)) {
+				freshest = candidate
+				ok = true
+			}
+		}
+	}
+	for _, key := range []string{"access_token", "accessToken", "id_token", "idToken"} {
+		if candidate, parsed := timeFromAuthValue(expiryFromJWT(stringFromMap(metadata, key))); parsed && (!ok || candidate.After(freshest)) {
+			freshest = candidate
+			ok = true
+		}
+	}
+	return freshest, ok
+}
+
+func timeFromAuthValue(value any) (time.Time, bool) {
+	text := expiryFromValue(value)
+	if text == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+func jwtClaims(token string) map[string]any {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var claims map[string]any
+	if err = json.Unmarshal(raw, &claims); err != nil {
+		return nil
+	}
+	return claims
 }

--- a/internal/cliproxy/auth.go
+++ b/internal/cliproxy/auth.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -88,7 +89,6 @@ func (s *Service) Login(ctx context.Context, provider string, opts LoginOptions)
 
 	if authProvider == ProviderCodex {
 		if imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider); imported.imported {
-			_ = s.Shutdown(context.Background())
 			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
 		}
 	}
@@ -99,7 +99,6 @@ func (s *Service) Login(ctx context.Context, provider string, opts LoginOptions)
 
 	if authProvider == authProviderClaude && keychainImportEnabled() {
 		if imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider); imported.imported {
-			_ = s.Shutdown(context.Background())
 			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
 		}
 	}
@@ -116,7 +115,6 @@ func (s *Service) Login(ctx context.Context, provider string, opts LoginOptions)
 	}); err != nil {
 		return AuthStatus{}, err
 	}
-	_ = s.Shutdown(context.Background())
 	return authenticatedStatus(statusProvider, "oauth", authProvider), nil
 }
 
@@ -146,7 +144,6 @@ func (s *Service) authStatus(ctx context.Context, provider string, allowImport b
 		imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider)
 		importMessage = imported.message
 		if imported.imported {
-			_ = s.Shutdown(context.Background())
 			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
 		}
 	}
@@ -159,7 +156,6 @@ func (s *Service) authStatus(ctx context.Context, provider string, allowImport b
 		imported, _ := importExternalAuth(ctx, cfg.AuthDir, authProvider)
 		importMessage = imported.message
 		if imported.imported {
-			_ = s.Shutdown(context.Background())
 			return authenticatedStatus(statusProvider, imported.source, authProvider), nil
 		}
 		if existing, err := findAuth(ctx, cfg.AuthDir, authProvider); err == nil && existing != nil {
@@ -179,13 +175,6 @@ func importExistingAuth(ctx context.Context, authDir string) {
 		return
 	}
 	for _, provider := range []string{ProviderCodex, authProviderClaude} {
-		if provider == ProviderCodex {
-			_, _ = importExternalAuth(ctx, authDir, provider)
-			continue
-		}
-		if existing, err := findAuth(ctx, authDir, provider); err == nil && existing != nil {
-			continue
-		}
 		_, _ = importExternalAuth(ctx, authDir, provider)
 	}
 }
@@ -619,6 +608,9 @@ func shouldKeepExistingAuth(path string, incoming map[string]any) bool {
 	if disabled, _ := existing["disabled"].(bool); disabled {
 		return false
 	}
+	if authMetadataEquivalent(existing, incoming) {
+		return true
+	}
 	existingTime, existingOK := authFreshnessTime(existing)
 	incomingTime, incomingOK := authFreshnessTime(incoming)
 	if !existingOK {
@@ -628,6 +620,13 @@ func shouldKeepExistingAuth(path string, incoming map[string]any) bool {
 		return true
 	}
 	return existingTime.After(incomingTime)
+}
+
+func authMetadataEquivalent(existing, incoming map[string]any) bool {
+	if len(existing) != len(incoming) {
+		return false
+	}
+	return reflect.DeepEqual(existing, incoming)
 }
 
 func authFreshnessTime(metadata map[string]any) (time.Time, bool) {

--- a/internal/cliproxy/auth_test.go
+++ b/internal/cliproxy/auth_test.go
@@ -2,6 +2,7 @@ package cliproxy
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
@@ -53,6 +54,142 @@ func TestAuthStatusImportsCodexHomeAuth(t *testing.T) {
 	}
 	if metadata["type"] != "codex" || metadata["access_token"] != "access" || metadata["refresh_token"] != "refresh" {
 		t.Fatalf("metadata = %#v, want codex tokens", metadata)
+	}
+}
+
+func TestAuthStatusRefreshesCodexHomeAuthWhenCLIProxyAuthExists(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	stale := map[string]any{
+		"type":          "codex",
+		"access_token":  "old-access",
+		"refresh_token": "old-refresh",
+		"account_id":    "acct_123",
+		"disabled":      false,
+	}
+	fileName := authFileName(ProviderCodex, stale, "codex-imported")
+	staleRaw, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, fileName), staleRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	accessToken := testJWT(t, `{"exp":1893456000}`)
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"last_refresh": "2029-12-31T23:00:00Z",
+		"tokens": {
+			"access_token": "`+accessToken+`",
+			"refresh_token": "new-refresh",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := (&Service{}).AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if !status.Authenticated || status.Source != "codex-home" {
+		t.Fatalf("status = %+v, want refreshed codex-home auth", status)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(authDir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["access_token"] != accessToken || metadata["refresh_token"] != "new-refresh" {
+		t.Fatalf("metadata = %#v, want refreshed tokens from codex home", metadata)
+	}
+	if metadata["expired"] != "2030-01-01T00:00:00Z" {
+		t.Fatalf("metadata expired = %#v, want JWT expiry", metadata["expired"])
+	}
+}
+
+func TestCodexMetadataFromAuthJSONExtractsAccessTokenExpiry(t *testing.T) {
+	metadata, err := codexMetadataFromAuthJSON([]byte(`{
+		"tokens": {
+			"access_token": "` + testJWT(t, `{"exp":1893456000}`) + `",
+			"refresh_token": "refresh"
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("codexMetadataFromAuthJSON() error = %v", err)
+	}
+	if metadata["expired"] != "2030-01-01T00:00:00Z" {
+		t.Fatalf("metadata expired = %#v, want JWT expiry", metadata["expired"])
+	}
+}
+
+func TestAuthStatusKeepsFresherCLIProxyCodexAuth(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	existing := map[string]any{
+		"type":          "codex",
+		"access_token":  "fresh-access",
+		"refresh_token": "fresh-refresh",
+		"account_id":    "acct_123",
+		"expired":       "2031-01-01T00:00:00Z",
+		"disabled":      false,
+	}
+	fileName := authFileName(ProviderCodex, existing, "codex-imported")
+	existingRaw, err := json.Marshal(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, fileName), existingRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	staleHomeAccess := testJWT(t, `{"exp":1893456000}`)
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"tokens": {
+			"access_token": "`+staleHomeAccess+`",
+			"refresh_token": "home-refresh",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := (&Service{}).AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if !status.Authenticated || status.Source != "cli-proxy" {
+		t.Fatalf("status = %+v, want existing cli-proxy auth", status)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(authDir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["access_token"] != "fresh-access" {
+		t.Fatalf("metadata = %#v, want existing auth preserved", metadata)
 	}
 }
 
@@ -139,6 +276,11 @@ func TestAuthStatusClaudeMalformedKeychainDoesNotWrite(t *testing.T) {
 	if err != nil || len(files) != 0 {
 		t.Fatalf("files = %v, %v; want no auth files", files, err)
 	}
+}
+
+func testJWT(t *testing.T, claims string) string {
+	t.Helper()
+	return "e30." + base64.RawURLEncoding.EncodeToString([]byte(claims)) + ".sig"
 }
 
 func stubKeychain(t *testing.T, reader func(context.Context, string, string) ([]byte, error)) func() {

--- a/internal/cliproxy/auth_test.go
+++ b/internal/cliproxy/auth_test.go
@@ -119,6 +119,89 @@ func TestAuthStatusRefreshesCodexHomeAuthWhenCLIProxyAuthExists(t *testing.T) {
 	}
 }
 
+func TestAuthStatusKeepsEquivalentCodexHomeAuth(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	accessToken := testJWT(t, `{"exp":1893456000,"email":"dev@example.test"}`)
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"last_refresh": "2029-12-31T23:00:00Z",
+		"tokens": {
+			"access_token": "`+accessToken+`",
+			"refresh_token": "refresh",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := (&Service{}).AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("first AuthStatus() error = %v", err)
+	}
+	if !first.Authenticated || first.Source != "codex-home" {
+		t.Fatalf("first status = %+v, want imported codex-home", first)
+	}
+
+	second, err := (&Service{}).AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("second AuthStatus() error = %v", err)
+	}
+	if !second.Authenticated || second.Source != "cli-proxy" {
+		t.Fatalf("second status = %+v, want existing cli-proxy auth", second)
+	}
+}
+
+func TestAuthStatusImportDoesNotRestartRunningService(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"tokens": {
+			"access_token": "`+testJWT(t, `{"exp":1893456000}`)+`",
+			"refresh_token": "refresh",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &Service{
+		started: true,
+		baseURL: "http://127.0.0.1:1",
+		cancel:  func() {},
+		errCh:   make(chan error, 1),
+	}
+	svc.errCh <- nil
+
+	status, err := svc.AuthStatus(context.Background(), ProviderCodex)
+	if err != nil {
+		t.Fatalf("AuthStatus() error = %v", err)
+	}
+	if !status.Authenticated || status.Source != "codex-home" {
+		t.Fatalf("status = %+v, want imported codex-home", status)
+	}
+	svc.mu.Lock()
+	started := svc.started
+	baseURL := svc.baseURL
+	svc.mu.Unlock()
+	if !started || baseURL == "" {
+		t.Fatalf("AuthStatus restarted service: started=%v baseURL=%q", started, baseURL)
+	}
+}
+
 func TestCodexMetadataFromAuthJSONExtractsAccessTokenExpiry(t *testing.T) {
 	metadata, err := codexMetadataFromAuthJSON([]byte(`{
 		"tokens": {
@@ -275,6 +358,55 @@ func TestAuthStatusClaudeMalformedKeychainDoesNotWrite(t *testing.T) {
 	files, err := filepath.Glob(filepath.Join(authDir, "*.json"))
 	if err != nil || len(files) != 0 {
 		t.Fatalf("files = %v, %v; want no auth files", files, err)
+	}
+}
+
+func TestImportExistingAuthRefreshesClaudeKeychainWhenExisting(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(authDirEnv, authDir)
+
+	existing := map[string]any{
+		"type":          authProviderClaude,
+		"email":         "dev@example.test",
+		"access_token":  "old-access",
+		"refresh_token": "old-refresh",
+		"disabled":      false,
+	}
+	fileName := authFileName(authProviderClaude, existing, "claude-keychain")
+	raw, err := json.Marshal(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, fileName), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := stubKeychain(t, func(context.Context, string, string) ([]byte, error) {
+		return []byte(`{
+			"oauthAccount": {"emailAddress": "dev@example.test"},
+			"claudeAiOauth": {
+				"accessToken": "new-access",
+				"refreshToken": "new-refresh",
+				"expiresAt": 1893456000000
+			}
+		}`), nil
+	})
+	defer restore()
+
+	importExistingAuth(context.Background(), authDir)
+
+	raw, err = os.ReadFile(filepath.Join(authDir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if metadata["access_token"] != "new-access" || metadata["refresh_token"] != "new-refresh" {
+		t.Fatalf("metadata = %#v, want refreshed keychain auth", metadata)
 	}
 }
 

--- a/internal/cliproxy/service.go
+++ b/internal/cliproxy/service.go
@@ -30,7 +30,8 @@ const (
 
 	reservedLegacyCLIProxyPort = 8300 + 17
 
-	configDirName  = "cliproxy"
+	authDirName    = "auth"
+	configDirName  = authDirName
 	configFileName = "config.yaml"
 
 	configDirEnv = "CSGCLAW_CLIPROXY_CONFIG_DIR"
@@ -131,6 +132,9 @@ func (s *Service) ProviderBaseURL(ctx context.Context, provider string) (string,
 	if err != nil {
 		return "", err
 	}
+	if err := waitForProviderModels(ctx, provider); err != nil {
+		return "", err
+	}
 	provider = providerPath(provider)
 	if provider == "" {
 		return "", fmt.Errorf("unsupported cliproxy provider %q", rawProvider)
@@ -145,6 +149,9 @@ func (s *Service) ListModels(ctx context.Context, provider string) ([]string, er
 	registryProvider := registryProvider(provider)
 	if registryProvider == "" {
 		return nil, fmt.Errorf("unsupported cliproxy provider %q", provider)
+	}
+	if err := waitForProviderModels(ctx, provider); err != nil {
+		return nil, err
 	}
 	models := registeredModels(registryProvider)
 	if len(models) > 0 {
@@ -186,6 +193,44 @@ func registeredModels(provider string) []string {
 	}
 	sort.Strings(models)
 	return models
+}
+
+func waitForProviderModels(ctx context.Context, provider string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	authProvider, _, err := normalizeAuthProvider(provider)
+	if err != nil {
+		return err
+	}
+	registryProvider := registryProvider(provider)
+	if registryProvider == "" {
+		return fmt.Errorf("unsupported cliproxy provider %q", provider)
+	}
+	cfg, err := authConfig()
+	if err != nil {
+		return err
+	}
+	existing, err := findAuth(ctx, cfg.AuthDir, authProvider)
+	if err != nil || existing == nil {
+		return err
+	}
+	if len(registeredModels(registryProvider)) > 0 {
+		return nil
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+		if len(registeredModels(registryProvider)) > 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("no %s models registered in embedded cliproxy after loading %s auth from %s", registryProvider, authProvider, cfg.AuthDir)
 }
 
 func fallbackModels(provider string) []string {
@@ -335,7 +380,11 @@ func buildConfig() (*sdkconfig.Config, string, string, error) {
 func configuredAuthDir() (string, error) {
 	authDir := strings.TrimSpace(os.Getenv(authDirEnv))
 	if authDir == "" {
-		authDir = "~/.cli-proxy-api"
+		dir, err := config.DefaultDomainDir(authDirName)
+		if err != nil {
+			return "", fmt.Errorf("resolve embedded cliproxy auth dir: %w", err)
+		}
+		return dir, nil
 	}
 	expanded, err := expandHomePath(authDir)
 	if err != nil {
@@ -366,11 +415,7 @@ func configDir() (string, error) {
 	if dir := strings.TrimSpace(os.Getenv(configDirEnv)); dir != "" {
 		return dir, nil
 	}
-	dir, err := config.DefaultDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, configDirName), nil
+	return config.DefaultDomainDir(configDirName)
 }
 
 func writeConfigFile(path string, cfg *sdkconfig.Config) error {

--- a/internal/cliproxy/service_test.go
+++ b/internal/cliproxy/service_test.go
@@ -1,6 +1,7 @@
 package cliproxy
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	cliproxysdk "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy"
@@ -75,6 +77,49 @@ func TestFallbackModelsCoverEmbeddedCLIProviders(t *testing.T) {
 	}
 }
 
+func TestEmbeddedCLIProxyRegistersImportedCodexAuthModels(t *testing.T) {
+	home := t.TempDir()
+	authDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(configDirEnv, t.TempDir())
+	t.Setenv(authDirEnv, authDir)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{
+		"tokens": {
+			"access_token": "`+testJWT(t, `{"exp":1893456000}`)+`",
+			"refresh_token": "refresh",
+			"id_token": "`+testJWT(t, `{"exp":1893456000}`)+`",
+			"account_id": "acct_123"
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	svc := &Service{client: &http.Client{Timeout: 5 * time.Second}}
+	if err := svc.EnsureStarted(ctx); err != nil {
+		t.Fatalf("EnsureStarted() error = %v", err)
+	}
+	defer func() {
+		if err := svc.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown() error = %v", err)
+		}
+	}()
+
+	models, err := svc.ListModels(ctx, ProviderCodex)
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if !containsString(models, "gpt-5.2") {
+		t.Fatalf("models = %v, want gpt-5.2 registered for imported codex auth", models)
+	}
+}
+
 func TestEmbeddedCLIProxyLoadsBuiltinTranslators(t *testing.T) {
 	input := []byte(`{"model":"client-model","messages":[{"role":"user","content":"hello"}],"max_completion_tokens":1024}`)
 
@@ -95,6 +140,15 @@ func TestEmbeddedCLIProxyLoadsBuiltinTranslators(t *testing.T) {
 	if !strings.Contains(text, `"model":"gpt-5.4"`) {
 		t.Fatalf("translated request missing resolved model: %s", text)
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildConfigUsesPrivateNonReservedPortAndWritesConfig(t *testing.T) {
@@ -183,8 +237,23 @@ func TestConfiguredAuthDirExpandsHome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("configuredAuthDir returned error: %v", err)
 	}
-	want := filepath.Join(home, ".cli-proxy-api")
+	want := filepath.Join(home, ".csgclaw", "auth")
 	if got != want {
 		t.Fatalf("configuredAuthDir = %q, want %q", got, want)
+	}
+}
+
+func TestConfigDirDefaultsToAuthDomain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(configDirEnv, "")
+
+	got, err := configDir()
+	if err != nil {
+		t.Fatalf("configDir returned error: %v", err)
+	}
+	want := filepath.Join(home, ".csgclaw", "auth")
+	if got != want {
+		t.Fatalf("configDir = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION

**Summary**

- Refreshes Codex provider auth from `~/.codex/auth.json` before reusing existing CLIProxy auth records.
- Preserves newer CLIProxy auth when it is fresher than Codex home auth.
- Extracts JWT expiry during Codex auth import so CLIProxy can refresh tokens before requests hit 401.
- Stabilizes an async serve test that waited for browser fallback before the fallback hint was printed.