### PR TITLE
fix(hub): complete agent template workspace sync

### DIFF
--- a/internal/agent/runtime_state.go
+++ b/internal/agent/runtime_state.go
@@ -11,6 +11,8 @@ import (
 	"csgclaw/internal/config"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/runtime/openclawsandbox"
+	"csgclaw/internal/runtime/picoclawsandbox"
+	"csgclaw/internal/runtime/sandboxgateway"
 	"csgclaw/internal/sandbox"
 )
 
@@ -53,10 +55,12 @@ type PicoClawRuntimeHost struct {
 	ResolveRuntimeProfile func(h agentruntime.Handle) (agentruntime.Profile, error)
 	SyncHandle            func(h agentruntime.Handle) error
 	EnsureGatewayConfig   func(agentName, botID string, profile agentruntime.Profile) error
-	EnsureWorkspace       func(agentName, template string) (string, error)
+	EnsureWorkspace       func(agentName, template string) (sandboxgateway.WorkspaceLayout, error)
+	WorkspaceLayout       func(agentName string) (sandboxgateway.WorkspaceLayout, error)
 	WorkspaceTemplate     func(name, botID string) (string, error)
 	EnsureProjectsRoot    func() (string, error)
 	HomeEnv               string
+	MountGuestPath        string
 	WorkspaceGuestPath    string
 	ProjectsGuestPath     string
 	GatewayLogPath        string
@@ -100,9 +104,14 @@ func (s *Service) PicoClawRuntimeHost() PicoClawRuntimeHost {
 			_, err := ensureAgentPicoClawConfig(agentName, botID, s.server, config.ModelConfig{ModelID: profile.ModelID})
 			return err
 		},
-		EnsureWorkspace:    ensureAgentWorkspace,
+		EnsureWorkspace:    ensurePicoClawWorkspace,
+		WorkspaceLayout:    picoClawWorkspaceLayout,
 		WorkspaceTemplate:  workspaceTemplateForAgent,
 		EnsureProjectsRoot: ensureAgentProjectsRoot,
+		MountGuestPath:     picoclawsandbox.BoxWorkspaceDir,
+		WorkspaceGuestPath: picoclawsandbox.BoxWorkspaceDir,
+		ProjectsGuestPath:  picoclawsandbox.BoxProjectsDir,
+		GatewayLogPath:     picoclawsandbox.BoxGatewayLogPath,
 		StreamLogs:         s.streamRuntimeHostLogs,
 	}
 }
@@ -126,25 +135,70 @@ func (s *Service) OpenClawRuntimeHost() PicoClawRuntimeHost {
 		}
 		return nil
 	}
-	host.EnsureWorkspace = func(agentName, template string) (string, error) {
-		agentHome, err := agentHomeDir(agentName)
-		if err != nil {
-			return "", err
-		}
-		if _, err := ensureWorkspaceAtRoot(openclawsandbox.WorkspaceRoot(agentHome), template); err != nil {
-			return "", err
-		}
-		return openclawsandbox.Root(agentHome), nil
-	}
+	host.EnsureWorkspace = ensureOpenClawWorkspace
+	host.WorkspaceLayout = openClawWorkspaceLayout
 	host.WorkspaceTemplate = func(name, botID string) (string, error) {
-		return resolveRuntimeTemplateRoot(RuntimeKindOpenClawSandbox, RoleWorker)
+		role := RoleWorker
+		if managerGatewayMatch(name, botID) {
+			role = RoleManager
+		}
+		return resolveRuntimeTemplateRoot(RuntimeKindOpenClawSandbox, role)
 	}
 	host.HomeEnv = openclawsandbox.BoxUserHome
-	host.WorkspaceGuestPath = openclawsandbox.BoxDir
+	host.MountGuestPath = openclawsandbox.BoxDir
+	host.WorkspaceGuestPath = openclawsandbox.BoxWorkspaceDir
 	host.ProjectsGuestPath = openclawsandbox.BoxProjectsDir
 	host.GatewayLogPath = openclawsandbox.BoxGatewayLogPath
 	host.GatewayCommand = openclawsandbox.GatewayRunCommand
 	return host
