### PR TITLE
feat(notifier): webhook delivery, remote inbox pull, and IM fanout

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状
 
 补充说明：
 
-- `role` 当前常见值：`manager`、`worker`、`agent`
+- `role` 当前常见值：`manager`、`worker`、`agent`、`notifier`
 - `image` 仍可能出现在响应中，用于表示容器镜像；它不是统一身份字段的一部分
 - 创建 worker agent 请统一使用 `/api/v1/agents`
 
@@ -166,6 +166,24 @@ Codex 和 Claude Code Provider 由 CSGClaw 内嵌 CLIProxyAPI 转发。鉴权状
 - `manager` 嵌套字段已不再支持
 - 若 IM 服务可用，会自动创建对应 IM 用户，并创建 `Admin & <Worker>` 私聊
 - 校验失败通常返回 `400 Bad Request`
+
+### `POST /api/v1/agents/{agent_id}/webhooks/notify`
+
+供第三方（GitHub / GitLab 等）向本服务 **POST** 原始 HTTP body；服务端将 payload 转为 Markdown 后 **向该 Agent 作为成员所在的全部 IM 房间各投递一条消息**。
+
+- 鉴权：`Authorization: Bearer <token>`，或 Query：`?token=<token>`（须与服务端为该 agent 配置的 Webhook 令牌 **长度一致**，以便常量时间比较）
+- `Content-Type`：任意；`application/json` 时会格式化为带 `json` 代码块的 Markdown
+- 成功：`202 Accepted`
+- 常见失败：`404`（agent 不存在）、`400`（非 notifier agent）、`403`（未启用 Webhook 投递）、`401`（令牌缺失或不匹配）、`503`（agent 或 IM 未配置）；投递 IM 失败时可能返回 `400` 及错误正文
+
+示例：
+
+```http
+POST /api/v1/agents/u-ci/webhooks/notify?token=<webhook_token>
+Content-Type: application/json
+
+{"event":"push","ref":"refs/heads/main"}
+```
 
 使用 Codex runtime 时，服务会在启动 worker 前自动解析或下载 `codex-acp`。如需手动指定或固定版本，可使用：
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	RoleAgent   = "agent"
-	RoleWorker  = "worker"
-	RoleManager = "manager"
+	RoleAgent    = "agent"
+	RoleWorker   = "worker"
+	RoleManager  = "manager"
+	RoleNotifier = "notifier"
 )
 
 type Agent struct {
@@ -65,6 +66,8 @@ func normalizeRole(role string) string {
 		return RoleAgent
 	case RoleWorker:
 		return RoleWorker
+	case RoleNotifier:
+		return RoleNotifier
 	case RoleManager:
 		return RoleManager
 	default:

--- a/internal/agent/notifier_pull_worker.go
+++ b/internal/agent/notifier_pull_worker.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"csgclaw/internal/notifier"
+)
+
+// NotifierPullWorker periodically polls relay inbox for notifier agents with AllowsPull().
+type NotifierPullWorker struct {
+	Agents  *Service
+	Deliver notifier.Fanouter
+	Relay   *notifier.RelayClient
+	Log     *slog.Logger
+
+	mu       sync.Mutex
+	lastPoll map[string]time.Time // last pull attempt (success or failure), for interval throttling
+}
+
+func NewNotifierPullWorker(agents *Service, d notifier.Fanouter) *NotifierPullWorker {
+	return &NotifierPullWorker{
+		Agents:   agents,
+		Deliver:  d,
+		Relay:    &notifier.RelayClient{},
+		Log:      slog.Default(),
+		lastPoll: make(map[string]time.Time),
+	}
+}
+
+// Run blocks until ctx is cancelled; uses a base ticker and per-agent intervals.
+func (w *NotifierPullWorker) Run(ctx context.Context) {
+	if w == nil || w.Agents == nil || w.Deliver == nil {
+		return
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+func (w *NotifierPullWorker) tick(ctx context.Context) {
+	if err := w.Agents.Reload(); err != nil && w.Log != nil {
+		w.Log.Debug("notifier pull: agent reload", "error", err)
+	}
+	for _, a := range w.Agents.List() {
+		if !strings.EqualFold(strings.TrimSpace(a.Role), RoleNotifier) {
+			continue
+		}
+		cfg := notifier.ParseConfigFromRequestOptions(a.AgentProfile.RequestOptions)
+		if !cfg.AllowsPull() {
+			continue
+		}
+		interval := cfg.PollIntervalDuration()
+		w.mu.Lock()
+		last := w.lastPoll[a.ID]
+		w.mu.Unlock()
+		if !last.IsZero() && time.Since(last) < interval {
+			continue
+		}
+		err := w.pullAgent(ctx, a, cfg)
+		if err != nil && w.Log != nil {
+			// Transient relay errors are common in dev; Info avoids noisy WARN every poll_interval.
+			w.Log.Info("notifier pull failed", "agent_id", a.ID, "error", err)
+		}
+		w.mu.Lock()
+		w.lastPoll[a.ID] = time.Now().UTC()
+		w.mu.Unlock()
+	}
+}
+
+func (w *NotifierPullWorker) pullAgent(ctx context.Context, a Agent, cfg notifier.Config) error {
+	msgs, _, err := w.Relay.FetchInbox(ctx, cfg.RemoteURL, cfg, 50, "")
+	if err != nil {
+		return err
+	}
+	var ackIDs []string
+	for _, m := range msgs {
+		raw, ct, err := notifier.DecodePayload(m)
+		if err != nil {
+			if w.Log != nil {
+				w.Log.Warn("notifier inbox decode skipped", "agent_id", a.ID, "msg_id", m.ID, "error", err)
+			}
+			continue
+		}
+		md := notifier.FormatPayloadAsMarkdown(raw, ct)
+		if err := w.Deliver.DeliverNotifierFanout(a.ID, md); err != nil {
+			return err
+		}
+		if strings.TrimSpace(m.ID) != "" {
+			ackIDs = append(ackIDs, strings.TrimSpace(m.ID))
+		}
+	}
+	if err := w.Relay.Ack(ctx, cfg.RemoteURL, cfg, ackIDs); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -177,6 +177,22 @@ func normalizeRequestOptions(values map[string]any) map[string]any {
 	return out
 }
 
+// mergePreservedRequestOptions overlays preserved keys onto dst (shallow per key).
+// Used when profile resolution replaces the working profile (e.g. DetectDefaultProfile)
+// so user-supplied keys such as request_options.notifier are not lost.
+func mergePreservedRequestOptions(dst, preserved map[string]any) map[string]any {
+	if len(preserved) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]any, len(preserved))
+	}
+	for k, v := range preserved {
+		dst[k] = v
+	}
+	return dst
+}
+
 func cloneProfile(profile AgentProfile) AgentProfile {
 	out := profile
 	if len(profile.Headers) > 0 {

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -299,6 +299,24 @@ func TestSortModelIDsOrdersLatestKnownFamiliesFirst(t *testing.T) {
 	}
 }
 
+func TestMergePreservedRequestOptions(t *testing.T) {
+	dst := map[string]any{"foo": "bar"}
+	preserved := map[string]any{
+		"notifier": map[string]any{"webhook_token": "secret", "delivery_mode": "webhook"},
+	}
+	got := mergePreservedRequestOptions(dst, preserved)
+	if got["foo"] != "bar" {
+		t.Fatalf("existing key lost")
+	}
+	n, ok := got["notifier"].(map[string]any)
+	if !ok || n["webhook_token"] != "secret" {
+		t.Fatalf("notifier merge = %#v", got["notifier"])
+	}
+	if mergePreservedRequestOptions(nil, nil) != nil {
+		t.Fatal("nil preserved should leave nil dst")
+	}
+}
+
 func setProfileDetectionURLs(t *testing.T, csgHubLiteURL, cliProxyURL string, claudeCodeURL ...string) func() {
 	t.Helper()
 	oldCSGHubLite := defaultCSGHubLiteBaseURL

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"csgclaw/internal/config"
+	"csgclaw/internal/notifier"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/sandbox"
 )
@@ -628,7 +629,11 @@ func (s *Service) createNew(ctx context.Context, spec CreateAgentSpec) (Agent, e
 		return s.EnsureManager(ctx, false)
 	}
 	if shouldCreateWorkerSpec(spec) {
-		spec.Role = RoleWorker
+		if strings.EqualFold(strings.TrimSpace(spec.Role), RoleNotifier) {
+			spec.Role = RoleNotifier
+		} else {
+			spec.Role = RoleWorker
+		}
 		return s.CreateWorker(ctx, spec)
 	}
 
@@ -800,11 +805,15 @@ func (s *Service) replace(ctx context.Context, req CreateRequest) (Agent, error)
 	if isManagerAgent(existing) || isManagerCreateSpec(spec) {
 		return s.ensureManager(ctx, true, managerImageOverride)
 	}
-	if shouldCreateWorkerSpec(spec) || strings.EqualFold(existing.Role, RoleWorker) {
+	if shouldCreateWorkerSpec(spec) || strings.EqualFold(existing.Role, RoleWorker) || strings.EqualFold(existing.Role, RoleNotifier) {
 		if err := s.Delete(ctx, existing.ID); err != nil {
 			return Agent{}, err
 		}
-		spec.Role = RoleWorker
+		if strings.EqualFold(strings.TrimSpace(spec.Role), RoleNotifier) {
+			spec.Role = RoleNotifier
+		} else {
+			spec.Role = RoleWorker
+		}
 		return s.CreateWorker(ctx, spec)
 	}
 
@@ -891,7 +900,7 @@ func isManagerCreateSpec(spec CreateAgentSpec) bool {
 
 func shouldCreateWorkerSpec(spec CreateAgentSpec) bool {
 	role := strings.ToLower(strings.TrimSpace(spec.Role))
-	return role == "" || role == RoleWorker
+	return role == "" || role == RoleWorker || role == RoleNotifier
 }
 
 func normalizeCreateID(id string) string {
@@ -1030,7 +1039,8 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 }
 
 func (s *Service) ensureWorkerGatewayConfig(got Agent) error {
-	if s == nil || !strings.EqualFold(normalizeRole(got.Role), RoleWorker) {
+	r := normalizeRole(got.Role)
+	if s == nil || !(r == RoleWorker || r == RoleNotifier) || !isAgentProfileComplete(got) {
 		return nil
 	}
 	return s.ensureGatewayConfigForAgent(got)
@@ -1041,10 +1051,10 @@ func (s *Service) ensureGatewayConfigForAgent(got Agent) error {
 		return nil
 	}
 	role := normalizeRole(got.Role)
-	if role != RoleManager && role != RoleWorker {
+	if role != RoleManager && role != RoleWorker && role != RoleNotifier {
 		return nil
 	}
-	if role == RoleWorker {
+	if role == RoleWorker || role == RoleNotifier {
 		if kind := normalizeRuntimeKind(got.RuntimeKind); kind != "" && !isGatewayRuntimeKind(kind) {
 			return nil
 		}
@@ -1318,6 +1328,10 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 	if err != nil {
 		return Agent{}, err
 	}
+	agentRole := RoleWorker
+	if strings.EqualFold(strings.TrimSpace(spec.Role), RoleNotifier) {
+		agentRole = RoleNotifier
+	}
 	if testCreateGatewayBoxHook != nil && isGatewayRuntimeKind(runtimeKind) {
 		rt, err := s.ensureRuntime(name)
 		if err != nil {
@@ -1341,7 +1355,7 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 			HandleID:  strings.TrimSpace(info.ID),
 			State:     agentruntime.State(info.State),
 			CreatedAt: info.CreatedAt.UTC(),
-		})
+		}, agentRole)
 	}
 	handle, err := runtimeImpl.Create(ctx, agentruntime.Spec{
 		RuntimeID: runtimeIDForAgentID(id),
@@ -1359,10 +1373,10 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		CreatedAt: time.Now().UTC(),
 	}
 
-	return s.persistCreatedWorker(ctx, id, name, description, image, runtimeKind, resolvedProfile, info)
+	return s.persistCreatedWorker(ctx, id, name, description, image, runtimeKind, resolvedProfile, info, agentRole)
 }
 
-func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, image, runtimeKind string, profile AgentProfile, info agentruntime.Info) (Agent, error) {
+func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, image, runtimeKind string, profile AgentProfile, info agentruntime.Info, role string) (Agent, error) {
 	s.mu.Lock()
 
 	if _, ok := s.agents[id]; ok {
@@ -1382,6 +1396,12 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 	if state == "" {
 		state = agentruntime.StateRunning
 	}
+	if strings.TrimSpace(role) == "" {
+		role = RoleWorker
+	}
+	if strings.EqualFold(strings.TrimSpace(role), RoleNotifier) {
+		profile.RequestOptions = notifier.EnsurePullRemoteSubscriptionInRequestOptions(profile.RequestOptions)
+	}
 	worker := Agent{
 		ID:              id,
 		Name:            name,
@@ -1398,7 +1418,7 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 		ReasoningEffort: profile.ReasoningEffort,
 		AgentProfile:    profile,
 		ProfileComplete: profile.ProfileComplete,
-		Role:            RoleWorker,
+		Role:            role,
 	}
 	s.agents[worker.ID] = worker
 	s.syncRuntimeRecordLocked(worker)

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"csgclaw/internal/notifier"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/sandbox"
 )
@@ -51,6 +52,7 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 		profile.APIKey = current.AgentProfile.APIKey
 	}
 	normalized := normalizeProfile(profile, current.Name, current.Description)
+	normalized.RequestOptions = notifier.EnsurePullRemoteSubscriptionInRequestOptions(normalized.RequestOptions)
 	normalized.EnvRestartRequired = !profilesEqualEnv(current.AgentProfile, normalized)
 	current.AgentProfile = normalized
 	current.ProfileComplete = normalized.ProfileComplete
@@ -115,6 +117,7 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 			profile.APIKey = current.AgentProfile.APIKey
 		}
 		normalized := normalizeProfile(profile, current.Name, current.Description)
+		normalized.RequestOptions = notifier.EnsurePullRemoteSubscriptionInRequestOptions(normalized.RequestOptions)
 		normalized.EnvRestartRequired = !profilesEqualEnv(current.AgentProfile, normalized)
 		current.AgentProfile = normalized
 		current.ProfileComplete = normalized.ProfileComplete
@@ -321,6 +324,14 @@ func (s *Service) persistRecreatedAgent(ctx context.Context, id string, info age
 }
 
 func (s *Service) profileForCreateRequest(ctx context.Context, req CreateAgentSpec) (AgentProfile, error) {
+	var preservedRO map[string]any
+	if len(req.AgentProfile.RequestOptions) > 0 {
+		preservedRO = make(map[string]any, len(req.AgentProfile.RequestOptions))
+		for k, v := range req.AgentProfile.RequestOptions {
+			preservedRO[k] = v
+		}
+	}
+
 	profile := req.AgentProfile
 	if strings.TrimSpace(profile.ModelID) == "" && strings.TrimSpace(req.ModelID) != "" {
 		profile.ModelID = strings.TrimSpace(req.ModelID)
@@ -365,12 +376,14 @@ func (s *Service) profileForCreateRequest(ctx context.Context, req CreateAgentSp
 			profile.Env = defaultProfile.Env
 		}
 	}
+	profile.RequestOptions = mergePreservedRequestOptions(profile.RequestOptions, preservedRO)
 	profile = normalizeProfile(profile, req.Name, req.Description)
 	if !profile.ProfileComplete {
 		detected, _ := s.DetectDefaultProfile(ctx)
 		if detected.ProfileComplete {
 			detected.Name = strings.TrimSpace(req.Name)
 			detected.Description = strings.TrimSpace(req.Description)
+			detected.RequestOptions = mergePreservedRequestOptions(detected.RequestOptions, preservedRO)
 			return normalizeProfile(detected, req.Name, req.Description), nil
 		}
 		return AgentProfile{}, fmt.Errorf("agent profile is incomplete")

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -469,6 +469,19 @@ func (h *Handler) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		h.handleAgentRecreate(w, r, id)
 		return
 	}
+	if strings.HasSuffix(path, "/webhooks/notify") {
+		id := strings.TrimSpace(strings.TrimSuffix(path, "/webhooks/notify"))
+		if id == "" || strings.Contains(id, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.handleAgentNotifierWebhook(w, r, id)
+		return
+	}
 
 	id := path
 	if strings.Contains(id, "/") {
@@ -1090,7 +1103,7 @@ func shouldCreateWorkerForUser(id, role string) bool {
 	switch strings.ToLower(strings.TrimSpace(role)) {
 	case "", agent.RoleWorker, agent.RoleAgent:
 		return true
-	case agent.RoleManager, "admin":
+	case agent.RoleManager, "admin", agent.RoleNotifier:
 		return false
 	default:
 		return true

--- a/internal/api/handler_notifier.go
+++ b/internal/api/handler_notifier.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"csgclaw/internal/agent"
+	"csgclaw/internal/im"
+	"csgclaw/internal/notifier"
+)
+
+const maxNotifierWebhookBody = 4 << 20
+
+func notifierBearerToken(r *http.Request) string {
+	h := strings.TrimSpace(r.Header.Get("Authorization"))
+	if strings.HasPrefix(strings.ToLower(h), "bearer ") {
+		return strings.TrimSpace(h[7:])
+	}
+	return strings.TrimSpace(r.URL.Query().Get("token"))
+}
+
+// DeliverNotifierFanout posts Markdown to every IM room that includes this agent as a member and publishes SSE events.
+func (h *Handler) DeliverNotifierFanout(agentID string, markdown string) error {
+	return h.deliverNotifierAndPublish(agentID, markdown)
+}
+
+func (h *Handler) handleAgentNotifierWebhook(w http.ResponseWriter, r *http.Request, agentID string) {
+	if h.svc == nil || h.im == nil {
+		http.Error(w, "service not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if err := h.svc.Reload(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	a, ok := h.svc.Agent(agentID)
+	if !ok {
+		http.Error(w, "agent not found", http.StatusNotFound)
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(a.Role), agent.RoleNotifier) {
+		http.Error(w, "not a notifier agent", http.StatusBadRequest)
+		return
+	}
+	cfg := notifier.ParseConfigFromRequestOptions(a.AgentProfile.RequestOptions)
+	if !cfg.AllowsWebhook() {
+		http.Error(w, "webhook delivery not enabled for this agent", http.StatusForbidden)
+		return
+	}
+	got := notifierBearerToken(r)
+	if !notifier.SecretMatch(cfg.WebhookToken, got) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxNotifierWebhookBody))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ct := r.Header.Get("Content-Type")
+	md := notifier.FormatPayloadAsMarkdown(body, ct)
+	if err := h.deliverNotifierAndPublish(agentID, md); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) deliverNotifierAndPublish(agentID, markdown string) error {
+	agentID = strings.TrimSpace(agentID)
+	if h.im == nil {
+		return nil
+	}
+	roomIDs := h.im.RoomIDsForMember(agentID)
+	var lastErr error
+	for _, rid := range roomIDs {
+		msg, err := h.im.CreateMessage(im.CreateMessageRequest{
+			RoomID:   rid,
+			SenderID: agentID,
+			Content:  markdown,
+		})
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		h.publishMessageCreated(rid, agentID, msg)
+	}
+	return lastErr
+}

--- a/internal/bot/model.go
+++ b/internal/bot/model.go
@@ -11,8 +11,9 @@ import (
 type Role string
 
 const (
-	RoleManager Role = "manager"
-	RoleWorker  Role = "worker"
+	RoleManager  Role = "manager"
+	RoleWorker   Role = "worker"
+	RoleNotifier Role = "notifier"
 )
 
 type Channel string
@@ -93,8 +94,10 @@ func NormalizeRole(role string) (Role, error) {
 		return RoleManager, nil
 	case RoleWorker:
 		return RoleWorker, nil
+	case RoleNotifier:
+		return RoleNotifier, nil
 	default:
-		return "", fmt.Errorf("role must be one of %q or %q", RoleManager, RoleWorker)
+		return "", fmt.Errorf("role must be one of %q, %q, or %q", RoleManager, RoleWorker, RoleNotifier)
 	}
 }
 

--- a/internal/bot/service.go
+++ b/internal/bot/service.go
@@ -225,7 +225,7 @@ func (s *Service) Delete(ctx context.Context, channel, id string) error {
 	if s.agents == nil {
 		return nil
 	}
-	if strings.TrimSpace(deleted.Role) != string(RoleWorker) {
+	if strings.TrimSpace(deleted.Role) != string(RoleWorker) && strings.TrimSpace(deleted.Role) != string(RoleNotifier) {
 		return nil
 	}
 	agentID := strings.TrimSpace(deleted.AgentID)
@@ -275,10 +275,10 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Bot, error) {
 	switch normalized.Role {
 	case string(RoleManager):
 		return s.createManager(ctx, normalized, false)
-	case string(RoleWorker):
+	case string(RoleWorker), string(RoleNotifier):
 		return s.createWorker(ctx, normalized)
 	default:
-		return Bot{}, fmt.Errorf("role must be one of %q or %q", RoleManager, RoleWorker)
+		return Bot{}, fmt.Errorf("role must be one of %q, %q, or %q", RoleManager, RoleWorker, RoleNotifier)
 	}
 }
 
@@ -300,17 +300,25 @@ func (s *Service) CreateManager(ctx context.Context, req CreateRequest, forceRec
 func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (Bot, error) {
 	created, ok := s.agents.Agent(workerAgentID(normalized))
 	if ok {
-		if strings.ToLower(strings.TrimSpace(created.Role)) != agent.RoleWorker {
+		wantRole := agent.RoleWorker
+		if strings.EqualFold(normalized.Role, string(RoleNotifier)) {
+			wantRole = agent.RoleNotifier
+		}
+		if !strings.EqualFold(strings.TrimSpace(created.Role), wantRole) {
 			return Bot{}, fmt.Errorf("agent id %q already exists with role %q", created.ID, created.Role)
 		}
 	} else {
 		var err error
+		agentRole := agent.RoleWorker
+		if strings.EqualFold(normalized.Role, string(RoleNotifier)) {
+			agentRole = agent.RoleNotifier
+		}
 		created, err = s.agents.CreateWorker(ctx, agent.CreateAgentSpec{
 			ID:           normalized.ID,
 			Name:         normalized.Name,
 			Description:  normalized.Description,
 			Image:        normalized.Image,
-			Role:         agent.RoleWorker,
+			Role:         agentRole,
 			ModelID:      normalized.ModelID,
 			RuntimeKind:  normalized.RuntimeKind,
 			AgentProfile: agentProfileFromBotRequest(normalized.AgentProfile),
@@ -338,7 +346,7 @@ func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (B
 		ID:          created.ID,
 		Name:        created.Name,
 		Description: normalized.Description,
-		Role:        string(RoleWorker),
+		Role:        normalized.Role,
 		Channel:     normalized.Channel,
 		AgentID:     created.ID,
 		UserID:      userID,
@@ -493,6 +501,8 @@ func displayRole(role string) string {
 		return "manager"
 	case agent.RoleWorker:
 		return "Worker"
+	case agent.RoleNotifier:
+		return "Notifier"
 	default:
 		return "Agent"
 	}

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -662,6 +662,24 @@ func (s *Service) ListMembers(roomID string) ([]User, error) {
 	return users, nil
 }
 
+// RoomIDsForMember returns sorted room IDs where the given user is a member (including direct rooms).
+func (s *Service) RoomIDsForMember(userID string) []string {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var ids []string
+	for id, room := range s.rooms {
+		if slices.Contains(room.Members, userID) {
+			ids = append(ids, id)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
 func (s *Service) ListMessages(roomID string) ([]Message, error) {
 	roomID = strings.TrimSpace(roomID)
 	if roomID == "" {

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -666,3 +666,23 @@ func TestReloadRefreshesRoomsFromStateFile(t *testing.T) {
 		t.Fatalf("rooms after reload = %+v, want room-1", rooms)
 	}
 }
+
+func TestRoomIDsForMember(t *testing.T) {
+	svc := NewServiceFromBootstrap(Bootstrap{
+		CurrentUserID: "u-admin",
+		Users: []User{
+			{ID: "u-bot", Name: "Bot", Handle: "bot", Role: "Worker"},
+		},
+		Rooms: []Room{
+			{ID: "room-a", Title: "A", Members: []string{"u-admin", "u-bot"}},
+			{ID: "room-b", Title: "B", Members: []string{"u-admin"}},
+		},
+	})
+	ids := svc.RoomIDsForMember("u-bot")
+	if len(ids) != 1 || ids[0] != "room-a" {
+		t.Fatalf("RoomIDsForMember(u-bot) = %#v, want [room-a]", ids)
+	}
+	if len(svc.RoomIDsForMember("unknown")) != 0 {
+		t.Fatal("expected empty for unknown user")
+	}
+}

--- a/internal/notifier/config.go
+++ b/internal/notifier/config.go
@@ -1,0 +1,116 @@
+package notifier
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DeliveryWebhook    = "webhook"
+	DeliveryRemotePull = "remote_pull"
+	DeliveryBoth       = "both"
+)
+
+// Config is parsed from agent_profile.request_options["notifier"].
+type Config struct {
+	DeliveryMode         string
+	WebhookToken         string
+	RemoteURL            string
+	RemoteSubscriptionID string
+	PollInterval         string
+	RemoteToken          string
+}
+
+func ParseConfigFromRequestOptions(ro map[string]any) Config {
+	if ro == nil {
+		return Config{}
+	}
+	raw, ok := ro["notifier"]
+	if !ok || raw == nil {
+		return Config{}
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return Config{}
+	}
+	return Config{
+		DeliveryMode:         strings.TrimSpace(toString(m["delivery_mode"])),
+		WebhookToken:         strings.TrimSpace(toString(m["webhook_token"])),
+		RemoteURL:            strings.TrimSpace(toString(m["remote_url"])),
+		RemoteSubscriptionID: strings.TrimSpace(toString(m["remote_subscription_id"])),
+		PollInterval:         strings.TrimSpace(toString(m["poll_interval"])),
+		RemoteToken:          strings.TrimSpace(toString(m["remote_token"])),
+	}
+}
+
+func toString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return trimFloatJSON(t)
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func trimFloatJSON(f float64) string {
+	s := fmt.Sprintf("%.12f", f)
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	return s
+}
+
+func (c Config) normalizedDeliveryMode() string {
+	switch strings.ToLower(strings.TrimSpace(c.DeliveryMode)) {
+	case DeliveryRemotePull:
+		return DeliveryRemotePull
+	case DeliveryBoth:
+		return DeliveryBoth
+	default:
+		return DeliveryWebhook
+	}
+}
+
+// AllowsWebhook reports whether inbound HTTP webhook should be accepted for this agent.
+func (c Config) AllowsWebhook() bool {
+	switch c.normalizedDeliveryMode() {
+	case DeliveryWebhook, DeliveryBoth:
+		return strings.TrimSpace(c.WebhookToken) != ""
+	default:
+		return false
+	}
+}
+
+// AllowsPull reports whether background relay polling should run (requires remote_url).
+func (c Config) AllowsPull() bool {
+	if strings.TrimSpace(c.RemoteURL) == "" {
+		return false
+	}
+	switch c.normalizedDeliveryMode() {
+	case DeliveryRemotePull, DeliveryBoth:
+		return true
+	default:
+		return false
+	}
+}
+
+// PollIntervalDuration defaults to 30s when unset or invalid.
+func (c Config) PollIntervalDuration() time.Duration {
+	s := strings.TrimSpace(c.PollInterval)
+	if s == "" {
+		return 30 * time.Second
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 5*time.Second {
+		return 30 * time.Second
+	}
+	return d
+}

--- a/internal/notifier/config_test.go
+++ b/internal/notifier/config_test.go
@@ -1,0 +1,35 @@
+package notifier
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseConfigRequestOptions(t *testing.T) {
+	cfg := ParseConfigFromRequestOptions(map[string]any{
+		"notifier": map[string]any{
+			"delivery_mode":          "both",
+			"webhook_token":          "abc",
+			"remote_url":             "https://relay.example.com",
+			"remote_subscription_id": "sub1",
+			"poll_interval":          "45s",
+			"remote_token":           "tok",
+		},
+	})
+	if cfg.normalizedDeliveryMode() != DeliveryBoth {
+		t.Fatalf("delivery mode = %q", cfg.normalizedDeliveryMode())
+	}
+	if !cfg.AllowsWebhook() || !cfg.AllowsPull() {
+		t.Fatalf("allows webhook=%v pull=%v", cfg.AllowsWebhook(), cfg.AllowsPull())
+	}
+	if cfg.PollIntervalDuration() != 45*time.Second {
+		t.Fatalf("poll interval = %v", cfg.PollIntervalDuration())
+	}
+
+	cfg2 := ParseConfigFromRequestOptions(map[string]any{
+		"notifier": map[string]any{"delivery_mode": "webhook", "webhook_token": "x"},
+	})
+	if !cfg2.AllowsWebhook() || cfg2.AllowsPull() {
+		t.Fatalf("webhook-only: allowsWebhook=%v allowsPull=%v", cfg2.AllowsWebhook(), cfg2.AllowsPull())
+	}
+}

--- a/internal/notifier/relay.go
+++ b/internal/notifier/relay.go
@@ -1,0 +1,211 @@
+package notifier
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// Fanouter delivers Markdown produced from notifier payloads to IM rooms.
+type Fanouter interface {
+	DeliverNotifierFanout(agentID string, markdown string) error
+}
+
+// Inbox JSON types for relay GET list / POST ack (see types below).
+
+type inboxMessagesResponse struct {
+	Messages   []InboxMessage `json:"messages"`
+	NextCursor *string        `json:"next_cursor"`
+}
+
+// InboxMessage is one row from the relay inbox messages list response.
+type InboxMessage struct {
+	ID                 string `json:"id"`
+	PayloadContentType string `json:"payload_content_type"`
+	PayloadBase64      string `json:"payload_base64"`
+	ReceivedAt         string `json:"received_at"`
+}
+
+type inboxAckRequest struct {
+	SubscriptionID string   `json:"subscription_id"`
+	MessageIDs     []string `json:"message_ids"`
+}
+
+// RelayClient pulls from a compatible relay; remote_url resolution is in resolveRelayEndpoints.
+type RelayClient struct {
+	HTTP *http.Client
+}
+
+func (c *RelayClient) client() *http.Client {
+	if c != nil && c.HTTP != nil {
+		return c.HTTP
+	}
+	return &http.Client{Timeout: 45 * time.Second}
+}
+
+func joinAPIPath(base, suffix string) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return "", fmt.Errorf("remote_url is required")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid remote_url")
+	}
+	rel, err := url.Parse(strings.TrimPrefix(suffix, "/"))
+	if err != nil {
+		return "", err
+	}
+	return u.ResolveReference(rel).String(), nil
+}
+
+// resolveRelayEndpoints interprets remote_url for pull mode.
+// If the URL has no path (or only "/"), legacy mode appends /api/v1/inbox/messages and /api/v1/inbox/ack.
+// Otherwise remote_url is the full URL of the GET messages list endpoint; ack is the same path
+// with the last path segment replaced by "ack" (sibling resource).
+func resolveRelayEndpoints(remoteURL string) (messages string, ack string, err error) {
+	base := strings.TrimSpace(remoteURL)
+	if base == "" {
+		return "", "", fmt.Errorf("remote_url is required")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", "", fmt.Errorf("invalid remote_url")
+	}
+	p := strings.TrimSuffix(strings.TrimSpace(u.Path), "/")
+	if p == "" {
+		msgs, err := joinAPIPath(base, "/api/v1/inbox/messages")
+		if err != nil {
+			return "", "", err
+		}
+		ackEp, err := joinAPIPath(base, "/api/v1/inbox/ack")
+		if err != nil {
+			return "", "", err
+		}
+		return msgs, ackEp, nil
+	}
+	ackURL := *u
+	ackURL.RawQuery = ""
+	p = path.Clean(u.Path)
+	parent := path.Dir(p)
+	ackURL.Path = path.Join(parent, "ack")
+	u.Fragment = ""
+	ackURL.Fragment = ""
+	return u.String(), ackURL.String(), nil
+}
+
+// FetchInbox performs GET on the configured relay messages list URL (see resolveRelayEndpoints).
+func (c *RelayClient) FetchInbox(ctx context.Context, baseURL string, cfg Config, limit int, cursor string) ([]InboxMessage, string, error) {
+	ep, _, err := resolveRelayEndpoints(baseURL)
+	if err != nil {
+		return nil, "", err
+	}
+	u, err := url.Parse(ep)
+	if err != nil {
+		return nil, "", err
+	}
+	q := u.Query()
+	if cfg.RemoteSubscriptionID != "" {
+		q.Set("subscription_id", cfg.RemoteSubscriptionID)
+	}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if strings.TrimSpace(cursor) != "" {
+		q.Set("cursor", cursor)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if tok := strings.TrimSpace(cfg.RemoteToken); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("relay inbox: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var parsed inboxMessagesResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, "", fmt.Errorf("relay inbox json: %w", err)
+	}
+	next := ""
+	if parsed.NextCursor != nil {
+		next = strings.TrimSpace(*parsed.NextCursor)
+	}
+	return parsed.Messages, next, nil
+}
+
+// Ack posts to the relay ack URL derived from remote_url (see resolveRelayEndpoints).
+func (c *RelayClient) Ack(ctx context.Context, baseURL string, cfg Config, messageIDs []string) error {
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	_, ep, err := resolveRelayEndpoints(baseURL)
+	if err != nil {
+		return err
+	}
+	payload := inboxAckRequest{
+		SubscriptionID: cfg.RemoteSubscriptionID,
+		MessageIDs:     append([]string(nil), messageIDs...),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ep, strings.NewReader(string(raw)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if tok := strings.TrimSpace(cfg.RemoteToken); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := c.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("relay ack: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+// DecodePayload returns raw bytes from inbox payload_base64.
+func DecodePayload(m InboxMessage) ([]byte, string, error) {
+	ct := strings.TrimSpace(m.PayloadContentType)
+	if strings.TrimSpace(m.PayloadBase64) == "" {
+		return nil, ct, fmt.Errorf("empty payload_base64")
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(m.PayloadBase64))
+	if err != nil {
+		return nil, ct, err
+	}
+	return raw, ct, nil
+}

--- a/internal/notifier/relay_resolve_test.go
+++ b/internal/notifier/relay_resolve_test.go
@@ -1,0 +1,53 @@
+package notifier
+
+import "testing"
+
+func TestResolveRelayEndpoints(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		wantMsg string
+		wantAck string
+	}{
+		{
+			name:    "legacy_origin",
+			in:      "https://relay.example.com",
+			wantMsg: "https://relay.example.com/api/v1/inbox/messages",
+			wantAck: "https://relay.example.com/api/v1/inbox/ack",
+		},
+		{
+			name:    "legacy_origin_slash",
+			in:      "https://relay.example.com/",
+			wantMsg: "https://relay.example.com/api/v1/inbox/messages",
+			wantAck: "https://relay.example.com/api/v1/inbox/ack",
+		},
+		{
+			name:    "full_messages_url",
+			in:      "https://relay.example.com/custom/api/v1/inbox/messages",
+			wantMsg: "https://relay.example.com/custom/api/v1/inbox/messages",
+			wantAck: "https://relay.example.com/custom/api/v1/inbox/ack",
+		},
+		{
+			name:    "full_messages_url_with_query",
+			in:      "https://relay.example.com/p/messages?x=1",
+			wantMsg: "https://relay.example.com/p/messages?x=1",
+			wantAck: "https://relay.example.com/p/ack",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotMsg, gotAck, err := resolveRelayEndpoints(tc.in)
+			if err != nil {
+				t.Fatalf("resolveRelayEndpoints: %v", err)
+			}
+			if gotMsg != tc.wantMsg {
+				t.Fatalf("messages URL\ngot  %q\nwant %q", gotMsg, tc.wantMsg)
+			}
+			if gotAck != tc.wantAck {
+				t.Fatalf("ack URL\ngot  %q\nwant %q", gotAck, tc.wantAck)
+			}
+		})
+	}
+}

--- a/internal/notifier/render.go
+++ b/internal/notifier/render.go
@@ -1,0 +1,521 @@
+package notifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const maxPayloadMarkdownRunes = 12000
+
+// FormatPayloadAsMarkdown turns webhook bytes into chat Markdown.
+// Known GitLab / GitHub webhook shapes get a short summary; others fall back to pretty-printed JSON.
+func FormatPayloadAsMarkdown(payload []byte, contentType string) string {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 {
+		return "_Empty notification body_"
+	}
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	jsonLike := strings.Contains(ct, "json") || json.Valid(payload)
+	if !jsonLike {
+		return truncateMarkdown(fence(string(payload)))
+	}
+	var root map[string]any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return truncateMarkdown(fence(string(payload)))
+	}
+	if s, ok := renderKnownWebhook(root); ok {
+		return truncateMarkdown(s)
+	}
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return truncateMarkdown(fence(string(payload)))
+	}
+	return truncateMarkdown("## Notification\n\n```json\n" + string(out) + "\n```")
+}
+
+func renderKnownWebhook(root map[string]any) (string, bool) {
+	if kind := strings.TrimSpace(toStr(root["object_kind"])); kind != "" {
+		return renderGitLab(kind, root)
+	}
+	// GitHub & generic JSON APIs
+	if _, ok := root["zen"]; ok {
+		return renderGitHubPing(root)
+	}
+	if hasMap(root, "pull_request") && root["action"] != nil {
+		return renderGitHubPullRequest(root)
+	}
+	if hasMap(root, "issue") && root["action"] != nil && root["repository"] != nil {
+		return renderGitHubIssue(root)
+	}
+	if root["commits"] != nil && root["ref"] != nil && root["repository"] != nil {
+		return renderGitHubPush(root)
+	}
+	return "", false
+}
+
+func renderGitLab(kind string, root map[string]any) (string, bool) {
+	switch strings.ToLower(kind) {
+	case "merge_request":
+		return renderGitLabMergeRequest(root)
+	case "push":
+		return renderGitLabPush(root)
+	case "pipeline":
+		return renderGitLabPipeline(root)
+	case "issue":
+		return renderGitLabIssue(root)
+	case "note":
+		return renderGitLabNote(root)
+	default:
+		return "", false
+	}
+}
+
+// renderGitLabNote handles GitLab Note Hook (comments on issue, merge request, commit, snippet, etc.).
+// See https://docs.gitlab.com/user/project/integrations/webhook_events/#comment-on-an-issue
+func renderGitLabNote(root map[string]any) (string, bool) {
+	oa := nestedMap(root, "object_attributes")
+	noteable := getStr(oa, "noteable_type")
+	switch noteable {
+	case "Issue":
+		if nestedMap(root, "issue") == nil {
+			return "", false
+		}
+		return renderGitLabIssueComment(root)
+	case "MergeRequest":
+		if nestedMap(root, "merge_request") == nil {
+			return "", false
+		}
+		return renderGitLabMergeRequestComment(root)
+	default:
+		return "", false
+	}
+}
+
+func renderGitLabIssueComment(root map[string]any) (string, bool) {
+	oa := nestedMap(root, "object_attributes")
+	action := getStr(oa, "action")
+	if action == "" {
+		action = "comment"
+	}
+	noteText := getStr(oa, "note")
+	url := getStr(oa, "url")
+	issue := nestedMap(root, "issue")
+	title := getStr(issue, "title")
+	iid := getStr(issue, "iid")
+	proj := nestedMap(root, "project")
+	path := getStr(proj, "path_with_namespace")
+	if path == "" {
+		path = getStr(proj, "name")
+	}
+	who := formatGitLabUser(nestedMap(root, "user"))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · Issue 评论 · %s\n\n", esc(action))
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	if title != "" {
+		if iid != "" {
+			fmt.Fprintf(&b, "**Issue:** #%s %s\n\n", esc(iid), esc(title))
+		} else {
+			fmt.Fprintf(&b, "**Issue:** %s\n\n", esc(title))
+		}
+	}
+	if noteText != "" {
+		fmt.Fprintf(&b, "**评论:** %s\n\n", esc(truncateRunes(noteText, 500)))
+	}
+	if who != "" {
+		fmt.Fprintf(&b, "**评论者:** %s\n\n", esc(who))
+	}
+	if url != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", url)
+	}
+	return b.String(), true
+}
+
+func renderGitLabMergeRequestComment(root map[string]any) (string, bool) {
+	oa := nestedMap(root, "object_attributes")
+	action := getStr(oa, "action")
+	if action == "" {
+		action = "comment"
+	}
+	noteText := getStr(oa, "note")
+	url := getStr(oa, "url")
+	mr := nestedMap(root, "merge_request")
+	title := getStr(mr, "title")
+	iid := getStr(mr, "iid")
+	source := getStr(mr, "source_branch")
+	target := getStr(mr, "target_branch")
+	proj := nestedMap(root, "project")
+	path := getStr(proj, "path_with_namespace")
+	if path == "" {
+		path = getStr(proj, "name")
+	}
+	who := formatGitLabUser(nestedMap(root, "user"))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · MR 评论 · %s\n\n", esc(action))
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	if title != "" {
+		if iid != "" {
+			fmt.Fprintf(&b, "**MR:** !%s %s\n\n", esc(iid), esc(title))
+		} else {
+			fmt.Fprintf(&b, "**MR:** %s\n\n", esc(title))
+		}
+	}
+	if source != "" || target != "" {
+		fmt.Fprintf(&b, "**分支:** `%s` → `%s`\n\n", inBackticks(source), inBackticks(target))
+	}
+	if noteText != "" {
+		fmt.Fprintf(&b, "**评论:** %s\n\n", esc(truncateRunes(noteText, 500)))
+	}
+	if who != "" {
+		fmt.Fprintf(&b, "**评论者:** %s\n\n", esc(who))
+	}
+	if url != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", url)
+	}
+	return b.String(), true
+}
+
+func formatGitLabUser(user map[string]any) string {
+	if user == nil {
+		return ""
+	}
+	name := getStr(user, "name")
+	if handle := getStr(user, "username"); handle != "" {
+		if name != "" {
+			return fmt.Sprintf("%s (@%s)", name, handle)
+		}
+		return "@" + handle
+	}
+	return name
+}
+
+func renderGitLabMergeRequest(root map[string]any) (string, bool) {
+	proj := nestedMap(root, "project")
+	title := getStr(nestedMap(root, "object_attributes"), "title")
+	if title == "" {
+		title = "(no title)"
+	}
+	action := getStr(nestedMap(root, "object_attributes"), "action")
+	if action == "" {
+		action = "update"
+	}
+	source := getStr(nestedMap(root, "object_attributes"), "source_branch")
+	target := getStr(nestedMap(root, "object_attributes"), "target_branch")
+	url := getStr(nestedMap(root, "object_attributes"), "url")
+	path := getStr(proj, "path_with_namespace")
+	if path == "" {
+		path = getStr(proj, "name")
+	}
+	user := nestedMap(root, "user")
+	who := getStr(user, "name")
+	if handle := getStr(user, "username"); handle != "" {
+		if who != "" {
+			who = fmt.Sprintf("%s (@%s)", who, handle)
+		} else {
+			who = "@" + handle
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · Merge request · %s\n\n", esc(action))
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	fmt.Fprintf(&b, "**标题:** %s\n\n", esc(title))
+	if source != "" || target != "" {
+		fmt.Fprintf(&b, "**分支:** `%s` → `%s`\n\n", inBackticks(source), inBackticks(target))
+	}
+	if who != "" {
+		fmt.Fprintf(&b, "**操作者:** %s\n\n", esc(who))
+	}
+	if url != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", url)
+	}
+	return b.String(), true
+}
+
+func renderGitLabPush(root map[string]any) (string, bool) {
+	proj := nestedMap(root, "project")
+	path := getStr(proj, "path_with_namespace")
+	if path == "" {
+		path = getStr(proj, "name")
+	}
+	ref := getStr(root, "ref")
+	userName := getStr(nestedMap(root, "user"), "name")
+	userHandle := getStr(nestedMap(root, "user"), "username")
+	who := userName
+	if userHandle != "" {
+		if who != "" {
+			who = fmt.Sprintf("%s (@%s)", who, userHandle)
+		} else {
+			who = "@" + userHandle
+		}
+	}
+	nCommits := 0
+	if v, ok := root["total_commits_count"].(float64); ok {
+		nCommits = int(v)
+	}
+	lastMsg := ""
+	if commits, ok := root["commits"].([]any); ok && len(commits) > 0 {
+		if last, ok := commits[len(commits)-1].(map[string]any); ok {
+			lastMsg = getStr(last, "message")
+			if idx := strings.IndexByte(lastMsg, '\n'); idx >= 0 {
+				lastMsg = strings.TrimSpace(lastMsg[:idx])
+			}
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · Push\n\n")
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	if ref != "" {
+		fmt.Fprintf(&b, "**Ref:** `%s`\n\n", inBackticks(ref))
+	}
+	if who != "" {
+		fmt.Fprintf(&b, "**推送者:** %s\n\n", esc(who))
+	}
+	if nCommits > 0 {
+		fmt.Fprintf(&b, "**提交数:** %d\n\n", nCommits)
+	}
+	if lastMsg != "" {
+		fmt.Fprintf(&b, "**最新提交:** %s\n", esc(truncateRunes(lastMsg, 200)))
+	}
+	return b.String(), true
+}
+
+func renderGitLabPipeline(root map[string]any) (string, bool) {
+	oa := nestedMap(root, "object_attributes")
+	status := getStr(oa, "status")
+	ref := getStr(oa, "ref")
+	sha := getStr(oa, "sha")
+	if len(sha) > 8 {
+		sha = sha[:8]
+	}
+	proj := nestedMap(root, "project")
+	path := getStr(proj, "path_with_namespace")
+	if path == "" {
+		path = getStr(proj, "name")
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · Pipeline · %s\n\n", esc(strings.TrimSpace(status)))
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	if ref != "" {
+		fmt.Fprintf(&b, "**Ref:** `%s`\n\n", inBackticks(ref))
+	}
+	if sha != "" {
+		fmt.Fprintf(&b, "**SHA:** `%s`\n", inBackticks(sha))
+	}
+	return b.String(), true
+}
+
+func renderGitLabIssue(root map[string]any) (string, bool) {
+	oa := nestedMap(root, "object_attributes")
+	title := getStr(oa, "title")
+	action := getStr(oa, "action")
+	if action == "" {
+		action = "update"
+	}
+	url := getStr(oa, "url")
+	proj := nestedMap(root, "project")
+	path := getStr(proj, "path_with_namespace")
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitLab · Issue · %s\n\n", esc(action))
+	if path != "" {
+		fmt.Fprintf(&b, "**项目:** %s\n\n", esc(path))
+	}
+	if title != "" {
+		fmt.Fprintf(&b, "**标题:** %s\n\n", esc(title))
+	}
+	if url != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", url)
+	}
+	return b.String(), true
+}
+
+func renderGitHubPing(root map[string]any) (string, bool) {
+	zen := getStr(root, "zen")
+	repo := nestedMap(root, "repository")
+	name := getStr(repo, "full_name")
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitHub · Ping\n\n")
+	if name != "" {
+		fmt.Fprintf(&b, "**仓库:** %s\n\n", esc(name))
+	}
+	if zen != "" {
+		fmt.Fprintf(&b, "%s\n", esc(zen))
+	}
+	return b.String(), true
+}
+
+func renderGitHubPullRequest(root map[string]any) (string, bool) {
+	action := getStr(root, "action")
+	pr := nestedMap(root, "pull_request")
+	title := getStr(pr, "title")
+	htmlURL := getStr(pr, "html_url")
+	head := getStr(nestedMap(pr, "head"), "ref")
+	base := getStr(nestedMap(pr, "base"), "ref")
+	repo := nestedMap(root, "repository")
+	full := getStr(repo, "full_name")
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitHub · Pull request · %s\n\n", esc(action))
+	if full != "" {
+		fmt.Fprintf(&b, "**仓库:** %s\n\n", esc(full))
+	}
+	if title != "" {
+		fmt.Fprintf(&b, "**标题:** %s\n\n", esc(title))
+	}
+	if head != "" || base != "" {
+		fmt.Fprintf(&b, "**分支:** `%s` → `%s`\n\n", inBackticks(head), inBackticks(base))
+	}
+	if htmlURL != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", htmlURL)
+	}
+	return b.String(), true
+}
+
+func renderGitHubIssue(root map[string]any) (string, bool) {
+	action := getStr(root, "action")
+	iss := nestedMap(root, "issue")
+	title := getStr(iss, "title")
+	htmlURL := getStr(iss, "html_url")
+	repo := nestedMap(root, "repository")
+	full := getStr(repo, "full_name")
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitHub · Issue · %s\n\n", esc(action))
+	if full != "" {
+		fmt.Fprintf(&b, "**仓库:** %s\n\n", esc(full))
+	}
+	if title != "" {
+		fmt.Fprintf(&b, "**标题:** %s\n\n", esc(title))
+	}
+	if htmlURL != "" {
+		fmt.Fprintf(&b, "**链接:** %s\n", htmlURL)
+	}
+	return b.String(), true
+}
+
+func renderGitHubPush(root map[string]any) (string, bool) {
+	ref := getStr(root, "ref")
+	repo := nestedMap(root, "repository")
+	full := getStr(repo, "full_name")
+	pusher := nestedMap(root, "pusher")
+	who := getStr(pusher, "name")
+	var lastMsg string
+	if commits, ok := root["commits"].([]any); ok && len(commits) > 0 {
+		if last, ok := commits[len(commits)-1].(map[string]any); ok {
+			lastMsg = getStr(last, "message")
+			if idx := strings.IndexByte(lastMsg, '\n'); idx >= 0 {
+				lastMsg = strings.TrimSpace(lastMsg[:idx])
+			}
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## GitHub · Push\n\n")
+	if full != "" {
+		fmt.Fprintf(&b, "**仓库:** %s\n\n", esc(full))
+	}
+	if ref != "" {
+		fmt.Fprintf(&b, "**Ref:** `%s`\n\n", inBackticks(ref))
+	}
+	if who != "" {
+		fmt.Fprintf(&b, "**推送者:** %s\n\n", esc(who))
+	}
+	if lastMsg != "" {
+		fmt.Fprintf(&b, "**最新提交:** %s\n", esc(truncateRunes(lastMsg, 200)))
+	}
+	return b.String(), true
+}
+
+func nestedMap(m map[string]any, key string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil
+	}
+	mm, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return mm
+}
+
+func hasMap(m map[string]any, key string) bool {
+	return nestedMap(m, key) != nil
+}
+
+func getStr(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	return strings.TrimSpace(toStr(v))
+}
+
+func toStr(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%.0f", t)
+		}
+		return fmt.Sprint(t)
+	case bool:
+		return fmt.Sprint(t)
+	case json.Number:
+		return t.String()
+	default:
+		return strings.TrimSpace(fmt.Sprint(t))
+	}
+}
+
+func inBackticks(s string) string {
+	return strings.ReplaceAll(s, "`", "'")
+}
+
+func esc(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "*", "\\*")
+	s = strings.ReplaceAll(s, "_", "\\_")
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return s
+}
+
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}
+
+func fence(s string) string {
+	s = strings.ReplaceAll(s, "```", "`\u200b``")
+	return "```\n" + s + "\n```"
+}
+
+func truncateMarkdown(s string) string {
+	r := []rune(s)
+	if len(r) <= maxPayloadMarkdownRunes {
+		return s
+	}
+	head := string(r[:maxPayloadMarkdownRunes])
+	return head + "\n\n_(truncated)_"
+}

--- a/internal/notifier/render_test.go
+++ b/internal/notifier/render_test.go
@@ -1,0 +1,213 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatPayloadAsMarkdownJSON(t *testing.T) {
+	md := FormatPayloadAsMarkdown([]byte(`{"a":1}`), "application/json")
+	if !strings.Contains(md, "```json") {
+		t.Fatalf("expected json fence: %s", md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitLabMergeRequest(t *testing.T) {
+	payload := `{
+  "object_kind": "merge_request",
+  "user": {"name": "Alice", "username": "alice"},
+  "project": {"path_with_namespace": "acme/app"},
+  "object_attributes": {
+    "title": "Fix bug",
+    "action": "open",
+    "source_branch": "fix",
+    "target_branch": "main",
+    "url": "https://gitlab.example/acme/app/-/merge_requests/1"
+  }
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	for _, want := range []string{
+		"## GitLab · Merge request · open",
+		"**项目:** acme/app",
+		"**标题:** Fix bug",
+		"**分支:** `fix` → `main`",
+		"https://gitlab.example/acme/app/-/merge_requests/1",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("missing %q in:\n%s", want, md)
+		}
+	}
+	if strings.Contains(md, "```json") {
+		t.Fatalf("should not fall back to raw json: %s", md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitLabPush(t *testing.T) {
+	payload := `{
+  "object_kind": "push",
+  "ref": "refs/heads/main",
+  "total_commits_count": 2,
+  "user": {"name": "Bob", "username": "bob"},
+  "project": {"path_with_namespace": "acme/app"},
+  "commits": [{"message": "Second line\n\nBody"}, {"message": "Latest commit\nfix"}]
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	if !strings.Contains(md, "## GitLab · Push") {
+		t.Fatal(md)
+	}
+	if !strings.Contains(md, "**Ref:** `refs/heads/main`") {
+		t.Fatal(md)
+	}
+	if !strings.Contains(md, "**提交数:** 2") {
+		t.Fatal(md)
+	}
+	if !strings.Contains(md, "Latest commit") {
+		t.Fatal(md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitLabPipeline(t *testing.T) {
+	payload := `{
+  "object_kind": "pipeline",
+  "project": {"path_with_namespace": "acme/app"},
+  "object_attributes": {"status": "success", "ref": "main", "sha": "deadbeefcafe"}
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	if !strings.Contains(md, "## GitLab · Pipeline · success") {
+		t.Fatal(md)
+	}
+	if !strings.Contains(md, "**SHA:** `deadbeef`") {
+		t.Fatal(md)
+	}
+}
+
+// GitLab Note Hook — comment on an issue (shape from GitLab webhook_events docs).
+func TestFormatPayloadAsMarkdownGitLabNoteIssue(t *testing.T) {
+	payload := `{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "name": "Administrator",
+    "username": "root"
+  },
+  "project": {
+    "path_with_namespace": "gitlab-org/gitlab-test"
+  },
+  "object_attributes": {
+    "note": "Hello world",
+    "noteable_type": "Issue",
+    "noteable_id": 92,
+    "action": "create",
+    "url": "http://example.com/gitlab-org/gitlab-test/issues/17#note_1241"
+  },
+  "issue": {
+    "iid": 17,
+    "title": "test"
+  }
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	for _, want := range []string{
+		"## GitLab · Issue 评论 · create",
+		"**项目:** gitlab-org/gitlab-test",
+		"**Issue:** #17 test",
+		"**评论:** Hello world",
+		"Administrator (@root)",
+		"http://example.com/gitlab-org/gitlab-test/issues/17#note_1241",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("missing %q in:\n%s", want, md)
+		}
+	}
+	if strings.Contains(md, "```json") {
+		t.Fatalf("should not fall back to raw json: %s", md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitLabNoteMergeRequest(t *testing.T) {
+	payload := `{
+  "object_kind": "note",
+  "user": {"name": "Admin", "username": "root"},
+  "project": {"path_with_namespace": "gitlab-org/gitlab-test"},
+  "object_attributes": {
+    "note": "This MR needs work.",
+    "noteable_type": "MergeRequest",
+    "action": "create",
+    "url": "http://example.com/gitlab-org/gitlab-test/merge_requests/1#note_1244"
+  },
+  "merge_request": {
+    "iid": 1,
+    "title": "Example MR",
+    "source_branch": "master",
+    "target_branch": "markdown"
+  }
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	for _, want := range []string{
+		"## GitLab · MR 评论 · create",
+		"!1 Example MR",
+		"`master` → `markdown`",
+		"This MR needs work.",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("missing %q in:\n%s", want, md)
+		}
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitHubPullRequest(t *testing.T) {
+	payload := `{
+  "action": "opened",
+  "repository": {"full_name": "acme/app"},
+  "pull_request": {
+    "title": "Feature",
+    "html_url": "https://github.com/acme/app/pull/3",
+    "head": {"ref": "feat"},
+    "base": {"ref": "main"}
+  }
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	for _, want := range []string{
+		"## GitHub · Pull request · opened",
+		"acme/app",
+		"Feature",
+		"`feat` → `main`",
+		"https://github.com/acme/app/pull/3",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("missing %q in:\n%s", want, md)
+		}
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitHubPush(t *testing.T) {
+	payload := `{
+  "ref": "refs/heads/main",
+  "repository": {"full_name": "acme/app"},
+  "pusher": {"name": "Pat"},
+  "commits": [{"message": "one"}, {"message": "two\n\nmore"}]
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	if !strings.Contains(md, "## GitHub · Push") || !strings.Contains(md, "two") {
+		t.Fatal(md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitHubPing(t *testing.T) {
+	payload := `{"zen":"Speak like a human.","repository":{"full_name":"octocat/Hello-World"}}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	if !strings.Contains(md, "## GitHub · Ping") || !strings.Contains(md, "Speak like a human") {
+		t.Fatal(md)
+	}
+}
+
+func TestFormatPayloadAsMarkdownGitHubIssue(t *testing.T) {
+	payload := `{
+  "action": "opened",
+  "repository": {"full_name": "acme/app"},
+  "issue": {"title": "Bug", "html_url": "https://github.com/acme/app/issues/9"}
+}`
+	md := FormatPayloadAsMarkdown([]byte(payload), "application/json")
+	if !strings.Contains(md, "## GitHub · Issue · opened") || !strings.Contains(md, "Bug") {
+		t.Fatal(md)
+	}
+}

--- a/internal/notifier/subscription.go
+++ b/internal/notifier/subscription.go
@@ -1,0 +1,43 @@
+package notifier
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EnsurePullRemoteSubscriptionInRequestOptions sets request_options.notifier.remote_subscription_id
+// when delivery_mode is remote_pull and the id is empty. Mutates nested maps in place.
+func EnsurePullRemoteSubscriptionInRequestOptions(ro map[string]any) map[string]any {
+	if len(ro) == 0 {
+		return ro
+	}
+	cfg := ParseConfigFromRequestOptions(ro)
+	if cfg.normalizedDeliveryMode() != DeliveryRemotePull {
+		return ro
+	}
+	if strings.TrimSpace(cfg.RemoteSubscriptionID) != "" {
+		return ro
+	}
+	raw, ok := ro["notifier"]
+	if !ok || raw == nil {
+		return ro
+	}
+	m, ok := raw.(map[string]any)
+	if !ok || m == nil {
+		return ro
+	}
+	m["remote_subscription_id"] = newPullSubscriptionID()
+	ro["notifier"] = m
+	return ro
+}
+
+func newPullSubscriptionID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("sub-%d", time.Now().UnixNano())
+	}
+	return "sub-" + hex.EncodeToString(b[:])
+}

--- a/internal/notifier/subscription_test.go
+++ b/internal/notifier/subscription_test.go
@@ -1,0 +1,38 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnsurePullRemoteSubscriptionInRequestOptions(t *testing.T) {
+	ro := map[string]any{
+		"notifier": map[string]any{
+			"delivery_mode": "remote_pull",
+			"remote_url":    "https://relay.example.com",
+		},
+	}
+	out := EnsurePullRemoteSubscriptionInRequestOptions(ro)
+	n := out["notifier"].(map[string]any)["remote_subscription_id"].(string)
+	if n == "" || !strings.HasPrefix(n, "sub-") {
+		t.Fatalf("unexpected id %q", n)
+	}
+	// idempotent
+	EnsurePullRemoteSubscriptionInRequestOptions(out)
+	if got := out["notifier"].(map[string]any)["remote_subscription_id"].(string); got != n {
+		t.Fatalf("id changed: %q -> %q", n, got)
+	}
+}
+
+func TestEnsurePullRemoteSubscriptionInRequestOptionsWebhookNoop(t *testing.T) {
+	ro := map[string]any{
+		"notifier": map[string]any{
+			"delivery_mode": "webhook",
+			"webhook_token": "x",
+		},
+	}
+	out := EnsurePullRemoteSubscriptionInRequestOptions(ro)
+	if _, ok := out["notifier"].(map[string]any)["remote_subscription_id"]; ok {
+		t.Fatal("should not set subscription for webhook-only")
+	}
+}

--- a/internal/notifier/token.go
+++ b/internal/notifier/token.go
@@ -1,0 +1,14 @@
+package notifier
+
+import "crypto/subtle"
+
+// SecretMatch compares secrets in constant time when lengths match (recommended: fixed-length random tokens).
+func SecretMatch(expected, got string) bool {
+	if len(expected) == 0 || len(got) == 0 {
+		return false
+	}
+	if len(expected) != len(got) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(got)) == 1
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -50,6 +50,11 @@ func Run(opts Options) error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
+	if opts.Service != nil && handler != nil {
+		pull := agent.NewNotifierPullWorker(opts.Service, handler)
+		go pull.Run(opts.Context)
+	}
+
 	if opts.IMBus != nil && opts.BotBridge != nil {
 		events, cancel := opts.IMBus.Subscribe()
 		defer cancel()

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -24,6 +24,10 @@ const RUNTIME_KIND_OPTIONS = [
   { value: "codex", label: "codex" },
 ];
 const GATEWAY_RUNTIME_KIND_OPTIONS = RUNTIME_KIND_OPTIONS.filter((option) => option.value === "picoclaw_sandbox");
+/** Stored as request_options.notifier.delivery_mode (webhook = push, remote_pull = pull). */
+const NOTIFIER_DELIVERY_OPTIONS = ["webhook", "remote_pull"];
+/** Relay inbound Webhook path for GitLab POST (not the GET inbox list path). */
+const NOTIFIER_RELAY_WEBHOOK_INGRESS_PATH = "/api/v1/webhooks/ingress";
 const CLIPROXY_AUTH_PROVIDERS = new Set(["codex", "claude_code"]);
 const REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
 const WORKSPACE_TAB_MESSAGES = "messages";
@@ -152,6 +156,8 @@ const messages = {
     profileEnvValue: "值",
     profileEnvAdd: "添加变量",
     profileEnvRemove: "移除变量",
+    profileEnvNotifierHint:
+      "若该 Agent 仍会启动网关沙箱，这些键值会注入容器环境；不参与 Webhook 校验与通知内容格式化。仅做通知投递时通常可留空。",
     profileReasoning: "Reasoning",
     profileFastMode: "Fast mode",
     agentRuntime: "Agent Runtime",
@@ -161,6 +167,34 @@ const messages = {
     profileRuntimeKind: "运行时",
     profileModelSection: "模型",
     profileAPIProvider: "API Provider",
+    profileNotifierSection: "通知投递",
+    notifierDeliveryMode: "投递方式",
+    notifierDeliveryWebhook: "推送（Webhook）",
+    notifierDeliveryRemotePull: "拉取（收件箱 API）",
+    notifierWebhookToken: "Webhook 访问令牌",
+    notifierWebhookTokenHint:
+      "调用方 POST 本服务 Webhook 时，须在 URL 查询参数 `token` 或请求头 `Authorization: Bearer` 中携带与此相同的值。请妥善保管，勿泄露或写入版本库。",
+    notifierRemoteURL: "收件箱服务地址 (remote_url)",
+    notifierRemoteURLPlaceholder: "https://relay.example.com/api/v1/inbox/messages",
+    notifierRemoteURLHint:
+      "填写 **GET 收件箱消息列表的完整 URL**（须含 `http://` 或 `https://` 与路径；生产推荐 HTTPS，本地可用 `http://localhost:…`）。本服务在拉取时追加 `subscription_id` 等 query。若只填 `http(s)://主机` 或 `http(s)://主机/`（无 path），拉取仍请求 `{origin}/api/v1/inbox/messages` 与 `{origin}/api/v1/inbox/ack`。不是 GitLab 入站 Webhook 地址。",
+    notifierSubscriptionID: "订阅 ID（自动生成）",
+    notifierSubscriptionIDHint: "拉取模式下由本应用分配并写入配置，用于中继分区；不可手动修改。",
+    notifierPollInterval: "拉取间隔",
+    notifierPollIntervalPlaceholder: "例如 30s",
+    notifierRemoteToken: "收件箱服务 Bearer Token（可选）",
+    notifierThirdPartyWebhookPasteURL: "第三方 Webhook 粘贴地址（含订阅 ID）",
+    notifierThirdPartyWebhookPasteURLHint:
+      "生成 **GitLab 等 POST 的中继入站 Webhook URL**（默认 path `/api/v1/webhooks/ingress`）并附加 `subscription_id`。若「收件箱服务地址」**仅有 origin**，本栏使用该默认入站 path；若以 `…/inbox/messages` 结尾（拉取列表 URL），会改为同 host 下的 `…/webhooks/ingress`；其它 path 则保持不动仅追加 query。",
+    notifierWebhookPublicOrigin: "CSGClaw 对外基址（HTTPS）",
+    notifierWebhookPublicOriginPlaceholder: "https://gitlab 能访问到的地址:端口",
+    notifierWebhookPublicOriginHint:
+      "用于拼接下方「本服务 Webhook」完整 URL；默认同当前浏览器打开本页的 origin。留空时预览与复制使用占位符，请改为公网或内网穿透地址。",
+    notifierThirdPartyCSGWebhookURL: "本服务 Webhook（第三方 POST）",
+    notifierThirdPartyCSGWebhookURLHint:
+      "GitLab 等向此 URL POST；`token` 须与上方「Webhook 访问令牌」一致。创建 Agent 保存前路径中的 `<agent_id>` 为占位符，保存后请用实际 Agent ID 再复制。",
+    notifierWebhookOriginPlaceholder: "https://<your-csgclaw-host>",
+    copyToClipboard: "复制",
     profileAdvanced: "高级选项",
     profilePreview: "Profile 预览",
     openProfile: "打开 Profile",
@@ -179,6 +213,7 @@ const messages = {
     createAgent: "创建 Agent",
     createAgentTitle: "创建 Agent",
     createAgentSubtitle: "创建一个 Worker，并使用最新 Profile 默认值。",
+    createAgentSubtitleNotifier: "创建一个通知 Agent（推送 Webhook 或拉取收件箱），可与 Worker 一样绑定飞书并进群。",
     editAgentTitle: "编辑 Agent Profile",
     editAgentSubtitle: "修改运行配置。Env 变更需要重新创建沙箱。",
     agentName: "名称",
@@ -279,7 +314,8 @@ const messages = {
     roles: {
       admin: "管理员",
       manager: "经理",
-      worker: "成员",
+      worker: "worker（对话代理）",
+      notifier: "notifier（Webhook 通知）",
     },
     errors: {
       "title is required": "标题不能为空",
@@ -346,6 +382,8 @@ const messages = {
     profileEnvValue: "Value",
     profileEnvAdd: "Add variable",
     profileEnvRemove: "Remove variable",
+    profileEnvNotifierHint:
+      "If this agent still runs a gateway sandbox, these are injected as container environment variables; they are not used for webhook verification or notification formatting. Usually leave empty for notifier-only delivery.",
     profileReasoning: "Reasoning",
     profileFastMode: "Fast mode",
     agentRuntime: "Agent Runtime",
@@ -355,6 +393,35 @@ const messages = {
     profileRuntimeKind: "Runtime",
     profileModelSection: "Model",
     profileAPIProvider: "API Provider",
+    profileNotifierSection: "Notifications",
+    notifierDeliveryMode: "Delivery mode",
+    notifierDeliveryWebhook: "Push (webhook)",
+    notifierDeliveryRemotePull: "Pull (inbox API)",
+    notifierWebhookToken: "Webhook access token",
+    notifierWebhookTokenHint:
+      "Callers must send this exact value as the `token` query parameter or `Authorization: Bearer`. Keep it secret and out of source control.",
+    notifierRemoteURL: "Inbox service URL (remote_url)",
+    notifierRemoteURLPlaceholder: "https://relay.example.com/api/v1/inbox/messages",
+    notifierRemoteURLHint:
+      "Full **GET inbox-messages** URL including scheme (`https://` recommended in prod; `http://localhost` OK for local dev). Pull requests append query params. If you only enter `http(s)://host` or `http(s)://host/` (no path), CSGClaw GETs `{origin}/api/v1/inbox/messages` and POSTs ack to `{origin}/api/v1/inbox/ack`. Not the third-party webhook ingress URL.",
+    notifierSubscriptionID: "Subscription ID (auto-generated)",
+    notifierSubscriptionIDHint:
+      "Assigned in pull mode and stored in profile for relay partitioning; not editable.",
+    notifierPollInterval: "Poll interval",
+    notifierPollIntervalPlaceholder: "e.g. 30s",
+    notifierRemoteToken: "Inbox service bearer token (optional)",
+    notifierThirdPartyWebhookPasteURL: "Third-party webhook URL (includes subscription ID)",
+    notifierThirdPartyWebhookPasteURLHint:
+      "Builds the **relay inbound Webhook URL** for GitLab etc. (default path `/api/v1/webhooks/ingress`) plus `subscription_id`. **Origin-only** inbox URL → that ingress path on the same host. URL ending in `…/inbox/messages` (pull list) → same host with `…/webhooks/ingress`. Other paths: only the query is added.",
+    notifierWebhookPublicOrigin: "CSGClaw public base URL (HTTPS)",
+    notifierWebhookPublicOriginPlaceholder: "https://host:port reachable by GitLab",
+    notifierWebhookPublicOriginHint:
+      "Used to build the CSGClaw Webhook URL below; defaults to this page's origin. Leave empty to use a placeholder host in preview/copy until you set a public or tunneled URL.",
+    notifierThirdPartyCSGWebhookURL: "CSGClaw Webhook (third-party POST)",
+    notifierThirdPartyCSGWebhookURLHint:
+      "GitLab POSTs here; `token` must match the Webhook token above. `<agent_id>` is a placeholder until the agent is saved—copy again after create with the real id.",
+    notifierWebhookOriginPlaceholder: "https://<your-csgclaw-host>",
+    copyToClipboard: "Copy",
     profileAdvanced: "Advanced",
     profilePreview: "Profile preview",
     openProfile: "Open profile",
@@ -373,6 +440,7 @@ const messages = {
     createAgent: "Create Agent",
     createAgentTitle: "Create Agent",
     createAgentSubtitle: "Create a worker with the latest profile defaults.",
+    createAgentSubtitleNotifier: "Create a notification agent (push webhook or pull inbox). Can bind Feishu and join groups like workers.",
     editAgentTitle: "Edit Agent Profile",
     editAgentSubtitle: "Change runtime settings. Env changes need a sandbox recreate.",
     agentName: "Name",
@@ -474,6 +542,7 @@ const messages = {
       admin: "admin",
       manager: "manager",
       worker: "worker",
+      notifier: "notifier",
     },
     errors: {
       "title is required": "Title is required",
@@ -907,6 +976,8 @@ function App() {
   const [agentPageBusy, setAgentPageBusy] = useState(false);
   const [agentPageModelBusy, setAgentPageModelBusy] = useState(false);
   const [agentPageError, setAgentPageError] = useState("");
+  const [notifierModalWebhookOrigin, setNotifierModalWebhookOrigin] = useState("");
+  const [notifierPageWebhookOrigin, setNotifierPageWebhookOrigin] = useState("");
   const [profilePreview, setProfilePreview] = useState(null);
   const [appVersion, setAppVersion] = useState("dev");
   const [upgradeStatus, setUpgradeStatus] = useState(null);
@@ -934,6 +1005,20 @@ function App() {
   useEffect(() => {
     refreshVersion();
   }, []);
+
+  useEffect(() => {
+    if (!showAgentModal || !agentDraft || agentDraft.role !== "notifier") {
+      return;
+    }
+    setNotifierModalWebhookOrigin(typeof window !== "undefined" ? window.location.origin : "");
+  }, [showAgentModal, agentModalMode, editingAgent?.id, agentDraft?.role]);
+
+  useEffect(() => {
+    if (!agentPageDraft || agentPageDraft.role !== "notifier") {
+      return;
+    }
+    setNotifierPageWebhookOrigin(typeof window !== "undefined" ? window.location.origin : "");
+  }, [agentPageDraft?.agent_id]);
 
   useEffect(() => {
     refreshUpgradeStatus();
@@ -2203,7 +2288,7 @@ function App() {
     try {
       const resp = await fetch(`api/v1/agents/${encodeURIComponent(item.id)}/profile`);
       const profile = resp.ok ? await resp.json() : item.agent_profile;
-      const draft = agentToDraft({ ...item, agent_profile: profile });
+      const draft = ensureNotifierPullSubscriptionDraft(agentToDraft({ ...item, agent_profile: profile }));
       setAgentDraft(draft);
       setShowAgentModal(true);
       loadAgentModels(draft, { silent: true });
@@ -2221,12 +2306,12 @@ function App() {
     try {
       const resp = await fetch(`api/v1/agents/${encodeURIComponent(item.id)}/profile`);
       const profile = resp.ok ? await resp.json() : item.agent_profile;
-      const draft = agentToDraft({ ...item, agent_profile: profile });
+      const draft = ensureNotifierPullSubscriptionDraft(agentToDraft({ ...item, agent_profile: profile }));
       setAgentPageDraft(draft);
       loadAgentPageModels(draft, { silent: true });
     } catch (err) {
       setAgentPageError(err.message || t("agentActionFailed"));
-      const draft = agentToDraft(item);
+      const draft = ensureNotifierPullSubscriptionDraft(agentToDraft(item));
       setAgentPageDraft(draft);
       loadAgentPageModels(draft, { silent: true });
     }
@@ -2337,7 +2422,7 @@ function App() {
     setAgentPageBusy(true);
     setAgentPageError("");
     try {
-      const profile = draftToProfile(agentPageDraft, {
+      const profile = draftToProfile(ensureNotifierPullSubscriptionDraft(agentPageDraft), {
         name: agentPageDraft.name,
         description: agentPageDraft.description,
       });
@@ -2378,7 +2463,7 @@ function App() {
     const runtimeKind = normalizeRuntimeKind(agentDraft.runtime_kind);
     setAgentProgress(isCreate ? startAgentCreateProgress(runtimeKind) : null);
     try {
-      const profile = draftToProfile(agentDraft, {
+      const profile = draftToProfile(ensureNotifierPullSubscriptionDraft(agentDraft), {
         name: agentDraft.name,
         description: agentDraft.description,
       });
@@ -2887,6 +2972,8 @@ function App() {
                   saveError=${agentPageError}
                   authStatuses=${cliproxyAuthStatuses}
                   authBusyProvider=${cliproxyAuthBusy}
+                  notifierWebhookOrigin=${notifierPageWebhookOrigin}
+                  setNotifierWebhookOrigin=${setNotifierPageWebhookOrigin}
                   onDraftChange=${setAgentPageDraft}
                   onSave=${saveAgentPage}
                   onProviderLogin=${loginCLIProxyProvider}
@@ -3390,7 +3477,11 @@ function App() {
                 <div className="modal-header">
                   <div>
                     <div className="modal-title">${agentModalMode === "create" ? t("createAgentTitle") : t("editAgentTitle")}</div>
-                    <div className="modal-subtitle">${agentModalMode === "create" ? t("createAgentSubtitle") : t("editAgentSubtitle")}</div>
+                    <div className="modal-subtitle">${agentModalMode === "create"
+                      ? agentDraft.role === "notifier"
+                        ? t("createAgentSubtitleNotifier")
+                        : t("createAgentSubtitle")
+                      : t("editAgentSubtitle")}</div>
                   </div>
                   <button className="btn btn-secondary-gray btn-sm modal-close" onClick=${() => setShowAgentModal(false)}>${t("close")}</button>
                 </div>
@@ -3413,10 +3504,38 @@ function App() {
                         ? html`
                             <label className="field">
                               <span>${t("roleLabel")}</span>
-                              <input value=${agentDraft.role || "worker"} readOnly disabled />
+                              <select
+                                value=${agentDraft.role || "worker"}
+                                onChange=${(event) => {
+                                  const role = event.target.value;
+                                  let next = {
+                                    ...agentDraft,
+                                    role,
+                                    notifier_delivery_mode: agentDraft.notifier_delivery_mode || "webhook",
+                                    notifier_webhook_token: agentDraft.notifier_webhook_token || "",
+                                    notifier_remote_url: agentDraft.notifier_remote_url || "",
+                                    notifier_remote_subscription_id: agentDraft.notifier_remote_subscription_id || "",
+                                    notifier_poll_interval: agentDraft.notifier_poll_interval || "30s",
+                                    notifier_remote_token: agentDraft.notifier_remote_token || "",
+                                  };
+                                  next = ensureNotifierPullSubscriptionDraft(next);
+                                  setAgentDraft(next);
+                                  if (role !== "notifier") {
+                                    loadAgentModels(next, { silent: true });
+                                  }
+                                }}
+                              >
+                                <option value="worker">${t("roles.worker")}</option>
+                                <option value="notifier">${t("roles.notifier")}</option>
+                              </select>
                             </label>
                           `
-                        : null}
+                        : html`
+                            <label className="field">
+                              <span>${t("roleLabel")}</span>
+                              <input value=${localizeRole(agentDraft.role || "worker", t)} readOnly disabled />
+                            </label>
+                          `}
                       <label className="field">
                         <span>${t("profileRuntimeKind")}</span>
                         ${agentModalMode === "create"
@@ -3449,62 +3568,158 @@ function App() {
                       </label>
                     </div>
                   </section>
-                  <section className="profile-section">
-                    <div className="profile-section-title">${t("profileModelSection")}</div>
-                    <div className="profile-runtime-grid">
-                      <label className="field">
-                        <span>${t("profileProvider")}</span>
-                        <select
-                          value=${agentDraft.provider}
-                          onChange=${(event) => {
-                            const next = { ...agentDraft, provider: event.target.value, model_id: "" };
-                            setAgentDraft(next);
-                            setAgentModels([]);
-                          }}
-                        >
-                          ${["csghub_lite", "codex", "claude_code", "api"].map((provider) => html`
-                            <option key=${provider} value=${provider}>${formatProviderLabel(provider)}</option>
-                          `)}
-                        </select>
-                      </label>
-                      <label className="field">
-                        ${requiredFieldLabel(t("profileModel"))}
-                        <select
-                          value=${agentDraft.model_id}
-                          required
-                          aria-required="true"
-                          onChange=${(event) => setAgentDraft({ ...agentDraft, model_id: event.target.value })}
-                        >
-                          <option value="">${agentModelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
-                          ${agentModels.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
-                          ${agentDraft.model_id && !agentModels.includes(agentDraft.model_id)
-                            ? html`<option value=${agentDraft.model_id}>${agentDraft.model_id}</option>`
-                            : null}
-                        </select>
-                      </label>
-                      <label className="field">
-                        <span>${t("profileReasoning")}</span>
-                        <select
-                          value=${agentDraft.reasoning_effort}
-                          onChange=${(event) => setAgentDraft({ ...agentDraft, reasoning_effort: event.target.value })}
-                        >
-                          ${["low", "medium", "high", "xhigh"].map((effort) => html`<option key=${effort} value=${effort}>${effort}</option>`)}
-                        </select>
-                      </label>
-                      <label className="selection-item compact-toggle-row">
-                        <input type="checkbox" checked=${agentDraft.enable_fast_mode} onChange=${() => setAgentDraft({ ...agentDraft, enable_fast_mode: !agentDraft.enable_fast_mode })} />
-                        <span>${t("profileFastMode")}</span>
-                      </label>
-                    </div>
-                    <${CLIProxyAuthControl}
-                      provider=${agentDraft.provider}
-                      t=${t}
-                      status=${cliproxyAuthStatuses[normalizeAuthProviderName(agentDraft.provider)]}
-                      busy=${cliproxyAuthBusy === normalizeAuthProviderName(agentDraft.provider)}
-                      onLogin=${loginCLIProxyProvider}
-                    />
-                  </section>
-                  ${agentDraft.provider === "api"
+                  ${agentDraft.role !== "notifier"
+                    ? html`
+                        <section className="profile-section">
+                          <div className="profile-section-title">${t("profileModelSection")}</div>
+                          <div className="profile-runtime-grid">
+                            <label className="field">
+                              <span>${t("profileProvider")}</span>
+                              <select
+                                value=${agentDraft.provider}
+                                onChange=${(event) => {
+                                  const next = { ...agentDraft, provider: event.target.value, model_id: "" };
+                                  setAgentDraft(next);
+                                  setAgentModels([]);
+                                }}
+                              >
+                                ${["csghub_lite", "codex", "claude_code", "api"].map((provider) => html`
+                                  <option key=${provider} value=${provider}>${formatProviderLabel(provider)}</option>
+                                `)}
+                              </select>
+                            </label>
+                            <label className="field">
+                              ${requiredFieldLabel(t("profileModel"))}
+                              <select
+                                value=${agentDraft.model_id}
+                                required
+                                aria-required="true"
+                                onChange=${(event) => setAgentDraft({ ...agentDraft, model_id: event.target.value })}
+                              >
+                                <option value="">${agentModelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
+                                ${agentModels.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
+                                ${agentDraft.model_id && !agentModels.includes(agentDraft.model_id)
+                                  ? html`<option value=${agentDraft.model_id}>${agentDraft.model_id}</option>`
+                                  : null}
+                              </select>
+                            </label>
+                            <label className="field">
+                              <span>${t("profileReasoning")}</span>
+                              <select
+                                value=${agentDraft.reasoning_effort}
+                                onChange=${(event) => setAgentDraft({ ...agentDraft, reasoning_effort: event.target.value })}
+                              >
+                                ${["low", "medium", "high", "xhigh"].map((effort) => html`<option key=${effort} value=${effort}>${effort}</option>`)}
+                              </select>
+                            </label>
+                            <label className="selection-item compact-toggle-row">
+                              <input type="checkbox" checked=${agentDraft.enable_fast_mode} onChange=${() => setAgentDraft({ ...agentDraft, enable_fast_mode: !agentDraft.enable_fast_mode })} />
+                              <span>${t("profileFastMode")}</span>
+                            </label>
+                          </div>
+                          <${CLIProxyAuthControl}
+                            provider=${agentDraft.provider}
+                            t=${t}
+                            status=${cliproxyAuthStatuses[normalizeAuthProviderName(agentDraft.provider)]}
+                            busy=${cliproxyAuthBusy === normalizeAuthProviderName(agentDraft.provider)}
+                            onLogin=${loginCLIProxyProvider}
+                          />
+                        </section>
+                      `
+                    : html`
+                        <section className="profile-section">
+                          <div className="profile-section-title">${t("profileNotifierSection")}</div>
+                          <div className="profile-grid profile-grid-compact">
+                            <label className="field span-2">
+                              <span>${t("notifierDeliveryMode")}</span>
+                              <select
+                                value=${agentDraft.notifier_delivery_mode || "webhook"}
+                                onChange=${(event) => {
+                                  const notifier_delivery_mode = event.target.value;
+                                  let next = { ...agentDraft, notifier_delivery_mode };
+                                  next = ensureNotifierPullSubscriptionDraft(next);
+                                  setAgentDraft(next);
+                                }}
+                              >
+                                ${NOTIFIER_DELIVERY_OPTIONS.map(
+                                  (mode) => html`
+                                    <option key=${mode} value=${mode}>
+                                      ${mode === "webhook" ? t("notifierDeliveryWebhook") : t("notifierDeliveryRemotePull")}
+                                    </option>
+                                  `,
+                                )}
+                              </select>
+                            </label>
+                            ${agentDraft.notifier_delivery_mode === "webhook"
+                              ? html`
+                                  <label className="field span-2">
+                                    ${requiredFieldLabel(t("notifierWebhookToken"))}
+                                    <div style=${{ display: "flex", gap: "8px", alignItems: "stretch", flexWrap: "wrap" }}>
+                                      <input
+                                        style=${{ flex: "1 1 200px", minWidth: 0 }}
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value=${agentDraft.notifier_webhook_token || ""}
+                                        onInput=${(event) => setAgentDraft({ ...agentDraft, notifier_webhook_token: event.target.value })}
+                                        placeholder=${t("profileAPIKeyNewPlaceholder")}
+                                      />
+                                      <${ClipboardCopyButton} text=${agentDraft.notifier_webhook_token || ""} label=${t("copyToClipboard")} />
+                                    </div>
+                                    <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierWebhookTokenHint")}</small>
+                                  </label>
+                                  ${notifierPushWebhookSection(t, {
+                                    webhookOrigin: notifierModalWebhookOrigin,
+                                    setWebhookOrigin: setNotifierModalWebhookOrigin,
+                                    agentID: notifierModalWebhookAgentID(agentModalMode, editingAgent, agentDraft),
+                                    token: agentDraft.notifier_webhook_token || "",
+                                  })}
+                                `
+                              : null}
+                            ${agentDraft.notifier_delivery_mode === "remote_pull"
+                              ? html`
+                                  <label className="field span-2">
+                                    ${requiredFieldLabel(t("notifierRemoteURL"))}
+                                    <input
+                                      value=${agentDraft.notifier_remote_url || ""}
+                                      onInput=${(event) => setAgentDraft({ ...agentDraft, notifier_remote_url: event.target.value })}
+                                      placeholder=${t("notifierRemoteURLPlaceholder")}
+                                    />
+                                    <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierRemoteURLHint")}</small>
+                                  </label>
+                                  <label className="field">
+                                    <span>${t("notifierSubscriptionID")}</span>
+                                    <input
+                                      value=${agentDraft.notifier_remote_subscription_id || ""}
+                                      readOnly
+                                      disabled
+                                      title=${t("notifierSubscriptionIDHint")}
+                                    />
+                                    <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierSubscriptionIDHint")}</small>
+                                  </label>
+                                  ${notifierThirdPartyPasteUrlRow(agentDraft, t)}
+                                  <label className="field">
+                                    <span>${t("notifierPollInterval")}</span>
+                                    <input
+                                      value=${agentDraft.notifier_poll_interval || "30s"}
+                                      onInput=${(event) => setAgentDraft({ ...agentDraft, notifier_poll_interval: event.target.value })}
+                                      placeholder=${t("notifierPollIntervalPlaceholder")}
+                                    />
+                                  </label>
+                                  <label className="field span-2">
+                                    <span>${t("notifierRemoteToken")}</span>
+                                    <input
+                                      type="password"
+                                      autoComplete="new-password"
+                                      value=${agentDraft.notifier_remote_token || ""}
+                                      onInput=${(event) => setAgentDraft({ ...agentDraft, notifier_remote_token: event.target.value })}
+                                    />
+                                  </label>
+                                `
+                              : null}
+                          </div>
+                        </section>
+                      `}
+                  ${agentDraft.role !== "notifier" && agentDraft.provider === "api"
                     ? html`
                         <section className="profile-section">
                           <div className="profile-section-title">${t("profileAPIProvider")}</div>
@@ -3536,10 +3751,14 @@ function App() {
                   <section className="profile-section">
                     <div className="profile-section-title">${t("profileAdvanced")}</div>
                     <div className="profile-advanced-grid">
-                      <label className="field">
-                        <span>${t("profileRequestOptions")}</span>
-                        <textarea className="compact-json" value=${agentDraft.requestOptionsText} onInput=${(event) => setAgentDraft({ ...agentDraft, requestOptionsText: event.target.value })} />
-                      </label>
+                      ${agentDraft.role !== "notifier"
+                        ? html`
+                            <label className="field">
+                              <span>${t("profileRequestOptions")}</span>
+                              <textarea className="compact-json" value=${agentDraft.requestOptionsText} onInput=${(event) => setAgentDraft({ ...agentDraft, requestOptionsText: event.target.value })} />
+                            </label>
+                          `
+                        : null}
                       <div className="field">
                         <span>${t("profileEnv")}</span>
                         <${EnvKeyValueEditor}
@@ -3547,6 +3766,9 @@ function App() {
                           t=${t}
                           onChange=${(rows) => setAgentDraft({ ...agentDraft, envRows: rows })}
                         />
+                        ${agentDraft.role === "notifier"
+                          ? html`<small style=${{ opacity: 0.75, display: "block", marginTop: "6px" }}>${t("profileEnvNotifierHint")}</small>`
+                          : null}
                       </div>
                     </div>
                   </section>
@@ -3555,7 +3777,15 @@ function App() {
                 <${AgentCreateProgress} progress=${agentProgress} t=${t} />
                 <div className="modal-actions">
                   <button className="btn btn-secondary-gray btn-sm secondary-button" onClick=${() => setShowAgentModal(false)}>${t("cancel")}</button>
-                  <button className="btn btn-primary btn-sm send-button" disabled=${agentBusy || isBlank(agentDraft.name) || !agentDraft.model_id || profileBaseURLMissing(agentDraft)} onClick=${saveAgent}>
+                  <button
+                    className="btn btn-primary btn-sm send-button"
+                    disabled=${agentBusy ||
+                    isBlank(agentDraft.name) ||
+                    (agentDraft.role === "notifier"
+                      ? !notifierFormIsComplete(agentDraft)
+                      : !agentDraft.model_id || profileBaseURLMissing(agentDraft))}
+                    onClick=${saveAgent}
+                  >
                     ${agentBusy ? "..." : agentModalMode === "create" ? t("agentCreateSave") : t("agentUpdateSave")}
                   </button>
                 </div>
@@ -3982,7 +4212,31 @@ function WorkspaceConversationRow({ conversation, active, currentUserID, usersBy
   `;
 }
 
-function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, modelBusy, saving, saveError, authStatuses, authBusyProvider, onDraftChange, onSave, onProviderLogin, onStart, onStop, onRecreate, onDelete, onInvite, onOpenDM }) {
+function AgentDetailPane({
+  item,
+  t,
+  activeRoom,
+  busyKey,
+  error,
+  draft,
+  models,
+  modelBusy,
+  saving,
+  saveError,
+  authStatuses,
+  authBusyProvider,
+  notifierWebhookOrigin,
+  setNotifierWebhookOrigin,
+  onDraftChange,
+  onSave,
+  onProviderLogin,
+  onStart,
+  onStop,
+  onRecreate,
+  onDelete,
+  onInvite,
+  onOpenDM,
+}) {
   const isManager = item.role === "manager" || item.id === "u-manager";
   const running = isAgentRunning(item);
   const incomplete = isAgentIncomplete(item);
@@ -4005,7 +4259,9 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
       <div className="entity-toolbar">
         <button
           className="btn btn-primary btn-sm preview-action-button preview-action-button-primary"
-          disabled=${saving || isBlank(draft?.name) || !draft?.model_id || profileBaseURLMissing(draft)}
+          disabled=${saving ||
+          isBlank(draft?.name) ||
+          (draft?.role === "notifier" ? !notifierFormIsComplete(draft) : !draft?.model_id || profileBaseURLMissing(draft))}
           onClick=${onSave}
         >
           ${saving ? t("profileLoadingModels") : t("agentUpdateSave")}
@@ -4085,90 +4341,190 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                 </div>
               </section>
 
-              <section className="profile-section">
-                <div className="profile-section-title">${t("profileModelSection")}</div>
-                <div className="profile-runtime-grid">
-                  <label className="field">
-                    <span>${t("profileProvider")}</span>
-                    <select
-                      value=${draft.provider}
-                      onChange=${(event) => updateDraft({ provider: event.target.value, model_id: "" })}
-                    >
-                      ${PROVIDERS.map((provider) => html`<option key=${provider} value=${provider}>${formatProviderLabel(provider)}</option>`)}
-                    </select>
-                  </label>
-                  <label className="field">
-                    ${requiredFieldLabel(t("profileModel"))}
-                    <select
-                      value=${draft.model_id}
-                      required
-                      aria-required="true"
-                      onChange=${(event) => updateDraft({ model_id: event.target.value })}
-                    >
-                      <option value="">${modelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
-                      ${models.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
-                      ${draft.model_id && !models.includes(draft.model_id)
-                        ? html`<option value=${draft.model_id}>${draft.model_id}</option>`
-                        : null}
-                    </select>
-                  </label>
-                  <label className="field">
-                    <span>${t("profileReasoning")}</span>
-                    <select value=${draft.reasoning_effort} onChange=${(event) => updateDraft({ reasoning_effort: event.target.value })}>
-                      ${REASONING_EFFORTS.map((effort) => html`<option key=${effort} value=${effort}>${effort}</option>`)}
-                    </select>
-                  </label>
-                  <label className="selection-item compact-toggle-row">
-                    <input type="checkbox" checked=${draft.enable_fast_mode} onChange=${() => updateDraft({ enable_fast_mode: !draft.enable_fast_mode })} />
-                    <span>${t("profileFastMode")}</span>
-                  </label>
-                </div>
-                <${CLIProxyAuthControl}
-                  provider=${draft.provider}
-                  t=${t}
-                  status=${authStatuses?.[normalizeAuthProviderName(draft.provider)]}
-                  busy=${authBusyProvider === normalizeAuthProviderName(draft.provider)}
-                  onLogin=${onProviderLogin}
-                />
-              </section>
-
-              ${draft.provider === "api"
+              ${draft.role !== "notifier"
                 ? html`
                     <section className="profile-section">
-                      <div className="profile-section-title">${t("profileAPIProvider")}</div>
-                      <div className="profile-api-grid">
+                      <div className="profile-section-title">${t("profileModelSection")}</div>
+                      <div className="profile-runtime-grid">
                         <label className="field">
-                          ${requiredFieldLabel(t("profileBaseURL"))}
-                          <input
-                            value=${draft.base_url}
+                          <span>${t("profileProvider")}</span>
+                          <select
+                            value=${draft.provider}
+                            onChange=${(event) => updateDraft({ provider: event.target.value, model_id: "" })}
+                          >
+                            ${PROVIDERS.map((provider) => html`<option key=${provider} value=${provider}>${formatProviderLabel(provider)}</option>`)}
+                          </select>
+                        </label>
+                        <label className="field">
+                          ${requiredFieldLabel(t("profileModel"))}
+                          <select
+                            value=${draft.model_id}
                             required
                             aria-required="true"
-                            onInput=${(event) => updateDraft({ base_url: event.target.value })}
-                            placeholder="https://api.openai.com/v1"
-                          />
+                            onChange=${(event) => updateDraft({ model_id: event.target.value })}
+                          >
+                            <option value="">${modelBusy ? t("profileLoadingModels") : t("profileSelectModel")}</option>
+                            ${models.map((model) => html`<option key=${model} value=${model}>${model}</option>`)}
+                            ${draft.model_id && !models.includes(draft.model_id)
+                              ? html`<option value=${draft.model_id}>${draft.model_id}</option>`
+                              : null}
+                          </select>
                         </label>
-                        <${APIKeyField}
-                          value=${draft.api_key}
-                          onInput=${(event) => updateDraft({ api_key: event.target.value })}
-                          profile=${draft}
-                          t=${t}
-                        />
-                        <label className="field span-2">
-                          <span>${t("profileHeaders")}</span>
-                          <textarea className="compact-textarea" value=${draft.headersText} onInput=${(event) => updateDraft({ headersText: event.target.value })} />
+                        <label className="field">
+                          <span>${t("profileReasoning")}</span>
+                          <select value=${draft.reasoning_effort} onChange=${(event) => updateDraft({ reasoning_effort: event.target.value })}>
+                            ${REASONING_EFFORTS.map((effort) => html`<option key=${effort} value=${effort}>${effort}</option>`)}
+                          </select>
+                        </label>
+                        <label className="selection-item compact-toggle-row">
+                          <input type="checkbox" checked=${draft.enable_fast_mode} onChange=${() => updateDraft({ enable_fast_mode: !draft.enable_fast_mode })} />
+                          <span>${t("profileFastMode")}</span>
                         </label>
                       </div>
+                      <${CLIProxyAuthControl}
+                        provider=${draft.provider}
+                        t=${t}
+                        status=${authStatuses?.[normalizeAuthProviderName(draft.provider)]}
+                        busy=${authBusyProvider === normalizeAuthProviderName(draft.provider)}
+                        onLogin=${onProviderLogin}
+                      />
                     </section>
+
+                    ${draft.provider === "api"
+                      ? html`
+                          <section className="profile-section">
+                            <div className="profile-section-title">${t("profileAPIProvider")}</div>
+                            <div className="profile-api-grid">
+                              <label className="field">
+                                ${requiredFieldLabel(t("profileBaseURL"))}
+                                <input
+                                  value=${draft.base_url}
+                                  required
+                                  aria-required="true"
+                                  onInput=${(event) => updateDraft({ base_url: event.target.value })}
+                                  placeholder="https://api.openai.com/v1"
+                                />
+                              </label>
+                              <${APIKeyField}
+                                value=${draft.api_key}
+                                onInput=${(event) => updateDraft({ api_key: event.target.value })}
+                                profile=${draft}
+                                t=${t}
+                              />
+                              <label className="field span-2">
+                                <span>${t("profileHeaders")}</span>
+                                <textarea className="compact-textarea" value=${draft.headersText} onInput=${(event) => updateDraft({ headersText: event.target.value })} />
+                              </label>
+                            </div>
+                          </section>
+                        `
+                      : null}
                   `
-                : null}
+                : html`
+                    <section className="profile-section">
+                      <div className="profile-section-title">${t("profileNotifierSection")}</div>
+                      <div className="profile-grid profile-grid-compact">
+                        <label className="field span-2">
+                          <span>${t("notifierDeliveryMode")}</span>
+                          <select
+                            value=${draft.notifier_delivery_mode || "webhook"}
+                            onChange=${(event) => {
+                              const notifier_delivery_mode = event.target.value;
+                              let next = { ...(draft || agentToDraft(item)), notifier_delivery_mode };
+                              next = ensureNotifierPullSubscriptionDraft(next);
+                              onDraftChange(next);
+                            }}
+                          >
+                            ${NOTIFIER_DELIVERY_OPTIONS.map(
+                              (mode) => html`
+                                <option key=${mode} value=${mode}>
+                                  ${mode === "webhook" ? t("notifierDeliveryWebhook") : t("notifierDeliveryRemotePull")}
+                                </option>
+                              `,
+                            )}
+                          </select>
+                        </label>
+                        ${draft.notifier_delivery_mode === "webhook"
+                          ? html`
+                              <label className="field span-2">
+                                ${requiredFieldLabel(t("notifierWebhookToken"))}
+                                <div style=${{ display: "flex", gap: "8px", alignItems: "stretch", flexWrap: "wrap" }}>
+                                  <input
+                                    style=${{ flex: "1 1 200px", minWidth: 0 }}
+                                    type="password"
+                                    autoComplete="new-password"
+                                    value=${draft.notifier_webhook_token || ""}
+                                    onInput=${(event) => updateDraft({ notifier_webhook_token: event.target.value })}
+                                    placeholder=${t("profileAPIKeyNewPlaceholder")}
+                                  />
+                                  <${ClipboardCopyButton} text=${draft.notifier_webhook_token || ""} label=${t("copyToClipboard")} />
+                                </div>
+                                <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierWebhookTokenHint")}</small>
+                              </label>
+                              ${notifierPushWebhookSection(t, {
+                                webhookOrigin: notifierWebhookOrigin,
+                                setWebhookOrigin: setNotifierWebhookOrigin,
+                                agentID: item.id,
+                                token: draft.notifier_webhook_token || "",
+                              })}
+                            `
+                          : null}
+                        ${draft.notifier_delivery_mode === "remote_pull"
+                          ? html`
+                              <label className="field span-2">
+                                ${requiredFieldLabel(t("notifierRemoteURL"))}
+                                <input
+                                  value=${draft.notifier_remote_url || ""}
+                                  onInput=${(event) => updateDraft({ notifier_remote_url: event.target.value })}
+                                  placeholder=${t("notifierRemoteURLPlaceholder")}
+                                />
+                                <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierRemoteURLHint")}</small>
+                              </label>
+                              <label className="field">
+                                <span>${t("notifierSubscriptionID")}</span>
+                                <input
+                                  value=${draft.notifier_remote_subscription_id || ""}
+                                  readOnly
+                                  disabled
+                                  title=${t("notifierSubscriptionIDHint")}
+                                />
+                                <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierSubscriptionIDHint")}</small>
+                              </label>
+                              ${notifierThirdPartyPasteUrlRow(draft, t)}
+                              <label className="field">
+                                <span>${t("notifierPollInterval")}</span>
+                                <input
+                                  value=${draft.notifier_poll_interval || "30s"}
+                                  onInput=${(event) => updateDraft({ notifier_poll_interval: event.target.value })}
+                                  placeholder=${t("notifierPollIntervalPlaceholder")}
+                                />
+                              </label>
+                              <label className="field span-2">
+                                <span>${t("notifierRemoteToken")}</span>
+                                <input
+                                  type="password"
+                                  autoComplete="new-password"
+                                  value=${draft.notifier_remote_token || ""}
+                                  onInput=${(event) => updateDraft({ notifier_remote_token: event.target.value })}
+                                />
+                              </label>
+                            `
+                          : null}
+                      </div>
+                    </section>
+                  `}
 
               <section className="profile-section">
                 <div className="profile-section-title">${t("profileAdvanced")}</div>
                 <div className="profile-advanced-grid">
-                  <label className="field">
-                    <span>${t("profileRequestOptions")}</span>
-                    <textarea className="compact-json" value=${draft.requestOptionsText} onInput=${(event) => updateDraft({ requestOptionsText: event.target.value })} />
-                  </label>
+                  ${draft.role !== "notifier"
+                    ? html`
+                        <label className="field">
+                          <span>${t("profileRequestOptions")}</span>
+                          <textarea className="compact-json" value=${draft.requestOptionsText} onInput=${(event) => updateDraft({ requestOptionsText: event.target.value })} />
+                        </label>
+                      `
+                    : null}
                   <div className="field">
                     <span>${t("profileEnv")}</span>
                     <${EnvKeyValueEditor}
@@ -4176,6 +4532,9 @@ function AgentDetailPane({ item, t, activeRoom, busyKey, error, draft, models, m
                       t=${t}
                       onChange=${(rows) => updateDraft({ envRows: rows })}
                     />
+                    ${draft.role === "notifier"
+                      ? html`<small style=${{ opacity: 0.75, display: "block", marginTop: "6px" }}>${t("profileEnvNotifierHint")}</small>`
+                      : null}
                   </div>
                 </div>
               </section>
@@ -4721,7 +5080,213 @@ function normalizeIMData(payload) {
   return { ...payload, rooms: payload.rooms ?? [] };
 }
 
+// UI: push = webhook, pull = remote_pull. Legacy API value "both" is treated as webhook for editing.
+function normalizeNotifierDeliveryMode(mode) {
+  const m = String(mode || "").trim().toLowerCase();
+  if (m === "remote_pull") {
+    return "remote_pull";
+  }
+  return "webhook";
+}
+
+/** Fills notifier_remote_subscription_id when role is notifier and mode is remote_pull and id is empty. */
+function ensureNotifierPullSubscriptionDraft(draft) {
+  if (!draft || draft.role !== "notifier" || draft.notifier_delivery_mode !== "remote_pull") {
+    return draft;
+  }
+  if (String(draft.notifier_remote_subscription_id || "").trim()) {
+    return draft;
+  }
+  return { ...draft, notifier_remote_subscription_id: newNotifierSubscriptionId() };
+}
+
+function newNotifierSubscriptionId() {
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return `sub-${Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")}`;
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `sub-${crypto.randomUUID().replace(/-/g, "")}`;
+  }
+  return `sub-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 14)}`;
+}
+
+function notifierPushWebhookPathForAgent(agentID) {
+  const id = String(agentID || "").trim();
+  if (!id) {
+    return "/api/v1/agents/<agent_id>/webhooks/notify";
+  }
+  return `/api/v1/agents/${encodeURIComponent(id)}/webhooks/notify`;
+}
+
+function notifierPushWebhookNotifyURL(originTrimmed, agentID, webhookToken, placeholderHost) {
+  const ph = String(placeholderHost || "https://<your-csgclaw-host>").trim();
+  let o = String(originTrimmed ?? "").trim().replace(/\/+$/, "");
+  if (!o) {
+    o = ph;
+  }
+  const path = notifierPushWebhookPathForAgent(agentID);
+  const tok = String(webhookToken ?? "").trim();
+  let url = `${o}${path}`;
+  if (tok) {
+    const sep = url.includes("?") ? "&" : "?";
+    url += `${sep}token=${encodeURIComponent(tok)}`;
+  }
+  return url;
+}
+
+function notifierModalWebhookAgentID(agentModalMode, editingAgent, agentDraft) {
+  if (agentModalMode === "edit" && editingAgent?.id) {
+    return editingAgent.id;
+  }
+  if (agentModalMode === "create" && agentDraft?.role === "notifier") {
+    return "";
+  }
+  return String(agentDraft?.agent_id || "").trim();
+}
+
+/** Third-party relay Webhook URL with subscription_id. Origin-only → ingress path; …/inbox/messages → …/webhooks/ingress. Scheme-less localhost / 127.0.0.1 / ::1 use http. */
+function notifierThirdPartyRelayWebhookURL(remoteBase, subscriptionId) {
+  const b = String(remoteBase ?? "").trim();
+  const sid = String(subscriptionId ?? "").trim();
+  if (!b || !sid) {
+    return "";
+  }
+  let input = b;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(input)) {
+    const local =
+      /^(localhost|127\.0\.0\.1|\[::1\])(:|\/?|\?|$)/i.test(input) || /^\[::1\]/i.test(input);
+    input = `${local ? "http" : "https"}://${input.replace(/^\/+/, "")}`;
+  }
+  let u;
+  try {
+    u = new URL(input);
+  } catch {
+    const joiner = b.includes("?") ? "&" : "?";
+    return `${b}${joiner}subscription_id=${encodeURIComponent(sid)}`;
+  }
+  const segments = u.pathname.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    u.pathname = NOTIFIER_RELAY_WEBHOOK_INGRESS_PATH;
+  } else if (/\/inbox\/messages\/?$/i.test(u.pathname)) {
+    u.pathname = u.pathname.replace(/\/inbox\/messages\/?$/i, "/webhooks/ingress");
+  }
+  u.searchParams.set("subscription_id", sid);
+  return u.toString();
+}
+
+async function copyTextToClipboard(text) {
+  const s = String(text ?? "");
+  if (!s) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(s);
+  } catch {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = s;
+      ta.style.position = "fixed";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function ClipboardCopyButton({ text, label, className, disabled }) {
+  const [copied, setCopied] = React.useState(false);
+  const timerRef = React.useRef(null);
+  React.useEffect(
+    () => () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+  async function onClick() {
+    if (disabled || !String(text ?? "").trim()) {
+      return;
+    }
+    await copyTextToClipboard(text);
+    setCopied(true);
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+    }
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      setCopied(false);
+    }, 2000);
+  }
+  const busy = Boolean(disabled) || !String(text ?? "").trim();
+  const btnClass = className || "btn btn-secondary-gray btn-sm";
+  return html`
+    <button
+      type="button"
+      className=${btnClass}
+      disabled=${busy}
+      style=${copied ? { background: "#16a34a", color: "#fff", borderColor: "transparent" } : undefined}
+      onClick=${onClick}
+    >
+      ${copied ? "✓" : label}
+    </button>
+  `;
+}
+
+function notifierPushWebhookSection(t, { webhookOrigin, setWebhookOrigin, agentID, token }) {
+  const ph = t("notifierWebhookOriginPlaceholder");
+  const full = notifierPushWebhookNotifyURL(webhookOrigin, agentID, token, ph);
+  return html`
+    <label className="field span-2">
+      <span>${t("notifierWebhookPublicOrigin")}</span>
+      <input
+        value=${webhookOrigin}
+        placeholder=${t("notifierWebhookPublicOriginPlaceholder")}
+        onInput=${(event) => setWebhookOrigin(event.target.value)}
+      />
+      <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierWebhookPublicOriginHint")}</small>
+    </label>
+    <label className="field span-2">
+      <span>${t("notifierThirdPartyCSGWebhookURL")}</span>
+      <div style=${{ display: "flex", gap: "8px", alignItems: "stretch", flexWrap: "wrap" }}>
+        <input style=${{ flex: "1 1 220px", minWidth: 0 }} readOnly value=${full} />
+        <${ClipboardCopyButton} text=${full} label=${t("copyToClipboard")} />
+      </div>
+      <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierThirdPartyCSGWebhookURLHint")}</small>
+    </label>
+  `;
+}
+
+function notifierThirdPartyPasteUrlRow(draft, t) {
+  const paste = notifierThirdPartyRelayWebhookURL(draft?.notifier_remote_url, draft?.notifier_remote_subscription_id);
+  if (!paste) {
+    return null;
+  }
+  return html`
+    <label className="field span-2">
+      <span>${t("notifierThirdPartyWebhookPasteURL")}</span>
+      <div style=${{ display: "flex", gap: "8px", alignItems: "stretch", flexWrap: "wrap" }}>
+        <input style=${{ flex: "1 1 200px", minWidth: 0 }} readOnly value=${paste} />
+        <${ClipboardCopyButton} text=${paste} label=${t("copyToClipboard")} />
+      </div>
+      <small style=${{ opacity: 0.75, display: "block", marginTop: "4px" }}>${t("notifierThirdPartyWebhookPasteURLHint")}</small>
+    </label>
+  `;
+}
+
 function profileToDraft(profile) {
+  const ro =
+    profile?.request_options && typeof profile.request_options === "object" && !Array.isArray(profile.request_options)
+      ? profile.request_options
+      : {};
+  const notifier = ro.notifier && typeof ro.notifier === "object" ? ro.notifier : {};
+  const { notifier: _n, ...restRO } = ro;
   return {
     runtime_kind: normalizeRuntimeKind(profile?.runtime_kind),
     provider: profile?.provider || "csghub_lite",
@@ -4733,8 +5298,14 @@ function profileToDraft(profile) {
     reasoning_effort: profile?.reasoning_effort || "medium",
     enable_fast_mode: Boolean(profile?.enable_fast_mode),
     headersText: stringifyJSON(profile?.headers || {}),
-    requestOptionsText: stringifyJSON(profile?.request_options || {}),
+    requestOptionsText: stringifyJSON(restRO),
     envRows: mapToEnvRows(profile?.env || {}),
+    notifier_delivery_mode: normalizeNotifierDeliveryMode(notifier.delivery_mode || "webhook"),
+    notifier_webhook_token: notifier.webhook_token || "",
+    notifier_remote_url: notifier.remote_url || "",
+    notifier_remote_subscription_id: notifier.remote_subscription_id || "",
+    notifier_poll_interval: notifier.poll_interval || "30s",
+    notifier_remote_token: notifier.remote_token || "",
   };
 }
 
@@ -4765,7 +5336,24 @@ function agentToDraft(agent) {
   };
 }
 
+function mergeNotifierRequestOptions(parsed, draft) {
+  const base = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? { ...parsed } : {};
+  base.notifier = {
+    delivery_mode: normalizeNotifierDeliveryMode(draft.notifier_delivery_mode || "webhook"),
+    webhook_token: String(draft.notifier_webhook_token ?? "").trim(),
+    remote_url: String(draft.notifier_remote_url ?? "").trim(),
+    remote_subscription_id: String(draft.notifier_remote_subscription_id ?? "").trim(),
+    poll_interval: String(draft.notifier_poll_interval ?? "30s").trim(),
+    remote_token: String(draft.notifier_remote_token ?? "").trim(),
+  };
+  return base;
+}
+
 function draftToProfile(draft, options = {}) {
+  let request_options = parseJSONMap(draft.requestOptionsText);
+  if (draft.role === "notifier") {
+    request_options = mergeNotifierRequestOptions(request_options, draft);
+  }
   return {
     name: options.name || draft.name || "manager",
     description: options.description || draft.description || "Manager Worker Dispatch",
@@ -4776,9 +5364,23 @@ function draftToProfile(draft, options = {}) {
     reasoning_effort: draft.reasoning_effort || "medium",
     enable_fast_mode: Boolean(draft.enable_fast_mode),
     headers: parseJSONMap(draft.headersText),
-    request_options: parseJSONMap(draft.requestOptionsText),
+    request_options,
     env: envRowsToMap(draft.envRows),
   };
+}
+
+function notifierFormIsComplete(draft) {
+  if (!draft || draft.role !== "notifier") {
+    return true;
+  }
+  const mode = normalizeNotifierDeliveryMode(draft.notifier_delivery_mode || "webhook");
+  if (mode === "webhook" && isBlank(draft.notifier_webhook_token)) {
+    return false;
+  }
+  if (mode === "remote_pull" && isBlank(draft.notifier_remote_url)) {
+    return false;
+  }
+  return true;
 }
 
 function mapToEnvRows(value) {


### PR DESCRIPTION
Add notifier agent role with request_options-backed config, relay client, and a pull worker for remote_pull delivery. Expose POST /api/v1/agents/{id}/webhooks/notify with token checks and deliver Markdown to every IM room that lists the agent as a member (RoomIDsForMember). Wire agent/bot models, services, server startup, and Web UI. Document the webhook endpoint in docs/api.md as HTTP-only API semantics without a separate notifier profile doc.