### PR TITLE
Support Responses API

### DIFF
--- a/cli/member/member.go
+++ b/cli/member/member.go
@@ -73,7 +73,7 @@ func (c cmd) runCreate(ctx context.Context, run *command.Context, args []string,
 	fs := run.NewFlagSet("member create", run.Program+" member create [flags]", "Add a member to a room.")
 	channelName := fs.String("channel", "csgclaw", "channel name: csgclaw or feishu")
 	roomID := fs.String("room-id", "", "target room id")
-	userID := fs.String("user-id", "", "bot-id to add")
+	userID := fs.String("user-id", "", "bot id to add")
 	inviterID := fs.String("inviter-id", "", "inviter bot id")
 	locale := fs.String("locale", "", "room locale")
 	if err := fs.Parse(args); err != nil {
@@ -83,7 +83,7 @@ func (c cmd) runCreate(ctx context.Context, run *command.Context, args []string,
 		return fmt.Errorf("member create does not accept positional arguments")
 	}
 	if *userID == "" {
-		return fmt.Errorf("--user-id is required")
+		return fmt.Errorf("--user-id bot id is required")
 	}
 
 	room, err := run.APIClient(globals).AddRoomMemberByChannel(ctx, *channelName, apitypes.AddRoomMembersRequest{

--- a/cli/message/message.go
+++ b/cli/message/message.go
@@ -89,7 +89,7 @@ func (c cmd) runCreate(ctx context.Context, run *command.Context, args []string,
 		return fmt.Errorf("room_id is required")
 	}
 	if *senderID == "" {
-		return fmt.Errorf("--sender-id is required")
+		return fmt.Errorf("--sender-id bot id is required")
 	}
 	if *content == "" {
 		return fmt.Errorf("content is required")

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,8 @@ This document is generated from the HTTP routes and behaviors currently implemen
   - `GET /api/bots/{id}/llm/v1/models`
   - `POST /api/bots/{id}/llm/chat/completions`
   - `POST /api/bots/{id}/llm/v1/chat/completions`
+  - `POST /api/bots/{id}/llm/responses`
+  - `POST /api/bots/{id}/llm/v1/responses`
 - If the server runs with `no_auth`, the checks above are skipped
 
 ## Health Check
@@ -404,6 +406,7 @@ Notes:
 - For `provider=codex` or `claude_code`, model choices are obtained through CLIProxy
 - For `provider=api`, the server calls the target OpenAI-compatible `/models` endpoint
 - If `agent_id` is provided and `api_key` is omitted in the request, the server may reuse the saved key from that agent
+- If `agent_id` is omitted and `api_key` is omitted, the server may reuse the saved default API key only when `provider=api` and `base_url` matches the current default profile
 
 ### `GET /api/v1/agent-profile-defaults`
 
@@ -978,6 +981,31 @@ Notes:
   }
 }
 ```
+
+### `POST /api/bots/{id}/llm/responses`
+
+### `POST /api/bots/{id}/llm/v1/responses`
+
+Forwards OpenAI-compatible Responses API requests to the LLM bridge. Codex runtime uses this entrypoint for provider traffic. If the selected upstream provider returns an unsupported Responses endpoint status, the bridge falls back to upstream chat completions and wraps the result in a Responses-compatible response for Codex.
+
+Example request body:
+
+```json
+{
+  "model": "ignored-by-server",
+  "input": "Review this patch.",
+  "stream": true
+}
+```
+
+Notes:
+
+- Requires Bearer Token
+- The request is first forwarded to the selected profile's `base_url + /responses`
+- If upstream `/responses` returns `404` or `405`, the bridge retries via `base_url + /chat/completions`
+- The `model` field is overwritten with the agent's resolved `model_id`
+- Responses forwarding does not inject the chat-only top-level `reasoning_effort`
+- Upstream Responses headers, status, and body are copied through, including streaming responses such as `text/event-stream`
 
 ## Compatibility Notes
 

--- a/docs/api.zh.md
+++ b/docs/api.zh.md
@@ -25,6 +25,8 @@
   - `GET /api/bots/{id}/llm/v1/models`
   - `POST /api/bots/{id}/llm/chat/completions`
   - `POST /api/bots/{id}/llm/v1/chat/completions`
+  - `POST /api/bots/{id}/llm/responses`
+  - `POST /api/bots/{id}/llm/v1/responses`
 - 若服务端开启 `no_auth`，上述鉴权会被跳过
 
 ## 健康检查
@@ -404,6 +406,7 @@ ok
 - `provider=codex` 或 `claude_code` 时会通过 CLIProxy 获取模型选项
 - `provider=api` 时会调用目标 OpenAI-compatible `/models`
 - 若提供了 `agent_id` 且当前请求未显式传 `api_key`，服务端可能复用该 agent 已保存的密钥
+- 若未提供 `agent_id` 且当前请求未显式传 `api_key`，仅当 `provider=api` 且 `base_url` 匹配当前默认 profile 时，服务端才可能复用已保存的默认 API key
 
 ### `GET /api/v1/agent-profile-defaults`
 
@@ -978,6 +981,31 @@ data: {"message_id":"msg-1","room_id":"room-1","sender_id":"u-admin","text":"hel
   }
 }
 ```
+
+### `POST /api/bots/{id}/llm/responses`
+
+### `POST /api/bots/{id}/llm/v1/responses`
+
+转发 OpenAI-compatible Responses API 请求到 LLM bridge。Codex runtime 使用这个入口发送 provider 流量。如果所选上游 provider 返回不支持 Responses endpoint 的状态，bridge 会回退到上游 chat completions，并把结果包装成 Codex 可消费的 Responses-compatible response。
+
+请求体示例：
+
+```json
+{
+  "model": "ignored-by-server",
+  "input": "Review this patch.",
+  "stream": true
+}
+```
+
+说明：
+
+- 需要 Bearer Token
+- 请求会先转发到所选 profile 的 `base_url + /responses`
+- 若上游 `/responses` 返回 `404` 或 `405`，bridge 会改为请求 `base_url + /chat/completions`
+- `model` 字段会被覆盖为 agent 已解析出的 `model_id`
+- Responses 转发不会注入 chat-only 的顶层 `reasoning_effort`
+- 上游 Responses 的 headers、status 和 body 会被透传，包括 `text/event-stream` 这类流式响应
 
 ## 兼容性说明
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -115,6 +115,8 @@ Auth is also managed locally:
 
 When a worker uses the Codex runtime, its local state is stored under `~/.csgclaw/agents/<agent-name>/.codex/`. The workspace lives at `~/.csgclaw/agents/<agent-name>/.codex/workspace`, shell home lives at `~/.csgclaw/agents/<agent-name>/.codex/home`, and Codex-managed files such as `auth.json` are stored directly under `~/.csgclaw/agents/<agent-name>/.codex`. This path is intentionally separate from the sandbox provider home such as `~/.csgclaw/agents/<agent-name>/boxlite`.
 
+For complete Codex worker profiles, CSGClaw writes `~/.csgclaw/agents/<agent-name>/.codex/config.toml` with an OpenAI-compatible proxy provider and always sets `wire_api = "responses"` because current `codex-acp` no longer accepts chat wire API providers. If the upstream provider reports the Responses endpoint as unsupported, CSGClaw keeps the Codex-facing Responses bridge and falls back to upstream chat completions behind that bridge. The raw upstream API key is not written to this file; it is injected into the runtime environment through `env_key = "OPENAI_API_KEY"`.
+
 When a worker uses the Codex runtime, CSGClaw resolves `codex-acp` automatically before startup. You can override that behavior with:
 
 - `CSGCLAW_CODEX_ACP_PATH` to point at a preinstalled `codex-acp` binary

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -115,6 +115,8 @@ bootstrap manager 当前固定使用 `picoclaw_sandbox`；`openclaw_sandbox` 支
 
 当 worker 使用 Codex runtime 时，它的本地状态会统一放在 `~/.csgclaw/agents/<agent-name>/.codex/` 下。workspace 路径是 `~/.csgclaw/agents/<agent-name>/.codex/workspace`，shell home 路径是 `~/.csgclaw/agents/<agent-name>/.codex/home`，而 `auth.json` 这类 Codex 自己管理的文件会直接放在 `~/.csgclaw/agents/<agent-name>/.codex` 下。这个路径会和 sandbox provider 的 home（例如 `~/.csgclaw/agents/<agent-name>/boxlite`）分开。
 
+对于完整的 Codex worker profile，CSGClaw 会写入 `~/.csgclaw/agents/<agent-name>/.codex/config.toml`，其中 OpenAI 兼容代理 provider 始终使用 `wire_api = "responses"`，因为当前 `codex-acp` 已不再接受 chat wire API provider。如果上游明确表示不支持 Responses 端点，CSGClaw 会保持 Codex 侧 Responses bridge 不变，并在 bridge 后面回退到上游 chat completions。原始上游 API key 不会写入这个文件，而是通过 `env_key = "OPENAI_API_KEY"` 注入到 runtime 环境变量。
+
 当 worker 使用 Codex runtime 时，CSGClaw 会在启动前自动解析 `codex-acp`；如果本地不存在，则会按需下载。你可以通过下面的环境变量覆盖默认行为：
 
 - `CSGCLAW_CODEX_ACP_PATH`：指定本地 `codex-acp` 可执行文件路径

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -267,6 +267,81 @@ func TestListModelsForRequestUsesStoredAgentAPIKeyForMatchingProfile(t *testing.
 	}
 }
 
+func TestListModelsForRequestUsesDefaultAPIKeyForMatchingProfile(t *testing.T) {
+	var authHeader string
+	var gotHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		gotHeader = r.Header.Get("X-Test")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-default"}]}`))
+	}))
+	defer upstream.Close()
+
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.profileDefaults = normalizeProfile(AgentProfile{
+		Name:     ManagerName,
+		Provider: ProviderAPI,
+		BaseURL:  upstream.URL + "/v1",
+		APIKey:   "default-key",
+		Headers:  map[string]string{"X-Test": "stored"},
+		ModelID:  "gpt-default",
+	}, ManagerName, "")
+
+	models, err := svc.ListModelsForRequest(context.Background(), ProfileModelRequest{
+		Provider: ProviderAPI,
+		BaseURL:  upstream.URL + "/v1",
+		Headers:  map[string]string{"X-Test": "draft"},
+	})
+	if err != nil {
+		t.Fatalf("ListModelsForRequest() error = %v", err)
+	}
+	if authHeader != "Bearer default-key" {
+		t.Fatalf("Authorization = %q, want default key", authHeader)
+	}
+	if gotHeader != "draft" {
+		t.Fatalf("X-Test header = %q, want draft header", gotHeader)
+	}
+	if got, want := strings.Join(models, ","), "gpt-default"; got != want {
+		t.Fatalf("models = %v, want %s", models, want)
+	}
+}
+
+func TestProfileForCreateRequestUsesDefaultAPIKeyWithoutReplacingSelectedModel(t *testing.T) {
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.profileDefaults = normalizeProfile(AgentProfile{
+		Name:     ManagerName,
+		Provider: ProviderAPI,
+		BaseURL:  "https://api.example/v1",
+		APIKey:   "default-key",
+		ModelID:  "gpt-default",
+	}, ManagerName, "")
+
+	profile, err := svc.profileForCreateRequest(context.Background(), &CreateAgentSpec{
+		Name:        "alice",
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		AgentProfile: AgentProfile{
+			Provider: ProviderAPI,
+			BaseURL:  "https://api.example/v1",
+			ModelID:  "gpt-selected",
+		},
+	})
+	if err != nil {
+		t.Fatalf("profileForCreateRequest() error = %v", err)
+	}
+	if got, want := profile.APIKey, "default-key"; got != want {
+		t.Fatalf("APIKey = %q, want %q", got, want)
+	}
+	if got, want := profile.ModelID, "gpt-selected"; got != want {
+		t.Fatalf("ModelID = %q, want %q", got, want)
+	}
+}
+
 func TestListModelsForRequestDoesNotReuseStoredAPIKeyForChangedBaseURL(t *testing.T) {
 	var authHeader string
 	otherUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -277,7 +277,7 @@ func TestListModelsForRequestUsesDefaultAPIKeyForMatchingProfile(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "manager-image:test", "")
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -310,7 +310,7 @@ func TestListModelsForRequestUsesDefaultAPIKeyForMatchingProfile(t *testing.T) {
 }
 
 func TestProfileForCreateRequestUsesDefaultAPIKeyWithoutReplacingSelectedModel(t *testing.T) {
-	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "", "")
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "manager-image:test", "")
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}

--- a/internal/agent/responses_probe.go
+++ b/internal/agent/responses_probe.go
@@ -1,0 +1,142 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"csgclaw/internal/modelprovider"
+)
+
+var checkResponsesAPIForProvider = modelprovider.CheckResponsesAPI
+
+const (
+	codexWireAPIResponses = "responses"
+	codexWireAPIChat      = "chat"
+)
+
+type responsesProbeResult struct {
+	wireAPI string
+	err     error
+}
+
+type responsesProbeCache struct {
+	mu      sync.Mutex
+	results map[string]responsesProbeResult
+}
+
+var codexResponsesProbeCache = responsesProbeCache{results: make(map[string]responsesProbeResult)}
+
+func TestOnlySetResponsesAPIProbe(probe func(context.Context, string, string, string, map[string]string) error) func() {
+	previous := checkResponsesAPIForProvider
+	checkResponsesAPIForProvider = probe
+	codexResponsesProbeCache.clear()
+	return func() {
+		checkResponsesAPIForProvider = previous
+		codexResponsesProbeCache.clear()
+	}
+}
+
+func (s *Service) ensureCodexWireAPI(ctx context.Context, runtimeKind string, profile AgentProfile) error {
+	if strings.TrimSpace(runtimeKind) != RuntimeKindCodex {
+		return nil
+	}
+	target, ok, err := responsesProbeTarget(profile)
+	if err != nil {
+		return fmt.Errorf("validate Codex provider Responses API: %w", err)
+	}
+	if !ok {
+		return nil
+	}
+	if _, err := codexResponsesProbeCache.wireAPI(ctx, target); err != nil {
+		return fmt.Errorf("validate Codex provider Responses API at %s for model %s: %w", target.baseURL, target.modelID, err)
+	}
+	return nil
+}
+
+type responsesProbeTargetConfig struct {
+	provider string
+	baseURL  string
+	apiKey   string
+	modelID  string
+	headers  map[string]string
+}
+
+func responsesProbeTarget(profile AgentProfile) (responsesProbeTargetConfig, bool, error) {
+	profile = normalizeProfile(profile, profile.Name, profile.Description)
+	switch profile.Provider {
+	case ProviderCodex, ProviderClaudeCode:
+		// CLIProxy-backed profiles do not expose their upstream as a static OpenAI-compatible
+		// provider here. Their auth and routing are validated by the existing CLIProxy flow.
+		return responsesProbeTargetConfig{}, false, nil
+	}
+	baseURL := profileBaseURL(profile)
+	if strings.TrimSpace(baseURL) == "" {
+		return responsesProbeTargetConfig{}, false, fmt.Errorf("provider base_url is required")
+	}
+	return responsesProbeTargetConfig{
+		provider: profile.Provider,
+		baseURL:  baseURL,
+		apiKey:   profileAPIKey(profile),
+		modelID:  strings.TrimSpace(profile.ModelID),
+		headers:  normalizeStringMap(profile.Headers),
+	}, true, nil
+}
+
+func (c *responsesProbeCache) wireAPI(ctx context.Context, target responsesProbeTargetConfig) (string, error) {
+	key := responsesProbeCacheKey(target)
+	c.mu.Lock()
+	if c.results == nil {
+		c.results = make(map[string]responsesProbeResult)
+	}
+	if result, ok := c.results[key]; ok {
+		c.mu.Unlock()
+		return result.wireAPI, result.err
+	}
+	c.mu.Unlock()
+
+	err := checkResponsesAPIForProvider(ctx, target.baseURL, target.apiKey, target.modelID, target.headers)
+	result := responsesProbeResult{wireAPI: codexWireAPIResponses}
+	if errors.Is(err, modelprovider.ErrResponsesAPIUnsupported) {
+		result.wireAPI = codexWireAPIChat
+		err = nil
+	}
+	result.err = err
+
+	if err == nil {
+		c.mu.Lock()
+		c.results[key] = result
+		c.mu.Unlock()
+	}
+	return result.wireAPI, result.err
+}
+
+func (c *responsesProbeCache) cachedWireAPI(target responsesProbeTargetConfig) (string, bool) {
+	key := responsesProbeCacheKey(target)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result, ok := c.results[key]
+	if !ok || result.err != nil || strings.TrimSpace(result.wireAPI) == "" {
+		return "", false
+	}
+	return result.wireAPI, true
+}
+
+func (c *responsesProbeCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.results = make(map[string]responsesProbeResult)
+}
+
+func responsesProbeCacheKey(target responsesProbeTargetConfig) string {
+	return strings.TrimSpace(target.provider) + "\x00" + strings.TrimRight(strings.TrimSpace(target.baseURL), "/") + "\x00" + strings.TrimSpace(target.modelID)
+}
+
+func codexWireAPIForProfile(runtimeKind string, profile AgentProfile) string {
+	if strings.TrimSpace(runtimeKind) != RuntimeKindCodex {
+		return ""
+	}
+	return codexWireAPIResponses
+}

