### PR TITLE
Improve stored API key masking and reuse for model loading

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -100,6 +100,10 @@ Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状
 
 获取全部 agent 列表。
 
+响应中的 `agent_profile` 不返回真实 `api_key`；若已保存密钥，只返回
+`api_key_set: true`，并在长密钥场景返回安全前缀 `api_key_preview`
+（例如 `sk-l...`）供 UI 展示。
+
 ### `POST /api/v1/agents`
 
 创建 `role=worker` 的 agent，并自动同步到 IM 用户体系。

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -55,6 +55,7 @@ type AgentProfileView struct {
 	Provider           string                   `json:"provider,omitempty"`
 	BaseURL            string                   `json:"base_url,omitempty"`
 	APIKeySet          bool                     `json:"api_key_set,omitempty"`
+	APIKeyPreview      string                   `json:"api_key_preview,omitempty"`
 	Headers            map[string]string        `json:"headers,omitempty"`
 	ModelID            string                   `json:"model_id,omitempty"`
 	ReasoningEffort    string                   `json:"reasoning_effort,omitempty"`
@@ -74,6 +75,7 @@ type ProfileDetectionResult struct {
 }
 
 type ProfileModelRequest struct {
+	AgentID  string            `json:"agent_id,omitempty"`
 	Provider string            `json:"provider"`
 	BaseURL  string            `json:"base_url,omitempty"`
 	APIKey   string            `json:"api_key,omitempty"`
@@ -206,6 +208,7 @@ func profileView(profile AgentProfile, detection []ProfileDetectionResult) Agent
 		Provider:           profile.Provider,
 		BaseURL:            profile.BaseURL,
 		APIKeySet:          strings.TrimSpace(profile.APIKey) != "",
+		APIKeyPreview:      apiKeyPreview(profile.APIKey),
 		Headers:            profile.Headers,
 		ModelID:            profile.ModelID,
 		ReasoningEffort:    profile.ReasoningEffort,
@@ -216,6 +219,23 @@ func profileView(profile AgentProfile, detection []ProfileDetectionResult) Agent
 		EnvRestartRequired: profile.EnvRestartRequired,
 		DetectionResults:   append([]ProfileDetectionResult(nil), detection...),
 	}
+}
+
+func apiKeyPreview(apiKey string) string {
+	const (
+		minPreviewRunes = 9
+		prefixRunes     = 4
+	)
+
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return ""
+	}
+	runes := []rune(apiKey)
+	if len(runes) < minPreviewRunes {
+		return ""
+	}
+	return string(runes[:prefixRunes]) + "..."
 }
 
 func RedactedProfileView(profile AgentProfile, detection []ProfileDetectionResult) AgentProfileView {

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -129,6 +129,42 @@ func TestProfileDefaultsPersistAfterProfileUpdate(t *testing.T) {
 	}
 }
 