+}
+
+func ensurePicoClawWorkspace(agentName, template string) (sandboxgateway.WorkspaceLayout, error) {
+	layout, err := picoClawWorkspaceLayout(agentName)
+	if err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	if _, err := ensureWorkspaceAtRoot(layout.WorkspaceHostPath, template); err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	return layout, nil
+}
+
+func picoClawWorkspaceLayout(agentName string) (sandboxgateway.WorkspaceLayout, error) {
+	workspaceRoot, err := agentWorkspaceRoot(agentName)
+	if err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	return sandboxgateway.WorkspaceLayout{
+		MountHostPath:      workspaceRoot,
+		MountGuestPath:     picoclawsandbox.BoxWorkspaceDir,
+		WorkspaceHostPath:  workspaceRoot,
+		WorkspaceGuestPath: picoclawsandbox.BoxWorkspaceDir,
+	}, nil
+}
+
+func ensureOpenClawWorkspace(agentName, template string) (sandboxgateway.WorkspaceLayout, error) {
+	layout, err := openClawWorkspaceLayout(agentName)
+	if err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	if _, err := ensureWorkspaceAtRoot(layout.WorkspaceHostPath, template); err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	return layout, nil
+}
+
+func openClawWorkspaceLayout(agentName string) (sandboxgateway.WorkspaceLayout, error) {
+	agentHome, err := agentHomeDir(agentName)
+	if err != nil {
+		return sandboxgateway.WorkspaceLayout{}, err
+	}
+	return sandboxgateway.WorkspaceLayout{
+		MountHostPath:      openclawsandbox.Root(agentHome),
+		MountGuestPath:     openclawsandbox.BoxDir,
+		WorkspaceHostPath:  openclawsandbox.WorkspaceRoot(agentHome),
+		WorkspaceGuestPath: openclawsandbox.BoxWorkspaceDir,
+	}, nil
 }
 
 func (s *Service) setGatewayWorkPhase(p uint32) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -19,6 +19,7 @@ import (
 	"csgclaw/internal/config"
 	"csgclaw/internal/hub"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/sandboxgateway"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/utils"
 )
