### PR TITLE
Fix unkown-model metadata warning for Codex runtime

### DIFF
--- a/internal/codexmodel/catalog.go
+++ b/internal/codexmodel/catalog.go
@@ -1,0 +1,76 @@
+package codexmodel
+
+import "strings"
+
+type Profile struct {
+	ModelID         string
+	ReasoningEffort string
+}
+
+func Catalog(profile Profile) map[string]any {
+	return map[string]any{
+		"models": []map[string]any{Metadata(profile)},
+	}
+}
+
+func Metadata(profile Profile) map[string]any {
+	modelID := strings.TrimSpace(profile.ModelID)
+	if modelID == "" {
+		modelID = "unknown"
+	}
+	reasoningEffort := strings.ToLower(strings.TrimSpace(profile.ReasoningEffort))
+	switch reasoningEffort {
+	case "none", "minimal", "low", "medium", "high", "xhigh":
+	default:
+		reasoningEffort = "medium"
+	}
+	baseInstructions := "You are Codex, a coding agent. Follow the user's instructions and use available tools carefully."
+	return map[string]any{
+		"slug":                    modelID,
+		"display_name":            modelID,
+		"description":             "CSGClaw OpenAI-compatible provider model",
+		"default_reasoning_level": reasoningEffort,
+		"supported_reasoning_levels": []map[string]any{
+			{"effort": "low", "description": "low"},
+			{"effort": "medium", "description": "medium"},
+			{"effort": "high", "description": "high"},
+		},
+		"shell_type":                   "default",
+		"visibility":                   "list",
+		"supported_in_api":             true,
+		"priority":                     1,
+		"availability_nux":             nil,
+		"upgrade":                      nil,
+		"base_instructions":            baseInstructions,
+		"model_messages":               modelMessages(baseInstructions),
+		"supports_search_tool":         false,
+		"supports_reasoning_summaries": false,
+		"default_reasoning_summary":    "auto",
+		"support_verbosity":            false,
+		"default_verbosity":            nil,
+		"apply_patch_tool_type":        nil,
+		"web_search_tool_type":         "text",
+		"truncation_policy": map[string]any{
+			"mode":  "bytes",
+			"limit": 10000,
+		},
+		"supports_parallel_tool_calls":     false,
+		"supports_image_detail_original":   false,
+		"context_window":                   272000,
+		"auto_compact_token_limit":         nil,
+		"effective_context_window_percent": 95,
+		"experimental_supported_tools":     []any{},
+		"input_modalities":                 []string{"text", "image"},
+	}
+}
+
+func modelMessages(baseInstructions string) map[string]any {
+	return map[string]any{
+		"instructions_template": "{{ personality }}\n\n" + baseInstructions,
+		"instructions_variables": map[string]any{
+			"personality_default":   "",
+			"personality_friendly":  "You are collaborative, supportive, and clear.",
+			"personality_pragmatic": "You are a deeply pragmatic, effective software engineer.",
+		},
+	}
+}

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -14,6 +14,7 @@ import (
 
 	"csgclaw/internal/agent"
 	"csgclaw/internal/cliproxy"
+	"csgclaw/internal/codexmodel"
 	"csgclaw/internal/config"
 )
 
@@ -78,75 +79,16 @@ func (s *Service) Models(_ context.Context, botID string) ([]byte, int, string, 
 				"owned_by": "csgclaw",
 			},
 		},
-		"models": []map[string]any{codexModelMetadata(profile)},
+		"models": []map[string]any{codexmodel.Metadata(codexmodel.Profile{
+			ModelID:         profile.ModelID,
+			ReasoningEffort: profile.ReasoningEffort,
+		})},
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, 0, "", &HTTPError{Status: http.StatusInternalServerError, Message: fmt.Sprintf("encode models response: %v", err)}
 	}
 	return body, http.StatusOK, "application/json", nil
