### PR TITLE
Polish Hub workspace browser UI

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -801,6 +801,31 @@ function StopIcon() {
   return IconImage("stop");
 }
 
+function WorkspaceFileIcon() {
+  return html`
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M8.16634 1.45817C8.16634 2.58384 8.16634 3.14668 8.38433 3.5745C8.57608 3.95083 8.88204 4.25679 9.25836 4.44853C9.68618 4.66652 10.249 4.66652 11.3747 4.66652M11.6663 5.40865V9.63317C11.6663 10.7533 11.6663 11.3133 11.4484 11.7412C11.2566 12.1175 10.9506 12.4234 10.5743 12.6152C10.1465 12.8332 9.58645 12.8332 8.46634 12.8332H5.53301C4.4129 12.8332 3.85285 12.8332 3.42503 12.6152C3.0487 12.4234 2.74274 12.1175 2.55099 11.7412C2.33301 11.3133 2.33301 10.7533 2.33301 9.63317V4.36651C2.33301 3.2464 2.33301 2.68635 2.55099 2.25852C2.74274 1.8822 3.0487 1.57624 3.42503 1.38449C3.85285 1.1665 4.4129 1.1665 5.53301 1.1665H7.42419C7.91337 1.1665 8.15796 1.1665 8.38814 1.22176C8.59221 1.27076 8.7873 1.35157 8.96624 1.46122C9.16808 1.58491 9.34103 1.75786 9.68693 2.10376L10.7291 3.14591C11.075 3.49182 11.2479 3.66477 11.3716 3.8666C11.4813 4.04555 11.5621 4.24063 11.6111 4.44471C11.6663 4.67488 11.6663 4.91947 11.6663 5.40865Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  `;
+}
+
+function WorkspaceDirIcon() {
+  return html`
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M3.52949 0.729004C2.5494 0.729004 2.05935 0.729004 1.68501 0.919743C1.35573 1.08752 1.08801 1.35524 0.920231 1.68452C0.729492 2.05887 0.729492 2.54891 0.729492 3.52901V9.53734C0.729492 10.8441 0.729492 11.4975 0.98381 11.9966C1.20751 12.4357 1.56447 12.7926 2.00351 13.0164C2.50264 13.2707 3.15604 13.2707 4.46283 13.2707H9.53783C10.8446 13.2707 11.498 13.2707 11.9971 13.0164C12.4362 12.7926 12.7931 12.4357 13.0168 11.9966C13.2712 11.4975 13.2712 10.8441 13.2712 9.53734V6.79567C13.2712 5.48888 13.2712 4.83549 13.0168 4.33636C12.7931 3.89731 12.4362 3.54036 11.9971 3.31666C11.498 3.06234 10.8446 3.06234 9.53783 3.06234H8.89755C8.58581 3.06234 8.42993 3.06234 8.2892 3.02677C8.05664 2.96799 7.84784 2.83894 7.69126 2.65722C7.59651 2.54725 7.5268 2.40784 7.38738 2.129C7.17826 1.71076 7.0737 1.50163 6.93157 1.33668C6.6967 1.06409 6.3835 0.870531 6.03465 0.782358C5.82356 0.729004 5.58975 0.729004 5.12213 0.729004H3.52949Z" fill="currentColor"/>
+    </svg>
+  `;
+}
+
+function HubPreviewEmptyIcon() {
+  return html`
+    <svg className="hub-preview-empty-icon" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path opacity="0.12" d="M5.33337 13.3337V18.667C5.33337 22.4007 5.33337 24.2675 6.06 25.6936C6.69915 26.948 7.71902 27.9679 8.97344 28.607C10.3995 29.3337 12.2664 29.3337 16 29.3337C19.7337 29.3337 21.6006 29.3337 23.0266 28.607C24.2811 27.9679 25.3009 26.948 25.9401 25.6936C26.6667 24.2675 26.6667 22.4007 26.6667 18.667V12.8003C26.6667 12.0536 26.6667 11.6802 26.5214 11.395C26.3936 11.1441 26.1896 10.9401 25.9387 10.8123C25.6535 10.667 25.2801 10.667 24.5334 10.667H22.9334C21.4399 10.667 20.6932 10.667 20.1227 10.3763C19.621 10.1207 19.213 9.71273 18.9574 9.21097C18.6667 8.64054 18.6667 7.8938 18.6667 6.40033V4.80033C18.6667 4.05359 18.6667 3.68022 18.5214 3.395C18.3936 3.14412 18.1896 2.94015 17.9387 2.81232C17.6535 2.66699 17.2801 2.66699 16.5334 2.66699H16C12.2664 2.66699 10.3995 2.66699 8.97344 3.39362C7.71902 4.03277 6.69915 5.05264 6.06 6.30706C5.33337 7.73313 5.33337 9.59997 5.33337 13.3337Z" fill="#4D6AD6"/>
+      <path d="M18.6667 3.33366V6.40037C18.6667 7.89384 18.6667 8.64058 18.9574 9.21101C19.213 9.71277 19.621 10.1207 20.1227 10.3764C20.6932 10.667 21.4399 10.667 22.9334 10.667H26M12 16.0003H20M12 21.3337H17.3334M26.6667 11.9846V22.9337C26.6667 25.1739 26.6667 26.294 26.2307 27.1496C25.8472 27.9023 25.2353 28.5142 24.4827 28.8977C23.627 29.3337 22.5069 29.3337 20.2667 29.3337H11.7334C9.49317 29.3337 8.37306 29.3337 7.51741 28.8977C6.76476 28.5142 6.15284 27.9023 5.76935 27.1496C5.33337 26.294 5.33337 25.1739 5.33337 22.9337V9.06699C5.33337 6.82678 5.33337 5.70668 5.76935 4.85103C6.15284 4.09838 6.76476 3.48646 7.51741 3.10297C8.37306 2.66699 9.49316 2.66699 11.7334 2.66699H17.3491C18.3274 2.66699 18.8166 2.66699 19.277 2.77751C19.6851 2.8755 20.0753 3.03712 20.4332 3.25643C20.8368 3.5038 21.1828 3.8497 21.8746 4.54151L24.7922 7.45914C25.484 8.15095 25.8299 8.49685 26.0773 8.90052C26.2966 9.25841 26.4582 9.64859 26.5562 10.0567C26.6667 10.5171 26.6667 11.0063 26.6667 11.9846Z" stroke="#4D6AD6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  `;
+}
+
 function paneFromLocation(pathname = window.location.pathname) {
   const parts = String(pathname || "/").split("/").filter(Boolean).map(decodePathSegment);
   const section = parts[0] || "";
@@ -3078,7 +3103,7 @@ function App() {
                                       <span className="workspace-row-title truncate">${item.name || item.id}</span>
                                       <span className="workspace-row-meta truncate">${item.description || item.source?.name || item.id}</span>
                                     </span>
-                                    <span className="mini-badge template-source-badge">${localizeTemplateSourceTag(item.source?.name, locale)}</span>
+                                    <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(item.source?.name, locale)}</span>
                                   </button>
                                 `)}
                         <//>
@@ -4453,10 +4478,27 @@ function HubDetailPane({
 }) {
   const workspaceEntries = selectedTemplate?.workspace?.entries || [];
   const [collapsedWorkspaceDirs, setCollapsedWorkspaceDirs] = useState({});
+  const [isTemplateListScrolling, setIsTemplateListScrolling] = useState(false);
+  const [isInspectorScrolling, setIsInspectorScrolling] = useState(false);
+  const templateListScrollTimerRef = useRef(null);
+  const inspectorScrollTimerRef = useRef(null);
   const visibleWorkspaceEntries = useMemo(
     () => buildVisibleHubWorkspaceEntries(workspaceEntries, collapsedWorkspaceDirs),
     [workspaceEntries, collapsedWorkspaceDirs],
   );
+  const workspacePreviewText = workspaceFile && !workspaceFile.binary
+    ? (workspaceFile.content || t("hubWorkspaceEmptyFile"))
+    : "";
+  const workspacePreviewLineCount = workspacePreviewText ? workspacePreviewText.split(/\r\n|\r|\n/).length : 0;
+
+  useEffect(() => () => {
+    if (templateListScrollTimerRef.current) {
+      window.clearTimeout(templateListScrollTimerRef.current);
+    }
+    if (inspectorScrollTimerRef.current) {
+      window.clearTimeout(inspectorScrollTimerRef.current);
+    }
+  }, []);
 
   useEffect(() => {
     setCollapsedWorkspaceDirs(buildInitialCollapsedHubWorkspaceDirs(workspaceEntries));
@@ -4490,6 +4532,28 @@ function HubDetailPane({
     }));
   }
 
+  function handleTemplateListScroll() {
+    setIsTemplateListScrolling(true);
+    if (templateListScrollTimerRef.current) {
+      window.clearTimeout(templateListScrollTimerRef.current);
+    }
+    templateListScrollTimerRef.current = window.setTimeout(() => {
+      setIsTemplateListScrolling(false);
+      templateListScrollTimerRef.current = null;
+    }, 900);
+  }
+
+  function handleInspectorScroll() {
+    setIsInspectorScrolling(true);
+    if (inspectorScrollTimerRef.current) {
+      window.clearTimeout(inspectorScrollTimerRef.current);
+    }
+    inspectorScrollTimerRef.current = window.setTimeout(() => {
+      setIsInspectorScrolling(false);
+      inspectorScrollTimerRef.current = null;
+    }, 900);
+  }
+
   return html`
     <section className="entity-pane hub-detail-pane">
       <header className="hub-page-header">
@@ -4516,7 +4580,10 @@ function HubDetailPane({
                     <button type="button" className="hub-filter-tab active">${t("hubAllTab")}</button>
                   </div>
                   <div className="hub-catalog-meta">${formatHubTemplateCount(templates.length, locale, t)}</div>
-                  <div className="hub-template-list">
+                  <div
+                    className=${`hub-template-list ${isTemplateListScrolling ? "is-scrolling" : ""}`}
+                    onScroll=${handleTemplateListScroll}
+                  >
                     ${templates.map((item) => html`
                       <button
                         key=${item.id}
@@ -4531,18 +4598,20 @@ function HubDetailPane({
                           </div>
                           <p>${item.description || item.id}</p>
                           <div className="hub-template-card-meta">
-                            <span className="mini-badge">${item.runtime_kind || item.workspace?.kind || "-"}</span>
-                            <span className="mini-badge template-source-badge">${localizeTemplateSourceTag(item.source?.name, locale)}</span>
+                            <span className="mini-badge template-runtime-badge">${item.runtime_kind || item.workspace?.kind || "-"}</span>
+                            <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(item.source?.name, locale)}</span>
                             <span className="hub-template-card-updated">${t("hubUpdatedAtLabel")} ${formatHubDate(item.updated_at, locale)}</span>
                           </div>
                         </div>
                       </button>
                     `)}
                   </div>
-                  <div className="hub-catalog-end">${t("hubListEnd")}</div>
                 </div>
 
-                <div className="hub-inspector-panel">
+                <div
+                  className=${`hub-inspector-panel ${isInspectorScrolling ? "is-scrolling" : ""}`}
+                  onScroll=${handleInspectorScroll}
+                >
                   ${selectedTemplate ? html`
                     <div className="hub-inspector-hero">
                       <div className="hub-inspector-hero-row">
@@ -4551,8 +4620,8 @@ function HubDetailPane({
                           <div className="hub-inspector-copy">
                             <h2>${selectedTemplate.name || selectedTemplate.id}</h2>
                             <p>${selectedTemplate.description || selectedTemplate.id}</p>
-                            <span className="mini-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
-                            <span className="mini-badge template-source-badge">${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
+                            <span className="mini-badge template-runtime-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
+                            <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
                           </div>
                         </div>
                         <div className="hub-template-actions">
@@ -4613,7 +4682,9 @@ function HubDetailPane({
                                       aria-expanded=${entry.type === "dir" ? String(!collapsed) : undefined}
                                     >
                                       <span className=${`hub-tree-toggle ${entry.type === "file" ? "spacer" : ""} ${collapsed ? "collapsed" : ""}`.trim()} aria-hidden="true"></span>
-                                      <span className="hub-tree-glyph" aria-hidden="true"></span>
+                                      <span className="hub-tree-glyph" aria-hidden="true">
+                                        ${entry.type === "dir" ? html`<${WorkspaceDirIcon} />` : html`<${WorkspaceFileIcon} />`}
+                                      </span>
                                       <span className="hub-tree-label">${entry.name}</span>
                                     </button>
                                   `;
@@ -4626,9 +4697,11 @@ function HubDetailPane({
                               ? html`<div className="workspace-empty">${t("hubWorkspaceFileLoading")}</div>`
                               : !workspaceFile
                                 ? html`
-                                    <div className="hub-preview-empty-icon" aria-hidden="true"></div>
-                                    <strong>${t("hubWorkspacePreviewTitle")}</strong>
-                                    <p>${t("hubWorkspacePreviewHint")}</p>
+                                    <div className="hub-preview-empty-state">
+                                      <${HubPreviewEmptyIcon} />
+                                      <strong>${t("hubWorkspacePreviewTitle")}</strong>
+                                      <p>${t("hubWorkspacePreviewHint")}</p>
+                                    </div>
                                   `
                                 : html`
                                     <div className="hub-preview-file-header">
@@ -4638,7 +4711,12 @@ function HubDetailPane({
                                     <div className="hub-preview-body">
                                       ${workspaceFile.binary
                                         ? html`<div className="workspace-empty">${t("hubWorkspaceBinary")}</div>`
-                                        : html`<pre className="hub-preview-code">${workspaceFile.content || t("hubWorkspaceEmptyFile")}</pre>`}
+                                        : html`
+                                            <div className="hub-preview-code-shell">
+                                              <pre className="hub-preview-line-numbers">${Array.from({ length: workspacePreviewLineCount }, (_, index) => index + 1).join("\n")}</pre>
+                                              <pre className="hub-preview-code">${workspacePreviewText}</pre>
+                                            </div>
+                                          `}
                                     </div>
                                   `}
                         </div>

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -2781,8 +2781,39 @@ body::after {
 }
 
 .template-source-badge {
-  color: var(--primary-strong);
-  background: var(--primary-soft);
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #344054;
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 400;
+  box-shadow: 0 1px 2px 0 rgba(16, 24, 40, 0.05);
+}
+
+.template-source-badge-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #4d6ad6;
+}
+
+.template-runtime-badge {
+  width: fit-content;
+  padding: 2px 6px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #344054;
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 400;
 }
 
 .mini-badge.warn,
@@ -2960,6 +2991,8 @@ body::after {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   gap: 18px;
+  max-height: calc(100dvh - 166px);
+  min-height: 0;
   background: color-mix(in srgb, var(--panel) 78%, white 22%);
 }
 
@@ -2996,13 +3029,42 @@ body::after {
   font-size: 13px;
 }
 
+.hub-template-list,
+.hub-inspector-panel {
+  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
+}
+
 .hub-template-list {
   min-height: 0;
   display: grid;
   align-content: start;
   gap: 14px;
-  overflow: auto;
-  padding-right: 4px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 8px 8px 8px 8px;
+  scrollbar-gutter: stable;
+}
+
+.hub-template-list.is-scrolling,
+.hub-inspector-panel.is-scrolling {
+  scrollbar-color: color-mix(in srgb, var(--muted) 58%, transparent) transparent;
+}
+
+.hub-template-list::-webkit-scrollbar,
+.hub-inspector-panel::-webkit-scrollbar {
+  width: 8px;
+}
+
+.hub-template-list::-webkit-scrollbar-thumb,
+.hub-inspector-panel::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+}
+
+.hub-template-list.is-scrolling::-webkit-scrollbar-thumb,
+.hub-inspector-panel.is-scrolling::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--muted) 44%, transparent);
 }
 
 .hub-template-card {
@@ -3062,7 +3124,19 @@ body::after {
   gap: 8px;
 }
 
-.hub-template-card-title-row h2,
+.hub-inspector-copy .mini-badge {
+  width: max-content;
+  max-width: 100%;
+}
+
+.hub-template-card-title-row h2 {
+  margin: 0;
+  color: color-mix(in srgb, var(--text) 78%, var(--muted) 22%);
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 500;
+}
+
 .hub-inspector-copy h2 {
   margin: 0;
   font-size: 18px;
@@ -3082,8 +3156,8 @@ body::after {
 .hub-template-card-meta {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  justify-content: flex-start;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -3097,9 +3171,12 @@ body::after {
   grid-template-rows: auto auto auto minmax(0, 1fr);
   align-content: stretch;
   gap: 20px;
+  max-height: calc(100dvh - 166px);
   min-height: 0;
   background: color-mix(in srgb, var(--panel) 88%, white 12%);
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 :root[data-theme="dark"] .hub-inspector-panel {
@@ -3158,10 +3235,10 @@ body::after {
 }
 
 .hub-inspector-field strong {
-  color: var(--text);
-  font-size: 15px;
+  color: var(--portal-gray-700);
+  font-size: 14px;
   line-height: 1.5;
-  font-weight: 620;
+  font-weight: 300;
 }
 
 .hub-field-value-multiline {
@@ -3176,73 +3253,69 @@ body::after {
 
 .hub-workspace-block {
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: 0;
+  min-height: 360px;
 }
 
 .hub-workspace-panels {
   display: grid;
-  grid-template-columns: minmax(240px, 0.42fr) minmax(0, 0.58fr);
-  gap: 14px;
-  min-height: 0;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 0;
+  min-height: 340px;
   align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--portal-gray-700);
+  border-radius: 12px;
+  background: var(--portal-gray-950);
 }
 
 .hub-workspace-tree,
 .hub-workspace-preview {
   min-width: 0;
-  min-height: 0;
+  min-height: 340px;
   height: 100%;
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  background: color-mix(in srgb, var(--panel) 64%, white 36%);
+  border: 0;
+  border-radius: 0;
 }
 
 .hub-workspace-tree {
-  padding: 14px;
+  padding: 12px 16px;
+  background: var(--portal-gray-900);
+  border-right: 1px solid var(--portal-gray-700);
   overflow: auto;
 }
 
 .hub-tree-row {
-  --indent-step: 18px;
+  --indent-step: 20px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 4px;
   min-height: 32px;
   width: 100%;
   border: 0;
   background: transparent;
-  padding-left: calc(var(--hub-tree-depth) * var(--indent-step));
-  padding-right: 10px;
-  color: var(--text);
+  padding: 4px 4px 4px calc(var(--hub-tree-depth) * var(--indent-step));
+  color: var(--portal-gray-100);
   font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
   text-align: left;
   cursor: default;
 }
 
 .hub-tree-glyph {
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
+  width: 24px;
+  height: 24px;
   flex: 0 0 auto;
-  background: color-mix(in srgb, var(--line) 60%, white 40%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--portal-gray-100);
 }
 
-.hub-tree-row.dir .hub-tree-glyph {
-  border-radius: 4px 4px 3px 3px;
-  background: linear-gradient(180deg, oklch(0.93 0.03 90), oklch(0.88 0.04 90));
-}
-
-.hub-tree-row.file .hub-tree-glyph {
-  background: linear-gradient(180deg, oklch(0.95 0.01 248), oklch(0.9 0.015 248));
-  border: 1px solid color-mix(in srgb, var(--line) 72%, white 28%);
-}
-
-:root[data-theme="dark"] .hub-tree-row.dir .hub-tree-glyph {
-  background: linear-gradient(180deg, oklch(0.48 0.06 90), oklch(0.38 0.05 90));
-}
-
-:root[data-theme="dark"] .hub-tree-row.file .hub-tree-glyph {
-  background: linear-gradient(180deg, oklch(0.34 0.02 248), oklch(0.28 0.015 248));
+.hub-tree-glyph svg {
+  display: block;
+  width: 18px;
+  height: 18px;
 }
 
 .hub-tree-label {
@@ -3262,12 +3335,11 @@ body::after {
 
 .hub-tree-toggle {
   position: relative;
-  width: 14px;
-  height: 14px;
+  width: 24px;
+  height: 24px;
   flex: 0 0 auto;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--panel) 72%, var(--line) 28%);
-  border: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  color: var(--portal-gray-100);
+  opacity: 0.8;
 }
 
 .hub-tree-toggle::before {
@@ -3288,8 +3360,7 @@ body::after {
 }
 
 .hub-tree-toggle.spacer {
-  background: transparent;
-  border-color: transparent;
+  color: transparent;
 }
 
 .hub-tree-toggle.spacer::before {
@@ -3297,49 +3368,64 @@ body::after {
 }
 
 .hub-tree-row.file.active {
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
-
-:root[data-theme="dark"] .hub-tree-toggle {
-  background: color-mix(in srgb, var(--panel) 62%, black 38%);
-}
-
-.hub-tree-row.dir[aria-expanded="true"] .hub-tree-toggle {
-  background: color-mix(in srgb, oklch(0.92 0.04 90) 70%, var(--panel) 30%);
-}
-
-:root[data-theme="dark"] .hub-tree-row.dir[aria-expanded="true"] .hub-tree-toggle {
-  background: color-mix(in srgb, oklch(0.42 0.05 90) 68%, var(--panel) 32%);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--portal-gray-25) 9%, transparent);
 }
 
 .hub-workspace-preview {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 10px;
-  padding: 28px;
-  min-height: 0;
+  gap: 0;
+  padding: 0;
+  background: var(--portal-gray-950);
+  color: var(--portal-gray-25);
   overflow: hidden;
+}
+
+.hub-workspace-preview:has(.hub-preview-empty-state) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hub-preview-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  max-width: 280px;
+  text-align: center;
 }
 
 .hub-workspace-preview strong {
   font-size: 16px;
 }
 
+.hub-preview-empty-state strong {
+  color: var(--portal-gray-25);
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
 .hub-workspace-preview p {
   margin: 0;
-  max-width: 280px;
   color: var(--muted);
   font-size: 14px;
   line-height: 1.6;
 }
 
+.hub-preview-empty-state p {
+  color: var(--portal-gray-400);
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .hub-preview-empty-icon {
-  width: 44px;
-  height: 56px;
-  border: 2px solid color-mix(in srgb, var(--line) 80%, white 20%);
-  border-radius: 12px;
-  position: relative;
+  display: block;
+  width: 32px;
+  height: 32px;
 }
 
 .hub-preview-file-header {
@@ -3347,12 +3433,21 @@ body::after {
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
+  padding: 20px 36px 8px 36px;
   text-align: left;
 }
 
+.hub-preview-file-header strong {
+  color: var(--portal-gray-25);
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
 .hub-preview-file-header span {
-  color: var(--muted);
-  font-size: 13px;
+  color: var(--portal-gray-400);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .hub-preview-body {
@@ -3360,37 +3455,41 @@ body::after {
   overflow: auto;
 }
 
+.hub-preview-code-shell {
+  min-height: 100%;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  width: max-content;
+  min-width: 100%;
+}
+
+.hub-preview-line-numbers,
 .hub-preview-code {
   margin: 0;
-  padding: 16px;
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--panel) 76%, black 24%);
-  color: var(--text);
   font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  word-break: break-word;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+  tab-size: 2;
+}
+
+.hub-preview-line-numbers {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  padding: 20px 22px 20px 0;
+  background: var(--portal-gray-800);
+  color: var(--portal-gray-300);
+  text-align: right;
+  user-select: none;
+}
+
+.hub-preview-code {
+  padding: 20px 36px;
+  background: var(--portal-gray-950);
+  color: var(--portal-gray-25);
   text-align: left;
-  overflow: auto;
-}
-
-.hub-preview-empty-icon::before,
-.hub-preview-empty-icon::after {
-  content: "";
-  position: absolute;
-  left: 10px;
-  right: 10px;
-  height: 2px;
-  background: color-mix(in srgb, var(--line) 78%, white 22%);
-}
-
-.hub-preview-empty-icon::before {
-  top: 18px;
-}
-
-.hub-preview-empty-icon::after {
-  top: 28px;
+  overflow: visible;
 }
 
 .hub-empty-state {
@@ -5099,6 +5198,7 @@ body::after {
 
   .hub-workspace-panels {
     grid-template-columns: 1fr;
+    min-height: 560px;
   }
 
   .hub-inspector-hero-row {


### PR DESCRIPTION
## Summary
- remove the misplaced Hub catalog end marker
- restyle the workspace tree and preview to match the Figma dark file browser
- add centered empty state, fixed line numbers, horizontal code scrolling, and responsive min heights

## Verification
- git diff --check -- web/static/app.js web/static/styles.css
- manually verified the Hub workspace browser styles in the in-app browser