@@ -962,7 +963,7 @@ func (s *Service) createNew(ctx context.Context, spec CreateAgentSpec) (Agent, e
 	defer func() {
 		_ = s.closeBox(box)
 	}()
-	if err := s.overlayTemplateWorkspace(name, spec.FromTemplate); err != nil {
+	if err := s.overlayTemplateWorkspace(name, "", spec.FromTemplate); err != nil {
 		return Agent{}, err
 	}
 
@@ -1603,7 +1604,7 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		defer func() {
 			_ = s.closeBox(box)
 		}()
-		if err := s.overlayTemplateWorkspace(name, spec.FromTemplate); err != nil {
+		if err := s.overlayTemplateWorkspace(name, runtimeKind, spec.FromTemplate); err != nil {
 			return Agent{}, err
 		}
 		return s.persistCreatedWorker(ctx, id, name, description, image, runtimeKind, resolvedProfile, spec.RuntimeOptions, agentruntime.Info{
@@ -1622,7 +1623,7 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 	if err != nil {
 		return Agent{}, fmt.Errorf("create worker box: %w", err)
 	}
-	if err := s.overlayTemplateWorkspace(name, spec.FromTemplate); err != nil {
+	if err := s.overlayTemplateWorkspace(name, runtimeKind, spec.FromTemplate); err != nil {
 		return Agent{}, err
 	}
 	info := agentruntime.Info{
@@ -1706,19 +1707,39 @@ func isResolvedWorkspacePath(path string) bool {
 	return err == nil && info.IsDir()
 }
 
-func (s *Service) overlayTemplateWorkspace(agentName, workspaceRoot string) error {
+func (s *Service) overlayTemplateWorkspace(agentName, runtimeKind, workspaceRoot string) error {
 	workspaceRoot = strings.TrimSpace(workspaceRoot)
 	if workspaceRoot == "" {
 		return nil
 	}
-	dstRoot, err := agentWorkspaceRoot(agentName)
+	layout, err := s.workspaceLayoutForOverlay(agentName, runtimeKind)
 	if err != nil {
 		return err
 	}
-	if err := overlayWorkspaceTree(workspaceRoot, dstRoot); err != nil {
+	if err := overlayWorkspaceTree(workspaceRoot, layout.WorkspaceHostPath); err != nil {
 		return fmt.Errorf("overlay template workspace for agent %q: %w", agentName, err)
 	}
 	return nil
+}
+
+func (s *Service) workspaceLayoutForOverlay(agentName, runtimeKind string) (sandboxgateway.WorkspaceLayout, error) {
+	switch normalizeRuntimeKind(runtimeKind) {
+	case RuntimeKindOpenClawSandbox:
+		return s.OpenClawRuntimeHost().WorkspaceLayout(agentName)
+	case "", RuntimeKindPicoClawSandbox:
+		return s.PicoClawRuntimeHost().WorkspaceLayout(agentName)
+	default:
+		workspaceRoot, err := agentWorkspaceRoot(agentName)
+		if err != nil {
+			return sandboxgateway.WorkspaceLayout{}, err
+		}
+		return sandboxgateway.WorkspaceLayout{
+			MountHostPath:      workspaceRoot,
+			MountGuestPath:     workspaceRoot,
+			WorkspaceHostPath:  workspaceRoot,
+			WorkspaceGuestPath: workspaceRoot,
+		}, nil
+	}
 }
 
 func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines int, w io.Writer) error {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -24,6 +24,7 @@ import (
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/sandbox/boxlitecli"
 	"csgclaw/internal/sandbox/sandboxtest"
+	"csgclaw/internal/templates"
 )
 
 func init() {
@@ -2709,6 +2710,52 @@ func TestCreateWorkerFromTemplateAppliesDefaultsAndOverlaysWorkspace(t *testing.
 	}
 }
 
+func TestCreateOpenClawWorkerFromTemplateOverlaysOpenClawWorkspace(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
+
+	hubSvc := mustNewLocalTemplateHubService(t, "openclaw-manager", hub.Template{
+		ID:          "openclaw-manager",
+		Name:        "openclaw-manager",
+		Description: "openclaw manager",
+		RuntimeKind: RuntimeKindOpenClawSandbox,
+		Image:       "openclaw-image:1",
+	})
+
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		WithHubService(hubSvc),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := svc.CreateWorker(context.Background(), CreateAgentSpec{
+		Name:         "alice",
+		RuntimeKind:  RuntimeKindOpenClawSandbox,
+		FromTemplate: "local/openclaw-manager",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorker() error = %v", err)
+	}
+	if got.RuntimeKind != RuntimeKindOpenClawSandbox {
+		t.Fatalf("RuntimeKind = %q, want %q", got.RuntimeKind, RuntimeKindOpenClawSandbox)
+	}
+
+	agentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
+	openclawWorkspace := openclawsandbox.WorkspaceRoot(agentHome)
+	if _, err := os.Stat(filepath.Join(openclawWorkspace, "skills", "custom", "SKILL.md")); err != nil {
+		t.Fatalf("template skill missing from OpenClaw workspace after overlay: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(agentHome, hostWorkspaceDir, "skills", "custom", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("template skill should not be written to legacy workspace path for OpenClaw, stat error = %v", err)
+	}
+}
+
 func TestCreateWorkerUsesConfiguredDefaultTemplate(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -3967,7 +4014,10 @@ func TestOpenClawRuntimeHostBuildsWorkerWorkspaceAndConfig(t *testing.T) {
 	if got, want := host.HomeEnv, openclawsandbox.BoxUserHome; got != want {
 		t.Fatalf("HomeEnv = %q, want %q", got, want)
 	}
-	if got, want := host.WorkspaceGuestPath, openclawsandbox.BoxDir; got != want {
+	if got, want := host.MountGuestPath, openclawsandbox.BoxDir; got != want {
+		t.Fatalf("MountGuestPath = %q, want %q", got, want)
+	}
+	if got, want := host.WorkspaceGuestPath, openclawsandbox.BoxWorkspaceDir; got != want {
 		t.Fatalf("WorkspaceGuestPath = %q, want %q", got, want)
 	}
 	if got, want := host.ProjectsGuestPath, openclawsandbox.BoxProjectsDir; got != want {
@@ -3990,10 +4040,31 @@ func TestOpenClawRuntimeHostBuildsWorkerWorkspaceAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WorkspaceTemplate() error = %v", err)
 	}
+	if templateRoot != templates.OpenClawWorkerRoot {
+		t.Fatalf("WorkspaceTemplate(worker) = %q, want %q", templateRoot, templates.OpenClawWorkerRoot)
+	}
+	managerTemplateRoot, err := host.WorkspaceTemplate(ManagerName, ManagerUserID)
+	if err != nil {
+		t.Fatalf("WorkspaceTemplate(manager) error = %v", err)
+	}
+	if managerTemplateRoot != templates.OpenClawManagerRoot {
+		t.Fatalf("WorkspaceTemplate(manager) = %q, want %q", managerTemplateRoot, templates.OpenClawManagerRoot)
+	}
 	if got, err := host.EnsureWorkspace("alice", templateRoot); err != nil {
 		t.Fatalf("EnsureWorkspace() error = %v", err)
-	} else if got != wantOpenClawRoot {
-		t.Fatalf("EnsureWorkspace() root = %q, want %q", got, wantOpenClawRoot)
+	} else {
+		if got.MountHostPath != wantOpenClawRoot {
+			t.Fatalf("EnsureWorkspace().MountHostPath = %q, want %q", got.MountHostPath, wantOpenClawRoot)
+		}
+		if got.MountGuestPath != openclawsandbox.BoxDir {
+			t.Fatalf("EnsureWorkspace().MountGuestPath = %q, want %q", got.MountGuestPath, openclawsandbox.BoxDir)
+		}
+		if got.WorkspaceHostPath != openclawsandbox.WorkspaceRoot(wantAgentHome) {
+			t.Fatalf("EnsureWorkspace().WorkspaceHostPath = %q, want %q", got.WorkspaceHostPath, openclawsandbox.WorkspaceRoot(wantAgentHome))
+		}
+		if got.WorkspaceGuestPath != openclawsandbox.BoxWorkspaceDir {
+			t.Fatalf("EnsureWorkspace().WorkspaceGuestPath = %q, want %q", got.WorkspaceGuestPath, openclawsandbox.BoxWorkspaceDir)
+		}
 	}
 	if _, err := os.Stat(filepath.Join(wantOpenClawRoot, openclawsandbox.HostWorkspaceDir, "AGENTS.md")); err != nil {
 		t.Fatalf("expected openclaw workspace template under openclaw root: %v", err)
@@ -4434,6 +4505,7 @@ func withTestSandboxRuntimeHost(host PicoClawRuntimeHost, provider feishu.BotCre
 			},
 			AddProfileEnv:      addProfileEnvVars,
 			HomeEnv:            host.HomeEnv,
+			MountGuestPath:     host.MountGuestPath,
 			WorkspaceGuestPath: host.WorkspaceGuestPath,
 			ProjectsGuestPath:  host.ProjectsGuestPath,
 			GatewayLogPath:     host.GatewayLogPath,

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -27,6 +27,7 @@ type CreateBotRequest struct {
 	Channel        string             `json:"channel,omitempty"`
 	ModelID        string             `json:"model_id,omitempty"`
 	RuntimeKind    string             `json:"runtime_kind,omitempty"`
+	FromTemplate   string             `json:"from_template,omitempty"`
 	RuntimeOptions map[string]any     `json:"runtime_options,omitempty"`
 	AgentProfile   CreateAgentProfile `json:"agent_profile,omitempty"`
 }

--- a/internal/app/runtimewiring/picoclaw.go
+++ b/internal/app/runtimewiring/picoclaw.go
@@ -90,6 +90,7 @@ func withSandboxRuntimeHost(host agent.PicoClawRuntimeHost, feishuProvider feish
 			},
 			AddProfileEnv:      agentAddProfileEnv,
 			HomeEnv:            host.HomeEnv,
+			MountGuestPath:     host.MountGuestPath,
 			WorkspaceGuestPath: host.WorkspaceGuestPath,
 			ProjectsGuestPath:  host.ProjectsGuestPath,
 			GatewayLogPath:     host.GatewayLogPath,

--- a/internal/bot/model.go
+++ b/internal/bot/model.go
@@ -33,6 +33,7 @@ func NormalizeCreateRequest(req CreateRequest) (CreateRequest, error) {
 	req.Image = strings.TrimSpace(req.Image)
 	req.ModelID = strings.TrimSpace(req.ModelID)
 	req.RuntimeKind = strings.TrimSpace(req.RuntimeKind)
+	req.FromTemplate = strings.TrimSpace(req.FromTemplate)
 	if req.Name == "" {
 		return CreateRequest{}, fmt.Errorf("name is required")
 	}

--- a/internal/bot/service.go
+++ b/internal/bot/service.go
@@ -318,6 +318,7 @@ func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (B
 			Role:           agent.RoleWorker,
 			ModelID:        normalized.ModelID,
 			RuntimeKind:    normalized.RuntimeKind,
+			FromTemplate:   normalized.FromTemplate,
 			RuntimeOptions: utils.CloneAnyMap(normalized.RuntimeOptions),
 			AgentProfile:   agentProfileFromBotRequest(normalized.AgentProfile),
 		})

--- a/internal/bot/service_test.go
+++ b/internal/bot/service_test.go
@@ -16,6 +16,7 @@ import (
 	"csgclaw/internal/app/runtimewiring"
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/config"
+	"csgclaw/internal/hub"
 	"csgclaw/internal/im"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/sandbox"
@@ -941,6 +942,58 @@ func TestServiceCreateWorkerRejectsDuplicateNameInSameChannel(t *testing.T) {
 	}
 }
 
+func TestServiceCreateWorkerUsesFromTemplateWorkspace(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	resetFakeBotRuntimeStates()
+	t.Cleanup(resetFakeBotRuntimeStates)
+	restoreDefault := agent.TestOnlySetDefaultServiceOption(func(s *agent.Service) error {
+		return agent.WithRuntime(fakeBotAgentRuntime{kind: agent.RuntimeKindPicoClawSandbox})(s)
+	})
+	t.Cleanup(restoreDefault)
+
+	hubSvc := mustNewBotLocalTemplateHubService(t, "frontend-worker", hub.Template{
+		ID:          "frontend-worker",
+		Name:        "frontend-worker",
+		Description: "frontend worker",
+		RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+		Image:       "worker-image:1",
+	})
+	agentSvc, err := agent.NewService(
+		testAgentModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		agent.WithHubService(hubSvc),
+	)
+	if err != nil {
+		t.Fatalf("agent.NewService() error = %v", err)
+	}
+	imSvc := im.NewService()
+	store, err := NewMemoryStore(nil)
+	if err != nil {
+		t.Fatalf("NewMemoryStore() error = %v", err)
+	}
+	svc, err := NewServiceWithDependencies(store, agentSvc, imSvc)
+	if err != nil {
+		t.Fatalf("NewServiceWithDependencies() error = %v", err)
+	}
+
+	if _, err := svc.Create(context.Background(), CreateRequest{
+		Name:         "alice",
+		Role:         string(RoleWorker),
+		Channel:      string(ChannelCSGClaw),
+		FromTemplate: "local/frontend-worker",
+	}); err != nil {
+		t.Fatalf("Create(worker) error = %v", err)
+	}
+
+	skillPath := filepath.Join(homeDir, config.AppDirName, "agents", "alice", "workspace", "skills", "custom", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("template skill missing after bot create: %v", err)
+	}
+}
+
 func TestServiceCreateCSGClawManagerBindsBootstrappedAgent(t *testing.T) {
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
@@ -1281,6 +1334,46 @@ func mustNewBotService(t *testing.T, bots []Bot) *Service {
 	svc, err := NewService(store)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
+	}
+	return svc
+}
+
+func mustNewBotLocalTemplateHubService(t *testing.T, id string, item hub.Template) *hub.Service {
+	t.Helper()
+
+	registryRoot := t.TempDir()
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "USER.md"), []byte("template user\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(USER.md) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "skills", "custom"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(skill dir) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "skills", "custom", "SKILL.md"), []byte("# Custom\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(SKILL.md) error = %v", err)
+	}
+
+	store := hub.NewLocalStore(registryRoot)
+	if _, err := store.Publish(context.Background(), hub.PublishSpec{
+		ID:           id,
+		Name:         item.Name,
+		Description:  item.Description,
+		RuntimeKind:  item.RuntimeKind,
+		Image:        item.Image,
+		WorkspaceRef: hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
+		UpdatedAt:    time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	svc, err := hub.NewService(config.HubConfig{
+		DefaultRegistry: "local",
+		Registries: []config.HubRegistryConfig{
+			{Name: "local", Kind: hub.RegistryKindLocal, Path: registryRoot, Enabled: true},
+		},
+	}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
 	}
 	return svc
 }

--- a/internal/runtime/openclawsandbox/runtime.go
+++ b/internal/runtime/openclawsandbox/runtime.go
@@ -8,11 +8,13 @@ import (
 type AgentRef = sandboxgateway.AgentRef
 type Dependencies = sandboxgateway.Dependencies
 type Runtime = sandboxgateway.Runtime
+type WorkspaceLayout = sandboxgateway.WorkspaceLayout
 
 func New(deps Dependencies) *Runtime {
 	deps.RuntimeKind = agentruntime.KindOpenClawSandbox
 	deps.HomeEnv = BoxUserHome
-	deps.WorkspaceGuestPath = BoxDir
+	deps.MountGuestPath = BoxDir
+	deps.WorkspaceGuestPath = BoxWorkspaceDir
 	deps.ProjectsGuestPath = BoxProjectsDir
 	deps.GatewayLogPath = BoxGatewayLogPath
 	if deps.WorkspaceTemplate == nil {

--- a/internal/runtime/picoclawsandbox/runtime.go
+++ b/internal/runtime/picoclawsandbox/runtime.go
@@ -21,10 +21,12 @@ const (
 type AgentRef = sandboxgateway.AgentRef
 type Dependencies = sandboxgateway.Dependencies
 type Runtime = sandboxgateway.Runtime
+type WorkspaceLayout = sandboxgateway.WorkspaceLayout
 
 func New(deps Dependencies) *Runtime {
 	deps.RuntimeKind = agentruntime.KindPicoClawSandbox
 	deps.HomeEnv = "/home/picoclaw"
+	deps.MountGuestPath = BoxWorkspaceDir
 	deps.WorkspaceGuestPath = BoxWorkspaceDir
 	deps.ProjectsGuestPath = BoxProjectsDir
 	deps.GatewayLogPath = BoxGatewayLogPath

--- a/internal/runtime/picoclawsandbox/runtime_channels_test.go
+++ b/internal/runtime/picoclawsandbox/runtime_channels_test.go
@@ -24,8 +24,9 @@ func TestRuntimeSetFeishuProviderUpdatesGatewayCreateSpecEnv(t *testing.T) {
 			return server.AdvertiseBaseURL
 		},
 		EnsureGatewayConfig: func(_, _ string, _ agentruntime.Profile) error { return nil },
-		EnsureWorkspace: func(_, _ string) (string, error) {
-			return t.TempDir(), nil
+		EnsureWorkspace: func(_, _ string) (WorkspaceLayout, error) {
+			root := t.TempDir()
+			return WorkspaceLayout{MountHostPath: root, WorkspaceHostPath: root}, nil
 		},
 		WorkspaceTemplate: func(_, _ string) (string, error) { return "", nil },
 		EnsureProjectsRoot: func() (string, error) {

--- a/internal/runtime/sandboxgateway/runtime.go
+++ b/internal/runtime/sandboxgateway/runtime.go
@@ -22,6 +22,13 @@ type AgentRef struct {
 	BoxID     string
 }
 
+type WorkspaceLayout struct {
+	MountHostPath      string
+	MountGuestPath     string
+	WorkspaceHostPath  string
+	WorkspaceGuestPath string
+}
+
 type Dependencies struct {
 	RuntimeKind    string
 	ModelFallback  string
@@ -45,12 +52,13 @@ type Dependencies struct {
 	ResolveAgent        func(h agentruntime.Handle) (AgentRef, error)
 	SyncHandle          func(h agentruntime.Handle) error
 	EnsureGatewayConfig func(agentName, botID string, profile agentruntime.Profile) error
-	EnsureWorkspace     func(agentName, template string) (string, error)
+	EnsureWorkspace     func(agentName, template string) (WorkspaceLayout, error)
 	WorkspaceTemplate   func(name, botID string) (string, error)
 	EnsureProjectsRoot  func() (string, error)
 	BuildRuntimeEnv     func(baseURL, accessToken, botID, llmBaseURL, modelID string, feishuProvider feishu.BotCredentialProvider) map[string]string
 	AddProfileEnv       func(envVars map[string]string, profileEnv map[string]string)
 	HomeEnv             string
+	MountGuestPath      string
 	WorkspaceGuestPath  string
 	ProjectsGuestPath   string
 	GatewayLogPath      string
@@ -311,10 +319,11 @@ func (r *Runtime) GatewayCreateSpec(image, name, botID string, profile agentrunt
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
-	hostWorkspaceRoot, err := r.deps.EnsureWorkspace(name, templateRoot)
+	workspaceLayout, err := r.deps.EnsureWorkspace(name, templateRoot)
 	if err != nil {
 		return sandbox.CreateSpec{}, err
 	}
+	workspaceLayout = r.normalizeWorkspaceLayout(workspaceLayout)
 	projectsRoot, err := r.deps.EnsureProjectsRoot()
 	if err != nil {
 		return sandbox.CreateSpec{}, err
@@ -322,13 +331,21 @@ func (r *Runtime) GatewayCreateSpec(image, name, botID string, profile agentrunt
 	envVars := r.deps.BuildRuntimeEnv(managerBaseURL, r.deps.Server.AccessToken, botID, llmBaseURL, modelID, r.feishuProvider())
 	r.deps.AddProfileEnv(envVars, profile.Env)
 	homeEnv := r.homeEnv()
-	workspaceGuestPath := r.workspaceGuestPath()
 	projectsGuestPath := r.projectsGuestPath()
 	gatewayCommand := r.gatewayCommand()
 	if homeEnv == "" {
 		return sandbox.CreateSpec{}, fmt.Errorf("runtime HOME env is required")
 	}
-	if workspaceGuestPath == "" {
+	if workspaceLayout.MountHostPath == "" {
+		return sandbox.CreateSpec{}, fmt.Errorf("workspace mount host path is required")
+	}
+	if workspaceLayout.MountGuestPath == "" {
+		return sandbox.CreateSpec{}, fmt.Errorf("workspace mount guest path is required")
+	}
+	if workspaceLayout.WorkspaceHostPath == "" {
+		return sandbox.CreateSpec{}, fmt.Errorf("workspace host path is required")
+	}
+	if workspaceLayout.WorkspaceGuestPath == "" {
 		return sandbox.CreateSpec{}, fmt.Errorf("workspace guest path is required")
 	}
 	if projectsGuestPath == "" {
@@ -347,7 +364,7 @@ func (r *Runtime) GatewayCreateSpec(image, name, botID string, profile agentrunt
 		Cmd:        []string{"/bin/sh", "-c", gatewayCommand},
 	}
 	spec.Mounts = append(spec.Mounts,
-		sandbox.Mount{HostPath: hostWorkspaceRoot, GuestPath: workspaceGuestPath},
+		sandbox.Mount{HostPath: workspaceLayout.MountHostPath, GuestPath: workspaceLayout.MountGuestPath},
 		sandbox.Mount{HostPath: projectsRoot, GuestPath: projectsGuestPath},
 	)
 	return spec, nil
@@ -369,6 +386,10 @@ func (r *Runtime) homeEnv() string {
 	return strings.TrimSpace(r.deps.HomeEnv)
 }
 
+func (r *Runtime) mountGuestPath() string {
+	return strings.TrimSpace(r.deps.MountGuestPath)
+}
+
 func (r *Runtime) workspaceGuestPath() string {
 	return strings.TrimSpace(r.deps.WorkspaceGuestPath)
 }
@@ -386,6 +407,23 @@ func (r *Runtime) gatewayCommand() string {
 		return strings.TrimSpace(r.deps.GatewayCommand())
 	}
 	return ""
+}
+
+func (r *Runtime) normalizeWorkspaceLayout(layout WorkspaceLayout) WorkspaceLayout {
+	layout.MountHostPath = strings.TrimSpace(layout.MountHostPath)
+	layout.MountGuestPath = strings.TrimSpace(layout.MountGuestPath)
+	layout.WorkspaceHostPath = strings.TrimSpace(layout.WorkspaceHostPath)
+	layout.WorkspaceGuestPath = strings.TrimSpace(layout.WorkspaceGuestPath)
+	if layout.WorkspaceHostPath == "" {
+		layout.WorkspaceHostPath = layout.MountHostPath
+	}
+	if layout.MountGuestPath == "" {
+		layout.MountGuestPath = r.mountGuestPath()
+	}
+	if layout.WorkspaceGuestPath == "" {
+		layout.WorkspaceGuestPath = r.workspaceGuestPath()
+	}
+	return layout
 }
 
 func (r *Runtime) openSandboxRuntime(agentName string) (sandbox.Runtime, string, error) {


### PR DESCRIPTION
## Summary

- Complete agent hub template sync for bot-created workers by carrying `from_template` through the bot creation flow.
- Apply synced template workspaces through runtime-aware layouts, so PicoClaw and OpenClaw land files in the right workspace without sharing mount assumptions.

## Tests

- `env GOCACHE=/Users/jared/opencsg-workspace/csgship/csgclaw/.gocache go test ./internal/agent ./internal/runtime/picoclawsandbox ./internal/bot ./internal/api`