--- a/internal/agent/responses_probe.go
+++ b/internal/agent/responses_probe.go
@@ -12,22 +12,12 @@ import (
 
 var checkResponsesAPIForProvider = modelprovider.CheckResponsesAPI
 
-const (
-	codexWireAPIResponses = "responses"
-	codexWireAPIChat      = "chat"
-)
-
-type responsesProbeResult struct {
-	wireAPI string
-	err     error
-}
-
 type responsesProbeCache struct {
 	mu      sync.Mutex
-	results map[string]responsesProbeResult
+	results map[string]struct{}
 }
 
-var codexResponsesProbeCache = responsesProbeCache{results: make(map[string]responsesProbeResult)}
+var codexResponsesProbeCache = responsesProbeCache{results: make(map[string]struct{})}
 
 func TestOnlySetResponsesAPIProbe(probe func(context.Context, string, string, string, map[string]string) error) func() {
 	previous := checkResponsesAPIForProvider
@@ -39,7 +29,7 @@ func TestOnlySetResponsesAPIProbe(probe func(context.Context, string, string, st
 	}
 }
 
-func (s *Service) ensureCodexWireAPI(ctx context.Context, runtimeKind string, profile AgentProfile) error {
+func (s *Service) ensureCodexResponsesAPI(ctx context.Context, runtimeKind string, profile AgentProfile) error {
 	if strings.TrimSpace(runtimeKind) != RuntimeKindCodex {
 		return nil
 	}
@@ -50,7 +40,7 @@ func (s *Service) ensureCodexWireAPI(ctx context.Context, runtimeKind string, pr
 	if !ok {
 		return nil
 	}
-	if _, err := codexResponsesProbeCache.wireAPI(ctx, target); err != nil {
+	if err := codexResponsesProbeCache.validate(ctx, target); err != nil {
 		return fmt.Errorf("validate Codex provider Responses API at %s for model %s: %w", target.baseURL, target.modelID, err)
 	}
 	return nil
@@ -85,58 +75,37 @@ func responsesProbeTarget(profile AgentProfile) (responsesProbeTargetConfig, boo
 	}, true, nil
 }
 
-func (c *responsesProbeCache) wireAPI(ctx context.Context, target responsesProbeTargetConfig) (string, error) {
+func (c *responsesProbeCache) validate(ctx context.Context, target responsesProbeTargetConfig) error {
 	key := responsesProbeCacheKey(target)
 	c.mu.Lock()
 	if c.results == nil {
-		c.results = make(map[string]responsesProbeResult)
+		c.results = make(map[string]struct{})
 	}
-	if result, ok := c.results[key]; ok {
+	if _, ok := c.results[key]; ok {
 		c.mu.Unlock()
-		return result.wireAPI, result.err
+		return nil
 	}
 	c.mu.Unlock()
 
 	err := checkResponsesAPIForProvider(ctx, target.baseURL, target.apiKey, target.modelID, target.headers)
-	result := responsesProbeResult{wireAPI: codexWireAPIResponses}
 	if errors.Is(err, modelprovider.ErrResponsesAPIUnsupported) {
-		result.wireAPI = codexWireAPIChat
 		err = nil
 	}
-	result.err = err
 
 	if err == nil {
 		c.mu.Lock()
-		c.results[key] = result
+		c.results[key] = struct{}{}
 		c.mu.Unlock()
 	}
-	return result.wireAPI, result.err
-}
-
-func (c *responsesProbeCache) cachedWireAPI(target responsesProbeTargetConfig) (string, bool) {
-	key := responsesProbeCacheKey(target)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	result, ok := c.results[key]
-	if !ok || result.err != nil || strings.TrimSpace(result.wireAPI) == "" {
-		return "", false
-	}
-	return result.wireAPI, true
+	return err
 }
 
 func (c *responsesProbeCache) clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.results = make(map[string]responsesProbeResult)
+	c.results = make(map[string]struct{})
 }
 
 func responsesProbeCacheKey(target responsesProbeTargetConfig) string {
 	return strings.TrimSpace(target.provider) + "\x00" + strings.TrimRight(strings.TrimSpace(target.baseURL), "/") + "\x00" + strings.TrimSpace(target.modelID)
-}
-
-func codexWireAPIForProfile(runtimeKind string, profile AgentProfile) string {
-	if strings.TrimSpace(runtimeKind) != RuntimeKindCodex {
-		return ""
-	}
-	return codexWireAPIResponses
 }

--- a/internal/agent/runtime_state.go
+++ b/internal/agent/runtime_state.go
@@ -138,6 +138,7 @@ func (s *Service) runtimeProfileForKind(runtimeKind, agentID, fallbackName, fall
 		APIKey:          apiKey,
 		ModelID:         profile.ModelID,
 		ReasoningEffort: profile.ReasoningEffort,
+		WireAPI:         codexWireAPIForProfile(runtimeKind, profile),
 		Env:             normalizeStringMap(profile.Env),
 	}).Normalized()
 }

--- a/internal/agent/runtime_state.go
+++ b/internal/agent/runtime_state.go
@@ -138,7 +138,6 @@ func (s *Service) runtimeProfileForKind(runtimeKind, agentID, fallbackName, fall
 		APIKey:          apiKey,
 		ModelID:         profile.ModelID,
 		ReasoningEffort: profile.ReasoningEffort,
-		WireAPI:         codexWireAPIForProfile(runtimeKind, profile),
 		Env:             normalizeStringMap(profile.Env),
 	}).Normalized()
 }

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1123,7 +1123,7 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 	if got.AgentProfile.EnvRestartRequired {
 		return s.Recreate(ctx, id)
 	}
-	if err := s.ensureCodexWireAPI(ctx, strings.TrimSpace(got.RuntimeKind), got.AgentProfile); err != nil {
+	if err := s.ensureCodexResponsesAPI(ctx, strings.TrimSpace(got.RuntimeKind), got.AgentProfile); err != nil {
 		return Agent{}, err
 	}
 
@@ -1416,7 +1416,7 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 	if err != nil {
 		return Agent{}, err
 	}
-	if err := s.ensureCodexWireAPI(ctx, runtimeKind, resolvedProfile); err != nil {
+	if err := s.ensureCodexResponsesAPI(ctx, runtimeKind, resolvedProfile); err != nil {
 		return Agent{}, err
 	}
 	runtimeProfile := s.runtimeProfileForKind(runtimeKind, id, name, description, resolvedProfile)

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1123,6 +1123,9 @@ func (s *Service) Start(ctx context.Context, id string) (Agent, error) {
 	if got.AgentProfile.EnvRestartRequired {
 		return s.Recreate(ctx, id)
 	}
+	if err := s.ensureCodexWireAPI(ctx, strings.TrimSpace(got.RuntimeKind), got.AgentProfile); err != nil {
+		return Agent{}, err
+	}
 
 	runtimeImpl, err := s.runtimeForKind(strings.TrimSpace(got.RuntimeKind))
 	if err != nil {
@@ -1413,6 +1416,9 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 	if err != nil {
 		return Agent{}, err
 	}
+	if err := s.ensureCodexWireAPI(ctx, runtimeKind, resolvedProfile); err != nil {
+		return Agent{}, err
+	}
 	runtimeProfile := s.runtimeProfileForKind(runtimeKind, id, name, description, resolvedProfile)
 	if err := s.provisionRuntime(ctx, runtimeImpl, runtimeKind, agentruntime.ProvisionRequest{
 		RuntimeID:        runtimeIDForAgentID(id),
@@ -1448,6 +1454,16 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 			CreatedAt: info.CreatedAt.UTC(),
 		})
 	}
+	if runtimeKind == RuntimeKindCodex {
+		if err := s.persistStartingWorker(ctx, id, name, description, image, runtimeKind, resolvedProfile, spec.RuntimeOptions); err != nil {
+			return Agent{}, err
+		}
+		defer func() {
+			if err != nil {
+				_ = s.removeStartingWorker(ctx, id)
+			}
+		}()
+	}
 	handle, err := runtimeImpl.New(ctx, agentruntime.Spec{
 		RuntimeID: runtimeIDForAgentID(id),
 		AgentID:   id,
@@ -1467,18 +1483,78 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 	return s.persistCreatedWorker(ctx, id, name, description, image, runtimeKind, resolvedProfile, spec.RuntimeOptions, info)
 }
 
-func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, image, runtimeKind string, profile AgentProfile, createRuntimeExt map[string]any, info agentruntime.Info) (Agent, error) {
+func (s *Service) persistStartingWorker(ctx context.Context, id, name, description, image, runtimeKind string, profile AgentProfile, runtimeOptions map[string]any) error {
 	s.mu.Lock()
 
 	if _, ok := s.agents[id]; ok {
 		s.mu.Unlock()
-		return Agent{}, fmt.Errorf("agent id %q already exists", id)
+		return fmt.Errorf("agent id %q already exists", id)
 	}
 	if s.hasNameLocked(name) {
+		s.mu.Unlock()
+		return fmt.Errorf("agent name %q already exists", name)
+	}
+
+	worker := newWorkerAgent(id, name, description, image, runtimeKind, profile, runtimeOptions, agentruntime.Info{
+		State:     agentruntime.StateCreated,
+		CreatedAt: time.Now().UTC(),
+	})
+	s.agents[worker.ID] = worker
+	s.syncRuntimeRecordLocked(worker)
+	err := s.saveLocked()
+	s.mu.Unlock()
+	if err != nil {
+		_ = s.removeStartingWorker(ctx, id)
+		return err
+	}
+	return nil
+}
+
+func (s *Service) removeStartingWorker(ctx context.Context, id string) error {
+	s.mu.Lock()
+	current, ok := s.agents[id]
+	if ok && strings.TrimSpace(current.BoxID) == "" && strings.EqualFold(strings.TrimSpace(current.Status), string(agentruntime.StateCreated)) {
+		delete(s.agents, id)
+		s.deleteRuntimeRecordLocked(current.RuntimeID)
+	}
+	err := s.saveLocked()
+	s.mu.Unlock()
+	return err
+}
+
+func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, image, runtimeKind string, profile AgentProfile, createRuntimeExt map[string]any, info agentruntime.Info) (Agent, error) {
+	s.mu.Lock()
+
+	if existing, ok := s.agents[id]; ok && !isStartingWorker(existing) {
+		s.mu.Unlock()
+		return Agent{}, fmt.Errorf("agent id %q already exists", id)
+	}
+	if s.hasNameLockedExcept(name, id) {
 		s.mu.Unlock()
 		return Agent{}, fmt.Errorf("agent name %q already exists", name)
 	}
 
+	worker := newWorkerAgent(id, name, description, image, runtimeKind, profile, createRuntimeExt, info)
+	s.agents[worker.ID] = worker
+	s.syncRuntimeRecordLocked(worker)
+	if worker.AgentProfile.ProfileComplete {
+		s.profileDefaults = cloneProfile(worker.AgentProfile)
+	}
+	if err := s.saveLocked(); err != nil {
+		delete(s.agents, worker.ID)
+		s.deleteRuntimeRecordLocked(worker.RuntimeID)
+		s.mu.Unlock()
+		return Agent{}, err
+	}
+	created := *cloneAgent(&worker)
+	s.mu.Unlock()
+	if err := s.syncLifecycleForAgent(ctx, created); err != nil {
+		return Agent{}, err
+	}
+	return created, nil
+}
+
+func newWorkerAgent(id, name, description, image, runtimeKind string, profile AgentProfile, runtimeOptions map[string]any, info agentruntime.Info) Agent {
 	createdAt := info.CreatedAt.UTC()
 	if info.CreatedAt.IsZero() {
 		createdAt = time.Now().UTC()
@@ -1489,10 +1565,10 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 	}
 	prof := cloneProfile(profile)
 	var agentRX map[string]any
-	if len(createRuntimeExt) > 0 {
-		agentRX = utils.CloneAnyMap(createRuntimeExt)
+	if len(runtimeOptions) > 0 {
+		agentRX = utils.CloneAnyMap(runtimeOptions)
 	}
-	worker := Agent{
+	return Agent{
 		ID:              id,
 		Name:            name,
 		RuntimeID:       runtimeIDForAgentID(id),
@@ -1508,23 +1584,10 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 		ProfileComplete: prof.ProfileComplete,
 		Role:            RoleWorker,
 	}
-	s.agents[worker.ID] = worker
-	s.syncRuntimeRecordLocked(worker)
-	if prof.ProfileComplete {
-		s.profileDefaults = cloneProfile(prof)
-	}
-	if err := s.saveLocked(); err != nil {
-		delete(s.agents, worker.ID)
-		s.deleteRuntimeRecordLocked(worker.RuntimeID)
-		s.mu.Unlock()
-		return Agent{}, err
-	}
-	created := *cloneAgent(&worker)
-	s.mu.Unlock()
-	if err := s.syncLifecycleForAgent(ctx, created); err != nil {
-		return Agent{}, err
-	}
-	return created, nil
+}
+
+func isStartingWorker(a Agent) bool {
+	return strings.TrimSpace(a.BoxID) == "" && strings.EqualFold(strings.TrimSpace(a.Status), string(agentruntime.StateCreated))
 }
 
 func isResolvedWorkspacePath(path string) bool {
@@ -1926,7 +1989,14 @@ func (s *Service) Close() error {
 }
 
 func (s *Service) hasNameLocked(name string) bool {
+	return s.hasNameLockedExcept(name, "")
+}
+
+func (s *Service) hasNameLockedExcept(name, exceptID string) bool {
 	for _, existing := range s.agents {
+		if strings.TrimSpace(exceptID) != "" && strings.EqualFold(existing.ID, exceptID) {
+			continue
+		}
 		if strings.EqualFold(existing.Name, name) {
 			return true
 		}

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -59,7 +59,7 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	s.mu.Unlock()
 
 	if normalized.ProfileComplete {
-		if err := s.ensureCodexWireAPI(context.Background(), runtimeKind, normalized); err != nil {
+		if err := s.ensureCodexResponsesAPI(context.Background(), runtimeKind, normalized); err != nil {
 			return AgentProfileView{}, err
 		}
 	}
@@ -188,7 +188,7 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 
 	if shouldEnsureProfile {
 		s.mu.Unlock()
-		if err := s.ensureCodexWireAPI(ctx, runtimeKind, ensureProfile); err != nil {
+		if err := s.ensureCodexResponsesAPI(ctx, runtimeKind, ensureProfile); err != nil {
 			return Agent{}, err
 		}
 		s.mu.Lock()
@@ -307,7 +307,7 @@ func (s *Service) Recreate(ctx context.Context, id string) (Agent, error) {
 	if !profile.ProfileComplete {
 		return Agent{}, fmt.Errorf("agent %q profile is incomplete", id)
 	}
-	if err := s.ensureCodexWireAPI(ctx, strings.TrimSpace(got.RuntimeKind), profile); err != nil {
+	if err := s.ensureCodexResponsesAPI(ctx, strings.TrimSpace(got.RuntimeKind), profile); err != nil {
 		return Agent{}, err
 	}
 

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -43,17 +44,33 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	current, ok := s.agents[id]
 	if !ok {
+		s.mu.Unlock()
 		return AgentProfileView{}, fmt.Errorf("agent %q not found", id)
 	}
 	if strings.TrimSpace(profile.APIKey) == "" {
 		profile.APIKey = current.AgentProfile.APIKey
 	}
 	normalized := normalizeProfileForAgentRuntime(profile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, nil)
-	normalized.EnvRestartRequired = !profilesEqualEnv(current.AgentProfile, normalized)
+	restartRequired := !profilesEqualEnv(current.AgentProfile, normalized) || codexProfileRuntimeRestartRequired(current, normalized)
+	runtimeKind := strings.TrimSpace(current.RuntimeKind)
+	runningCodex := runtimeKind == RuntimeKindCodex && isRuntimeRunning(current)
+	s.mu.Unlock()
+
+	if normalized.ProfileComplete {
+		if err := s.ensureCodexWireAPI(context.Background(), runtimeKind, normalized); err != nil {
+			return AgentProfileView{}, err
+		}
+	}
+
+	s.mu.Lock()
+	current, ok = s.agents[id]
+	if !ok {
+		s.mu.Unlock()
+		return AgentProfileView{}, fmt.Errorf("agent %q not found", id)
+	}
+	normalized.EnvRestartRequired = restartRequired
 	current.AgentProfile = normalized
 	current.ProfileComplete = normalized.ProfileComplete
 	current.Profile = profileSelector(normalized)
@@ -64,9 +81,35 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 		s.detectionResults = nil
 	}
 	if err := s.saveLocked(); err != nil {
+		s.mu.Unlock()
 		return AgentProfileView{}, err
 	}
+	s.mu.Unlock()
+	if restartRequired && runningCodex {
+		s.stopLifecycleAgent(id)
+	}
 	return profileViewWithAgentRuntimeOptions(normalized, current.RuntimeOptions, current.RuntimeKind, current.DetectionResults), nil
+}
+
+func codexProfileRuntimeRestartRequired(current Agent, next AgentProfile) bool {
+	if strings.TrimSpace(current.RuntimeKind) != RuntimeKindCodex {
+		return false
+	}
+	if !isRuntimeRunning(current) {
+		return false
+	}
+	previous := normalizeProfileForAgentRuntime(current.AgentProfile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, nil)
+	return !codexProfileRuntimeInputsEqual(previous, next)
+}
+
+func codexProfileRuntimeInputsEqual(a, b AgentProfile) bool {
+	return strings.TrimSpace(a.Provider) == strings.TrimSpace(b.Provider) &&
+		strings.TrimRight(strings.TrimSpace(a.BaseURL), "/") == strings.TrimRight(strings.TrimSpace(b.BaseURL), "/") &&
+		strings.TrimSpace(a.APIKey) == strings.TrimSpace(b.APIKey) &&
+		strings.TrimSpace(a.ModelID) == strings.TrimSpace(b.ModelID) &&
+		strings.TrimSpace(a.ReasoningEffort) == strings.TrimSpace(b.ReasoningEffort) &&
+		reflect.DeepEqual(a.Headers, b.Headers) &&
+		reflect.DeepEqual(a.RequestOptions, b.RequestOptions)
 }
 
 func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Agent, error) {
@@ -84,6 +127,13 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 		s.mu.Unlock()
 		return Agent{}, fmt.Errorf("agent %q not found", id)
 	}
+	previous := current
+	runtimeKind := strings.TrimSpace(current.RuntimeKind)
+	runningCodex := runtimeKind == RuntimeKindCodex && isRuntimeRunning(current)
+	restartRequired := false
+	ensureProfile := AgentProfile{}
+	shouldEnsureProfile := false
+	profileUpdated := false
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
 		if name == "" {
@@ -109,6 +159,7 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 		current.Image = strings.TrimSpace(*req.Image)
 	}
 	if req.AgentProfile != nil || req.RuntimeOptions != nil {
+		profileUpdated = true
 		profile := current.AgentProfile
 		if req.AgentProfile != nil {
 			profile = *req.AgentProfile
@@ -123,15 +174,32 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 		mergedFlat := runtimeOptionsAfterPatch(current.RuntimeKind, current.RuntimeOptions, patch)
 		current.RuntimeOptions = nextAgentRuntimeOptions(current.RuntimeKind, current.RuntimeOptions, mergedFlat)
 		normalized := normalizeProfileForAgentRuntime(profile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, mergedFlat)
-		normalized.EnvRestartRequired = !profilesEqualEnv(current.AgentProfile, normalized)
+		restartRequired = !profilesEqualEnv(previous.AgentProfile, normalized) || codexProfileRuntimeRestartRequired(previous, normalized)
+		normalized.EnvRestartRequired = restartRequired
 		current.AgentProfile = normalized
 		current.ProfileComplete = normalized.ProfileComplete
 		current.Profile = profileSelector(normalized)
 		current.DetectionResults = nil
-		if normalized.ProfileComplete {
-			s.profileDefaults = cloneProfile(normalized)
-			s.detectionResults = nil
+		if normalized.ProfileComplete && runtimeKind == RuntimeKindCodex {
+			ensureProfile = normalized
+			shouldEnsureProfile = true
 		}
+	}
+
+	if shouldEnsureProfile {
+		s.mu.Unlock()
+		if err := s.ensureCodexWireAPI(ctx, runtimeKind, ensureProfile); err != nil {
+			return Agent{}, err
+		}
+		s.mu.Lock()
+		if _, ok := s.agents[id]; !ok {
+			s.mu.Unlock()
+			return Agent{}, fmt.Errorf("agent %q not found", id)
+		}
+	}
+	if profileUpdated && current.ProfileComplete {
+		s.profileDefaults = cloneProfile(current.AgentProfile)
+		s.detectionResults = nil
 	}
 	s.agents[id] = current
 	s.syncRuntimeRecordLocked(current)
@@ -140,6 +208,9 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 		return Agent{}, err
 	}
 	s.mu.Unlock()
+	if restartRequired && runningCodex {
+		s.stopLifecycleAgent(id)
+	}
 
 	updated, ok := s.Agent(id)
 	if !ok {
@@ -159,6 +230,9 @@ func (s *Service) ListModelsForRequest(ctx context.Context, req ProfileModelRequ
 	profile = normalizeProfile(profile, profile.Name, profile.Description)
 	if strings.TrimSpace(profile.APIKey) == "" {
 		profile.APIKey = s.storedAPIKeyForModelRequest(req, profile)
+	}
+	if strings.TrimSpace(profile.APIKey) == "" {
+		profile = s.withDefaultAPIKeyForMatchingProfile(profile)
 	}
 	if profile.Provider == ProviderCodex || profile.Provider == ProviderClaudeCode {
 		models, err := listCLIProxyModelChoices(ctx, profile.Provider)
@@ -189,6 +263,25 @@ func (s *Service) storedAPIKeyForModelRequest(req ProfileModelRequest, profile A
 	return stored.APIKey
 }
 
+func (s *Service) withDefaultAPIKeyForMatchingProfile(profile AgentProfile) AgentProfile {
+	if s == nil || strings.TrimSpace(profile.APIKey) != "" || normalizeProfileProvider(profile.Provider) != ProviderAPI {
+		return profile
+	}
+	s.mu.RLock()
+	defaultProfile := cloneProfile(s.profileDefaults)
+	s.mu.RUnlock()
+	defaultProfile = normalizeProfile(defaultProfile, defaultProfile.Name, defaultProfile.Description)
+	if defaultProfile.Provider != ProviderAPI || strings.TrimSpace(defaultProfile.APIKey) == "" {
+		return profile
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/")
+	if baseURL == "" || baseURL != defaultProfile.BaseURL {
+		return profile
+	}
+	profile.APIKey = defaultProfile.APIKey
+	return profile
+}
+
 func (s *Service) ResolvedAgentProfile(agentID string) (AgentProfile, error) {
 	got, ok := s.Agent(agentID)
 	if !ok {
@@ -213,6 +306,9 @@ func (s *Service) Recreate(ctx context.Context, id string) (Agent, error) {
 	profile := normalizeProfileForAgentRuntime(got.AgentProfile, got.RuntimeOptions, got.Name, got.Description, got.RuntimeKind, nil)
 	if !profile.ProfileComplete {
 		return Agent{}, fmt.Errorf("agent %q profile is incomplete", id)
+	}
+	if err := s.ensureCodexWireAPI(ctx, strings.TrimSpace(got.RuntimeKind), profile); err != nil {
+		return Agent{}, err
 	}
 
 	runtimeImpl, err := s.runtimeForKind(strings.TrimSpace(got.RuntimeKind))
@@ -376,6 +472,7 @@ func (s *Service) profileForCreateRequest(ctx context.Context, spec *CreateAgent
 			}
 		}
 	}
+	profile = s.withDefaultAPIKeyForMatchingProfile(profile)
 	runtimeOptionsAfterPatch := runtimeOptionsAfterPatch(rk, nil, spec.RuntimeOptions)
 	profile = normalizeProfileForAgentRuntime(profile, nil, spec.Name, spec.Description, spec.RuntimeKind, runtimeOptionsAfterPatch)
 	if !profile.ProfileComplete {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -16,6 +16,7 @@ import (
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/config"
 	"csgclaw/internal/hub"
+	"csgclaw/internal/modelprovider"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/runtime/notifier"
 	"csgclaw/internal/runtime/openclawsandbox"
@@ -29,6 +30,9 @@ import (
 
 func init() {
 	testDefaultServiceOption = withTestPicoClawSandboxRuntime()
+	checkResponsesAPIForProvider = func(context.Context, string, string, string, map[string]string) error {
+		return nil
+	}
 }
 
 type fakeRuntime struct{}
@@ -529,6 +533,9 @@ func TestCreateWorkerUsesCodexRuntimeWhenRequested(t *testing.T) {
 				if got, want := spec.Profile.APIKey, "shared-token"; got != want {
 					t.Fatalf("Create() profile api key = %q, want %q", got, want)
 				}
+				if got, want := spec.Profile.WireAPI, "responses"; got != want {
+					t.Fatalf("Create() profile wire API = %q, want %q", got, want)
+				}
 				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
 			},
 		}),
@@ -561,6 +568,436 @@ func TestCreateWorkerUsesCodexRuntimeWhenRequested(t *testing.T) {
 	}
 	if rt := svc.runtimeRecords[got.RuntimeID]; rt.Kind != RuntimeKindCodex {
 		t.Fatalf("runtime record kind = %q, want %q", rt.Kind, RuntimeKindCodex)
+	}
+}
+
+func TestCreateWorkerPersistsCodexProfileBeforeRuntimeNew(t *testing.T) {
+	var svc *Service
+	var sawProfile bool
+	var err error
+	svc, err = NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				profile, err := svc.ResolvedAgentProfile(spec.AgentID)
+				if err != nil {
+					t.Fatalf("ResolvedAgentProfile(%q) during runtime New = %v", spec.AgentID, err)
+				}
+				if got, want := profile.ModelID, "deepseek-v4-pro"; got != want {
+					t.Fatalf("ResolvedAgentProfile().ModelID = %q, want %q", got, want)
+				}
+				sawProfile = true
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderAPI,
+			BaseURL:         "https://api.deepseek.com",
+			APIKey:          "api-key",
+			ModelID:         "deepseek-v4-pro",
+			ProfileComplete: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateWorker() error = %v", err)
+	}
+	if !sawProfile {
+		t.Fatal("runtime New did not observe persisted profile")
+	}
+	if got.Status != string(agentruntime.StateRunning) {
+		t.Fatalf("CreateWorker().Status = %q, want running", got.Status)
+	}
+}
+
+func TestCreateWorkerRemovesStartingCodexAgentWhenRuntimeNewFails(t *testing.T) {
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(context.Context, agentruntime.Spec) (agentruntime.Handle, error) {
+				return agentruntime.Handle{}, errors.New("boom")
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderAPI,
+			BaseURL:         "https://api.deepseek.com",
+			APIKey:          "api-key",
+			ModelID:         "deepseek-v4-pro",
+			ProfileComplete: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "create worker box: boom") {
+		t.Fatalf("CreateWorker() error = %v, want runtime New failure", err)
+	}
+	if _, ok := svc.Agent("u-alice"); ok {
+		t.Fatal("Agent(\"u-alice\") exists after runtime New failure")
+	}
+}
+
+func TestCreateWorkerPreservesProfileDefaultsWhenCodexRuntimeNewFails(t *testing.T) {
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(context.Context, agentruntime.Spec) (agentruntime.Handle, error) {
+				return agentruntime.Handle{}, errors.New("boom")
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.profileDefaults = normalizeProfile(AgentProfile{
+		Name:            ManagerName,
+		Provider:        ProviderAPI,
+		BaseURL:         "https://default.example/v1",
+		APIKey:          "default-key",
+		ModelID:         "default-model",
+		ProfileComplete: true,
+	}, ManagerName, "")
+
+	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderAPI,
+			BaseURL:         "https://api.deepseek.com",
+			APIKey:          "api-key",
+			ModelID:         "deepseek-v4-pro",
+			ProfileComplete: true,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "create worker box: boom") {
+		t.Fatalf("CreateWorker() error = %v, want runtime New failure", err)
+	}
+	if got, want := svc.profileDefaults.ModelID, "default-model"; got != want {
+		t.Fatalf("profileDefaults.ModelID = %q, want %q", got, want)
+	}
+	if got, want := svc.profileDefaults.APIKey, "default-key"; got != want {
+		t.Fatalf("profileDefaults.APIKey = %q, want preserved default key", got)
+	}
+}
+
+func TestEnsureCodexWireAPIRetriesAfterTransientProbeError(t *testing.T) {
+	calls := 0
+	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
+		calls++
+		if baseURL != "https://api.example/v1" {
+			t.Fatalf("responses probe baseURL = %q, want api.example", baseURL)
+		}
+		if modelID != "gpt-5.5" {
+			t.Fatalf("responses probe modelID = %q, want gpt-5.5", modelID)
+		}
+		if calls == 1 {
+			if apiKey != "bad-key" {
+				t.Fatalf("first responses probe apiKey = %q, want bad-key", apiKey)
+			}
+			return errors.New("temporary outage")
+		}
+		if apiKey != "fixed-key" {
+			t.Fatalf("second responses probe apiKey = %q, want fixed-key", apiKey)
+		}
+		return nil
+	})
+	t.Cleanup(restore)
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = svc.ensureCodexWireAPI(context.Background(), RuntimeKindCodex, AgentProfile{
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.example/v1",
+		APIKey:          "bad-key",
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "temporary outage") {
+		t.Fatalf("first ensureCodexWireAPI() error = %v, want temporary outage", err)
+	}
+
+	err = svc.ensureCodexWireAPI(context.Background(), RuntimeKindCodex, AgentProfile{
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.example/v1",
+		APIKey:          "fixed-key",
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("second ensureCodexWireAPI() error = %v, want retry success", err)
+	}
+	if calls != 2 {
+		t.Fatalf("responses probe calls = %d, want 2", calls)
+	}
+}
+
+func TestCreateWorkerCodexRuntimeKeepsResponsesWireAPIWhenResponsesUnsupported(t *testing.T) {
+	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
+		if baseURL != "https://unsupported.example/v1" {
+			t.Fatalf("responses probe baseURL = %q, want upstream profile URL", baseURL)
+		}
+		if apiKey != "api-key" {
+			t.Fatalf("responses probe apiKey = %q, want upstream profile key", apiKey)
+		}
+		if modelID != "gpt-4.1" {
+			t.Fatalf("responses probe modelID = %q, want gpt-4.1", modelID)
+		}
+		return modelprovider.ErrResponsesAPIUnsupported
+	})
+	t.Cleanup(restore)
+
+	var gotWireAPI string
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				gotWireAPI = spec.Profile.WireAPI
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderAPI,
+			BaseURL:         "https://unsupported.example/v1",
+			APIKey:          "api-key",
+			ModelID:         "gpt-4.1",
+			ProfileComplete: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateWorker() error = %v", err)
+	}
+	if got.BoxID != "codex-session-alice" {
+		t.Fatalf("CreateWorker().BoxID = %q, want codex-session-alice", got.BoxID)
+	}
+	if gotWireAPI != "responses" {
+		t.Fatalf("runtime profile wire API = %q, want responses", gotWireAPI)
+	}
+}
+
+func TestUpdateCodexAgentProfilePatchRestartsActiveBridge(t *testing.T) {
+	probeCalls := 0
+	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
+		probeCalls++
+		if baseURL != "https://api.deepseek.com" {
+			t.Fatalf("responses probe baseURL = %q, want deepseek upstream", baseURL)
+		}
+		if apiKey != "deepseek-key" {
+			t.Fatalf("responses probe apiKey = %q, want updated profile key", apiKey)
+		}
+		if modelID != "deepseek-v4-pro" {
+			t.Fatalf("responses probe modelID = %q, want deepseek-v4-pro", modelID)
+		}
+		return modelprovider.ErrResponsesAPIUnsupported
+	})
+	t.Cleanup(restore)
+
+	observer := &fakeLifecycleObserver{}
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithLifecycleObserver(observer),
+		WithRuntime(fakeAgentRuntime{kind: RuntimeKindCodex}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	currentProfile := AgentProfile{
+		Name:            "dev",
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.openai.com/v1",
+		APIKey:          "openai-key",
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	}
+	svc.agents["u-dev"] = Agent{
+		ID:              "u-dev",
+		Name:            "dev",
+		RuntimeID:       "rt-u-dev",
+		RuntimeKind:     RuntimeKindCodex,
+		BoxID:           "codex-session-old",
+		Role:            RoleWorker,
+		Status:          string(agentruntime.StateRunning),
+		Profile:         profileSelector(currentProfile),
+		AgentProfile:    currentProfile,
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 5, 18, 9, 0, 0, 0, time.UTC),
+	}
+	nextProfile := AgentProfile{
+		Provider: ProviderAPI,
+		BaseURL:  "https://api.deepseek.com",
+		APIKey:   "deepseek-key",
+		ModelID:  "deepseek-v4-pro",
+	}
+
+	updated, err := svc.Update(context.Background(), "u-dev", UpdateRequest{AgentProfile: &nextProfile})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("responses probe calls = %d, want 1", probeCalls)
+	}
+	if !updated.AgentProfile.EnvRestartRequired {
+		t.Fatal("Update().AgentProfile.EnvRestartRequired = false, want true so running Codex bridge is refreshed")
+	}
+	if len(observer.stopCalls) != 1 || observer.stopCalls[0] != "u-dev" {
+		t.Fatalf("StopAgent() calls = %+v, want [u-dev]", observer.stopCalls)
+	}
+}
+
+func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T) {
+	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
+		if baseURL != "https://api.deepseek.com" {
+			t.Fatalf("responses probe baseURL = %q, want deepseek upstream", baseURL)
+		}
+		if apiKey != "deepseek-key" {
+			t.Fatalf("responses probe apiKey = %q, want updated profile key", apiKey)
+		}
+		if modelID != "deepseek-v4-pro" {
+			t.Fatalf("responses probe modelID = %q, want deepseek-v4-pro", modelID)
+		}
+		return modelprovider.ErrResponsesAPIUnsupported
+	})
+	t.Cleanup(restore)
+
+	observer := &fakeLifecycleObserver{}
+	var gotWireAPI string
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"",
+		"",
+		WithLifecycleObserver(observer),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				gotWireAPI = spec.Profile.WireAPI
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-dev"}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	currentProfile := AgentProfile{
+		Name:            "dev",
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.openai.com/v1",
+		APIKey:          "openai-key",
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	}
+	svc.agents["u-dev"] = Agent{
+		ID:              "u-dev",
+		Name:            "dev",
+		RuntimeID:       "rt-u-dev",
+		RuntimeKind:     RuntimeKindCodex,
+		BoxID:           "codex-session-old",
+		Role:            RoleWorker,
+		Status:          string(agentruntime.StateRunning),
+		Profile:         profileSelector(currentProfile),
+		AgentProfile:    currentProfile,
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 5, 18, 9, 0, 0, 0, time.UTC),
+	}
+
+	view, err := svc.UpdateAgentProfile("u-dev", AgentProfile{
+		Provider: ProviderAPI,
+		BaseURL:  "https://api.deepseek.com",
+		APIKey:   "deepseek-key",
+		ModelID:  "deepseek-v4-pro",
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgentProfile() error = %v", err)
+	}
+	if !view.EnvRestartRequired {
+		t.Fatal("UpdateAgentProfile().EnvRestartRequired = false, want true so running Codex bridge is refreshed")
+	}
+	if len(observer.stopCalls) != 1 || observer.stopCalls[0] != "u-dev" {
+		t.Fatalf("StopAgent() calls = %+v, want [u-dev]", observer.stopCalls)
+	}
+
+	started, err := svc.Start(context.Background(), "u-dev")
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if started.AgentProfile.EnvRestartRequired {
+		t.Fatal("Start().AgentProfile.EnvRestartRequired = true, want false after recreate")
+	}
+	if gotWireAPI != "responses" {
+		t.Fatalf("runtime profile wire API = %q, want responses", gotWireAPI)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -533,9 +533,6 @@ func TestCreateWorkerUsesCodexRuntimeWhenRequested(t *testing.T) {
 				if got, want := spec.Profile.APIKey, "shared-token"; got != want {
 					t.Fatalf("Create() profile api key = %q, want %q", got, want)
 				}
-				if got, want := spec.Profile.WireAPI, "responses"; got != want {
-					t.Fatalf("Create() profile wire API = %q, want %q", got, want)
-				}
 				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
 			},
 		}),
@@ -572,6 +569,8 @@ func TestCreateWorkerUsesCodexRuntimeWhenRequested(t *testing.T) {
 }
 
 func TestCreateWorkerPersistsCodexProfileBeforeRuntimeNew(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	var svc *Service
 	var sawProfile bool
 	var err error
@@ -582,7 +581,7 @@ func TestCreateWorkerPersistsCodexProfileBeforeRuntimeNew(t *testing.T) {
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
@@ -628,6 +627,8 @@ func TestCreateWorkerPersistsCodexProfileBeforeRuntimeNew(t *testing.T) {
 }
 
 func TestCreateWorkerRemovesStartingCodexAgentWhenRuntimeNewFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	svc, err := NewService(
 		testModelConfig(),
 		config.ServerConfig{
@@ -635,7 +636,7 @@ func TestCreateWorkerRemovesStartingCodexAgentWhenRuntimeNewFails(t *testing.T) 
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
@@ -670,6 +671,8 @@ func TestCreateWorkerRemovesStartingCodexAgentWhenRuntimeNewFails(t *testing.T) 
 }
 
 func TestCreateWorkerPreservesProfileDefaultsWhenCodexRuntimeNewFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	svc, err := NewService(
 		testModelConfig(),
 		config.ServerConfig{
@@ -677,7 +680,7 @@ func TestCreateWorkerPreservesProfileDefaultsWhenCodexRuntimeNewFails(t *testing
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
@@ -722,7 +725,9 @@ func TestCreateWorkerPreservesProfileDefaultsWhenCodexRuntimeNewFails(t *testing
 	}
 }
 
-func TestEnsureCodexWireAPIRetriesAfterTransientProbeError(t *testing.T) {
+func TestEnsureCodexResponsesAPIRetriesAfterTransientProbeError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	calls := 0
 	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
 		calls++
@@ -745,12 +750,12 @@ func TestEnsureCodexWireAPIRetriesAfterTransientProbeError(t *testing.T) {
 	})
 	t.Cleanup(restore)
 
-	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "", "")
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	err = svc.ensureCodexWireAPI(context.Background(), RuntimeKindCodex, AgentProfile{
+	err = svc.ensureCodexResponsesAPI(context.Background(), RuntimeKindCodex, AgentProfile{
 		Provider:        ProviderAPI,
 		BaseURL:         "https://api.example/v1",
 		APIKey:          "bad-key",
@@ -758,10 +763,10 @@ func TestEnsureCodexWireAPIRetriesAfterTransientProbeError(t *testing.T) {
 		ProfileComplete: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "temporary outage") {
-		t.Fatalf("first ensureCodexWireAPI() error = %v, want temporary outage", err)
+		t.Fatalf("first ensureCodexResponsesAPI() error = %v, want temporary outage", err)
 	}
 
-	err = svc.ensureCodexWireAPI(context.Background(), RuntimeKindCodex, AgentProfile{
+	err = svc.ensureCodexResponsesAPI(context.Background(), RuntimeKindCodex, AgentProfile{
 		Provider:        ProviderAPI,
 		BaseURL:         "https://api.example/v1",
 		APIKey:          "fixed-key",
@@ -769,14 +774,16 @@ func TestEnsureCodexWireAPIRetriesAfterTransientProbeError(t *testing.T) {
 		ProfileComplete: true,
 	})
 	if err != nil {
-		t.Fatalf("second ensureCodexWireAPI() error = %v, want retry success", err)
+		t.Fatalf("second ensureCodexResponsesAPI() error = %v, want retry success", err)
 	}
 	if calls != 2 {
 		t.Fatalf("responses probe calls = %d, want 2", calls)
 	}
 }
 
-func TestCreateWorkerCodexRuntimeKeepsResponsesWireAPIWhenResponsesUnsupported(t *testing.T) {
+func TestCreateWorkerCodexRuntimeContinuesWhenResponsesUnsupported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
 		if baseURL != "https://unsupported.example/v1" {
 			t.Fatalf("responses probe baseURL = %q, want upstream profile URL", baseURL)
@@ -791,7 +798,6 @@ func TestCreateWorkerCodexRuntimeKeepsResponsesWireAPIWhenResponsesUnsupported(t
 	})
 	t.Cleanup(restore)
 
-	var gotWireAPI string
 	svc, err := NewService(
 		testModelConfig(),
 		config.ServerConfig{
@@ -799,12 +805,11 @@ func TestCreateWorkerCodexRuntimeKeepsResponsesWireAPIWhenResponsesUnsupported(t
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
 			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
-				gotWireAPI = spec.Profile.WireAPI
 				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
 			},
 		}),
@@ -832,12 +837,11 @@ func TestCreateWorkerCodexRuntimeKeepsResponsesWireAPIWhenResponsesUnsupported(t
 	if got.BoxID != "codex-session-alice" {
 		t.Fatalf("CreateWorker().BoxID = %q, want codex-session-alice", got.BoxID)
 	}
-	if gotWireAPI != "responses" {
-		t.Fatalf("runtime profile wire API = %q, want responses", gotWireAPI)
-	}
 }
 
 func TestUpdateCodexAgentProfilePatchRestartsActiveBridge(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	probeCalls := 0
 	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
 		probeCalls++
@@ -862,7 +866,7 @@ func TestUpdateCodexAgentProfilePatchRestartsActiveBridge(t *testing.T) {
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithLifecycleObserver(observer),
 		WithRuntime(fakeAgentRuntime{kind: RuntimeKindCodex}),
@@ -914,6 +918,8 @@ func TestUpdateCodexAgentProfilePatchRestartsActiveBridge(t *testing.T) {
 }
 
 func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	restore := TestOnlySetResponsesAPIProbe(func(_ context.Context, baseURL, apiKey, modelID string, _ map[string]string) error {
 		if baseURL != "https://api.deepseek.com" {
 			t.Fatalf("responses probe baseURL = %q, want deepseek upstream", baseURL)
@@ -929,7 +935,6 @@ func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T
 	t.Cleanup(restore)
 
 	observer := &fakeLifecycleObserver{}
-	var gotWireAPI string
 	svc, err := NewService(
 		testModelConfig(),
 		config.ServerConfig{
@@ -937,13 +942,12 @@ func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T
 			AdvertiseBaseURL: "http://127.0.0.1:18080",
 			AccessToken:      "shared-token",
 		},
-		"",
+		"manager-image:test",
 		"",
 		WithLifecycleObserver(observer),
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
 			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
-				gotWireAPI = spec.Profile.WireAPI
 				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-dev"}, nil
 			},
 		}),
@@ -995,9 +999,6 @@ func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T
 	}
 	if started.AgentProfile.EnvRestartRequired {
 		t.Fatal("Start().AgentProfile.EnvRestartRequired = true, want false after recreate")
-	}
-	if gotWireAPI != "responses" {
-		t.Fatalf("runtime profile wire API = %q, want responses", gotWireAPI)
 	}
 }
 

--- a/internal/api/bot_compat.go
+++ b/internal/api/bot_compat.go
@@ -31,6 +31,8 @@ func (h *Handler) registerBotCompatibilityRoutes(router chi.Router) {
 		r.Get("/llm/v1/models", h.handleBotCompatibilityLLMModels)
 		r.Post("/llm/chat/completions", h.handleBotCompatibilityLLMChatCompletions)
 		r.Post("/llm/v1/chat/completions", h.handleBotCompatibilityLLMChatCompletions)
+		r.Post("/llm/responses", h.handleBotCompatibilityLLMResponses)
+		r.Post("/llm/v1/responses", h.handleBotCompatibilityLLMResponses)
 	})
 }
 
@@ -80,6 +82,14 @@ func (h *Handler) handleBotCompatibilityLLMChatCompletions(w http.ResponseWriter
 		return
 	}
 	h.handleBotLLMChatCompletions(w, r, botID)
+}
+
+func (h *Handler) handleBotCompatibilityLLMResponses(w http.ResponseWriter, r *http.Request) {
+	botID, ok := h.requireBotCompatibilityBotID(w, r)
+	if !ok {
+		return
+	}
+	h.handleBotLLMResponses(w, r, botID)
 }
 
 func (h *Handler) requireBotCompatibilityBotID(w http.ResponseWriter, r *http.Request) (string, bool) {
@@ -376,7 +386,7 @@ func parseBotCompatibilityPath(path string) (botID, action string, ok bool) {
 	botID = parts[0]
 	action = strings.Join(parts[1:], "/")
 	switch action {
-	case "events", "messages/send", "llm/models", "llm/v1/models", "llm/chat/completions", "llm/v1/chat/completions":
+	case "events", "messages/send", "llm/models", "llm/v1/models", "llm/chat/completions", "llm/v1/chat/completions", "llm/responses", "llm/v1/responses":
 		return botID, action, true
 	default:
 		return "", "", false

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -44,6 +44,9 @@ func init() {
 		}
 		return runtimewiring.WithOpenClawSandboxRuntime()(s)
 	})
+	_ = agent.TestOnlySetResponsesAPIProbe(func(context.Context, string, string, string, map[string]string) error {
+		return nil
+	})
 }
 
 func testFeishuBotInfoResolver(t *testing.T, openIDsByAppID map[string]string) func(context.Context, feishu.AppConfig) (feishu.BotInfo, error) {
@@ -139,6 +142,8 @@ func TestParseBotCompatibilityPath(t *testing.T) {
 		{path: "/api/bots/u-manager/llm/v1/models", wantBotID: "u-manager", wantAction: "llm/v1/models", wantOK: true},
 		{path: "/api/bots/u-manager/llm/chat/completions", wantBotID: "u-manager", wantAction: "llm/chat/completions", wantOK: true},
 		{path: "/api/bots/u-manager/llm/v1/chat/completions", wantBotID: "u-manager", wantAction: "llm/v1/chat/completions", wantOK: true},
+		{path: "/api/bots/u-manager/llm/responses", wantBotID: "u-manager", wantAction: "llm/responses", wantOK: true},
+		{path: "/api/bots/u-manager/llm/v1/responses", wantBotID: "u-manager", wantAction: "llm/v1/responses", wantOK: true},
 		{path: "/api/bots/u-manager", wantOK: false},
 		{path: "/api/bots//events", wantOK: false},
 	}
@@ -3629,7 +3634,9 @@ func TestHandleBotLLMModelsReturnsBridgeCatalog(t *testing.T) {
 			RuntimeKind: agent.RuntimeKindCodex,
 			Profile:     config.DefaultLLMProfile,
 			AgentProfile: agent.AgentProfile{
-				Provider:        agent.ProviderCodex,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         "http://127.0.0.1:4000",
+				APIKey:          "sk-test",
 				ModelID:         "gpt-5.4",
 				ReasoningEffort: agent.DefaultReasoningEffort,
 				ProfileComplete: true,
@@ -3689,7 +3696,9 @@ func TestHandleBotLLMModelsLegacyRouteReturnsBridgeCatalog(t *testing.T) {
 			RuntimeKind: agent.RuntimeKindCodex,
 			Profile:     config.DefaultLLMProfile,
 			AgentProfile: agent.AgentProfile{
-				Provider:        agent.ProviderCodex,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         "http://127.0.0.1:4000",
+				APIKey:          "sk-test",
 				ModelID:         "gpt-5.4",
 				ReasoningEffort: agent.DefaultReasoningEffort,
 				ProfileComplete: true,

--- a/internal/api/llm.go
+++ b/internal/api/llm.go
@@ -3,6 +3,7 @@ package api
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"csgclaw/internal/llm"
 )
@@ -40,6 +41,38 @@ func (h *Handler) handleBotLLMChatCompletions(w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(status)
 	_, _ = w.Write(respBody)
+}
+
+func (h *Handler) handleBotLLMResponses(w http.ResponseWriter, r *http.Request, botID string) {
+	if h.llm == nil {
+		http.Error(w, "llm bridge is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 10*1024*1024))
+	if err != nil {
+		http.Error(w, "read request body", http.StatusBadRequest)
+		return
+	}
+	resp, callErr := h.llm.Responses(r.Context(), botID, body)
+	if callErr != nil {
+		writeLLMError(w, callErr)
+		return
+	}
+	defer resp.Body.Close()
+	copyLLMHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func copyLLMHeaders(dst, src http.Header) {
+	for key, values := range src {
+		if strings.EqualFold(key, "connection") || strings.EqualFold(key, "content-length") {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }
 
 func writeLLMError(w http.ResponseWriter, err error) {

--- a/internal/bot/service.go
+++ b/internal/bot/service.go
@@ -310,16 +310,18 @@ func (s *Service) createWorker(ctx context.Context, normalized CreateRequest) (B
 			return Bot{}, fmt.Errorf("agent id %q already exists with role %q", created.ID, created.Role)
 		}
 	} else {
-		created, err = s.agents.CreateWorker(ctx, agent.CreateAgentSpec{
-			ID:             normalized.ID,
-			Name:           normalized.Name,
-			Description:    normalized.Description,
-			Image:          normalized.Image,
-			Role:           agent.RoleWorker,
-			RuntimeKind:    normalized.RuntimeKind,
-			FromTemplate:   normalized.FromTemplate,
-			RuntimeOptions: utils.CloneAnyMap(normalized.RuntimeOptions),
-			AgentProfile:   agentProfileFromBotRequest(normalized.AgentProfile),
+		created, err = s.agents.Create(ctx, agent.CreateRequest{
+			Spec: agent.CreateAgentSpec{
+				ID:             normalized.ID,
+				Name:           normalized.Name,
+				Description:    normalized.Description,
+				Image:          normalized.Image,
+				Role:           agent.RoleWorker,
+				RuntimeKind:    normalized.RuntimeKind,
+				FromTemplate:   normalized.FromTemplate,
+				RuntimeOptions: utils.CloneAnyMap(normalized.RuntimeOptions),
+				AgentProfile:   agentProfileFromBotRequest(normalized.AgentProfile),
+			},
 		})
 		if err != nil {
 			return Bot{}, err

--- a/internal/bot/service_test.go
+++ b/internal/bot/service_test.go
@@ -814,6 +814,7 @@ func TestServiceCreateFeishuWorkerCreatesAgentUserAndBot(t *testing.T) {
 		Description: "test lead",
 		Role:        string(RoleWorker),
 		Channel:     string(ChannelFeishu),
+		RuntimeKind: agent.RuntimeKindCodex,
 	})
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
@@ -872,18 +873,20 @@ func TestServiceCreateWorkerReusesAgentAcrossChannels(t *testing.T) {
 	}
 
 	csgclawBot, err := svc.Create(context.Background(), CreateRequest{
-		Name:    "alice",
-		Role:    string(RoleWorker),
-		Channel: string(ChannelCSGClaw),
+		Name:        "alice",
+		Role:        string(RoleWorker),
+		Channel:     string(ChannelCSGClaw),
+		RuntimeKind: agent.RuntimeKindCodex,
 	})
 	if err != nil {
 		t.Fatalf("Create(csgclaw worker) error = %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
 	feishuBot, err := svc.Create(context.Background(), CreateRequest{
-		Name:    "alice",
-		Role:    string(RoleWorker),
-		Channel: string(ChannelFeishu),
+		Name:        "alice",
+		Role:        string(RoleWorker),
+		Channel:     string(ChannelFeishu),
+		RuntimeKind: agent.RuntimeKindCodex,
 	})
 	if err != nil {
 		t.Fatalf("Create(feishu worker) error = %v", err)
@@ -944,17 +947,19 @@ func TestServiceCreateWorkerRejectsDuplicateNameInSameChannel(t *testing.T) {
 	}
 
 	if _, err := svc.Create(context.Background(), CreateRequest{
-		Name:    "alice",
-		Role:    string(RoleWorker),
-		Channel: string(ChannelCSGClaw),
+		Name:        "alice",
+		Role:        string(RoleWorker),
+		Channel:     string(ChannelCSGClaw),
+		RuntimeKind: agent.RuntimeKindCodex,
 	}); err != nil {
 		t.Fatalf("first Create(worker) error = %v", err)
 	}
 
 	_, err = svc.Create(context.Background(), CreateRequest{
-		Name:    "alice",
-		Role:    string(RoleWorker),
-		Channel: string(ChannelCSGClaw),
+		Name:        "alice",
+		Role:        string(RoleWorker),
+		Channel:     string(ChannelCSGClaw),
+		RuntimeKind: agent.RuntimeKindCodex,
 	})
 	if err == nil || !strings.Contains(err.Error(), `bot name "alice" already exists in channel "csgclaw"`) {
 		t.Fatalf("second Create(worker) error = %v, want duplicate name error", err)

--- a/internal/bot/service_test.go
+++ b/internal/bot/service_test.go
@@ -19,6 +19,7 @@ import (
 	"csgclaw/internal/hub"
 	"csgclaw/internal/im"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/sandboxgateway"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/sandbox/sandboxtest"
 )
@@ -27,6 +28,12 @@ var (
 	fakeBotRuntimeStateMu sync.RWMutex
 	fakeBotRuntimeStates  = make(map[string]agentruntime.Info)
 )
+
+func init() {
+	_ = agent.TestOnlySetResponsesAPIProbe(func(context.Context, string, string, string, map[string]string) error {
+		return nil
+	})
+}
 
 type fakeBotAgentRuntime struct {
 	kind string
@@ -41,6 +48,18 @@ func (f fakeBotAgentRuntime) New(_ context.Context, spec agentruntime.Spec) (age
 		RuntimeID: spec.RuntimeID,
 		HandleID:  fmt.Sprintf("%s-%s", f.kind, spec.AgentName),
 	}, nil
+}
+
+func (f fakeBotAgentRuntime) Provision(_ context.Context, req agentruntime.ProvisionRequest) error {
+	if strings.TrimSpace(req.WorkspaceOverlay) == "" {
+		return nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	workspaceRoot := filepath.Join(homeDir, config.AppDirName, "agents", req.AgentName, "workspace")
+	return sandboxgateway.OverlayWorkspaceTree(req.WorkspaceOverlay, workspaceRoot)
 }
 
 func (f fakeBotAgentRuntime) Start(context.Context, agentruntime.Handle) (agentruntime.State, error) {
@@ -304,11 +323,11 @@ func TestServiceListFeishuIncludesConfiguredUnavailableBots(t *testing.T) {
 	)
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        "u-worker",
-			Name:      "worker",
-			Role:      agent.RoleWorker,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           "u-worker",
+			Name:         "worker",
+			Role:         agent.RoleWorker,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	svc, err := NewServiceWithDependencies(store, agentSvc, nil, feishuSvc)
@@ -339,11 +358,11 @@ func TestServiceListFeishuConfiguredBotUsesMatchingAgent(t *testing.T) {
 	}
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        "u-manager",
-			Name:      "manager",
-			Role:      agent.RoleManager,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           "u-manager",
+			Name:         "manager",
+			Role:         agent.RoleManager,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	feishuSvc := feishu.NewServiceWithBotOpenIDResolver(
@@ -393,11 +412,11 @@ func TestServiceListStoredBotUnavailableWhenAgentNotRunning(t *testing.T) {
 	}
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        "u-worker",
-			Name:      "worker",
-			Role:      agent.RoleWorker,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           "u-worker",
+			Name:         "worker",
+			Role:         agent.RoleWorker,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	svc, err := NewServiceWithDependencies(store, agentSvc, nil)
@@ -436,11 +455,11 @@ func TestServiceListWithoutFiltersRefreshesAvailability(t *testing.T) {
 	}
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        "u-worker",
-			Name:      "worker",
-			Role:      agent.RoleWorker,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           "u-worker",
+			Name:         "worker",
+			Role:         agent.RoleWorker,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	svc, err := NewServiceWithDependencies(store, agentSvc, nil)
@@ -722,8 +741,8 @@ func TestServiceCreateCSGClawWorkerCreatesAgentUserAndBot(t *testing.T) {
 	if createdAgent.Image != "agent-image:1" {
 		t.Fatalf("agent.Image = %q, want agent-image:1", createdAgent.Image)
 	}
-	if createdAgent.Provider != agent.ProviderCSGHubLite || createdAgent.ModelID != "glm-4.5" {
-		t.Fatalf("agent profile = %s/%s, want csghub_lite/glm-4.5", createdAgent.Provider, createdAgent.ModelID)
+	if createdAgent.AgentProfile.Provider != agent.ProviderCSGHubLite || createdAgent.AgentProfile.ModelID != "glm-4.5" {
+		t.Fatalf("agent profile = %s/%s, want csghub_lite/glm-4.5", createdAgent.AgentProfile.Provider, createdAgent.AgentProfile.ModelID)
 	}
 	if createdAgent.AgentProfile.ReasoningEffort != "high" {
 		t.Fatalf("agent reasoning = %q, want high", createdAgent.AgentProfile.ReasoningEffort)
@@ -997,11 +1016,11 @@ func TestServiceCreateWorkerUsesFromTemplateWorkspace(t *testing.T) {
 func TestServiceCreateCSGClawManagerBindsBootstrappedAgent(t *testing.T) {
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        agent.ManagerUserID,
-			Name:      agent.ManagerName,
-			Role:      agent.RoleManager,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           agent.ManagerUserID,
+			Name:         agent.ManagerName,
+			Role:         agent.RoleManager,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	imSvc := im.NewService()
@@ -1036,11 +1055,11 @@ func TestServiceCreateCSGClawManagerBindsBootstrappedAgent(t *testing.T) {
 func TestServiceCreateManagerBindsSameAgentAcrossChannels(t *testing.T) {
 	agentSvc := mustNewSeededAgentService(t, []agent.Agent{
 		{
-			ID:        agent.ManagerUserID,
-			Name:      agent.ManagerName,
-			Role:      agent.RoleManager,
-			CreatedAt: time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
-			ModelID:   "default-model",
+			ID:           agent.ManagerUserID,
+			Name:         agent.ManagerName,
+			Role:         agent.RoleManager,
+			CreatedAt:    time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			AgentProfile: agent.AgentProfile{ModelID: "default-model"},
 		},
 	})
 	imSvc := im.NewService()
@@ -1397,6 +1416,11 @@ func mustNewSeededAgentService(t *testing.T, agents []agent.Agent) *agent.Servic
 
 	if agents == nil {
 		agents = []agent.Agent{}
+	}
+	for i := range agents {
+		if strings.TrimSpace(agents[i].RuntimeKind) == "" {
+			agents[i].RuntimeKind = agent.RuntimeKindPicoClawSandbox
+		}
 	}
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "agents.json")

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -368,6 +368,10 @@ func responsesCapabilityKey(profile agent.AgentProfile, baseURL string) string {
 }
 
 func responsesPayloadToChatPayload(payload map[string]any) (map[string]any, error) {
+	if responsesPayloadHasToolSemantics(payload) {
+		return nil, fmt.Errorf("active tool-use Responses requests are not supported by chat-completions fallback")
+	}
+
 	messages := make([]map[string]any, 0, 4)
 	if instructions := strings.TrimSpace(stringValue(payload["instructions"])); instructions != "" {
 		messages = append(messages, map[string]any{"role": "system", "content": instructions})
@@ -407,6 +411,96 @@ func responsesPayloadToChatPayload(payload map[string]any) (map[string]any, erro
 	copyResponsesOptionToChat(payload, chatPayload, "user", "user")
 	copyResponsesOptionToChat(payload, chatPayload, "max_output_tokens", "max_tokens")
 	return chatPayload, nil
+}
+
+func responsesPayloadHasToolSemantics(payload map[string]any) bool {
+	if toolChoiceRequestsTools(payload["tool_choice"]) {
+		return true
+	}
+	return responseValueHasToolSemantics(payload["input"])
+}
+
+func toolChoiceRequestsTools(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case string:
+		text := strings.ToLower(strings.TrimSpace(v))
+		return text != "" && text != "none" && text != "auto"
+	case map[string]any:
+		if len(v) == 0 {
+			return false
+		}
+		if len(v) == 1 && strings.EqualFold(strings.TrimSpace(stringValue(v["type"])), "none") {
+			return false
+		}
+		return true
+	default:
+		return payloadValuePresent(v)
+	}
+}
+
+func responseValueHasToolSemantics(value any) bool {
+	switch v := value.(type) {
+	case []any:
+		for _, item := range v {
+			if responseValueHasToolSemantics(item) {
+				return true
+			}
+		}
+	case []map[string]any:
+		for _, item := range v {
+			if responseValueHasToolSemantics(item) {
+				return true
+			}
+		}
+	case map[string]any:
+		itemType := strings.ToLower(strings.TrimSpace(stringValue(v["type"])))
+		switch {
+		case strings.Contains(itemType, "tool"),
+			itemType == "function_call",
+			itemType == "function_call_output",
+			strings.HasSuffix(itemType, "_call"),
+			strings.HasSuffix(itemType, "_call_output"):
+			return true
+		}
+		if strings.EqualFold(strings.TrimSpace(stringValue(v["role"])), "tool") {
+			return true
+		}
+		for _, key := range []string{"tool_calls", "function_call", "tool_call_id"} {
+			if payloadValuePresent(v[key]) {
+				return true
+			}
+		}
+		if payloadValuePresent(v["call_id"]) && payloadValuePresent(v["output"]) {
+			return true
+		}
+		for _, item := range v {
+			if responseValueHasToolSemantics(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func payloadValuePresent(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(v) != ""
+	case bool:
+		return v
+	case []any:
+		return len(v) > 0
+	case []map[string]any:
+		return len(v) > 0
+	case map[string]any:
+		return len(v) > 0
+	default:
+		return true
+	}
 }
 
 func responseInputItemToChatMessage(item any) (map[string]any, bool) {

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"csgclaw/internal/agent"
@@ -16,9 +18,11 @@ import (
 )
 
 type Service struct {
-	defaults config.ModelConfig
-	agents   *agent.Service
-	client   *http.Client
+	defaults              config.ModelConfig
+	agents                *agent.Service
+	client                *http.Client
+	responsesCapabilityMu sync.Mutex
+	responsesUnsupported  map[string]struct{}
 }
 
 type HTTPError struct {
@@ -26,6 +30,12 @@ type HTTPError struct {
 	Message  string
 	Code     string
 	Provider string
+}
+
+type UpstreamResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       io.ReadCloser
 }
 
 var embeddedCLIProxyProviderBaseURL = func(ctx context.Context, provider string) (string, error) {
@@ -45,9 +55,10 @@ func (e *HTTPError) Error() string {
 
 func NewService(defaults config.ModelConfig, agents *agent.Service) *Service {
 	return &Service{
-		defaults: defaults.Resolved(),
-		agents:   agents,
-		client:   &http.Client{Timeout: 60 * time.Second},
+		defaults:             defaults.Resolved(),
+		agents:               agents,
+		client:               &http.Client{Timeout: 60 * time.Second},
+		responsesUnsupported: make(map[string]struct{}),
 	}
 }
 
@@ -56,16 +67,18 @@ func (s *Service) Models(_ context.Context, botID string) ([]byte, int, string, 
 	if err != nil {
 		return nil, 0, "", err
 	}
+	modelID := strings.TrimSpace(profile.ModelID)
 	payload := map[string]any{
 		"object": "list",
 		"data": []map[string]any{
 			{
-				"id":       profile.ModelID,
+				"id":       modelID,
 				"object":   "model",
 				"created":  0,
 				"owned_by": "csgclaw",
 			},
 		},
+		"models": []map[string]any{codexModelMetadata(profile)},
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -74,12 +87,82 @@ func (s *Service) Models(_ context.Context, botID string) ([]byte, int, string, 
 	return body, http.StatusOK, "application/json", nil
 }
 
+func codexModelMetadata(profile agent.AgentProfile) map[string]any {
+	modelID := strings.TrimSpace(profile.ModelID)
+	if modelID == "" {
+		modelID = "unknown"
+	}
+	reasoningEffort := strings.ToLower(strings.TrimSpace(profile.ReasoningEffort))
+	switch reasoningEffort {
+	case "none", "minimal", "low", "medium", "high", "xhigh":
+	default:
+		reasoningEffort = "medium"
+	}
+	baseInstructions := "You are Codex, a coding agent. Follow the user's instructions and use available tools carefully."
+	return map[string]any{
+		"slug":                    modelID,
+		"display_name":            modelID,
+		"description":             "CSGClaw OpenAI-compatible provider model",
+		"default_reasoning_level": reasoningEffort,
+		"supported_reasoning_levels": []map[string]any{
+			{"effort": "low", "description": "low"},
+			{"effort": "medium", "description": "medium"},
+			{"effort": "high", "description": "high"},
+		},
+		"shell_type":                   "default",
+		"visibility":                   "list",
+		"supported_in_api":             true,
+		"priority":                     1,
+		"availability_nux":             nil,
+		"upgrade":                      nil,
+		"base_instructions":            baseInstructions,
+		"model_messages":               codexModelMessages(baseInstructions),
+		"supports_search_tool":         false,
+		"supports_reasoning_summaries": false,
+		"default_reasoning_summary":    "auto",
+		"support_verbosity":            false,
+		"default_verbosity":            nil,
+		"apply_patch_tool_type":        nil,
+		"web_search_tool_type":         "text",
+		"truncation_policy": map[string]any{
+			"mode":  "bytes",
+			"limit": 10000,
+		},
+		"supports_parallel_tool_calls":     false,
+		"supports_image_detail_original":   false,
+		"context_window":                   272000,
+		"auto_compact_token_limit":         nil,
+		"effective_context_window_percent": 95,
+		"experimental_supported_tools":     []any{},
+		"input_modalities":                 []string{"text", "image"},
+	}
+}
+
+func codexModelMessages(baseInstructions string) map[string]any {
+	return map[string]any{
+		"instructions_template": "{{ personality }}\n\n" + baseInstructions,
+		"instructions_variables": map[string]any{
+			"personality_default":   "",
+			"personality_friendly":  "You are collaborative, supportive, and clear.",
+			"personality_pragmatic": "You are a deeply pragmatic, effective software engineer.",
+		},
+	}
+}
+
 func (s *Service) ChatCompletions(ctx context.Context, botID string, body []byte) ([]byte, int, string, error) {
 	profile, err := s.resolveProfile(botID)
 	if err != nil {
 		return nil, 0, "", err
 	}
 	return s.forwardRemoteChat(ctx, profile, body)
+}
+
+func (s *Service) Responses(ctx context.Context, botID string, body []byte) (*UpstreamResponse, error) {
+	profile, err := s.resolveProfile(botID)
+	if err != nil {
+		return nil, err
+	}
+	return s.forwardRemoteResponses(ctx, profile, body)
 }
 
 func (s *Service) resolveProfile(botID string) (agent.AgentProfile, error) {
@@ -149,6 +232,574 @@ func (s *Service) forwardRemoteChat(ctx context.Context, profile agent.AgentProf
 	return respBody, resp.StatusCode, contentType, nil
 }
 
+func (s *Service) forwardRemoteResponses(ctx context.Context, profile agent.AgentProfile, body []byte) (*UpstreamResponse, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("decode request: %v", err)}
+	}
+	mergeResponsesPayload(payload, profile)
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("encode request: %v", err)}
+	}
+
+	baseURL, apiKey, err := s.agentProfileTarget(ctx, profile)
+	if err != nil {
+		return nil, err
+	}
+	if baseURL == "" {
+		return nil, &HTTPError{Status: http.StatusBadRequest, Message: "profile base_url is required"}
+	}
+	if s.responsesAPIUnsupportedCached(profile, baseURL) {
+		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey)
+	}
+	upstreamURL := strings.TrimRight(baseURL, "/") + "/responses"
+	req, err := newProfileJSONRequest(ctx, upstreamURL, encoded, apiKey, profile.Headers)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusInternalServerError, Message: fmt.Sprintf("build upstream request: %v", err)}
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("send upstream request: %v", err)}
+	}
+	if responsesAPIUnsupportedStatus(resp.StatusCode) {
+		_ = resp.Body.Close()
+		s.markResponsesAPIUnsupported(profile, baseURL)
+		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey)
+	}
+	return &UpstreamResponse{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header.Clone(),
+		Body:       resp.Body,
+	}, nil
+}
+
+func (s *Service) forwardResponsesViaChat(ctx context.Context, profile agent.AgentProfile, responsesPayload map[string]any, baseURL, apiKey string) (*UpstreamResponse, error) {
+	chatPayload, err := responsesPayloadToChatPayload(responsesPayload)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadRequest, Message: err.Error()}
+	}
+	mergeProfilePayload(chatPayload, profile)
+	encoded, err := json.Marshal(chatPayload)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("encode chat fallback request: %v", err)}
+	}
+
+	upstreamURL := strings.TrimRight(baseURL, "/") + "/chat/completions"
+	req, err := newProfileJSONRequest(ctx, upstreamURL, encoded, apiKey, profile.Headers)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusInternalServerError, Message: fmt.Sprintf("build chat fallback request: %v", err)}
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("send chat fallback request: %v", err)}
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &UpstreamResponse{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+			Body:       resp.Body,
+		}, nil
+	}
+	if payloadBool(chatPayload["stream"]) {
+		return streamChatCompletionAsResponse(resp, strings.TrimSpace(profile.ModelID)), nil
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("read chat fallback response: %v", err)}
+	}
+	converted, err := chatCompletionResponseToResponses(respBody, strings.TrimSpace(profile.ModelID))
+	if err != nil {
+		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("convert chat fallback response: %v", err)}
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return &UpstreamResponse{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(converted)),
+	}, nil
+}
+
+func newProfileJSONRequest(ctx context.Context, url string, body []byte, apiKey string, headers map[string]string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		key = strings.TrimSpace(key)
+		if key == "" || strings.EqualFold(key, "authorization") || strings.EqualFold(key, "content-type") {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+	return req, nil
+}
+
+func responsesAPIUnsupportedStatus(status int) bool {
+	return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
+}
+
+func (s *Service) responsesAPIUnsupportedCached(profile agent.AgentProfile, baseURL string) bool {
+	key := responsesCapabilityKey(profile, baseURL)
+	s.responsesCapabilityMu.Lock()
+	defer s.responsesCapabilityMu.Unlock()
+	_, ok := s.responsesUnsupported[key]
+	return ok
+}
+
+func (s *Service) markResponsesAPIUnsupported(profile agent.AgentProfile, baseURL string) {
+	key := responsesCapabilityKey(profile, baseURL)
+	s.responsesCapabilityMu.Lock()
+	defer s.responsesCapabilityMu.Unlock()
+	if s.responsesUnsupported == nil {
+		s.responsesUnsupported = make(map[string]struct{})
+	}
+	s.responsesUnsupported[key] = struct{}{}
+}
+
+func responsesCapabilityKey(profile agent.AgentProfile, baseURL string) string {
+	return strings.TrimSpace(profile.Provider) + "\x00" + strings.TrimRight(strings.TrimSpace(baseURL), "/") + "\x00" + strings.TrimSpace(profile.ModelID)
+}
+
+func responsesPayloadToChatPayload(payload map[string]any) (map[string]any, error) {
+	messages := make([]map[string]any, 0, 4)
+	if instructions := strings.TrimSpace(stringValue(payload["instructions"])); instructions != "" {
+		messages = append(messages, map[string]any{"role": "system", "content": instructions})
+	}
+	switch input := payload["input"].(type) {
+	case string:
+		if strings.TrimSpace(input) != "" {
+			messages = append(messages, map[string]any{"role": "user", "content": input})
+		}
+	case []any:
+		for _, item := range input {
+			message, ok := responseInputItemToChatMessage(item)
+			if ok {
+				messages = append(messages, message)
+			}
+		}
+	case nil:
+	default:
+		text := strings.TrimSpace(stringValue(input))
+		if text != "" {
+			messages = append(messages, map[string]any{"role": "user", "content": text})
+		}
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("responses input is required for chat fallback")
+	}
+
+	chatPayload := map[string]any{"messages": messages}
+	copyResponsesOptionToChat(payload, chatPayload, "stream", "stream")
+	copyResponsesOptionToChat(payload, chatPayload, "temperature", "temperature")
+	copyResponsesOptionToChat(payload, chatPayload, "top_p", "top_p")
+	copyResponsesOptionToChat(payload, chatPayload, "presence_penalty", "presence_penalty")
+	copyResponsesOptionToChat(payload, chatPayload, "frequency_penalty", "frequency_penalty")
+	copyResponsesOptionToChat(payload, chatPayload, "stop", "stop")
+	copyResponsesOptionToChat(payload, chatPayload, "seed", "seed")
+	copyResponsesOptionToChat(payload, chatPayload, "response_format", "response_format")
+	copyResponsesOptionToChat(payload, chatPayload, "user", "user")
+	copyResponsesOptionToChat(payload, chatPayload, "max_output_tokens", "max_tokens")
+	return chatPayload, nil
+}
+
+func responseInputItemToChatMessage(item any) (map[string]any, bool) {
+	switch value := item.(type) {
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return nil, false
+		}
+		return map[string]any{"role": "user", "content": value}, true
+	case map[string]any:
+		role := normalizeChatFallbackRole(stringValue(value["role"]))
+		if role == "" {
+			role = "user"
+		}
+		content := responseContentToText(value["content"])
+		if strings.TrimSpace(content) == "" {
+			content = responseContentToText(value["text"])
+		}
+		if strings.TrimSpace(content) == "" {
+			return nil, false
+		}
+		return map[string]any{"role": role, "content": content}, true
+	default:
+		text := responseContentToText(value)
+		if strings.TrimSpace(text) == "" {
+			return nil, false
+		}
+		return map[string]any{"role": "user", "content": text}, true
+	}
+}
+
+func normalizeChatFallbackRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "developer", "latest_reminder", "system":
+		return "system"
+	case "user", "assistant", "tool":
+		return strings.ToLower(strings.TrimSpace(role))
+	default:
+		return "user"
+	}
+}
+
+func responseContentToText(content any) string {
+	switch value := content.(type) {
+	case string:
+		return value
+	case []any:
+		var b strings.Builder
+		for _, part := range value {
+			text := responseContentToText(part)
+			if text != "" {
+				b.WriteString(text)
+			}
+		}
+		return b.String()
+	case map[string]any:
+		if text := stringValue(value["text"]); text != "" {
+			return text
+		}
+		if text := stringValue(value["content"]); text != "" {
+			return text
+		}
+		return ""
+	default:
+		return stringValue(value)
+	}
+}
+
+func copyResponsesOptionToChat(src, dst map[string]any, srcKey, dstKey string) {
+	value, ok := src[srcKey]
+	if !ok || value == nil {
+		return
+	}
+	if _, exists := dst[dstKey]; exists {
+		return
+	}
+	dst[dstKey] = value
+}
+
+func chatCompletionResponseToResponses(body []byte, fallbackModel string) ([]byte, error) {
+	var chat struct {
+		ID      string         `json:"id"`
+		Created int64          `json:"created"`
+		Model   string         `json:"model"`
+		Choices []chatChoice   `json:"choices"`
+		Usage   map[string]any `json:"usage,omitempty"`
+	}
+	if err := json.Unmarshal(body, &chat); err != nil {
+		return nil, err
+	}
+	text := ""
+	if len(chat.Choices) > 0 {
+		text = responseContentToText(chat.Choices[0].Message["content"])
+	}
+	model := strings.TrimSpace(chat.Model)
+	if model == "" {
+		model = fallbackModel
+	}
+	response := completedResponsesPayload(responseID(chat.ID), model, chat.Created, text, chat.Usage)
+	return json.Marshal(response)
+}
+
+type chatChoice struct {
+	Message      map[string]any `json:"message"`
+	Delta        map[string]any `json:"delta"`
+	FinishReason any            `json:"finish_reason"`
+}
+
+func completedResponsesPayload(id, model string, created int64, text string, usage map[string]any) map[string]any {
+	if id == "" {
+		id = responseID("")
+	}
+	if created == 0 {
+		created = time.Now().Unix()
+	}
+	messageID := id + "_msg"
+	item := map[string]any{
+		"id":     messageID,
+		"type":   "message",
+		"status": "completed",
+		"role":   "assistant",
+		"content": []map[string]any{
+			{
+				"type":        "output_text",
+				"text":        text,
+				"annotations": []any{},
+			},
+		},
+	}
+	response := map[string]any{
+		"id":          id,
+		"object":      "response",
+		"created_at":  created,
+		"status":      "completed",
+		"model":       model,
+		"output":      []map[string]any{item},
+		"output_text": text,
+	}
+	if len(usage) > 0 {
+		response["usage"] = usage
+	}
+	return response
+}
+
+func streamChatCompletionAsResponse(resp *http.Response, fallbackModel string) *UpstreamResponse {
+	reader, writer := io.Pipe()
+	go func() {
+		defer resp.Body.Close()
+		err := writeChatCompletionStreamAsResponse(writer, resp.Body, fallbackModel)
+		_ = writer.CloseWithError(err)
+	}()
+	header := make(http.Header)
+	header.Set("Content-Type", "text/event-stream")
+	header.Set("Cache-Control", "no-cache")
+	return &UpstreamResponse{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       reader,
+	}
+}
+
+func writeChatCompletionStreamAsResponse(w io.Writer, r io.Reader, fallbackModel string) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	responseIDValue := responseID("")
+	messageID := responseIDValue + "_msg"
+	model := fallbackModel
+	created := time.Now().Unix()
+	var text strings.Builder
+	started := false
+	completed := false
+
+	ensureStarted := func() error {
+		if started {
+			return nil
+		}
+		started = true
+		if err := writeSSE(w, "response.created", map[string]any{
+			"type":     "response.created",
+			"response": inProgressResponsePayload(responseIDValue, model, created),
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.output_item.added", map[string]any{
+			"type":         "response.output_item.added",
+			"output_index": 0,
+			"item": map[string]any{
+				"id":      messageID,
+				"type":    "message",
+				"status":  "in_progress",
+				"role":    "assistant",
+				"content": []any{},
+			},
+		}); err != nil {
+			return err
+		}
+		return writeSSE(w, "response.content_part.added", map[string]any{
+			"type":          "response.content_part.added",
+			"item_id":       messageID,
+			"output_index":  0,
+			"content_index": 0,
+			"part": map[string]any{
+				"type":        "output_text",
+				"text":        "",
+				"annotations": []any{},
+			},
+		})
+	}
+	complete := func() error {
+		if completed {
+			return nil
+		}
+		completed = true
+		fullText := text.String()
+		if err := ensureStarted(); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.output_text.done", map[string]any{
+			"type":          "response.output_text.done",
+			"item_id":       messageID,
+			"output_index":  0,
+			"content_index": 0,
+			"text":          fullText,
+		}); err != nil {
+			return err
+		}
+		item := completedResponseItem(messageID, fullText)
+		if err := writeSSE(w, "response.content_part.done", map[string]any{
+			"type":          "response.content_part.done",
+			"item_id":       messageID,
+			"output_index":  0,
+			"content_index": 0,
+			"part":          item["content"].([]map[string]any)[0],
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.output_item.done", map[string]any{
+			"type":         "response.output_item.done",
+			"output_index": 0,
+			"item":         item,
+		}); err != nil {
+			return err
+		}
+		return writeSSE(w, "response.completed", map[string]any{
+			"type":     "response.completed",
+			"response": completedResponsesPayload(responseIDValue, model, created, fullText, nil),
+		})
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" {
+			continue
+		}
+		if data == "[DONE]" {
+			if err := complete(); err != nil {
+				return err
+			}
+			continue
+		}
+		var chunk struct {
+			ID      string       `json:"id"`
+			Created int64        `json:"created"`
+			Model   string       `json:"model"`
+			Choices []chatChoice `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return err
+		}
+		if chunk.ID != "" && strings.HasPrefix(responseIDValue, "resp_csgclaw_") {
+			responseIDValue = responseID(chunk.ID)
+			messageID = responseIDValue + "_msg"
+		}
+		if chunk.Created != 0 {
+			created = chunk.Created
+		}
+		if strings.TrimSpace(chunk.Model) != "" {
+			model = strings.TrimSpace(chunk.Model)
+		}
+		for _, choice := range chunk.Choices {
+			delta := responseContentToText(choice.Delta["content"])
+			if delta != "" {
+				if err := ensureStarted(); err != nil {
+					return err
+				}
+				text.WriteString(delta)
+				if err := writeSSE(w, "response.output_text.delta", map[string]any{
+					"type":          "response.output_text.delta",
+					"item_id":       messageID,
+					"output_index":  0,
+					"content_index": 0,
+					"delta":         delta,
+				}); err != nil {
+					return err
+				}
+			}
+			if choice.FinishReason != nil {
+				if err := complete(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if !completed {
+		return complete()
+	}
+	return nil
+}
+
+func inProgressResponsePayload(id, model string, created int64) map[string]any {
+	if created == 0 {
+		created = time.Now().Unix()
+	}
+	return map[string]any{
+		"id":         id,
+		"object":     "response",
+		"created_at": created,
+		"status":     "in_progress",
+		"model":      model,
+		"output":     []any{},
+	}
+}
+
+func completedResponseItem(messageID, text string) map[string]any {
+	return map[string]any{
+		"id":     messageID,
+		"type":   "message",
+		"status": "completed",
+		"role":   "assistant",
+		"content": []map[string]any{
+			{
+				"type":        "output_text",
+				"text":        text,
+				"annotations": []any{},
+			},
+		},
+	}
+}
+
+func writeSSE(w io.Writer, event string, payload map[string]any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+		return err
+	}
+	if flusher, ok := w.(interface{ Flush() error }); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
+func responseID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Sprintf("resp_csgclaw_%d", time.Now().UnixNano())
+	}
+	if strings.HasPrefix(id, "resp_") {
+		return id
+	}
+	return "resp_" + id
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return ""
+	}
+}
+
+func payloadBool(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	default:
+		return false
+	}
+}
+
 func applyReasoningEffortDefault(payload map[string]any, defaultEffort string) {
 	defaultEffort = strings.ToLower(strings.TrimSpace(defaultEffort))
 	if defaultEffort == "" {
@@ -191,6 +842,27 @@ func mergeProfilePayload(payload map[string]any, profile agent.AgentProfile) {
 		if _, exists := payload["service_tier"]; !exists {
 			payload["service_tier"] = "priority"
 		}
+	}
+}
+
+func mergeResponsesPayload(payload map[string]any, profile agent.AgentProfile) {
+	payload["model"] = strings.TrimSpace(profile.ModelID)
+	for key, value := range profile.RequestOptions {
+		key = strings.TrimSpace(key)
+		if key == "" || strings.EqualFold(key, "model") || strings.EqualFold(key, "reasoning_effort") {
+			continue
+		}
+		if _, exists := payload[key]; exists {
+			continue
+		}
+		payload[key] = value
+	}
+	applyProviderPayloadConstraints(payload, profile)
+	if !profile.EnableFastMode {
+		return
+	}
+	if _, exists := payload["service_tier"]; !exists {
+		payload["service_tier"] = "priority"
 	}
 }
 

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,14 +45,20 @@ func TestChatCompletionsLLMAPIOverridesModelAndProxiesUpstream(t *testing.T) {
 		ReasoningEffort: "medium",
 	}), []agent.Agent{
 		{
-			ID:              agent.ManagerUserID,
-			Name:            agent.ManagerName,
-			Role:            agent.RoleManager,
-			Profile:         config.DefaultLLMProfile,
-			Provider:        config.ProviderLLMAPI,
-			ModelID:         "gpt-5.4",
-			ReasoningEffort: "medium",
-			CreatedAt:       time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			ID:          agent.ManagerUserID,
+			Name:        agent.ManagerName,
+			Role:        agent.RoleManager,
+			Profile:     config.DefaultLLMProfile,
+			RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+			AgentProfile: agent.AgentProfile{
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "gpt-5.4",
+				ReasoningEffort: "medium",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		},
 	})
 
@@ -97,14 +104,20 @@ func TestChatCompletionsLLMAPIDoesNotOverrideRequestReasoningEffort(t *testing.T
 		ReasoningEffort: "medium",
 	}), []agent.Agent{
 		{
-			ID:              agent.ManagerUserID,
-			Name:            agent.ManagerName,
-			Role:            agent.RoleManager,
-			Profile:         config.DefaultLLMProfile,
-			Provider:        config.ProviderLLMAPI,
-			ModelID:         "gpt-5.4",
-			ReasoningEffort: "medium",
-			CreatedAt:       time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			ID:          agent.ManagerUserID,
+			Name:        agent.ManagerName,
+			Role:        agent.RoleManager,
+			Profile:     config.DefaultLLMProfile,
+			RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+			AgentProfile: agent.AgentProfile{
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "gpt-5.4",
+				ReasoningEffort: "medium",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		},
 	})
 
@@ -301,6 +314,363 @@ func TestChatCompletionsCodexRequiresAuth(t *testing.T) {
 	}
 }
 
+func TestResponsesLLMAPIOverridesModelAndProxiesUpstream(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var gotModel string
+	var gotReasoningEffort any
+	var gotContentType string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/v1/responses")
+		}
+		gotContentType = r.Header.Get("Content-Type")
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		gotModel, _ = payload["model"].(string)
+		gotReasoningEffort = payload["reasoning_effort"]
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("X-Upstream-Test", "responses")
+		_, _ = w.Write([]byte("event: response.completed\ndata: {}\n\n"))
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "gpt-5.5",
+				ReasoningEffort: "medium",
+				RequestOptions: map[string]any{
+					"temperature":      0.2,
+					"reasoning_effort": "high",
+				},
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":"hello"}`))
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("request Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotModel != "gpt-5.5" {
+		t.Fatalf("upstream model = %q, want %q", gotModel, "gpt-5.5")
+	}
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+	if resp.Header.Get("X-Upstream-Test") != "responses" {
+		t.Fatalf("X-Upstream-Test = %q, want responses", resp.Header.Get("X-Upstream-Test"))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !strings.Contains(string(body), "response.completed") {
+		t.Fatalf("body = %q, want response.completed event", string(body))
+	}
+	if gotReasoningEffort != nil {
+		t.Fatalf("reasoning_effort = %#v, want omitted for Responses payload", gotReasoningEffort)
+	}
+}
+
+func TestResponsesLLMAPIFallsBackToChatCompletionsWhenUnsupported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var sawResponses bool
+	var gotChatModel string
+	var gotChatMessages []map[string]any
+	var gotChatStream any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			sawResponses = true
+			http.Error(w, "no responses here", http.StatusNotFound)
+		case "/v1/chat/completions":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode() chat payload error = %v", err)
+			}
+			gotChatModel, _ = payload["model"].(string)
+			gotChatStream = payload["stream"]
+			if messages, ok := payload["messages"].([]any); ok {
+				for _, msg := range messages {
+					if m, ok := msg.(map[string]any); ok {
+						gotChatMessages = append(gotChatMessages, m)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"fallback result"},"finish_reason":"stop"}]}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "deepseek-v4-pro",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":"hello","stream":false}`))
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if !sawResponses {
+		t.Fatal("upstream /responses was not attempted before chat fallback")
+	}
+	if gotChatModel != "deepseek-v4-pro" {
+		t.Fatalf("chat model = %q, want deepseek-v4-pro", gotChatModel)
+	}
+	if gotChatStream != false {
+		t.Fatalf("chat stream = %#v, want false", gotChatStream)
+	}
+	if len(gotChatMessages) != 1 || gotChatMessages[0]["role"] != "user" || gotChatMessages[0]["content"] != "hello" {
+		t.Fatalf("chat messages = %#v, want single user hello message", gotChatMessages)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("Decode fallback response error = %v body=%s", err, body)
+	}
+	if out["object"] != "response" || out["status"] != "completed" {
+		t.Fatalf("fallback response = %#v, want completed response object", out)
+	}
+	if out["output_text"] != "fallback result" {
+		t.Fatalf("output_text = %#v, want fallback result", out["output_text"])
+	}
+}
+
+func TestResponsesLLMAPIFallbackMapsDeveloperRoleToSystem(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var gotChatMessages []map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			http.Error(w, "no responses here", http.StatusNotFound)
+		case "/v1/chat/completions":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode() chat payload error = %v", err)
+			}
+			messages, _ := payload["messages"].([]any)
+			for _, msg := range messages {
+				if m, ok := msg.(map[string]any); ok {
+					gotChatMessages = append(gotChatMessages, m)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "deepseek-v4-flash",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":[{"role":"user","content":"hello"},{"role":"developer","content":"follow repo rules"}],"stream":false}`))
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(gotChatMessages) != 2 {
+		t.Fatalf("chat messages = %#v, want 2 messages", gotChatMessages)
+	}
+	if gotChatMessages[0]["role"] != "user" {
+		t.Fatalf("first chat role = %#v, want user", gotChatMessages[0]["role"])
+	}
+	if gotChatMessages[1]["role"] != "system" {
+		t.Fatalf("developer role mapped to %#v, want system; messages=%#v", gotChatMessages[1]["role"], gotChatMessages)
+	}
+}
+
+func TestResponsesLLMAPIFallbackCachesUnsupportedResponsesAPI(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var responsesCalls int
+	var chatCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesCalls++
+			http.Error(w, "no responses here", http.StatusNotFound)
+		case "/v1/chat/completions":
+			chatCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "deepseek-v4-flash",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	for i := 0; i < 2; i++ {
+		resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":"hello","stream":false}`))
+		if err != nil {
+			t.Fatalf("Responses() attempt %d error = %v", i+1, err)
+		}
+		_ = resp.Body.Close()
+	}
+	if responsesCalls != 1 {
+		t.Fatalf("/responses calls = %d, want 1 after unsupported cache", responsesCalls)
+	}
+	if chatCalls != 2 {
+		t.Fatalf("/chat/completions calls = %d, want 2", chatCalls)
+	}
+}
+
+func TestResponsesLLMAPIFallsBackToStreamingChatCompletionsWhenUnsupported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var gotChatStream any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			http.Error(w, "no responses here", http.StatusMethodNotAllowed)
+		case "/v1/chat/completions":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode() chat payload error = %v", err)
+			}
+			gotChatStream = payload["stream"]
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-fallback\",\"object\":\"chat.completion.chunk\",\"created\":1710000000,\"model\":\"deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"fallback\"},\"finish_reason\":null}]}\n\n"))
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-fallback\",\"object\":\"chat.completion.chunk\",\"created\":1710000000,\"model\":\"deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" stream\"},\"finish_reason\":null}]}\n\n"))
+			_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-fallback\",\"object\":\"chat.completion.chunk\",\"created\":1710000000,\"model\":\"deepseek-v4-pro\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "deepseek-v4-pro",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":"hello","stream":true}`))
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if gotChatStream != true {
+		t.Fatalf("chat stream = %#v, want true", gotChatStream)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"event: response.output_text.delta",
+		`"delta":"fallback"`,
+		`"delta":" stream"`,
+		"event: response.completed",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stream body missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestModelsReturnsResolvedAgentModel(t *testing.T) {
 	agentSvc := mustSeededAgentService(t, config.SingleProfileLLM(config.ModelConfig{
 		Provider:        config.ProviderLLMAPI,
@@ -310,14 +680,20 @@ func TestModelsReturnsResolvedAgentModel(t *testing.T) {
 		ReasoningEffort: "high",
 	}), []agent.Agent{
 		{
-			ID:              agent.ManagerUserID,
-			Name:            agent.ManagerName,
-			Role:            agent.RoleManager,
-			Profile:         config.DefaultLLMProfile,
-			Provider:        config.ProviderLLMAPI,
-			ModelID:         "gpt-5.4-mini",
-			ReasoningEffort: "high",
-			CreatedAt:       time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			ID:          agent.ManagerUserID,
+			Name:        agent.ManagerName,
+			Role:        agent.RoleManager,
+			Profile:     config.DefaultLLMProfile,
+			RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+			AgentProfile: agent.AgentProfile{
+				Provider:        agent.ProviderAPI,
+				BaseURL:         "https://example.test/v1",
+				APIKey:          "sk-test",
+				ModelID:         "gpt-5.4-mini",
+				ReasoningEffort: "high",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		},
 	})
 
@@ -332,10 +708,34 @@ func TestModelsReturnsResolvedAgentModel(t *testing.T) {
 	if !strings.Contains(string(body), `"id":"gpt-5.4-mini"`) {
 		t.Fatalf("body = %s, want resolved model id", body)
 	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode models body: %v", err)
+	}
+	models, ok := payload["models"].([]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one Codex model metadata entry", payload["models"])
+	}
+	model, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("models[0] = %#v, want object", models[0])
+	}
+	if model["slug"] != "gpt-5.4-mini" {
+		t.Fatalf("models[0].slug = %#v, want gpt-5.4-mini", model["slug"])
+	}
+	if _, ok := model["model_messages"]; !ok {
+		t.Fatalf("models[0] missing model_messages: %#v", model)
+	}
 }
 
 func mustSeededAgentService(t *testing.T, llmCfg config.LLMConfig, agents []agent.Agent) *agent.Service {
 	t.Helper()
+
+	for i := range agents {
+		if strings.TrimSpace(agents[i].RuntimeKind) == "" {
+			agents[i].RuntimeKind = agent.RuntimeKindPicoClawSandbox
+		}
+	}
 
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "agents.json")

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -671,6 +671,136 @@ func TestResponsesLLMAPIFallsBackToStreamingChatCompletionsWhenUnsupported(t *te
 	}
 }
 
+func TestResponsesLLMAPIFallbackAllowsAdvertisedToolsForTextOnlyRequests(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var gotChatPayload map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			http.Error(w, "no responses here", http.StatusNotFound)
+		case "/v1/chat/completions":
+			if err := json.NewDecoder(r.Body).Decode(&gotChatPayload); err != nil {
+				t.Fatalf("Decode() chat payload error = %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:   agent.ManagerUserID,
+			Name: agent.ManagerName,
+			Role: agent.RoleManager,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderAPI,
+				BaseURL:         upstream.URL + "/v1",
+				APIKey:          "sk-test",
+				ModelID:         "deepseek-v4-pro",
+				ProfileComplete: true,
+			},
+			CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	svc := NewService(config.ModelConfig{}, agentSvc)
+	resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(`{"model":"client-model","input":"hi","tools":[{"type":"function","name":"shell","description":"run shell"}],"stream":false}`))
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if _, ok := gotChatPayload["tools"]; ok {
+		t.Fatalf("chat fallback payload includes tools: %#v", gotChatPayload["tools"])
+	}
+	messages, _ := gotChatPayload["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("chat messages = %#v, want single text message", messages)
+	}
+	if msg, _ := messages[0].(map[string]any); msg["role"] != "user" || msg["content"] != "hi" {
+		t.Fatalf("chat messages = %#v, want user hi", messages)
+	}
+}
+
+func TestResponsesLLMAPIFallbackRejectsActiveToolSemantics(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "tool output",
+			body: `{"model":"client-model","input":[{"type":"function_call_output","call_id":"call-1","output":"done"}],"stream":false}`,
+		},
+		{
+			name: "required tool choice",
+			body: `{"model":"client-model","input":"hello","tools":[{"type":"function","name":"shell","description":"run shell"}],"tool_choice":"required","stream":false}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			var chatCalls int
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/responses":
+					http.Error(w, "no responses here", http.StatusNotFound)
+				case "/v1/chat/completions":
+					chatCalls++
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"fallback result"},"finish_reason":"stop"}]}`))
+				default:
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+			}))
+			defer upstream.Close()
+
+			agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+				{
+					ID:   agent.ManagerUserID,
+					Name: agent.ManagerName,
+					Role: agent.RoleManager,
+					AgentProfile: agent.AgentProfile{
+						Name:            agent.ManagerName,
+						Provider:        agent.ProviderAPI,
+						BaseURL:         upstream.URL + "/v1",
+						APIKey:          "sk-test",
+						ModelID:         "deepseek-v4-pro",
+						ProfileComplete: true,
+					},
+					CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+				},
+			})
+
+			svc := NewService(config.ModelConfig{}, agentSvc)
+			resp, err := svc.Responses(context.Background(), agent.ManagerUserID, []byte(tc.body))
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			if err == nil {
+				t.Fatal("Responses() error = nil, want explicit tool-bearing fallback rejection")
+			}
+			httpErr, ok := err.(*HTTPError)
+			if !ok {
+				t.Fatalf("Responses() error type = %T, want *HTTPError", err)
+			}
+			if httpErr.Status != http.StatusBadRequest {
+				t.Fatalf("HTTP status = %d, want %d", httpErr.Status, http.StatusBadRequest)
+			}
+			if !strings.Contains(httpErr.Message, "active tool-use") {
+				t.Fatalf("error message = %q, want active tool-use rejection", httpErr.Message)
+			}
+			if chatCalls != 0 {
+				t.Fatalf("/chat/completions calls = %d, want 0", chatCalls)
+			}
+		})
+	}
+}
+
 func TestModelsReturnsResolvedAgentModel(t *testing.T) {
 	agentSvc := mustSeededAgentService(t, config.SingleProfileLLM(config.ModelConfig{
 		Provider:        config.ProviderLLMAPI,

--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -1,9 +1,12 @@
 package modelprovider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -19,6 +22,33 @@ type openAIModelsResponse struct {
 	Data []struct {
 		ID string `json:"id"`
 	} `json:"data"`
+}
+
+type openAIResponsesProbeResponse struct {
+	Object string `json:"object"`
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+var ErrResponsesAPIUnsupported = errors.New("responses API unsupported")
+
+type ResponsesAPIStatusError struct {
+	BaseURL    string
+	Status     string
+	StatusCode int
+	Body       string
+}
+
+func (e *ResponsesAPIStatusError) Error() string {
+	msg := fmt.Sprintf("request responses from %s: status %s", e.BaseURL, e.Status)
+	if strings.TrimSpace(e.Body) != "" {
+		msg += ": " + strings.TrimSpace(e.Body)
+	}
+	return msg
+}
+
+func (e *ResponsesAPIStatusError) Is(target error) bool {
+	return target == ErrResponsesAPIUnsupported && (e.StatusCode == http.StatusNotFound || e.StatusCode == http.StatusMethodNotAllowed)
 }
 
 func ListOpenAIModels(ctx context.Context, baseURL, apiKey string) ([]string, error) {
@@ -80,4 +110,73 @@ func ListOpenAIModelsWithClient(ctx context.Context, client *http.Client, baseUR
 		return nil, fmt.Errorf("no models returned from %s", baseURL)
 	}
 	return models, nil
+}
+
+func CheckResponsesAPI(ctx context.Context, baseURL, apiKey, modelID string, headers map[string]string) error {
+	return CheckResponsesAPIWithClient(ctx, &http.Client{Timeout: 10 * time.Second}, baseURL, apiKey, modelID, headers)
+}
+
+func CheckResponsesAPIWithClient(ctx context.Context, client *http.Client, baseURL, apiKey, modelID string, headers map[string]string) error {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	modelID = strings.TrimSpace(modelID)
+	if baseURL == "" {
+		return fmt.Errorf("base URL is required")
+	}
+	if modelID == "" {
+		return fmt.Errorf("model ID is required")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	payload := map[string]any{
+		"model":             modelID,
+		"input":             "ping",
+		"store":             false,
+		"stream":            false,
+		"max_output_tokens": 16,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode responses probe request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/responses", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build responses probe request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for key, value := range headers {
+		key = strings.TrimSpace(key)
+		if key == "" || strings.EqualFold(key, "authorization") || strings.EqualFold(key, "content-type") {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request responses from %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return &ResponsesAPIStatusError{
+			BaseURL:    baseURL,
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(errBody)),
+		}
+	}
+
+	var probe openAIResponsesProbeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&probe); err != nil {
+		return fmt.Errorf("decode responses probe from %s: %w", baseURL, err)
+	}
+	if strings.TrimSpace(probe.Object) != "response" {
+		return fmt.Errorf("responses probe from %s returned object %q, want response", baseURL, probe.Object)
+	}
+	return nil
 }

--- a/internal/modelprovider/openai_test.go
+++ b/internal/modelprovider/openai_test.go
@@ -1,0 +1,68 @@
+package modelprovider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckResponsesAPIWithClientPostsMinimalResponsesRequest(t *testing.T) {
+	var gotAuth string
+	var gotPayload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Fatalf("path = %q, want /v1/responses", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-test","object":"response","status":"completed"}`))
+	}))
+	defer srv.Close()
+
+	err := CheckResponsesAPIWithClient(context.Background(), srv.Client(), srv.URL+"/v1", "sk-test", "gpt-test", map[string]string{
+		"X-Test":        "ok",
+		"Authorization": "Bearer ignored",
+	})
+	if err != nil {
+		t.Fatalf("CheckResponsesAPIWithClient() error = %v", err)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q, want Bearer sk-test", gotAuth)
+	}
+	if gotPayload["model"] != "gpt-test" {
+		t.Fatalf("model = %#v, want gpt-test", gotPayload["model"])
+	}
+	if gotPayload["input"] == nil {
+		t.Fatalf("input missing from payload: %#v", gotPayload)
+	}
+	if gotPayload["store"] != false {
+		t.Fatalf("store = %#v, want false", gotPayload["store"])
+	}
+	if gotPayload["stream"] != false {
+		t.Fatalf("stream = %#v, want false", gotPayload["stream"])
+	}
+	if gotPayload["max_output_tokens"] != float64(16) {
+		t.Fatalf("max_output_tokens = %#v, want 16", gotPayload["max_output_tokens"])
+	}
+}
+
+func TestCheckResponsesAPIWithClientClassifiesUnsupportedEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no responses here", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := CheckResponsesAPIWithClient(context.Background(), srv.Client(), srv.URL+"/v1", "sk-test", "gpt-test", nil)
+	if err == nil {
+		t.Fatal("CheckResponsesAPIWithClient() error = nil, want unsupported status")
+	}
+	if !errors.Is(err, ErrResponsesAPIUnsupported) {
+		t.Fatalf("CheckResponsesAPIWithClient() error = %v, want ErrResponsesAPIUnsupported", err)
+	}
+}

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -400,14 +400,6 @@ func (r *Runtime) seedCodexHomeConfig(runtimeCodexHome string, profile agentrunt
 		return fmt.Errorf("codex home dir is required")
 	}
 	configPath := filepath.Join(runtimeCodexHome, configFileName)
-	if hasAuth, err := r.codexHomeHasAuth(runtimeCodexHome); err != nil {
-		return err
-	} else if hasAuth {
-		if err := r.removeAll(configPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove runtime codex config %s: %w", configPath, err)
-		}
-		return nil
-	}
 	profile = profile.Normalized()
 	slog.Info("codex runtime profile before writing config",
 		"codex_home", runtimeCodexHome,
@@ -423,8 +415,9 @@ func (r *Runtime) seedCodexHomeConfig(runtimeCodexHome string, profile agentrunt
 	fmt.Fprintf(&b, "model_provider = %s\n\n", strconv.Quote(codexProxyProviderName))
 	fmt.Fprintf(&b, "[model_providers.%s]\n", codexProxyProviderName)
 	fmt.Fprintf(&b, "name = %s\n", strconv.Quote("OpenAI using LLM proxy"))
-	// fmt.Fprintf(&b, "wire_api = %s\n", strconv.Quote("chat"))
 	fmt.Fprintf(&b, "base_url = %s\n", strconv.Quote(profile.BaseURL))
+	fmt.Fprintf(&b, "wire_api = %s\n", strconv.Quote("responses"))
+	fmt.Fprintf(&b, "supports_websockets = false\n")
 	if profile.APIKey != "" {
 		fmt.Fprintf(&b, "env_key = %s\n", strconv.Quote("OPENAI_API_KEY"))
 	}
@@ -433,17 +426,6 @@ func (r *Runtime) seedCodexHomeConfig(runtimeCodexHome string, profile agentrunt
 		return fmt.Errorf("write runtime codex config %s: %w", configPath, err)
 	}
 	return nil
-}
-
-func (r *Runtime) codexHomeHasAuth(runtimeCodexHome string) (bool, error) {
-	runtimeAuthPath := filepath.Join(strings.TrimSpace(runtimeCodexHome), "auth.json")
-	if _, err := r.readFile(runtimeAuthPath); err == nil {
-		return true, nil
-	} else if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	} else {
-		return false, fmt.Errorf("read runtime codex auth %s: %w", runtimeAuthPath, err)
-	}
 }
 
 func (r *Runtime) ensureBinary(ctx context.Context) (string, error) {

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -163,9 +163,12 @@ func TestRuntimeCreateStartAndInfo(t *testing.T) {
 		t.Fatalf("runtime auth = %q, want copied host auth", string(authRaw))
 	}
 
-	if _, err := os.Stat(filepath.Join(root, "alice", ".codex", configFileName)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("config.toml should not be written when auth.json exists, stat err = %v", err)
-	}
+	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
+		`model = "gpt-5.5"`,
+		`model_provider = "proxy"`,
+		`wire_api = "responses"`,
+		`supports_websockets = false`,
+	)
 }
 
 func TestRuntimeStopAndDelete(t *testing.T) {
@@ -372,7 +375,7 @@ func TestRuntimeCreateKeepsExistingRuntimeAuth(t *testing.T) {
 	}
 }
 
-func TestRuntimeCreateSkipsConfigWhenHostAuthIsSeeded(t *testing.T) {
+func TestRuntimeCreateWritesConfigWhenHostAuthIsSeeded(t *testing.T) {
 	root := t.TempDir()
 	hostHome := t.TempDir()
 	t.Setenv("HOME", hostHome)
@@ -433,9 +436,11 @@ func TestRuntimeCreateSkipsConfigWhenHostAuthIsSeeded(t *testing.T) {
 		t.Fatalf("Create() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(root, "alice", ".codex", configFileName)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("config.toml should not be written after host auth seeding, stat err = %v", err)
-	}
+	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
+		`model = "gpt-5.5"`,
+		`wire_api = "responses"`,
+		`supports_websockets = false`,
+	)
 }
 
 func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
@@ -506,6 +511,8 @@ func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
 		`name = "OpenAI using LLM proxy"`,
 		`base_url = "https://runtime.example/v1"`,
 		`env_key = "OPENAI_API_KEY"`,
+		`wire_api = "responses"`,
+		`supports_websockets = false`,
 	} {
 		if !strings.Contains(configText, want) {
 			t.Fatalf("runtime config missing %q:\n%s", want, configText)
@@ -513,10 +520,66 @@ func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
 	}
 	for _, unwanted := range []string{
 		`wire_api = "chat"`,
+		`runtime-key`,
 	} {
 		if strings.Contains(configText, unwanted) {
 			t.Fatalf("runtime config unexpectedly contains %q:\n%s", unwanted, configText)
 		}
+	}
+}
+
+func TestRuntimeCreateKeepsResponsesWireAPIWhenProfileRequestsFallback(t *testing.T) {
+	root := t.TempDir()
+	rt := New(Dependencies{
+		BinaryProvider: fakeBinaryProvider{path: "/tmp/codex-acp"},
+		AgentHome: func(agentName string) (string, error) {
+			return filepath.Join(root, agentName), nil
+		},
+		Manager: fakeManager{
+			start: func(_ context.Context, spec SessionSpec) (*Session, error) {
+				return &Session{
+					RuntimeID:    spec.RuntimeID,
+					AgentID:      spec.AgentID,
+					AgentName:    spec.AgentName,
+					SessionID:    "sess-chat",
+					BinaryPath:   spec.BinaryPath,
+					WorkspaceDir: spec.WorkspaceDir,
+					HomeDir:      spec.HomeDir,
+					CodexHomeDir: spec.CodexHomeDir,
+					StderrPath:   spec.StderrPath,
+					ProcessID:    os.Getpid(),
+					CreatedAt:    time.Now().UTC(),
+					StartedAt:    time.Now().UTC(),
+				}, nil
+			},
+		},
+	})
+
+	if _, err := rt.New(context.Background(), agentruntime.Spec{
+		RuntimeID: "rt-u-alice",
+		AgentID:   "u-alice",
+		AgentName: "alice",
+		Profile: agentruntime.Profile{
+			ModelID: "deepseek-v4-pro",
+			BaseURL: "https://runtime.example/v1",
+			APIKey:  "runtime-key",
+			WireAPI: "chat",
+		},
+	}); err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
+		`model = "deepseek-v4-pro"`,
+		`wire_api = "responses"`,
+		`supports_websockets = false`,
+	)
+	configText, err := os.ReadFile(filepath.Join(root, "alice", ".codex", configFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(configText), `wire_api = "chat"`) {
+		t.Fatalf("runtime config must not contain chat wire API:\n%s", configText)
 	}
 }
 
@@ -583,8 +646,33 @@ func TestRuntimeCreateRemovesStaleConfigWhenAuthExists(t *testing.T) {
 		t.Fatalf("Create() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(runtimeRoot, configFileName)); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stale config.toml should be removed when auth.json exists, stat err = %v", err)
+	configRaw, err := os.ReadFile(filepath.Join(runtimeRoot, configFileName))
+	if err != nil {
+		t.Fatalf("read rewritten config: %v", err)
+	}
+	configText := string(configRaw)
+	if strings.Contains(configText, "stale = true") {
+		t.Fatalf("stale config was not replaced:\n%s", configText)
+	}
+	for _, want := range []string{`model = "gpt-5.5"`, `wire_api = "responses"`} {
+		if !strings.Contains(configText, want) {
+			t.Fatalf("runtime config missing %q:\n%s", want, configText)
+		}
+	}
+}
+
+func assertRuntimeConfigContains(t *testing.T, path string, wants ...string) {
+	t.Helper()
+
+	configRaw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime config: %v", err)
+	}
+	configText := string(configRaw)
+	for _, want := range wants {
+		if !strings.Contains(configText, want) {
+			t.Fatalf("runtime config missing %q:\n%s", want, configText)
+		}
 	}
 }
 

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -528,7 +528,7 @@ func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
 	}
 }
 
-func TestRuntimeCreateKeepsResponsesWireAPIWhenProfileRequestsFallback(t *testing.T) {
+func TestRuntimeCreateAlwaysWritesResponsesConfig(t *testing.T) {
 	root := t.TempDir()
 	rt := New(Dependencies{
 		BinaryProvider: fakeBinaryProvider{path: "/tmp/codex-acp"},
@@ -563,7 +563,6 @@ func TestRuntimeCreateKeepsResponsesWireAPIWhenProfileRequestsFallback(t *testin
 			ModelID: "deepseek-v4-pro",
 			BaseURL: "https://runtime.example/v1",
 			APIKey:  "runtime-key",
-			WireAPI: "chat",
 		},
 	}); err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -579,7 +578,7 @@ func TestRuntimeCreateKeepsResponsesWireAPIWhenProfileRequestsFallback(t *testin
 		t.Fatal(err)
 	}
 	if strings.Contains(string(configText), `wire_api = "chat"`) {
-		t.Fatalf("runtime config must not contain chat wire API:\n%s", configText)
+		t.Fatalf("runtime config must not contain chat wire_api:\n%s", configText)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -75,6 +75,7 @@ type Profile struct {
 	APIKey          string
 	ModelID         string
 	ReasoningEffort string
+	WireAPI         string
 	Env             map[string]string
 }
 
@@ -84,6 +85,7 @@ func (p Profile) Normalized() Profile {
 	p.BaseURL = strings.TrimRight(strings.TrimSpace(p.BaseURL), "/")
 	p.APIKey = strings.TrimSpace(p.APIKey)
 	p.ReasoningEffort = strings.TrimSpace(p.ReasoningEffort)
+	p.WireAPI = strings.ToLower(strings.TrimSpace(p.WireAPI))
 	if len(p.Env) == 0 {
 		p.Env = nil
 		return p

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -75,7 +75,6 @@ type Profile struct {
 	APIKey          string
 	ModelID         string
 	ReasoningEffort string
-	WireAPI         string
 	Env             map[string]string
 }
 
@@ -85,7 +84,6 @@ func (p Profile) Normalized() Profile {
 	p.BaseURL = strings.TrimRight(strings.TrimSpace(p.BaseURL), "/")
 	p.APIKey = strings.TrimSpace(p.APIKey)
 	p.ReasoningEffort = strings.TrimSpace(p.ReasoningEffort)
-	p.WireAPI = strings.ToLower(strings.TrimSpace(p.WireAPI))
 	if len(p.Env) == 0 {
 		p.Env = nil
 		return p


### PR DESCRIPTION
- **Responses API support:** Adds Codex-facing `/llm/responses` routes and keeps Codex runtime on `wire_api = "responses"`.
- **Compatibility fallback:** Keeps upstream compatibility by falling back from unsupported `/responses` providers to chat completions behind the bridge.
- **Fix stale API provider state(nit):** Refreshes Codex profile/provider handling so changed API provider settings are probed/restarted correctly and stale failed probe/default state does not stick.

No architecture adjusted.