### PR TITLE
fix(api): keep create operations alive across request disconnects

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,6 +34,18 @@ type Handler struct {
 	upgradeManager    *upgrade.Manager
 	upgradeConfigPath string
 	upgradeApply      func(upgrade.ApplyHelperOptions) error
+}
+
+const (
+	createOperationTimeout = 10 * time.Minute
+	sseHeartbeatInterval   = 15 * time.Second
+)
+
+func detachedCreateContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), createOperationTimeout)
 }
 
 type imBootstrapResponse struct {
@@ -223,7 +236,9 @@ func (h *Handler) handleBots(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
 			return
 		}
-		created, err := h.botSvc.Create(r.Context(), req)
+		createCtx, cancel := detachedCreateContext(r.Context())
+		defer cancel()
+		created, err := h.botSvc.Create(createCtx, req)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -596,7 +611,9 @@ func (h *Handler) handleCreateAgentWorker(w http.ResponseWriter, r *http.Request
 		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
 		return
 	}
-	created, err := h.svc.Create(r.Context(), agentCreateRequestFromAPI(req))
+	createCtx, cancel := detachedCreateContext(r.Context())
+	defer cancel()
+	created, err := h.svc.Create(createCtx, agentCreateRequestFromAPI(req))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1079,10 +1096,18 @@ func (h *Handler) handleIMEvents(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.WriteString(w, ": connected\n\n")
 	flusher.Flush()
 
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-ticker.C:
+			if _, err := io.WriteString(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
 		case evt, ok := <-events:
 			if !ok {
 				return


### PR DESCRIPTION
## Summary

This PR makes bot and agent creation more resilient to short-lived HTTP request interruptions.

The create handlers now run creation with a detached context that keeps the operation alive for up to 10 minutes even if the browser refreshes, the frontend aborts the request, or a proxy closes the client connection. The IM SSE stream also sends periodic heartbeat comments so idle event connections are less likely to be treated as stale.

## Why

Creating a bot or agent is not a small request-scoped operation. It can involve runtime setup, sandbox creation, agent metadata persistence, and channel/user provisioning. If that work is tied directly to `r.Context()`, a temporary frontend or network interruption can cancel the operation after some side effects have already happened.

That can leave awkward intermediate state: for example, a sandbox or agent runtime may already exist while the higher-level bot/agent records or channel bindings are incomplete. Retrying from the UI can then run into duplicate names, existing runtime resources, or confusing "failed but partially created" state.

This change is a pragmatic stability step: once creation has started, the backend attempts to finish it within a bounded timeout instead of letting page-level request churn interrupt it halfway through.

## Follow-up

This is not meant to be the final cancellation model. A more complete flow should likely make creation an explicit background task with persisted status, progress reporting, and a real cancel endpoint that the backend can honor safely across each creation stage.

## Testing

- `env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/api -run 'TestHandleBotsCreate(CodexWorkerEnsuresCodexBridge|CSGClawWorker)'`

Full `go test ./internal/api` was also attempted locally, but this sandbox environment blocks `httptest` listener creation (`bind: operation not permitted`) and has a local profile-dependent Feishu worker test failure unrelated to this isolated API handler change.
