### PR TITLE
feat(ci): unify release artifacts; fix Windows picoclaw gateway paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,38 +17,40 @@ env:
   BOXLITE_CLI_VERSION: v0.9.0
 
 jobs:
-  build-and-release:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build matrix from release-platforms.txt
+        id: set-matrix
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          rows = []
+          for line in Path("scripts/release-platforms.txt").read_text().splitlines():
+              line = line.strip()
+              if not line or line.startswith("#"):
+                  continue
+              parts = line.split()
+              if len(parts) != 2:
+                  raise SystemExit(f"bad platform line: {line!r}")
+              goos, goarch = parts
+              rows.append({"goos": goos, "goarch": goarch})
+          print("matrix=" + json.dumps({"include": rows}))
+          PY
+
+  build:
+    needs: [prepare]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            goos: linux
-            goarch: amd64
-            include_boxlite: 1
-            cgo_enabled: 0
-          - runner: ubuntu-24.04-arm
-            goos: linux
-            goarch: arm64
-            include_boxlite: 1
-            cgo_enabled: 0
-          - runner: macos-latest
-            goos: darwin
-            goarch: arm64
-            include_boxlite: 1
-            cgo_enabled: 0
-          - runner: macos-latest
-            goos: darwin
-            goarch: amd64
-            include_boxlite: 0
-            cgo_enabled: 0
-          - runner: windows-latest
-            goos: windows
-            goarch: amd64
-            include_boxlite: 0
-            cgo_enabled: 0
-    runs-on: ${{ matrix.runner }}
-
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,29 +78,46 @@ jobs:
           echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - name: Package release archive
+      - name: Package release archives (one platform)
         shell: bash
         run: |
-          chmod +x scripts/package-release.sh
+          chmod +x scripts/release-build-all.sh
           VERSION="${{ steps.version.outputs.value }}" \
           COMMIT="${{ steps.build_meta.outputs.commit }}" \
           BUILD_TIME="${{ steps.build_meta.outputs.build_time }}" \
           DIST_DIR=dist \
-          APP=csgclaw \
           GOCACHE="${{ github.workspace }}/.gocache" \
-          INCLUDE_BOXLITE="${{ matrix.include_boxlite }}" \
           BOXLITE_CLI_VERSION="${{ env.BOXLITE_CLI_VERSION }}" \
-          CGO_ENABLED="${{ matrix.cgo_enabled }}" \
-          ./scripts/package-release.sh "${{ matrix.goos }}" "${{ matrix.goarch }}"
-          VERSION="${{ steps.version.outputs.value }}" \
-          COMMIT="${{ steps.build_meta.outputs.commit }}" \
-          BUILD_TIME="${{ steps.build_meta.outputs.build_time }}" \
-          DIST_DIR=dist \
-          APP=csgclaw-cli \
-          GOCACHE="${{ github.workspace }}/.gocache" \
-          INCLUDE_BOXLITE=0 \
-          CGO_ENABLED="${{ matrix.cgo_enabled }}" \
-          ./scripts/package-release.sh "${{ matrix.goos }}" "${{ matrix.goarch }}"
+          ./scripts/release-build-all.sh "${{ matrix.goos }}" "${{ matrix.goarch }}"
+
+      - name: Upload platform artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*
+          if-no-files-found: error
+
+  merge-and-release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME}"
+          fi
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2