-}
-
-func codexModelMetadata(profile agent.AgentProfile) map[string]any {
-	modelID := strings.TrimSpace(profile.ModelID)
-	if modelID == "" {
-		modelID = "unknown"
-	}
-	reasoningEffort := strings.ToLower(strings.TrimSpace(profile.ReasoningEffort))
-	switch reasoningEffort {
-	case "none", "minimal", "low", "medium", "high", "xhigh":
-	default:
-		reasoningEffort = "medium"
-	}
-	baseInstructions := "You are Codex, a coding agent. Follow the user's instructions and use available tools carefully."
-	return map[string]any{
-		"slug":                    modelID,
-		"display_name":            modelID,
-		"description":             "CSGClaw OpenAI-compatible provider model",
-		"default_reasoning_level": reasoningEffort,
-		"supported_reasoning_levels": []map[string]any{
-			{"effort": "low", "description": "low"},
-			{"effort": "medium", "description": "medium"},
-			{"effort": "high", "description": "high"},
-		},
-		"shell_type":                   "default",
-		"visibility":                   "list",
-		"supported_in_api":             true,
-		"priority":                     1,
-		"availability_nux":             nil,
-		"upgrade":                      nil,
-		"base_instructions":            baseInstructions,
-		"model_messages":               codexModelMessages(baseInstructions),
-		"supports_search_tool":         false,
-		"supports_reasoning_summaries": false,
-		"default_reasoning_summary":    "auto",
-		"support_verbosity":            false,
-		"default_verbosity":            nil,
-		"apply_patch_tool_type":        nil,
-		"web_search_tool_type":         "text",
-		"truncation_policy": map[string]any{
-			"mode":  "bytes",
-			"limit": 10000,
-		},
-		"supports_parallel_tool_calls":     false,
-		"supports_image_detail_original":   false,
-		"context_window":                   272000,
-		"auto_compact_token_limit":         nil,
-		"effective_context_window_percent": 95,
-		"experimental_supported_tools":     []any{},
-		"input_modalities":                 []string{"text", "image"},
-	}
-}
-
-func codexModelMessages(baseInstructions string) map[string]any {
-	return map[string]any{
-		"instructions_template": "{{ personality }}\n\n" + baseInstructions,
-		"instructions_variables": map[string]any{
-			"personality_default":   "",
-			"personality_friendly":  "You are collaborative, supportive, and clear.",
-			"personality_pragmatic": "You are a deeply pragmatic, effective software engineer.",
-		},
-	}
 }
 
 func (s *Service) ChatCompletions(ctx context.Context, botID string, body []byte) ([]byte, int, string, error) {

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"csgclaw/internal/codexacp"
+	"csgclaw/internal/codexmodel"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/sandbox"
 
@@ -24,6 +25,7 @@ import (
 const (
 	hostStateDirName       = ".codex"
 	configFileName         = "config.toml"
+	modelCatalogFileName   = "model_catalog.json"
 	runtimeFileName        = "runtime.json"
 	sessionFileName        = "session.json"
 	stderrLogFileName      = "stderr.log"
@@ -410,9 +412,14 @@ func (r *Runtime) seedCodexHomeConfig(runtimeCodexHome string, profile agentrunt
 		return nil
 	}
 
+	if err := r.writeModelCatalog(runtimeCodexHome, profile); err != nil {
+		return err
+	}
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "model = %s\n", strconv.Quote(profile.ModelID))
 	fmt.Fprintf(&b, "model_provider = %s\n\n", strconv.Quote(codexProxyProviderName))
+	fmt.Fprintf(&b, "model_catalog_json = %s\n\n", strconv.Quote(modelCatalogFileName))
 	fmt.Fprintf(&b, "[model_providers.%s]\n", codexProxyProviderName)
 	fmt.Fprintf(&b, "name = %s\n", strconv.Quote("OpenAI using LLM proxy"))
 	fmt.Fprintf(&b, "base_url = %s\n", strconv.Quote(profile.BaseURL))
@@ -424,6 +431,22 @@ func (r *Runtime) seedCodexHomeConfig(runtimeCodexHome string, profile agentrunt
 
 	if err := r.writeFile(configPath, []byte(b.String()), 0o600); err != nil {
 		return fmt.Errorf("write runtime codex config %s: %w", configPath, err)
+	}
+	return nil
+}
+
+func (r *Runtime) writeModelCatalog(runtimeCodexHome string, profile agentruntime.Profile) error {
+	catalogPath := filepath.Join(runtimeCodexHome, modelCatalogFileName)
+	body, err := json.MarshalIndent(codexmodel.Catalog(codexmodel.Profile{
+		ModelID:         profile.ModelID,
+		ReasoningEffort: profile.ReasoningEffort,
+	}), "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode runtime codex model catalog: %w", err)
+	}
+	body = append(body, '\n')
+	if err := r.writeFile(catalogPath, body, 0o600); err != nil {
+		return fmt.Errorf("write runtime codex model catalog %s: %w", catalogPath, err)
 	}
 	return nil
 }

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -166,9 +166,11 @@ func TestRuntimeCreateStartAndInfo(t *testing.T) {
 	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
 		`model = "gpt-5.5"`,
 		`model_provider = "proxy"`,
+		`model_catalog_json = "model_catalog.json"`,
 		`wire_api = "responses"`,
 		`supports_websockets = false`,
 	)
+	assertRuntimeModelCatalog(t, filepath.Join(root, "alice", ".codex", modelCatalogFileName), "gpt-5.5")
 }
 
 func TestRuntimeStopAndDelete(t *testing.T) {
@@ -438,9 +440,11 @@ func TestRuntimeCreateWritesConfigWhenHostAuthIsSeeded(t *testing.T) {
 
 	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
 		`model = "gpt-5.5"`,
+		`model_catalog_json = "model_catalog.json"`,
 		`wire_api = "responses"`,
 		`supports_websockets = false`,
 	)
+	assertRuntimeModelCatalog(t, filepath.Join(root, "alice", ".codex", modelCatalogFileName), "gpt-5.5")
 }
 
 func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
