### PR TITLE
chore: update default openclaw image

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,7 +261,7 @@ const (
 	DefaultHTTPPort                 = apiclient.DefaultHTTPPort
 	DefaultAccessToken              = "your_access_token"
 	DefaultManagerImage             = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.9"
-	DefaultOpenClawManagerImage     = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260509.1-csgclaw"
+	DefaultOpenClawManagerImage     = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260518.1-csgclaw"
 	CSGHubProvider                  = "csghub"
 	DockerProvider                  = "docker"
 	BoxLiteProvider                 = "boxlite"

--- a/internal/templates/embed/openclaw-manager/agent.toml
+++ b/internal/templates/embed/openclaw-manager/agent.toml
@@ -1,5 +1,5 @@
 name = "openclaw-manager"
 description = "Builtin OpenClaw manager template"
 runtime_kind = "openclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260509.1-csgclaw"
-updated_at = "2026-05-13T01:23:34Z"
+image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260518.1-csgclaw"
+updated_at = "2026-05-18T10:39:05Z"

--- a/internal/templates/embed/openclaw-worker/agent.toml
+++ b/internal/templates/embed/openclaw-worker/agent.toml
@@ -1,5 +1,5 @@
 name = "openclaw-worker"
 description = "Builtin OpenClaw worker template"
 runtime_kind = "openclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260509.1-csgclaw"
-updated_at = "2026-05-13T01:23:34Z"
+image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260518.1-csgclaw"
+updated_at = "2026-05-18T10:39:05Z"


### PR DESCRIPTION
## Summary
- Update the default OpenClaw manager image tag to 20260518.1-csgclaw.
- Refresh builtin OpenClaw manager and worker template image metadata.

## Verification
- env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/config