--- a/.gitlab/bookworm-mirror.sh
+++ b/.gitlab/bookworm-mirror.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Rewrite Debian bookworm apt sources to Aliyun (or DEBIAN_APT_MIRROR_*). Used by GitLab CI.
+set -euo pipefail
+
+deb="${DEBIAN_APT_MIRROR_DEB:-http://mirrors.aliyun.com/debian}"
+sec="${DEBIAN_APT_MIRROR_SEC:-http://mirrors.aliyun.com/debian-security}"
+
+rewrite_sources() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  sed -i \
+    -e "s|https://deb.debian.org/debian|${deb}|g" \
+    -e "s|http://deb.debian.org/debian|${deb}|g" \
+    -e "s|https://security.debian.org/debian-security|${sec}|g" \
+    -e "s|http://security.debian.org/debian-security|${sec}|g" \
+    "$f"
+}
+
+rewrite_sources /etc/apt/sources.list
+if [ -d /etc/apt/sources.list.d ]; then
+  for f in /etc/apt/sources.list.d/*; do
+    [ -f "$f" ] || continue
+    case "$f" in
+      *.list|*.sources) rewrite_sources "$f" ;;
+    esac
+  done
+fi

--- a/.gitlab/ci-gitlab-release-upload.sh
+++ b/.gitlab/ci-gitlab-release-upload.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# GitLab CI helper: build release archives (package-release.sh) and upload to SSH.
-# Intended to run after before_script has configured ~/.ssh and REMOTE_SSH.
+# GitLab CI helper: upload dist/ and install scripts to SSH storage (no build).
+# Builds run in parallel job release-build; merged artifacts are available here.
 #
 # Environment (required):
 #   CI_COMMIT_TAG – release tag, e.g. v0.3.0
@@ -9,8 +9,7 @@
 # Optional:
 #   CI_PROJECT_DIR – repo root (default: git root or pwd)
 #   DIST_DIR       – default dist
-#   PACKAGE_MODE, BOXLITE_CLI_VERSION, REMOTE_BASE_DIR, SSH_PORT, SSH_IDENTITY_FILE
-#   GOPROXY – set by .gitlab/ci.yml variables (Go modules); optional override in CI vars
+#   REMOTE_BASE_DIR, SSH_PORT, SSH_IDENTITY_FILE
 set -euo pipefail
 
 ROOT="${CI_PROJECT_DIR:-}"
@@ -19,16 +18,13 @@ if [[ -z "${ROOT}" ]]; then
 fi
 cd "${ROOT}"
 
-chmod +x scripts/package-release.sh scripts/sync-agent-runtimes.sh scripts/fetch-boxlite-cli.sh
-
 VERSION="${CI_COMMIT_TAG:?CI_COMMIT_TAG is required}"
-COMMIT="$(git rev-parse --short HEAD)"
-BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 DIST_DIR="${DIST_DIR:-dist}"
-mkdir -p "${DIST_DIR}" "${ROOT}/.gocache"
-GOCACHE="${GOCACHE:-${ROOT}/.gocache}"
-export GOCACHE
-PACKAGE_MODE="${PACKAGE_MODE:-bundled-boxlite-cli}"
+
+if [[ ! -d "${DIST_DIR}" ]] || ! compgen -G "${DIST_DIR}/*" >/dev/null; then
+  echo "no files in ${DIST_DIR}/; run release-build or set DIST_DIR" >&2
+  exit 1
+fi
 
 ssh_scp_opts() {
   SSH_OPTS=(-p "${SSH_PORT:-22}")
@@ -38,21 +34,6 @@ ssh_scp_opts() {
     SCP_OPTS+=(-i "${SSH_IDENTITY_FILE}")
   fi
 }
-
-build_pair() {
-  local goos="$1" goarch="$2"
-  CGO_ENABLED=0 APP=csgclaw VERSION="${VERSION}" COMMIT="${COMMIT}" BUILD_TIME="${BUILD_TIME}" \
-    DIST_DIR="${DIST_DIR}" GOCACHE="${GOCACHE}" PACKAGE_MODE="${PACKAGE_MODE}" \
-    BOXLITE_CLI_VERSION="${BOXLITE_CLI_VERSION:-v0.9.0}" \
-    ./scripts/package-release.sh "${goos}" "${goarch}"
-  CGO_ENABLED=0 APP=csgclaw-cli VERSION="${VERSION}" COMMIT="${COMMIT}" BUILD_TIME="${BUILD_TIME}" \
-    DIST_DIR="${DIST_DIR}" GOCACHE="${GOCACHE}" BOXLITE_CLI_VERSION="${BOXLITE_CLI_VERSION:-v0.9.0}" \
-    ./scripts/package-release.sh "${goos}" "${goarch}"
-}
-
-build_pair linux amd64
-build_pair linux arm64
-build_pair darwin arm64
 
 REMOTE_BASE="${REMOTE_BASE_DIR:-/data/csgclaw}"
 REL="${REMOTE_BASE}/releases/${VERSION}"
@@ -65,5 +46,7 @@ ssh_scp_opts
 ssh "${SSH_OPTS[@]}" "${REMOTE_SSH}" "mkdir -p '${REMOTE_BASE}'"
 scp "${SCP_OPTS[@]}" scripts/install.sh "${REMOTE_SSH}:${REMOTE_BASE}/install.sh"
 ssh "${SSH_OPTS[@]}" "${REMOTE_SSH}" "chmod 0644 '${REMOTE_BASE}/install.sh'"
+scp "${SCP_OPTS[@]}" scripts/install.ps1 "${REMOTE_SSH}:${REMOTE_BASE}/install.ps1"
+ssh "${SSH_OPTS[@]}" "${REMOTE_SSH}" "chmod 0644 '${REMOTE_BASE}/install.ps1'"
 
 echo "==> Uploaded ${VERSION} to ${REMOTE_SSH}:${REMOTE_BASE}"

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -1,8 +1,10 @@
-# GitLab CI: on tag v*, build release archives and upload to SSH storage.
+# GitLab CI: on tag v*, build release archives in parallel, then upload to SSH storage.
+#
+# Platform list: scripts/release-platforms.txt — keep parallel.matrix below in sync (same GOOS/GOARCH rows).
 #
 # Trigger: tags matching v* (e.g. pull mirror with "Trigger pipelines for mirror updates").
 #
-# Implementation: .gitlab/ci-gitlab-release-upload.sh (build + scp).
+# Implementation: scripts/release-build-all.sh (per matrix cell); .gitlab/ci-gitlab-release-upload.sh (upload only); .gitlab/bookworm-mirror.sh (apt sources).
 #
 # Required CI/CD variables:
 #   REMOTE_SSH – e.g. root@cdn.example.com
@@ -17,7 +19,7 @@
 #   REMOTE_BASE_DIR – default /data/csgclaw (releases under .../releases/<tag>/)
 #   BOXLITE_CLI_VERSION – default v0.9.0
 #   BOXLITE_CLI_BASE_URL – boxlite-cli tarballs; default mirrors https://csgclaw.opencsg.com/boxlite-cli/{version}/{filename} (matches fetch-boxlite-cli.sh)
-#   BOXLITE_CURL_INSECURE – default 1 (TLS inspection); set 0 if mirror uses publicly trusted certs only
+#   BOXLITE_CURL_INSECURE – default 1 (TLS inspection); set 0 if csgclaw.opencsg.com is trusted as-is
 #
 # Debian apt: before install, rewrite official mirrors to Aliyun (faster in CN). Override DEBIAN_APT_MIRROR_* in CI vars if needed.
 #
@@ -34,49 +36,71 @@ variables:
   GIT_DEPTH: "0"
   BOXLITE_CLI_VERSION: "v0.9.0"
   BOXLITE_CLI_BASE_URL: "https://csgclaw.opencsg.com/boxlite-cli"
-  # curl -k for boxlite download when TLS inspection breaks cert verify; use 0 if csgclaw.opencsg.com is trusted as-is.
   BOXLITE_CURL_INSECURE: "1"
-  # go.mod may require a newer toolchain than the image; fetch if needed.
   GOTOOLCHAIN: "auto"
-  # Default module proxy (no GitLab HTTP proxy vars required). Override GOPROXY in project/group CI vars if needed.
   GOPROXY: "https://goproxy.cn,direct"
-  # Used by before_script to replace deb.debian.org / security.debian.org in sources (bookworm).
   DEBIAN_APT_MIRROR_DEB: "http://mirrors.aliyun.com/debian"
   DEBIAN_APT_MIRROR_SEC: "http://mirrors.aliyun.com/debian-security"
 
 stages:
-  - release
+  - build
+  - upload
 
-release-upload:
-  stage: release
-  image:
-    name: ${ACR_REGISTRY}/opencsg_public/golang:bookworm
+.release_rules:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v/
+
+.release_image:
+  image:
+    name: ${ACR_REGISTRY}/opencsg_public/golang:bookworm
+
+# Must match scripts/release-platforms.txt (order need not match; set must match).
+release-build:
+  extends:
+    - .release_image
+    - .release_rules
+  stage: build
+  parallel:
+    matrix:
+      - GOOS: linux
+        GOARCH: amd64
+      - GOOS: linux
+        GOARCH: arm64
+      - GOOS: darwin
+        GOARCH: arm64
+      - GOOS: darwin
+        GOARCH: amd64
+      - GOOS: windows
+        GOARCH: amd64
   before_script:
-    - |
-      set -e
-      deb="${DEBIAN_APT_MIRROR_DEB:-http://mirrors.aliyun.com/debian}"
-      sec="${DEBIAN_APT_MIRROR_SEC:-http://mirrors.aliyun.com/debian-security}"
-      rewrite_sources() {
-        local f="$1"
-        [ -f "$f" ] || return 0
-        sed -i \
-          -e "s|https://deb.debian.org/debian|${deb}|g" \
-          -e "s|http://deb.debian.org/debian|${deb}|g" \
-          -e "s|https://security.debian.org/debian-security|${sec}|g" \
-          -e "s|http://security.debian.org/debian-security|${sec}|g" \
-          "$f"
-      }
-      rewrite_sources /etc/apt/sources.list
-      if [ -d /etc/apt/sources.list.d ]; then
-        for f in /etc/apt/sources.list.d/*; do
-          [ -f "$f" ] || continue
-          case "$f" in
-            *.list|*.sources) rewrite_sources "$f" ;;
-          esac
-        done
-      fi
+    - chmod +x .gitlab/bookworm-mirror.sh scripts/release-build-all.sh
+    - bash .gitlab/bookworm-mirror.sh
+    - apt-get update -qq && apt-get install -y --no-install-recommends zip ca-certificates
+  script:
+    - export VERSION="$CI_COMMIT_TAG"
+    - export COMMIT="$(git rev-parse --short HEAD)"
+    - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    - export DIST_DIR="${DIST_DIR:-dist}"
+    - mkdir -p "$DIST_DIR" "${CI_PROJECT_DIR}/.gocache"
+    - export GOCACHE="${GOCACHE:-${CI_PROJECT_DIR}/.gocache}"
+    - export BOXLITE_CLI_VERSION="${BOXLITE_CLI_VERSION:-v0.9.0}"
+    - ./scripts/release-build-all.sh "$GOOS" "$GOARCH"
+  artifacts:
+    paths:
+      - dist/
+    expire_in: 1 day
+
+release-upload:
+  extends:
+    - .release_image
+    - .release_rules
+  stage: upload
+  needs:
+    - job: release-build
+      artifacts: true
+  before_script:
+    - chmod +x .gitlab/bookworm-mirror.sh
+    - bash .gitlab/bookworm-mirror.sh
     - apt-get update -qq && apt-get install -y --no-install-recommends openssh-client python3 ca-certificates
     - mkdir -p ~/.ssh && chmod 700 ~/.ssh
     - |

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -313,10 +313,16 @@ func (s *Service) DetectDefaultProfile(ctx context.Context) (AgentProfile, []Pro
 		s.mu.RUnlock()
 		defaultProfile = normalizeProfile(defaultProfile, ManagerName, "")
 		if defaultProfile.ProfileComplete {
+			if strings.TrimSpace(defaultProfile.ModelID) != "" {
+				// Trust explicit config (e.g. tests, headless bootstrap) without probing /v1/models.
+				return defaultProfile, []ProfileDetectionResult{{
+					Provider: defaultProfile.Provider,
+					Status:   "ok",
+					ModelID:  defaultProfile.ModelID,
+				}}
+			}
 			if models, err := ListModelsForProfile(ctx, defaultProfile); err == nil && len(models) > 0 {
-				if defaultProfile.ModelID == "" {
-					defaultProfile.ModelID = models[0]
-				}
+				defaultProfile.ModelID = models[0]
 				defaultProfile.ProfileComplete = true
 				return defaultProfile, []ProfileDetectionResult{{
 					Provider: defaultProfile.Provider,

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -2786,14 +2786,14 @@ func TestEnsureBootstrapStateForceRecreatePrefersStoredManagerBoxID(t *testing.T
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, config.ModelConfig{}, "", true); err != nil {
+	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, testModelConfig(), "", true); err != nil {
 		t.Fatalf("EnsureBootstrapState() error = %v", err)
 	}
 	if removed != "box-old" {
 		t.Fatalf("ForceRemove() target = %q, want %q", removed, "box-old")
 	}
 
-	reloaded, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", statePath)
+	reloaded, err := NewService(testModelConfig(), config.ServerConfig{}, "", statePath)
 	if err != nil {
 		t.Fatalf("NewService() reload error = %v", err)
 	}
@@ -2883,7 +2883,7 @@ func TestEnsureBootstrapStateForceRecreateResetsManagerHomeBeforeCreate(t *testi
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, config.ModelConfig{}, "", true); err != nil {
+	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, testModelConfig(), "", true); err != nil {
 		t.Fatalf("EnsureBootstrapState() error = %v", err)
 	}
 	if got, want := len(ensuredHomes), 2; got != want {
@@ -2936,7 +2936,7 @@ func TestEnsureBootstrapStateClosesManagerBoxHandleAfterCreate(t *testing.T) {
 
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "agents.json")
-	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, config.ModelConfig{}, "", false); err != nil {
+	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, testModelConfig(), "", false); err != nil {
 		t.Fatalf("EnsureBootstrapState() error = %v", err)
 	}
 	if closeCalls != 1 {
@@ -2946,7 +2946,7 @@ func TestEnsureBootstrapStateClosesManagerBoxHandleAfterCreate(t *testing.T) {
 		t.Fatalf("closeRuntime() calls = %d, want %d", closeRuntimeCalls, 1)
 	}
 
-	reloaded, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", statePath)
+	reloaded, err := NewService(testModelConfig(), config.ServerConfig{}, "", statePath)
 	if err != nil {
 		t.Fatalf("NewService() reload error = %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ const (
 
 	DefaultHTTPPort     = apiclient.DefaultHTTPPort
 	DefaultAccessToken  = "your_access_token"
-	DefaultManagerImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.4.29.0"
+	DefaultManagerImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.9"
 	CSGHubProvider      = "csghub"
 	DockerProvider      = "docker"
 	BoxLiteCLIProvider  = "boxlite"

--- a/internal/runtime/picoclawsandbox/runtime.go
+++ b/internal/runtime/picoclawsandbox/runtime.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -437,16 +437,18 @@ func stateFromSandboxState(state sandbox.State) agentruntime.State {
 }
 
 func GatewayRunCommand() string {
+	// Use path (not filepath): this string runs inside the Linux container's /bin/sh.
+	// On Windows hosts filepath.Join emits '\' which breaks the shell and mangles cp paths.
 	configPath := boxWorkspaceConfigPath(HostPicoClawConfig)
 	securityPath := boxWorkspaceConfigPath(HostPicoClawSecurity)
 	return "mkdir -p " + BoxPicoClawDir +
-		" && cp " + configPath + " " + filepath.Join(BoxPicoClawDir, HostPicoClawConfig) +
-		" && cp " + securityPath + " " + filepath.Join(BoxPicoClawDir, HostPicoClawSecurity) +
+		" && cp " + configPath + " " + path.Join(BoxPicoClawDir, HostPicoClawConfig) +
+		" && cp " + securityPath + " " + path.Join(BoxPicoClawDir, HostPicoClawSecurity) +
 		" && /usr/local/bin/picoclaw gateway -d 1>" + BoxGatewayLogPath + " 2>/dev/null"
 }
 
 func boxWorkspaceConfigPath(name string) string {
-	return filepath.Join(BoxWorkspaceDir, filepath.FromSlash(HostPicoClawStateDir), name)
+	return path.Join(BoxWorkspaceDir, HostPicoClawStateDir, name)
 }
 
 func llmBridgeBaseURL(managerBaseURL, botID string) string {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,9 +10,30 @@ $BaseUrl = if ($env:BASE_URL) { $env:BASE_URL } else { "$MirrorHost/releases" }
 $LatestReleaseUrl = if ($env:LATEST_RELEASE_URL) { $env:LATEST_RELEASE_URL } else { "$MirrorHost/releases/latest" }
 
 function Resolve-Arch {
-    switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()) {
+    $name = $null
+    try {
+        $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        if ($null -ne $osArch) {
+            $name = $osArch.ToString().ToLowerInvariant()
+        }
+    } catch {
+        $name = $null
+    }
+    if (-not $name) {
+        # 32-bit PowerShell on 64-bit Windows exposes native CPU here.
+        if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
+            return "amd64"
+        }
+        if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
+            return "amd64"
+        }
+        throw "Unsupported architecture: could not detect CPU (PROCESSOR_ARCHITECTURE=$($env:PROCESSOR_ARCHITECTURE); PROCESSOR_ARCHITEW6432=$($env:PROCESSOR_ARCHITEW6432)). Official Windows installer supports windows/amd64 only."
+    }
+    switch ($name) {
         "x64" { return "amd64" }
-        default { throw "Unsupported architecture: $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture). Official Windows installer currently supports windows/amd64 only." }
+        default {
+            throw "Unsupported architecture: $name. Official Windows installer currently supports windows/amd64 only."
+        }
     }
 }
 
@@ -89,7 +110,7 @@ function Install-Bundle {
         $extractDir = Join-Path $tmpDir "extract"
 
         Write-Host "Downloading $downloadUrl"
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
 
         Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
 

--- a/scripts/release-build-all.sh
+++ b/scripts/release-build-all.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Build release archives (csgclaw + csgclaw-cli) for one or all platforms listed in
+# scripts/release-platforms.txt. Shared by GitHub Actions (one matrix cell) and GitLab
+# (parallel matrix), and by local full builds.
+#
+# Usage:
+#   ./scripts/release-build-all.sh              # all platforms from release-platforms.txt
+#   ./scripts/release-build-all.sh linux amd64  # single platform
+#
+# Required env:
+#   VERSION – tag or version string (e.g. v0.3.0)
+#
+# Optional env (see scripts/package-release.sh):
+#   COMMIT, BUILD_TIME, DIST_DIR, GOCACHE, BOXLITE_CLI_VERSION, BOXLITE_CLI_BASE_URL
+#
+# Do not set PACKAGE_MODE or INCLUDE_BOXLITE for APP=csgclaw: defaults in
+# package-release.sh match bundled boxlite only on linux/* and darwin/arm64.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+PLATFORMS_FILE="${ROOT}/scripts/release-platforms.txt"
+
+VERSION="${VERSION:?VERSION is required}"
+COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+BUILD_TIME="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+DIST_DIR="${DIST_DIR:-dist}"
+GOCACHE="${GOCACHE:-${ROOT}/.gocache}"
+mkdir -p "${DIST_DIR}" "${GOCACHE}"
+export GOCACHE
+
+chmod +x scripts/package-release.sh scripts/sync-agent-runtimes.sh scripts/fetch-boxlite-cli.sh
+
+build_pair() {
+  local goos="$1" goarch="$2"
+  CGO_ENABLED=0 APP=csgclaw VERSION="${VERSION}" COMMIT="${COMMIT}" BUILD_TIME="${BUILD_TIME}" \
+    DIST_DIR="${DIST_DIR}" GOCACHE="${GOCACHE}" \
+    BOXLITE_CLI_VERSION="${BOXLITE_CLI_VERSION:-v0.9.0}" \
+    ./scripts/package-release.sh "${goos}" "${goarch}"
+  CGO_ENABLED=0 APP=csgclaw-cli VERSION="${VERSION}" COMMIT="${COMMIT}" BUILD_TIME="${BUILD_TIME}" \
+    DIST_DIR="${DIST_DIR}" GOCACHE="${GOCACHE}" \
+    BOXLITE_CLI_VERSION="${BOXLITE_CLI_VERSION:-v0.9.0}" \
+    INCLUDE_BOXLITE=0 \
+    ./scripts/package-release.sh "${goos}" "${goarch}"
+}
+
+run_all_from_file() {
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "${line}" || "${line}" =~ ^# ]] && continue
+    read -r goos goarch <<<"${line}"
+    if [[ -z "${goos:-}" || -z "${goarch:-}" ]]; then
+      echo "invalid platform line in ${PLATFORMS_FILE}: ${line}" >&2
+      exit 1
+    fi
+    build_pair "${goos}" "${goarch}"
+  done <"${PLATFORMS_FILE}"
+}
+
+if [[ "$#" -eq 2 ]]; then
+  build_pair "$1" "$2"
+elif [[ "$#" -eq 0 ]]; then
+  [[ -f "${PLATFORMS_FILE}" ]] || {
+    echo "missing ${PLATFORMS_FILE}" >&2
+    exit 1
+  }
+  run_all_from_file
+else
+  echo "usage: $0 [<goos> <goarch>]" >&2
+  exit 1
+fi

--- a/scripts/release-platforms.txt
+++ b/scripts/release-platforms.txt
@@ -1,0 +1,8 @@
+# Canonical release targets (goos goarch). Keep GitLab parallel matrix in .gitlab/ci.yml in sync.
+# Used by: scripts/release-build-all.sh, GitHub Actions (dynamic matrix), GitLab release-build.
+
+linux amd64
+linux arm64
+darwin arm64
+darwin amd64
+windows amd64


### PR DESCRIPTION
- Add scripts/release-platforms.txt and release-build-all.sh as single source
- GitHub: dynamic matrix from platforms file; parallel build + merge upload
- GitLab: parallel release-build matrix, upload-only job, .gitlab/bookworm-mirror.sh
- fix(picoclawsandbox): use path.Join for container /bin/sh cp paths on Windows hosts
- fix(agent): skip /v1/models probe when default profile already has model ID
- test(agent): use testModelConfig in EnsureBootstrapState tests that create manager box
- chore(config): default manager image picoclaw:2026.5.9
- install.ps1: harden Resolve-Arch for PS 5.1 / .NET edge cases