### PR TITLE
Fix manager recreate workspace and image selection

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -437,15 +437,16 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 	managerImage := strings.TrimSpace(imageOverride)
 	previousGatewayRuntime := ""
 	previousManagerImage := ""
-	if runtimeKind != s.gatewayRuntimeKind() {
+	shouldUpdateGatewayDefaults := runtimeKind != s.gatewayRuntimeKind() || managerImage != ""
+	if shouldUpdateGatewayDefaults {
 		s.mu.Lock()
 		previousGatewayRuntime = s.gatewayRuntime
 		previousManagerImage = s.managerImage
 		s.gatewayRuntime = runtimeKind
-		if managerImage == "" {
-			if defaultImage := managerImageForRuntimeKind(runtimeKind); defaultImage != "" {
-				s.managerImage = defaultImage
-			}
+		if managerImage != "" {
+			s.managerImage = managerImage
+		} else if defaultImage := managerImageForRuntimeKind(runtimeKind); defaultImage != "" {
+			s.managerImage = defaultImage
 		}
 		managerImage = s.managerImage
 		s.mu.Unlock()
@@ -458,14 +459,19 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 			s.managerImage = previousManagerImage
 			s.mu.Unlock()
 		}()
-	} else if managerImage == "" {
+	} else {
+		s.mu.RLock()
 		managerImage = s.managerImage
+		s.mu.RUnlock()
 	}
 	startProfile, detectionResults := s.managerStartupProfile(ctx)
-	if startProfile.ProfileComplete {
+	provisionBootstrapManagerRuntime := func() error {
+		if !startProfile.ProfileComplete {
+			return nil
+		}
 		runtimeImpl, err := s.runtimeForKind(runtimeKind)
 		if err != nil {
-			return Agent{}, err
+			return err
 		}
 		if err := s.provisionRuntime(ctx, runtimeImpl, runtimeKind, agentruntime.ProvisionRequest{
 			RuntimeID: runtimeIDForAgentID(ManagerUserID),
@@ -473,10 +479,10 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 			AgentName: ManagerName,
 			Profile:   s.runtimeProfileForKind(runtimeKind, ManagerUserID, ManagerName, "", startProfile),
 		}); err != nil {
-			return Agent{}, fmt.Errorf("provision bootstrap manager runtime: %w", err)
+			return fmt.Errorf("provision bootstrap manager runtime: %w", err)
 		}
+		return nil
 	}
-
 	rt, box, err := s.lookupBootstrapManager(ctx)
 	if err != nil {
 		return Agent{}, err
@@ -489,39 +495,14 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 		_ = s.closeRuntime(runtimeHome, rt)
 	}()
 	if forceRecreate {
-		log.Printf("force recreating bootstrap manager box %q", ManagerName)
-		removed := false
-		for _, managerBoxIDOrName := range s.bootstrapManagerLookupKeys() {
-			if err := s.forceRemoveBox(ctx, rt, managerBoxIDOrName); err != nil {
-				if sandbox.IsNotFound(err) {
-					log.Printf("bootstrap manager box %q (%q) does not exist yet; continuing", ManagerName, managerBoxIDOrName)
-					continue
-				}
-				return Agent{}, fmt.Errorf("force remove bootstrap manager box %q (%q): %w", ManagerName, managerBoxIDOrName, err)
-			}
-			log.Printf("bootstrap manager box %q (%q) removed", ManagerName, managerBoxIDOrName)
-			removed = true
-			break
-		}
-		if !removed {
-			log.Printf("bootstrap manager box %q not found under known identifiers; continuing", ManagerName)
-		}
-		if err := s.closeRuntime(runtimeHome, rt); err != nil {
-			return Agent{}, fmt.Errorf("close bootstrap manager runtime before recreate: %w", err)
-		}
-		rt = nil
-		managerHome, err := agentHomeDir(ManagerName)
-		if err != nil {
-			return Agent{}, err
-		}
-		if err := removeAllWithRetry(managerHome); err != nil {
-			return Agent{}, fmt.Errorf("remove bootstrap manager home: %w", err)
-		}
-		rt, err = s.ensureRuntimeAtHome(runtimeHome)
+		rt, err = s.cleanupBootstrapManagerForRecreate(ctx, rt, runtimeHome)
 		if err != nil {
 			return Agent{}, err
 		}
 		box = nil
+	}
+	if err := provisionBootstrapManagerRuntime(); err != nil {
+		return Agent{}, err
 	}
 	if !startProfile.ProfileComplete {
 		now := time.Now().UTC()
@@ -630,6 +611,42 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 		return Agent{}, err
 	}
 	return *cloneAgent(&manager), nil
+}
+
+func (s *Service) cleanupBootstrapManagerForRecreate(ctx context.Context, rt sandbox.Runtime, runtimeHome string) (sandbox.Runtime, error) {
+	log.Printf("force recreating bootstrap manager box %q", ManagerName)
+	removed := false
+	for _, managerBoxIDOrName := range s.bootstrapManagerLookupKeys() {
+		if err := s.forceRemoveBox(ctx, rt, managerBoxIDOrName); err != nil {
+			if sandbox.IsNotFound(err) {
+				log.Printf("bootstrap manager box %q (%q) does not exist yet; continuing", ManagerName, managerBoxIDOrName)
+				continue
+			}
+			return rt, fmt.Errorf("force remove bootstrap manager box %q (%q): %w", ManagerName, managerBoxIDOrName, err)
+		}
+		log.Printf("bootstrap manager box %q (%q) removed", ManagerName, managerBoxIDOrName)
+		removed = true
+		break
+	}
+	if !removed {
+		log.Printf("bootstrap manager box %q not found under known identifiers; continuing", ManagerName)
+	}
+	if err := s.closeRuntime(runtimeHome, rt); err != nil {
+		return rt, fmt.Errorf("close bootstrap manager runtime before recreate: %w", err)
+	}
+	rt = nil
+	managerHome, err := agentHomeDir(ManagerName)
+	if err != nil {
+		return nil, err
+	}
+	if err := removeAllWithRetry(managerHome); err != nil {
+		return nil, fmt.Errorf("remove bootstrap manager home: %w", err)
+	}
+	rt, err = s.ensureRuntimeAtHome(runtimeHome)
+	if err != nil {
+		return nil, err
+	}
+	return rt, nil
 }
 
 func (s *Service) managerStartupProfile(ctx context.Context) (AgentProfile, []ProfileDetectionResult) {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1366,6 +1366,85 @@ func TestCreateReplaceManagerUsesRequestedImage(t *testing.T) {
 	}
 }
 
+func TestCreateReplaceManagerReprovisionsWorkspaceAfterHomeRemoval(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	rt := sandboxtest.NewRuntime()
+	createCalls := 0
+	rt.CreateFunc = func(_ context.Context, spec sandbox.CreateSpec) (sandbox.Instance, error) {
+		createCalls++
+		if len(spec.Mounts) == 0 {
+			return nil, fmt.Errorf("create spec mounts are empty")
+		}
+		if _, err := os.Stat(spec.Mounts[0].HostPath); err != nil {
+			return nil, fmt.Errorf("workspace mount host path %q is not available: %w", spec.Mounts[0].HostPath, err)
+		}
+		info := sandbox.Info{
+			ID:        "box-" + spec.Name,
+			Name:      spec.Name,
+			State:     sandbox.StateRunning,
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		}
+		inst := sandboxtest.NewInstance(info)
+		rt.CreateCalls = append(rt.CreateCalls, spec)
+		if rt.Instances == nil {
+			rt.Instances = make(map[string]*sandboxtest.Instance)
+		}
+		rt.Instances[info.ID] = inst
+		rt.Instances[info.Name] = inst
+		return inst, nil
+	}
+
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		WithSandboxProvider(fakeProvider{
+			open: func(context.Context, string) (sandbox.Runtime, error) {
+				return rt, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if _, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			ID:   ManagerUserID,
+			Name: ManagerName,
+		},
+	}); err != nil {
+		t.Fatalf("seed Create() error = %v", err)
+	}
+
+	replaced, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			ID:    ManagerUserID,
+			Name:  ManagerName,
+			Image: "manager-image:2",
+		},
+		Replace: true,
+	})
+	if err != nil {
+		t.Fatalf("Create() replace error = %v", err)
+	}
+	if createCalls != 2 {
+		t.Fatalf("sandbox Create() calls = %d, want 2", createCalls)
+	}
+	if replaced.Image != "manager-image:2" {
+		t.Fatalf("Create() image = %q, want requested image", replaced.Image)
+	}
+	workspaceRoot, err := agentWorkspaceRoot(ManagerName)
+	if err != nil {
+		t.Fatalf("agentWorkspaceRoot() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "AGENT.md")); err != nil {
+		t.Fatalf("manager workspace was not reprovisioned after replace: %v", err)
+	}
+}
+
 func TestCreateReplaceManagerWithoutRequestedImageUsesManagerDefault(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -1490,6 +1569,79 @@ func TestCreateReplaceManagerSwitchesRuntimeKind(t *testing.T) {
 		t.Fatalf("createGatewayBox() calls = %d, want 2", len(gotImages))
 	}
 	if got, want := gotImages[1], config.DefaultOpenClawManagerImage; got != want {
+		t.Fatalf("recreate manager image = %q, want %q", got, want)
+	}
+}
+
+func TestCreateReplaceManagerSwitchesRuntimeKindUsesRequestedImage(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	var gotImages []string
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) { return &fakeRuntime{}, nil },
+		func(_ *Service, _ context.Context, _ sandbox.Runtime, image, name, _ string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+			gotImages = append(gotImages, image)
+			return &fakeInstance{}, sandbox.Info{
+				ID:        "box-" + name,
+				Name:      name,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	)
+	testGetBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string) (sandbox.Instance, error) {
+		return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+	}
+	testForceRemoveBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string) error {
+		return nil
+	}
+	defer ResetTestHooks()
+
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"picoclaw-manager:old",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if _, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			ID:   ManagerUserID,
+			Name: ManagerName,
+		},
+	}); err != nil {
+		t.Fatalf("seed Create() error = %v", err)
+	}
+
+	const requestedImage = "openclaw-manager:requested"
+	replaced, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			ID:          ManagerUserID,
+			Name:        ManagerName,
+			Image:       requestedImage,
+			RuntimeKind: RuntimeKindOpenClawSandbox,
+		},
+		Replace: true,
+	})
+	if err != nil {
+		t.Fatalf("Create() replace error = %v", err)
+	}
+	if got, want := replaced.RuntimeKind, RuntimeKindOpenClawSandbox; got != want {
+		t.Fatalf("Create() runtime_kind = %q, want %q", got, want)
+	}
+	if got, want := replaced.Image, requestedImage; got != want {
+		t.Fatalf("Create() image = %q, want %q", got, want)
+	}
+	if got, want := svc.managerImage, requestedImage; got != want {
+		t.Fatalf("managerImage = %q, want %q", got, want)
+	}
+	if len(gotImages) != 2 {
+		t.Fatalf("createGatewayBox() calls = %d, want 2", len(gotImages))
+	}
+	if got, want := gotImages[1], requestedImage; got != want {
 		t.Fatalf("recreate manager image = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## What was broken

1. When the bootstrap manager was recreated, the code prepared the manager workspace before deleting the old manager home. The delete step then removed the newly prepared workspace, including AGENT.md. The new manager box could then be created with missing workspace files.
2. When changing the manager runtime and passing a custom image, the code could replace that requested image with the runtime default image.

## How this fixes it

- Clean up the old manager box and home first, then prepare the manager workspace again before creating the new box.
- Keep the requested manager image when one is provided, instead of overwriting it with the runtime default.
- Add tests for both cases.

## Tested

- env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/agent