+func TestRedactedProfileViewIncludesSafeAPIKeyPreview(t *testing.T) {
+	view := RedactedProfileView(AgentProfile{
+		Name:   "alice",
+		APIKey: "sk-live-secret-token",
+	}, nil)
+	if !view.APIKeySet {
+		t.Fatalf("APIKeySet = false, want true")
+	}
+	if got, want := view.APIKeyPreview, "sk-l..."; got != want {
+		t.Fatalf("APIKeyPreview = %q, want %q", got, want)
+	}
+	data, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(data), "secret-token") {
+		t.Fatalf("redacted view leaked API key: %s", string(data))
+	}
+	if strings.Contains(string(data), `"api_key"`) {
+		t.Fatalf("redacted view includes api_key: %s", string(data))
+	}
+}
+
+func TestRedactedProfileViewOmitsAPIKeyPreviewForShortKeys(t *testing.T) {
+	view := RedactedProfileView(AgentProfile{
+		Name:   "alice",
+		APIKey: "local",
+	}, nil)
+	if !view.APIKeySet {
+		t.Fatalf("APIKeySet = false, want true")
+	}
+	if view.APIKeyPreview != "" {
+		t.Fatalf("APIKeyPreview = %q, want empty for short key", view.APIKeyPreview)
+	}
+}
+
 func TestListModelsForRequestUsesCLIProxyChoicesForDropdown(t *testing.T) {
 	oldChoices := listCLIProxyModelChoices
 	defer func() {
@@ -151,6 +187,83 @@ func TestListModelsForRequestUsesCLIProxyChoicesForDropdown(t *testing.T) {
 	want := []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-4.1"}
 	if strings.Join(models, ",") != strings.Join(want, ",") {
 		t.Fatalf("models = %v, want %v", models, want)
+	}
+}
+
+func TestListModelsForRequestUsesStoredAgentAPIKeyForMatchingProfile(t *testing.T) {
+	var authHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[{"id":"deepseek-chat"}]}`))
+	}))
+	defer upstream.Close()
+
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:   "u-alice",
+		Name: "alice",
+		AgentProfile: normalizeProfile(AgentProfile{
+			Name:     "alice",
+			Provider: ProviderAPI,
+			BaseURL:  upstream.URL + "/v1",
+			APIKey:   "stored-key",
+			ModelID:  "deepseek-chat",
+		}, "alice", ""),
+	}
+
+	models, err := svc.ListModelsForRequest(context.Background(), ProfileModelRequest{
+		AgentID:  "u-alice",
+		Provider: ProviderAPI,
+		BaseURL:  upstream.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("ListModelsForRequest() error = %v", err)
+	}
+	if authHeader != "Bearer stored-key" {
+		t.Fatalf("Authorization = %q, want stored key", authHeader)
+	}
+	if got, want := strings.Join(models, ","), "deepseek-chat"; got != want {
+		t.Fatalf("models = %v, want %s", models, want)
+	}
+}
+
+func TestListModelsForRequestDoesNotReuseStoredAPIKeyForChangedBaseURL(t *testing.T) {
+	var authHeader string
+	otherUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer otherUpstream.Close()
+
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:   "u-alice",
+		Name: "alice",
+		AgentProfile: normalizeProfile(AgentProfile{
+			Name:     "alice",
+			Provider: ProviderAPI,
+			BaseURL:  "https://api.deepseek.com",
+			APIKey:   "stored-key",
+			ModelID:  "deepseek-chat",
+		}, "alice", ""),
+	}
+
+	_, err = svc.ListModelsForRequest(context.Background(), ProfileModelRequest{
+		AgentID:  "u-alice",
+		Provider: ProviderAPI,
+		BaseURL:  otherUpstream.URL + "/v1",
+	})
+	if err == nil {
+		t.Fatal("ListModelsForRequest() error = nil, want upstream auth failure")
+	}
+	if authHeader != "" {
+		t.Fatalf("Authorization sent to changed base URL = %q, want empty", authHeader)
 	}
 }
 

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -192,8 +192,10 @@ func TestListModelsForRequestUsesCLIProxyChoicesForDropdown(t *testing.T) {
 
 func TestListModelsForRequestUsesStoredAgentAPIKeyForMatchingProfile(t *testing.T) {
 	var authHeader string
+	var gotHeader string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader = r.Header.Get("Authorization")
+		gotHeader = r.Header.Get("X-Test")
 		_, _ = w.Write([]byte(`{"data":[{"id":"deepseek-chat"}]}`))
 	}))
 	defer upstream.Close()
@@ -210,6 +212,7 @@ func TestListModelsForRequestUsesStoredAgentAPIKeyForMatchingProfile(t *testing.
 			Provider: ProviderAPI,
 			BaseURL:  upstream.URL + "/v1",
 			APIKey:   "stored-key",
+			Headers:  map[string]string{"X-Test": "stored"},
 			ModelID:  "deepseek-chat",
 		}, "alice", ""),
 	}
@@ -218,12 +221,16 @@ func TestListModelsForRequestUsesStoredAgentAPIKeyForMatchingProfile(t *testing.
 		AgentID:  "u-alice",
 		Provider: ProviderAPI,
 		BaseURL:  upstream.URL + "/v1",
+		Headers:  map[string]string{"X-Test": "draft"},
 	})
 	if err != nil {
 		t.Fatalf("ListModelsForRequest() error = %v", err)
 	}
 	if authHeader != "Bearer stored-key" {
 		t.Fatalf("Authorization = %q, want stored key", authHeader)
+	}
+	if gotHeader != "draft" {
+		t.Fatalf("X-Test header = %q, want draft header", gotHeader)
 	}
 	if got, want := strings.Join(models, ","), "deepseek-chat"; got != want {
 		t.Fatalf("models = %v, want %s", models, want)

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"maps"
 	"strings"
 	"time"
 
@@ -179,9 +178,6 @@ func (s *Service) storedAPIKeyForModelRequest(req ProfileModelRequest, profile A
 		return ""
 	}
 	if profile.BaseURL != stored.BaseURL {
-		return ""
-	}
-	if !maps.Equal(profile.Headers, stored.Headers) {
 		return ""
 	}
 	return stored.APIKey

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -151,6 +152,9 @@ func (s *Service) ListModelsForRequest(ctx context.Context, req ProfileModelRequ
 		Headers:  req.Headers,
 	}
 	profile = normalizeProfile(profile, profile.Name, profile.Description)
+	if strings.TrimSpace(profile.APIKey) == "" {
+		profile.APIKey = s.storedAPIKeyForModelRequest(req, profile)
+	}
 	if profile.Provider == ProviderCodex || profile.Provider == ProviderClaudeCode {
 		models, err := listCLIProxyModelChoices(ctx, profile.Provider)
 		if err != nil {
@@ -159,6 +163,28 @@ func (s *Service) ListModelsForRequest(ctx context.Context, req ProfileModelRequ
 		return sortModelIDs(models), nil
 	}
 	return ListModelsForProfile(ctx, profile)
+}
+
+func (s *Service) storedAPIKeyForModelRequest(req ProfileModelRequest, profile AgentProfile) string {
+	agentID := strings.TrimSpace(req.AgentID)
+	if s == nil || agentID == "" || profile.Provider != ProviderAPI {
+		return ""
+	}
+	got, ok := s.Agent(agentID)
+	if !ok {
+		return ""
+	}
+	stored := normalizeProfile(got.AgentProfile, got.Name, got.Description)
+	if stored.Provider != ProviderAPI || strings.TrimSpace(stored.APIKey) == "" {
+		return ""
+	}
+	if profile.BaseURL != stored.BaseURL {
+		return ""
+	}
+	if !maps.Equal(profile.Headers, stored.Headers) {
+		return ""
+	}
+	return stored.APIKey
 }
 
 func (s *Service) ResolvedAgentProfile(agentID string) (AgentProfile, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1040,6 +1040,9 @@ func TestHandleAgentsListRedactsProfileAPIKey(t *testing.T) {
 	if !ok || profile["api_key_set"] != true {
 		t.Fatalf("agent_profile = %#v, want api_key_set true", got[0]["agent_profile"])
 	}
+	if got, want := profile["api_key_preview"], "secr..."; got != want {
+		t.Fatalf("agent_profile api_key_preview = %#v, want %q", got, want)
+	}
 	if _, ok := profile["api_key"]; ok {
 		t.Fatalf("agent_profile includes api_key: %#v", profile)
 	}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -132,6 +132,7 @@ const messages = {
     profileModel: "Model",
     profileBaseURL: "Base URL",
     profileAPIKey: "API Key",
+    profileAPIKeyNewPlaceholder: "sk-...",
     profileHeaders: "Headers JSON",
     profileRequestOptions: "请求选项（JSON，合并到请求顶层）",
     profileEnv: "环境变量",
@@ -313,6 +314,7 @@ const messages = {
     profileModel: "Model",
     profileBaseURL: "Base URL",
     profileAPIKey: "API Key",
+    profileAPIKeyNewPlaceholder: "sk-...",
     profileHeaders: "Headers JSON",
     profileRequestOptions: "Request options (JSON, merged into top-level request)",
     profileEnv: "Environment variables",
@@ -459,6 +461,36 @@ function requiredFieldLabel(label) {
       ${label}
       <span className="field-required-star" aria-hidden="true">*</span>
     </span>
+  `;
+}
+
+function APIKeyField({ value, onInput, profile, t }) {
+  const stored = Boolean(profile?.api_key_set);
+  const preview = String(profile?.api_key_preview || "").trim();
+  const showStoredMask = stored && isBlank(value);
+  const previewPrefix = preview.endsWith("...") ? preview.slice(0, -3) : "";
+  const placeholder = stored ? "" : t("profileAPIKeyNewPlaceholder");
+  return html`
+    <label className="field api-key-field">
+      <span>${t("profileAPIKey")}</span>
+      <div className="api-key-input-shell">
+        <input
+          value=${value}
+          onInput=${onInput}
+          placeholder=${placeholder}
+          autoComplete="off"
+          spellCheck=${false}
+        />
+        ${showStoredMask
+          ? html`
+              <div className="api-key-mask" aria-hidden="true">
+                ${previewPrefix ? html`<span className="api-key-mask-prefix">${previewPrefix}</span>` : null}
+                <span className="api-key-mask-dots">••••••••</span>
+              </div>
+            `
+          : null}
+      </div>
+    </label>
   `;
 }
 
@@ -1751,7 +1783,7 @@ function App() {
       }
       const profile = await resp.json();
       setManagerProfile(profile);
-      setProfileDraft(profileToDraft(profile));
+      setProfileDraft({ ...profileToDraft(profile), agent_id: "u-manager" });
     } catch (_) {
       // The manager may not exist during the first bootstrap milliseconds.
     }
