### PR TITLE
[codex] fix upgrade prompt for git describe versions

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -66,7 +66,8 @@ func (c Client) Check(ctx context.Context, currentVersion string) (CheckResult, 
 		CurrentVersion: normalizeSemver(currentVersion),
 		LatestVersion:  normalizeSemver(latestVersion),
 	}
-	if compareSemver(result.CurrentVersion, result.LatestVersion) >= 0 {
+	currentComparable := comparableCurrentVersion(result.CurrentVersion)
+	if compareSemver(currentComparable, result.LatestVersion) >= 0 {
 		return result, nil
 	}
 	result.UpdateAvailable = true
@@ -245,6 +246,37 @@ func compareSemver(a, b string) int {
 		return compareInts(av.patch, bv.patch)
 	}
 	return comparePrerelease(av.pre, bv.pre)
+}
+
+func comparableCurrentVersion(version string) string {
+	version = normalizeSemver(version)
+	base, suffix, ok := strings.Cut(version, "-")
+	if !ok {
+		return version
+	}
+	if suffix == "dirty" || isGitDescribeSuffix(suffix) {
+		return base
+	}
+	return version
+}
+
+func isGitDescribeSuffix(suffix string) bool {
+	if strings.HasSuffix(suffix, "-dirty") {
+		suffix = strings.TrimSuffix(suffix, "-dirty")
+	}
+	count, commit, ok := strings.Cut(suffix, "-g")
+	if !ok || count == "" || commit == "" {
+		return false
+	}
+	if _, err := strconv.Atoi(count); err != nil {
+		return false
+	}
+	for _, r := range commit {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 func compareInts(a, b int) int {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -101,6 +101,56 @@ func TestClientCheckNoUpdate(t *testing.T) {
 	}
 }
 
+func TestClientCheckNoUpdateForGitDescribeVersionAtLatestRelease(t *testing.T) {
+	client := Client{
+		HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{"name":"v0.2.9","assets":[]}`), nil
+		}),
+		LatestURL: "https://example.test/releases/latest",
+		GOOS:      "darwin",
+		GOARCH:    "arm64",
+	}
+
+	result, err := client.Check(context.Background(), "v0.2.9-4-gd1e3c28-dirty")
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if result.UpdateAvailable {
+		t.Fatal("Check().UpdateAvailable = true, want false")
+	}
+	if got, want := result.CurrentVersion, "v0.2.9-4-gd1e3c28-dirty"; got != want {
+		t.Fatalf("CurrentVersion = %q, want %q", got, want)
+	}
+	if result.Asset != nil {
+		t.Fatalf("Asset = %#v, want nil", result.Asset)
+	}
+}
+
+func TestClientCheckStillUpdatesPrereleaseToRelease(t *testing.T) {
+	client := Client{
+		HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{
+				"name":"v0.2.9",
+				"assets":[{"name":"csgclaw_v0.2.9_darwin_arm64.tar.gz","browser_download_url":"http://csgclaw.opencsg.com/releases/v0.2.9/csgclaw_v0.2.9_darwin_arm64.tar.gz"}]
+			}`), nil
+		}),
+		LatestURL: "https://example.test/releases/latest",
+		GOOS:      "darwin",
+		GOARCH:    "arm64",
+	}
+
+	result, err := client.Check(context.Background(), "v0.2.9-rc.1")
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if !result.UpdateAvailable {
+		t.Fatal("Check().UpdateAvailable = false, want true")
+	}
+	if result.Asset == nil {
+		t.Fatal("Asset = nil, want matched asset")
+	}
+}
+
 func TestClientCheckRejectsInvalidCurrentVersion(t *testing.T) {
 	client := Client{LatestURL: "https://example.test/releases/latest"}
 	_, err := client.Check(context.Background(), "dev")
@@ -626,6 +676,9 @@ func TestCompareSemver(t *testing.T) {
 		{a: "v0.3.0", b: "v0.2.9", want: 1},
 		{a: "v0.2.7-rc.1", b: "v0.2.7", want: -1},
 		{a: "v0.2.7", b: "v0.2.7-rc.1", want: 1},
+		{a: comparableCurrentVersion("v0.2.9-4-gd1e3c28-dirty"), b: "v0.2.9", want: 0},
+		{a: comparableCurrentVersion("v0.2.9-dirty"), b: "v0.2.9", want: 0},
+		{a: comparableCurrentVersion("v0.2.9-rc.1"), b: "v0.2.9", want: -1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Treat local git describe versions such as v0.2.9-4-gd1e3c28-dirty as their base release when checking for updates.
- Keep real prerelease versions such as v0.2.9-rc.1 eligible to update to the final release.
- Add regression coverage for both paths.

## Root Cause

The upgrade checker parsed git describe output as a semver prerelease. That made a local build based on v0.2.9 compare lower than the official v0.2.9 release, so the Web UI showed Update & Restart even when the release was already current.

## Validation

- env GOCACHE=/Users/shenyongfan/OpenCSG/csgclaw/.gocache go test ./internal/upgrade
- env GOCACHE=/Users/shenyongfan/OpenCSG/csgclaw/.gocache go test ./cli/upgrade
- env GOCACHE=/Users/shenyongfan/OpenCSG/csgclaw/.gocache go test ./internal/api -run 'TestHandleUpgrade|TestIMEventsIncludesUpgradeStatus'