@@ -507,6 +511,7 @@ func TestRuntimeCreateWritesConfigWithoutAuth(t *testing.T) {
 	for _, want := range []string{
 		`model = "gpt-5.5"`,
 		`model_provider = "proxy"`,
+		`model_catalog_json = "model_catalog.json"`,
 		`[model_providers.proxy]`,
 		`name = "OpenAI using LLM proxy"`,
 		`base_url = "https://runtime.example/v1"`,
@@ -570,9 +575,11 @@ func TestRuntimeCreateAlwaysWritesResponsesConfig(t *testing.T) {
 
 	assertRuntimeConfigContains(t, filepath.Join(root, "alice", ".codex", configFileName),
 		`model = "deepseek-v4-pro"`,
+		`model_catalog_json = "model_catalog.json"`,
 		`wire_api = "responses"`,
 		`supports_websockets = false`,
 	)
+	assertRuntimeModelCatalog(t, filepath.Join(root, "alice", ".codex", modelCatalogFileName), "deepseek-v4-pro")
 	configText, err := os.ReadFile(filepath.Join(root, "alice", ".codex", configFileName))
 	if err != nil {
 		t.Fatal(err)
@@ -658,6 +665,7 @@ func TestRuntimeCreateRemovesStaleConfigWhenAuthExists(t *testing.T) {
 			t.Fatalf("runtime config missing %q:\n%s", want, configText)
 		}
 	}
+	assertRuntimeModelCatalog(t, filepath.Join(runtimeRoot, modelCatalogFileName), "gpt-5.5")
 }
 
 func assertRuntimeConfigContains(t *testing.T, path string, wants ...string) {
@@ -672,6 +680,33 @@ func assertRuntimeConfigContains(t *testing.T, path string, wants ...string) {
 		if !strings.Contains(configText, want) {
 			t.Fatalf("runtime config missing %q:\n%s", want, configText)
 		}
+	}
+}
+
+func assertRuntimeModelCatalog(t *testing.T, path, wantModel string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime model catalog: %v", err)
+	}
+	if strings.Contains(string(raw), "runtime-key") {
+		t.Fatalf("runtime model catalog contains raw API key:\n%s", raw)
+	}
+	var payload struct {
+		Models []map[string]any `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode runtime model catalog: %v", err)
+	}
+	if len(payload.Models) != 1 {
+		t.Fatalf("runtime model catalog models = %#v, want one model", payload.Models)
+	}
+	if got := payload.Models[0]["slug"]; got != wantModel {
+		t.Fatalf("runtime model catalog slug = %#v, want %q", got, wantModel)
+	}
+	if _, ok := payload.Models[0]["model_messages"]; !ok {
+		t.Fatalf("runtime model catalog missing model_messages: %#v", payload.Models[0])
 	}
 }
 


### PR DESCRIPTION
Codex runtime now generates a local model catalog for OpenAI-compatible providers, preventing unknown-model metadata warnings without brittle text filtering.