@@ -1837,6 +1869,7 @@ function App() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          agent_id: draft.agent_id,
           provider: draft.provider,
           base_url: draft.base_url,
           api_key: draft.api_key,
@@ -1889,7 +1922,7 @@ function App() {
       }
       const saved = await resp.json();
       setManagerProfile(saved);
-      setProfileDraft(profileToDraft(saved));
+      setProfileDraft({ ...profileToDraft(saved), agent_id: "u-manager" });
       if (saved.profile_complete) {
         await fetch("api/v1/agents/u-manager/recreate", { method: "POST" });
       }
@@ -1937,12 +1970,12 @@ function App() {
     try {
       const resp = await fetch("api/v1/agent-profile-defaults");
       const defaults = resp.ok ? await resp.json() : managerProfile;
-      const draft = agentToDraft({ image: managerAgent?.image || "", runtime_kind: managerAgent?.runtime_kind || "", agent_profile: defaults });
+      const draft = agentToDraft({ id: managerAgent?.id || "u-manager", image: managerAgent?.image || "", runtime_kind: managerAgent?.runtime_kind || "", agent_profile: defaults });
       setAgentDraft(draft);
       setShowAgentModal(true);
       loadAgentModels(draft, { silent: true });
     } catch (_) {
-      const draft = agentToDraft({ image: managerAgent?.image || "", runtime_kind: managerAgent?.runtime_kind || "", agent_profile: managerProfile });
+      const draft = agentToDraft({ id: managerAgent?.id || "u-manager", image: managerAgent?.image || "", runtime_kind: managerAgent?.runtime_kind || "", agent_profile: managerProfile });
       setAgentDraft(draft);
       setShowAgentModal(true);
       loadAgentModels(draft, { silent: true });
@@ -2000,6 +2033,7 @@ function App() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          agent_id: draft.agent_id,
           provider: draft.provider,
           base_url: draft.base_url,
           api_key: draft.api_key,
@@ -2048,6 +2082,7 @@ function App() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          agent_id: draft.agent_id,
           provider: draft.provider,
           base_url: draft.base_url,
           api_key: draft.api_key,
@@ -3264,10 +3299,12 @@ function App() {
                                 placeholder="https://api.openai.com/v1"
                               />
                             </label>
-                            <label className="field">
-                              <span>${t("profileAPIKey")}</span>
-                              <input value=${agentDraft.api_key} onInput=${(event) => setAgentDraft({ ...agentDraft, api_key: event.target.value })} placeholder=${editingAgent?.agent_profile?.api_key_set ? "Stored key will be kept if blank" : "sk-..."} />
-                            </label>
+                            <${APIKeyField}
+                              value=${agentDraft.api_key}
+                              onInput=${(event) => setAgentDraft({ ...agentDraft, api_key: event.target.value })}
+                              profile=${agentDraft}
+                              t=${t}
+                            />
                             <label className="field span-2">
                               <span>${t("profileHeaders")}</span>
                               <textarea className="compact-textarea" value=${agentDraft.headersText} onInput=${(event) => setAgentDraft({ ...agentDraft, headersText: event.target.value })} />
@@ -3404,10 +3441,12 @@ function App() {
                                 placeholder="https://api.openai.com/v1"
                               />
                             </label>
-                            <label className="field">
-                              <span>${t("profileAPIKey")}</span>
-                              <input value=${profileDraft.api_key} onInput=${(event) => setProfileDraft({ ...profileDraft, api_key: event.target.value })} placeholder=${managerProfile.api_key_set ? "Stored key will be kept if blank" : "sk-..."} />
-                            </label>
+                            <${APIKeyField}
+                              value=${profileDraft.api_key}
+                              onInput=${(event) => setProfileDraft({ ...profileDraft, api_key: event.target.value })}
+                              profile=${profileDraft}
+                              t=${t}
+                            />
                             <label className="field span-2">
                               <span>${t("profileHeaders")}</span>
                               <textarea className="compact-textarea" value=${profileDraft.headersText} onInput=${(event) => setProfileDraft({ ...profileDraft, headersText: event.target.value })} />
@@ -3874,10 +3913,12 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                             placeholder="https://api.openai.com/v1"
                           />
                         </label>
-                        <label className="field">
-                          <span>${t("profileAPIKey")}</span>
-                          <input value=${draft.api_key} onInput=${(event) => updateDraft({ api_key: event.target.value })} placeholder=${item.agent_profile?.api_key_set ? "Stored key will be kept if blank" : "sk-..."} />
-                        </label>
+                        <${APIKeyField}
+                          value=${draft.api_key}
+                          onInput=${(event) => updateDraft({ api_key: event.target.value })}
+                          profile=${draft}
+                          t=${t}
+                        />
                         <label className="field span-2">
                           <span>${t("profileHeaders")}</span>
                           <textarea className="compact-textarea" value=${draft.headersText} onInput=${(event) => updateDraft({ headersText: event.target.value })} />
@@ -4451,6 +4492,8 @@ function profileToDraft(profile) {
     provider: profile?.provider || "csghub_lite",
     base_url: profile?.base_url || "",
     api_key: "",
+    api_key_set: Boolean(profile?.api_key_set),
+    api_key_preview: profile?.api_key_preview || "",
     model_id: profile?.model_id || "",
     reasoning_effort: profile?.reasoning_effort || "medium",
     enable_fast_mode: Boolean(profile?.enable_fast_mode),
@@ -4465,6 +4508,7 @@ function modelRequestKey(draft) {
     return "";
   }
   return JSON.stringify({
+    agent_id: draft.agent_id || "",
     provider: draft.provider || "",
     base_url: draft.base_url || "",
     api_key: draft.api_key || "",
@@ -4475,6 +4519,7 @@ function modelRequestKey(draft) {
 function agentToDraft(agent) {
   const profile = agent?.agent_profile || agent || {};
   return {
+    agent_id: agent?.id || "",
     name: agent?.name || "",
     role: agent?.role || "worker",
     description: agent?.description || profile.description || "",

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -2043,6 +2043,54 @@ body::after {
   font-weight: 720;
 }
 
+.api-key-field {
+  min-width: 0;
+}
+
+.api-key-input-shell {
+  position: relative;
+  min-width: 0;
+}
+
+.api-key-input-shell input {
+  position: relative;
+  z-index: 1;
+}
+
+.api-key-mask {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  padding: 9px 11px;
+  color: color-mix(in oklab, var(--text) 54%, var(--muted));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.api-key-mask-prefix {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-weight: 650;
+}
+
+.api-key-mask-dots {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin-left: 1px;
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
 .profile-section .field input,
 .profile-section .field textarea,
 .profile-section .field select {


### PR DESCRIPTION
**Summary**

- Fixes /api/v1/agent-profiles/models so model loading can reuse the stored agent API key when the request matches the same provider, base URL, and headers.

and

<img width="1046" height="127" alt="image" src="https://github.com/user-attachments/assets/9fcec21c-9cb6-4098-ba17-c0e928068191" />
