### PR TITLE
fix(web): refine hub template detail layout

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -4996,8 +4996,10 @@ function HubDetailPane({
                           <div className="hub-inspector-copy">
                             <h2>${selectedTemplate.name || selectedTemplate.id}</h2>
                             <p>${selectedTemplate.description || selectedTemplate.id}</p>
-                            <span className="mini-badge template-runtime-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
-                            <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
+                            <div className="hub-inspector-badge-row">
+                              <span className="mini-badge template-runtime-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
+                              <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
+                            </div>
                           </div>
                         </div>
                         <div className="hub-template-actions">
@@ -5029,11 +5031,6 @@ function HubDetailPane({
                         <span>${t("hubUpdatedAtLabel")}</span>
                         <strong>${formatHubDateTime(selectedTemplate.updated_at, locale)}</strong>
                       </div>
-                    </div>
-
-                    <div className="hub-description-block">
-                      <span className="hub-section-label">${t("hubDescriptionLabel")}</span>
-                      <p>${selectedTemplate.description || selectedTemplate.id}</p>
                     </div>
 
                     <div className="hub-workspace-block">

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -2909,20 +2909,24 @@ body::after {
 
 .template-runtime-badge {
   width: fit-content;
+  display: inline-flex;
+  align-items: center;
   padding: 2px 8px;
-  border: 1px solid #e9eaeb;
+  border: 1px solid #d5d7da;
   border-radius: 6px;
-  background: #fafafa;
+  background: #fff;
   color: #414651;
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 :root[data-theme="dark"] .template-runtime-badge {
   border-color: #333741;
-  background: #161b26;
+  background: #0c111d;
   color: #cecfd2;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 .mini-badge.warn,
@@ -3238,6 +3242,13 @@ body::after {
   max-width: 100%;
 }
 
+.hub-inspector-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .hub-template-card-title-row h2 {
   margin: 0;
   color: color-mix(in srgb, var(--text) 78%, var(--muted) 22%);
@@ -3276,8 +3287,9 @@ body::after {
 }
 
 .hub-inspector-panel {
+  container-type: inline-size;
   display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   align-content: stretch;
   gap: 20px;
   max-height: calc(100dvh - 166px);
@@ -3322,7 +3334,7 @@ body::after {
 
 .hub-inspector-grid {
   display: grid;
-  grid-template-columns: minmax(180px, 0.8fr) minmax(280px, 1.8fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   padding: 22px;
   border: 1px solid var(--line);
@@ -3362,6 +3374,12 @@ body::after {
 
 :root[data-theme="dark"] .hub-inspector-field strong {
   color: color-mix(in srgb, var(--text) 78%, var(--muted) 22%);
+}
+
+@container (max-width: 620px) {
+  .hub-inspector-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hub-field-value-multiline {
@@ -5313,7 +5331,6 @@ body::after {
     border-bottom: 1px solid var(--line);
   }
 
-  .hub-inspector-grid,
   .entity-grid,
   .metric-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- Align Hub runtime badges with the Untitled UI-style badge treatment in dark mode.
- Render the runtime/source badges in a single horizontal row in the template inspector.
- Rework the template metadata panel into a balanced two-column grid with a single-column fallback for narrow containers.
- Remove the duplicate description block from the Hub detail inspector.

## Verification
- make build
- Refreshed http://127.0.0.1:18080/hub in the in-app browser and verified the badge row, 2x2 metadata grid, and removed duplicate description block.