### PR TITLE
fix(api): keep IM event streams alive

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -35,6 +35,8 @@ type Handler struct {
 	upgradeApply      func(upgrade.ApplyHelperOptions) error
 }
 
+const sseHeartbeatInterval = 15 * time.Second
+
 type imBootstrapResponse struct {
 	CurrentUserID      string    `json:"current_user_id"`
 	Users              []im.User `json:"users"`
@@ -1079,10 +1081,18 @@ func (h *Handler) handleIMEvents(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.WriteString(w, ": connected\n\n")
 	flusher.Flush()
 
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-ticker.C:
+			if _, err := io.WriteString(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
 		case evt, ok := <-events:
 			if !ok {
 				return


### PR DESCRIPTION
## Summary

This PR keeps the IM event SSE stream alive while the conversation is idle.

`/api/v1/events` now sends a lightweight SSE comment heartbeat every 15 seconds. This does not change the event payload contract, but it gives browsers, proxies, and other network layers periodic bytes so they are less likely to close an otherwise idle conversation stream.

## Why

The web UI depends on the SSE connection for chat and room updates. When there is no message traffic for a while, the connection can look idle from the network layer's perspective and may be dropped. If that happens silently, the conversation UI can miss later updates until the client reconnects.

Sending SSE comments is a low-risk keepalive mechanism: clients ignore comment lines such as `: ping`, while the TCP/HTTP connection still sees activity.

## Testing

- `env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/api -run TestHandleIMEventsExposeRoomIDOnly`

I also attempted:

- `env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/api -run 'TestIMEvents|TestHandleIMEvents'`

The broader event test run is blocked in this local sandbox by `httptest` listener creation failing with `bind: operation not permitted`.
