### PR TITLE
fix(bot): preserve agent profile on worker create

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -506,7 +506,7 @@ func TestHandleBotsCreateCSGClawWorker(t *testing.T) {
 		imBus:  bus,
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/bots", strings.NewReader(`{"name":"alice","description":"test lead","role":"worker","channel":"csgclaw"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bots", strings.NewReader(`{"name":"alice","description":"test lead","image":"agent-image:1","role":"worker","channel":"csgclaw","agent_profile":{"provider":"csghub_lite","model_id":"glm-4.5","reasoning_effort":"high"}}`))
 	rec := httptest.NewRecorder()
 
 	srv.Routes().ServeHTTP(rec, req)
@@ -552,6 +552,12 @@ func TestHandleBotsCreateCSGClawWorker(t *testing.T) {
 	}
 	if len(agents) != 1 || agents[0].ID != "u-alice" {
 		t.Fatalf("agents = %+v, want u-alice", agents)
+	}
+	if agents[0].Image != "agent-image:1" {
+		t.Fatalf("agents[0].Image = %q, want agent-image:1", agents[0].Image)
+	}
+	if agents[0].Provider != agent.ProviderCSGHubLite || agents[0].ModelID != "glm-4.5" {
+		t.Fatalf("agent profile = %s/%s, want csghub_lite/glm-4.5", agents[0].Provider, agents[0].ModelID)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -19,13 +19,15 @@ type Bot struct {
 }
 
 type CreateBotRequest struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Role        string `json:"role"`
-	Channel     string `json:"channel,omitempty"`
-	ModelID     string `json:"model_id,omitempty"`
-	RuntimeKind string `json:"runtime_kind,omitempty"`
+	ID           string             `json:"id,omitempty"`
+	Name         string             `json:"name"`
+	Description  string             `json:"description,omitempty"`
+	Image        string             `json:"image,omitempty"`
+	Role         string             `json:"role"`
+	Channel      string             `json:"channel,omitempty"`
+	ModelID      string             `json:"model_id,omitempty"`
+	RuntimeKind  string             `json:"runtime_kind,omitempty"`
+	AgentProfile CreateAgentProfile `json:"agent_profile,omitempty"`
 }
 
 type User struct {

--- a/internal/bot/model.go
+++ b/internal/bot/model.go
@@ -30,6 +30,7 @@ func NormalizeCreateRequest(req CreateRequest) (CreateRequest, error) {
 	req.ID = strings.TrimSpace(req.ID)
 	req.Name = strings.TrimSpace(req.Name)
 	req.Description = strings.TrimSpace(req.Description)
+	req.Image = strings.TrimSpace(req.Image)
 	req.ModelID = strings.TrimSpace(req.ModelID)
 	req.RuntimeKind = strings.TrimSpace(req.RuntimeKind)
 	if req.Name == "" {

--- a/internal/bot/service.go
+++ b/internal/bot/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"csgclaw/internal/agent"
+	"csgclaw/internal/apitypes"
 	"csgclaw/internal/channel"
 	"csgclaw/internal/im"
 )
@@ -305,12 +306,14 @@ func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (B
 	} else {
 		var err error
 		created, err = s.agents.CreateWorker(ctx, agent.CreateAgentSpec{
-			ID:          normalized.ID,
-			Name:        normalized.Name,
-			Description: normalized.Description,
-			Role:        agent.RoleWorker,
-			ModelID:     normalized.ModelID,
-			RuntimeKind: normalized.RuntimeKind,
+			ID:           normalized.ID,
+			Name:         normalized.Name,
+			Description:  normalized.Description,
+			Image:        normalized.Image,
+			Role:         agent.RoleWorker,
+			ModelID:      normalized.ModelID,
+			RuntimeKind:  normalized.RuntimeKind,
+			AgentProfile: agentProfileFromBotRequest(normalized.AgentProfile),
 		})
 		if err != nil {
 			return Bot{}, err
@@ -354,6 +357,23 @@ func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (B
 		return Bot{}, err
 	}
 	return b, nil
+}
+
+func agentProfileFromBotRequest(req apitypes.CreateAgentProfile) agent.AgentProfile {
+	return agent.AgentProfile{
+		Name:            req.Name,
+		Description:     req.Description,
+		Provider:        req.Provider,
+		BaseURL:         req.BaseURL,
+		APIKey:          req.APIKey,
+		Headers:         req.Headers,
+		ModelID:         req.ModelID,
+		ReasoningEffort: req.ReasoningEffort,
+		EnableFastMode:  req.EnableFastMode,
+		RequestOptions:  req.RequestOptions,
+		Env:             req.Env,
+		ProfileComplete: req.ProfileComplete,
+	}
 }
 
 func (s *Service) createManager(ctx context.Context, normalized CreateRequest, forceRecreateAgent bool) (Bot, error) {

--- a/internal/bot/service_test.go
+++ b/internal/bot/service_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"csgclaw/internal/agent"
+	"csgclaw/internal/apitypes"
 	"csgclaw/internal/channel"
 	"csgclaw/internal/config"
 	"csgclaw/internal/im"
@@ -666,9 +667,15 @@ func TestServiceCreateCSGClawWorkerCreatesAgentUserAndBot(t *testing.T) {
 	got, err := svc.Create(context.Background(), CreateRequest{
 		Name:        "alice",
 		Description: "test lead",
+		Image:       "agent-image:1",
 		Role:        string(RoleWorker),
 		Channel:     string(ChannelCSGClaw),
 		RuntimeKind: agent.RuntimeKindCodex,
+		AgentProfile: apitypes.CreateAgentProfile{
+			Provider:        agent.ProviderCSGHubLite,
+			ModelID:         "glm-4.5",
+			ReasoningEffort: "high",
+		},
 	})
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
@@ -688,6 +695,15 @@ func TestServiceCreateCSGClawWorkerCreatesAgentUserAndBot(t *testing.T) {
 	}
 	if createdAgent.RuntimeKind != agent.RuntimeKindCodex {
 		t.Fatalf("agent.RuntimeKind = %q, want %q", createdAgent.RuntimeKind, agent.RuntimeKindCodex)
+	}
+	if createdAgent.Image != "agent-image:1" {
+		t.Fatalf("agent.Image = %q, want agent-image:1", createdAgent.Image)
+	}
+	if createdAgent.Provider != agent.ProviderCSGHubLite || createdAgent.ModelID != "glm-4.5" {
+		t.Fatalf("agent profile = %s/%s, want csghub_lite/glm-4.5", createdAgent.Provider, createdAgent.ModelID)
+	}
+	if createdAgent.AgentProfile.ReasoningEffort != "high" {
+		t.Fatalf("agent reasoning = %q, want high", createdAgent.AgentProfile.ReasoningEffort)
 	}
 	users := imSvc.ListUsers()
 	if !containsUser(users, "u-alice") {


### PR DESCRIPTION
## Summary

- Preserve `image` and `agent_profile` fields when workers are created through the bot API.
- Forward the full bot create profile into `agent.CreateWorker` instead of only passing the legacy `model_id`.
- Add bot service and API coverage proving `/api/v1/bots` creation keeps `csghub_lite` provider/model values in the created Agent.

## Test

```bash
make sync-agent-runtimes
env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw-agent-profile-fix/.gocache go test ./internal/bot ./internal/api
```

Fixes #36