### PR TITLE
docs(web): add frontend documentation overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ make release
 - Prefer existing patterns and the standard library before adding dependencies.
 - Format with `make fmt`.
 - Add or update tests when changing CLI, config, API, or runtime behavior.
-- When changing the Vite web app, follow `docs/web/FRONTEND.md` for frontend structure, source layout, components, styling, state, accessibility, and verification.
+- When changing the Vite web app, follow `docs/web/development.md` for frontend structure, source layout, components, styling, state, accessibility, and verification.
 - Do not change BoxLite sandbox integration or packaging paths unless the task is about sandbox/runtime integration.
 - When changing config fields or defaults, update loader, saver, onboard flow, tests, and docs together.
 - Never hardcode or print real secrets; startup and logs must keep tokens redacted.
@@ -60,6 +60,6 @@ make release
 
 - `README.md`
 - `docs/README.go.md`
-- `docs/web/FRONTEND.md`
+- `docs/web/development.md`
 - `Makefile`
 - `.github/workflows/release.yml`

--- a/docs/web/README.md
+++ b/docs/web/README.md
@@ -1,0 +1,16 @@
+# Web Documentation
+
+This directory documents the CSGClaw frontend under `web/app`.
+
+## Documents
+
+- `development.md`: The main frontend development guide. Use this as the source of truth for tooling, source layout, component boundaries, imports, styling, state/data flow, accessibility, tests, and generated output rules.
+- `development.zh.md`: Chinese companion to `development.md`. It mirrors the development guide for Chinese readers.
+- `architecture.md`: A single ASCII architecture diagram for the frontend. Use it for a quick visual overview of build boundaries, runtime boundaries, source ownership, UI composition, data flow, dependency direction, component packaging, and quality gates.
+- `architecture.zh.md`: Chinese companion to `architecture.md`. It explains the same architecture diagram in Chinese.
+
+## Reading Order
+
+Start with `architecture.md` or `architecture.zh.md` when you need a fast mental model of the frontend.
+
+Use `development.md` or `development.zh.md` when you are creating, moving, or reviewing frontend code and need the exact rules.

--- a/docs/web/architecture.md
+++ b/docs/web/architecture.md
@@ -1,0 +1,218 @@
+# Frontend Architecture Diagram
+
+This document explains the `web/app` frontend architecture as one complete ASCII diagram. It is a visual companion to `development.md`.
+
+Chinese companion: `architecture.zh.md`.
+
+```text
++==============================================================================================+
+|                                   CSGClaw Web Frontend                                        |
+|                         Vite + React app under web/app/src                                    |
++==============================================================================================+
+
+  Build / Hosting Boundary
+  ----------------------------------------------------------------------------------------------
+
+  +-----------------------+        +-----------------------+        +---------------------------+
+  | Developer Source      |        | Vite Build            |        | Embedded Output           |
+  | web/app/src           | -----> | pnpm / make build-web | -----> | web/static-dist           |
+  | edit here             |        | generated assets      |        | served by Go embed        |
+  +-----------------------+        +-----------------------+        +---------------------------+
+            |
+            | compare only, do not edit by default
+            v
+  +-----------------------+
+  | Legacy Frontend       |
+  | web/static            |
+  +-----------------------+
+
+
+  Runtime Boundary
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------------------------------------------------------------------------------+
+  | Browser Runtime                                                                            |
+  | React renders Workspace UI, owns interaction state, calls HTTP APIs, receives realtime data |
+  +---------------------------------------------+----------------------------------------------+
+                                                |
+                                                | HTTP JSON + SSE / shared worker events
+                                                v
+  +--------------------------------------------------------------------------------------------+
+  | Go Server                                                                                  |
+  | hosts embedded Web UI, exposes app / im / agents / hub / upgrade APIs                      |
+  +---------------------------------------------+----------------------------------------------+
+                                                |
+                                                | backend coordination
+                                                v
+  +--------------------------------------------------------------------------------------------+
+  | Local Runtime                                                                               |
+  | agents, rooms, IM bridge, manager / worker runtime, hub templates, upgrade actions          |
+  +--------------------------------------------------------------------------------------------+
+
+
+  Source Architecture
+  ----------------------------------------------------------------------------------------------
+
+  web/app/src
+  |
+  +-- main.tsx
+  |     React entrypoint only
+  |
+  +-- bootstrap/
+  |     App startup, providers, query client, error boundary, root assembly
+  |
+  +-- routes/
+  |     URL to page mapping only; no page implementation details
+  |
+  +-- pages/
+  |     Route owners and page-private modules
+  |     |
+  |     +-- WorkspacePage
+  |     |     Main shell: sidebar, layout, modals, overlays, nested outlet
+  |     |
+  |     +-- ConversationPage
+  |     |     Conversation route content and conversation-private components
+  |     |
+  |     +-- ComputerPage
+  |     |     Computer route content and computer-private components
+  |     |
+  |     +-- AgentPage
+  |     |     Agent route content and agent-private components
+  |     |
+  |     +-- HubPage
+  |           Hub route content and hub-private components
+  |
+  +-- hooks/
+  |     Shared React controllers and reusable hooks
+  |     Example: workspace controller composes navigation, data, mutations, UI state
+  |
+  +-- api/
+  |     HTTP transport boundary
+  |     Owns endpoint paths, payloads, response types, low-level error mapping
+  |     Must not own rendering logic, React state, or page-specific defaults
+  |
+  +-- models/
+  |     Pure domain logic
+  |     Owns normalizers, formatters, serializers, routing helpers, state transition helpers
+  |     Must not fetch, read browser storage, or depend on React
+  |
+  +-- components/
+  |     Shared components only
+  |     |
+  |     +-- ui/
+  |     |     Source-agnostic primitives: layout, buttons, form controls, icons
+  |     |     Must not import api, pages, storage clients, realtime clients, or route models
+  |     |
+  |     +-- business/
+  |           Shared app-aware components
+  |           May combine UI primitives with business labels, state, callbacks, API-shaped data
+  |
+  +-- shared/
+        Cross-cutting infrastructure
+        |
+        +-- constants/   Stable app contracts: API names, agent defaults, message types
+        +-- i18n/        Message catalogs, locale selection, translator helpers
+        +-- realtime/    Event bus, SSE/shared worker plumbing, subscriptions
+        +-- storage/     Storage keys and local/session storage wrappers
+        +-- styles/      Global CSS, reset, design tokens, CSS variables
+        +-- theme/       Theme selection and theme helpers
+        +-- lib/         Generic helpers with no React, API, storage, or page dependency
+
+
+  Main UI Composition
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------------------------------------------------------------------------------+
+  | WorkspacePage                                                                               |
+  |                                                                                            |
+  |  +-----------------------+      +--------------------------------------------------------+  |
+  |  | WorkspaceSidebar      |      | WorkspaceMainPanel                                     |  |
+  |  | tabs, groups, footer  |      | renders nested route page through Outlet               |  |
+  |  +-----------------------+      |                                                        |  |
+  |                                 | ConversationPage / ComputerPage / AgentPage / HubPage  |  |
+  |  +-----------------------+      +--------------------------------------------------------+  |
+  |  | WorkspaceModals       |      +--------------------------------------------------------+  |
+  |  | create, invite, setup |      | WorkspaceOverlays                                      |  |
+  |  +-----------------------+      | popovers, previews, transient UI                       |  |
+  |                                 +--------------------------------------------------------+  |
+  +--------------------------------------------------------------------------------------------+
+
+
+  Data Flow
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------+      +-----------------------+      +---------------------+
+  | User Action        | ---> | Page / Controller     | ---> | api/                |
+  | click, type, submit|      | load, mutate, decide  |      | request boundary    |
+  +--------------------+      +-----------+-----------+      +----------+----------+
+                                           ^                             |
+                                           |                             v
+  +--------------------+      +------------+----------+      +---------------------+
+  | UI Components      | <--- | Page State / Props    | <--- | models/             |
+  | render only        |      | loading/error/empty   |      | normalize and shape |
+  +--------------------+      +-----------------------+      +----------+----------+
+                                                                         ^
+                                                                         |
+  +--------------------+      +-----------------------+      +----------+----------+
+  | Realtime Events    | ---> | shared/realtime       | ---> | event adapter       |
+  | SSE / worker data  |      | subscribe and dispatch|      | reuse model helpers |
+  +--------------------+      +-----------------------+      +---------------------+
+
+
+  Dependency Rules
+  ----------------------------------------------------------------------------------------------
+
+  Allowed direction:
+
+    pages  --->  hooks/controllers  --->  api + models
+      |                 |
+      v                 v
+    components/business ---> components/ui ---> shared
+
+  Keep close to owner first:
+
+    one page only        -> pages/<PageName>/
+    page component       -> pages/<PageName>/components/
+    shared primitive     -> components/ui/
+    shared app-aware UI  -> components/business/
+    HTTP boundary        -> api/
+    pure domain logic    -> models/
+    cross-cutting infra  -> shared/
+
+  Avoid:
+
+    components/ui  ----X----> api/
+    components/ui  ----X----> pages/
+    pages/A        ----X----> pages/B private modules
+    api/           ----X----> React state or rendering logic
+    models/        ----X----> fetch, storage, browser effects
+
+
+  Component Package Rules
+  ----------------------------------------------------------------------------------------------
+
+  Exported component package:
+
+    PascalCaseDirectory/
+      PascalCaseDirectory.tsx
+      PascalCaseDirectory.css
+      index.ts
+      types.ts / utils.ts / tests when needed
+
+  Promote to package when:
+
+    has CSS, tests, types, utils, constants, child components,
+    two or more importers, or grows beyond about 150-200 lines.
+
+
+  Quality Gates
+  ----------------------------------------------------------------------------------------------
+
+  Documentation only                  -> read and review Markdown
+  TypeScript or import path changes   -> pnpm --dir web/app typecheck
+  Frontend source changes             -> pnpm --dir web/app lint
+  Pure model/helper changes           -> pnpm --dir web/app test
+  Standard frontend verification      -> pnpm --dir web/app check
+  Bundle smoke without static-dist    -> pnpm --dir web/app exec vite build --outDir /private/tmp/csgclaw-web-build --emptyOutDir
+  Intentional embedded output update  -> pnpm --dir web/app build
+```

--- a/docs/web/architecture.zh.md
+++ b/docs/web/architecture.zh.md
@@ -1,0 +1,218 @@
+# 前端架构图解
+
+这张图用一个完整视角解释 `web/app` 前端架构，是 `development.zh.md` 的图形化补充。
+
+英文版: `architecture.md`。
+
+```text
++==============================================================================================+
+|                                   CSGClaw Web 前端架构                                        |
+|                           web/app/src 下的 Vite + React 应用                                  |
++==============================================================================================+
+
+  构建与托管边界
+  ----------------------------------------------------------------------------------------------
+
+  +-----------------------+        +-----------------------+        +---------------------------+
+  | 开发源码              |        | Vite 构建             |        | 嵌入产物                  |
+  | web/app/src           | -----> | pnpm / make build-web | -----> | web/static-dist           |
+  | 只在这里改源码        |        | 生成前端资源          |        | 由 Go embed 托管          |
+  +-----------------------+        +-----------------------+        +---------------------------+
+            |
+            | 仅作旧前端对照，默认不要修改
+            v
+  +-----------------------+
+  | 旧前端对照资产        |
+  | web/static            |
+  +-----------------------+
+
+
+  运行时边界
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------------------------------------------------------------------------------+
+  | 浏览器运行时                                                                               |
+  | React 渲染工作区 UI，管理交互状态，调用 HTTP API，接收实时数据                            |
+  +---------------------------------------------+----------------------------------------------+
+                                                |
+                                                | HTTP JSON + SSE / shared worker 事件
+                                                v
+  +--------------------------------------------------------------------------------------------+
+  | Go 服务端                                                                                  |
+  | 托管嵌入的 Web UI，并暴露 app / im / agents / hub / upgrade APIs                          |
+  +---------------------------------------------+----------------------------------------------+
+                                                |
+                                                | 后端编排
+                                                v
+  +--------------------------------------------------------------------------------------------+
+  | 本地运行时                                                                                 |
+  | agents, rooms, IM bridge, manager / worker runtime, hub templates, upgrade actions          |
+  +--------------------------------------------------------------------------------------------+
+
+
+  源码架构
+  ----------------------------------------------------------------------------------------------
+
+  web/app/src
+  |
+  +-- main.tsx
+  |     只做 React 入口
+  |
+  +-- bootstrap/
+  |     应用启动、providers、query client、错误边界、根装配
+  |
+  +-- routes/
+  |     只做 URL 到页面的映射，不放页面实现细节
+  |
+  +-- pages/
+  |     路由页面 owner 和页面私有模块
+  |     |
+  |     +-- WorkspacePage
+  |     |     主工作区外壳: sidebar、layout、modals、overlays、nested outlet
+  |     |
+  |     +-- ConversationPage
+  |     |     会话页面内容和会话页私有组件
+  |     |
+  |     +-- ComputerPage
+  |     |     电脑页面内容和电脑页私有组件
+  |     |
+  |     +-- AgentPage
+  |     |     Agent 页面内容和 Agent 页私有组件
+  |     |
+  |     +-- HubPage
+  |           Hub 页面内容和 Hub 页私有组件
+  |
+  +-- hooks/
+  |     共享 React controller 和复用 hook
+  |     例如 workspace controller 组合导航、数据、mutation、UI 状态
+  |
+  +-- api/
+  |     HTTP 传输边界
+  |     负责 endpoint path、payload、response type、底层错误映射
+  |     不承载渲染逻辑、React 状态或页面专属默认值
+  |
+  +-- models/
+  |     纯领域逻辑
+  |     负责 normalizer、formatter、serializer、routing helper、状态流转 helper
+  |     不发请求、不读浏览器 storage、不依赖 React
+  |
+  +-- components/
+  |     只放共享组件
+  |     |
+  |     +-- ui/
+  |     |     与数据来源无关的基础组件: layout、buttons、form controls、icons
+  |     |     不导入 api、pages、storage client、realtime client 或 route models
+  |     |
+  |     +-- business/
+  |           跨页面复用的业务组件
+  |           可以组合 UI 基础件和业务文案、状态、回调、API 整理后的数据
+  |
+  +-- shared/
+        跨模块基础设施
+        |
+        +-- constants/   稳定应用契约: API 名称、agent 默认值、message types
+        +-- i18n/        文案表、语言选择、翻译 helper
+        +-- realtime/    event bus、SSE/shared worker 管道、订阅能力
+        +-- storage/     storage key 和 local/session storage wrapper
+        +-- styles/      全局 CSS、reset、设计 token、CSS 变量
+        +-- theme/       主题选择和主题 helper
+        +-- lib/         不依赖 React、API、storage、page 的通用 helper
+
+
+  主界面组合
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------------------------------------------------------------------------------+
+  | WorkspacePage                                                                               |
+  |                                                                                            |
+  |  +-----------------------+      +--------------------------------------------------------+  |
+  |  | WorkspaceSidebar      |      | WorkspaceMainPanel                                     |  |
+  |  | tabs, groups, footer  |      | 通过 Outlet 渲染嵌套路由页面                           |  |
+  |  +-----------------------+      |                                                        |  |
+  |                                 | ConversationPage / ComputerPage / AgentPage / HubPage  |  |
+  |  +-----------------------+      +--------------------------------------------------------+  |
+  |  | WorkspaceModals       |      +--------------------------------------------------------+  |
+  |  | 创建、邀请、配置      |      | WorkspaceOverlays                                      |  |
+  |  +-----------------------+      | popover、preview、临时 UI                              |  |
+  |                                 +--------------------------------------------------------+  |
+  +--------------------------------------------------------------------------------------------+
+
+
+  数据流
+  ----------------------------------------------------------------------------------------------
+
+  +--------------------+      +-----------------------+      +---------------------+
+  | 用户操作           | ---> | 页面 / Controller     | ---> | api/                |
+  | click, type, submit|      | load, mutate, decide  |      | 请求边界            |
+  +--------------------+      +-----------+-----------+      +----------+----------+
+                                           ^                             |
+                                           |                             v
+  +--------------------+      +------------+----------+      +---------------------+
+  | UI 组件            | <--- | 页面状态 / Props      | <--- | models/             |
+  | 只负责渲染         |      | loading/error/empty   |      | 归一化和整理数据    |
+  +--------------------+      +-----------------------+      +----------+----------+
+                                                                         ^
+                                                                         |
+  +--------------------+      +-----------------------+      +----------+----------+
+  | 实时事件           | ---> | shared/realtime       | ---> | event adapter       |
+  | SSE / worker data  |      | 订阅并分发            |      | 复用 model helper   |
+  +--------------------+      +-----------------------+      +---------------------+
+
+
+  依赖规则
+  ----------------------------------------------------------------------------------------------
+
+  允许的依赖方向:
+
+    pages  --->  hooks/controllers  --->  api + models
+      |                 |
+      v                 v
+    components/business ---> components/ui ---> shared
+
+  先靠近 owner，再按真实复用提升:
+
+    只属于一个页面       -> pages/<PageName>/
+    页面私有组件         -> pages/<PageName>/components/
+    共享基础 UI          -> components/ui/
+    共享业务 UI          -> components/business/
+    HTTP 边界            -> api/
+    纯领域逻辑           -> models/
+    跨模块基础设施       -> shared/
+
+  避免:
+
+    components/ui  ----X----> api/
+    components/ui  ----X----> pages/
+    pages/A        ----X----> pages/B private modules
+    api/           ----X----> React state or rendering logic
+    models/        ----X----> fetch, storage, browser effects
+
+
+  组件包规则
+  ----------------------------------------------------------------------------------------------
+
+  导出的组件包:
+
+    PascalCaseDirectory/
+      PascalCaseDirectory.tsx
+      PascalCaseDirectory.css
+      index.ts
+      types.ts / utils.ts / tests when needed
+
+  升级成组件包的条件:
+
+    有 CSS、tests、types、utils、constants、子组件，
+    有两个及以上 importers，或增长到大约 150-200 行。
+
+
+  质量门禁
+  ----------------------------------------------------------------------------------------------
+
+  只改文档                         -> 通读并检查 Markdown
+  TypeScript 或 import 路径变化    -> pnpm --dir web/app typecheck
+  前端源码变化                     -> pnpm --dir web/app lint
+  纯 model/helper 变化             -> pnpm --dir web/app test
+  标准前端验证                     -> pnpm --dir web/app check
+  不写 static-dist 的打包冒烟      -> pnpm --dir web/app exec vite build --outDir /private/tmp/csgclaw-web-build --emptyOutDir
+  明确要更新嵌入产物               -> pnpm --dir web/app build
+```

--- a/docs/web/development.md
+++ b/docs/web/development.md
@@ -2,7 +2,7 @@
 
 These rules apply to the Vite web app in `web/app`.
 
-Chinese companion: `FRONTEND.zh.md`. This English document is the agent-facing source of truth.
+Chinese companion: `development.zh.md`. This English document is the agent-facing source of truth.
 
 ## Tooling
 
@@ -75,7 +75,6 @@ If a subdirectory later needs its own rules, add a short README in that subdirec
 
 ## Constants And Shared Contracts
 
-- Do not use `src/bootstrap/constants.ts` or any other single catch-all constants module.
 - Page-private constants belong next to the page, component, hook, or helper that owns them.
 - Pure domain constants used by model helpers belong in the owning `src/models/<domain>.ts` module. Routing constants, pane types, route segment aliases, and path builders should stay together in `src/models/routing.ts`.
 - Stable cross-cutting contracts that are imported by multiple distant modules belong in focused files under `src/shared/constants/`, for example `api.ts`, `agents.ts`, `messages.ts`, or `workspace.ts`.
@@ -147,6 +146,18 @@ src/pages/WorkspacePage/components/
 - Keep transient UI state inside the owning page or component.
 - Add shared state only when state must be read or updated by multiple distant modules.
 - Do not mix fetch calls, normalization, and rendering logic in one large component when the logic can be cleanly separated.
+
+## Data Flow
+
+- Treat `src/api/` as the transport boundary. API modules should own endpoint paths, request payloads, response types, low-level error mapping, and OpenAPI/server shape compatibility. They should not own React state, rendering decisions, or page-specific defaults.
+- Convert raw API responses into app-facing shapes before they reach broad UI code when the conversion is reused, non-trivial, or needs regression coverage. Put those pure helpers in `src/models/<domain>.ts` or a focused model module.
+- Route pages or page-owned hooks should compose data loading, mutations, loading/error/empty state, and page-specific defaults. Keep this orchestration near the route until another page needs the same behavior.
+- Shared components should receive already-shaped props or focused callbacks. They may display business state, but they should not fetch directly unless they are intentionally app-aware components in `src/components/business/` with a documented cross-page use.
+- UI primitives in `src/components/ui/` must stay data-source agnostic. They should not import `src/api/`, route models, storage clients, realtime clients, or page modules.
+- Realtime events, polling, and shared subscriptions belong in `src/shared/realtime/` or in a page-owned hook when only one page consumes them. Normalize realtime payloads through the same model helpers used by HTTP data when possible.
+- Keep mutation flows explicit: call the API at the page/controller layer, update local or shared state in one place, and surface loading, disabled, and error states through props. Use optimistic updates only when rollback behavior is clear.
+- Introduce app-wide stores or context only for state that is genuinely shared across distant routes or layout areas. Prefer page-local hooks and derived props for data that has one visible owner.
+- Test the pure parts of the flow first: API shape adapters, model normalizers, serializers, routing helpers, and state-transition helpers. Add component tests only for the user-visible wiring around those helpers.
 
 ## i18n And Text
 

--- a/docs/web/development.zh.md
+++ b/docs/web/development.zh.md
@@ -2,7 +2,7 @@
 
 本规范适用于 `web/app` 下的 Vite 前端应用。
 
-英文版为 `FRONTEND.md`，Agent 默认以英文版为准。
+英文版为 `development.md`，Agent 默认以英文版为准。
 
 ## 工具链
 
@@ -75,7 +75,6 @@ pnpm --dir web/app install
 
 ## 常量与共享契约
 
-- 不要使用 `src/bootstrap/constants.ts` 或其它单个万能 constants 模块。
 - 页面私有常量放在拥有它的页面、组件、hook 或 helper 附近。
 - 被 model helper 使用的纯领域常量放在对应的 `src/models/<domain>.ts`。路由常量、pane type、route segment alias 和 path builder 应一起放在 `src/models/routing.ts`。
 - 被多个远距离模块导入的稳定跨模块契约，放在 `src/shared/constants/` 下的聚焦文件里，例如 `api.ts`、`agents.ts`、`messages.ts` 或 `workspace.ts`。
@@ -147,6 +146,18 @@ src/pages/WorkspacePage/components/
 - 临时 UI 状态留在拥有它的页面或组件里。
 - 只有多个远距离模块都需要读写时，才引入共享状态。
 - 不要把 fetch、数据归一化和渲染逻辑都混在一个大组件里；可以清晰拆分时就拆出去。
+
+## 数据流
+
+- 把 `src/api/` 当作传输边界。API 模块负责 endpoint path、请求 payload、响应类型、底层错误映射，以及与 OpenAPI/server 返回形态的兼容；不要在这里承载 React 状态、渲染决策或页面专属默认值。
+- 原始 API 响应进入大范围 UI 代码前，如果转换逻辑会复用、足够复杂或需要回归测试，先转换成前端应用使用的形态。纯转换 helper 放在 `src/models/<domain>.ts` 或聚焦的 model 模块里。
+- 路由页面或页面拥有的 hook 负责组合数据加载、mutation、loading/error/empty 状态和页面专属默认值。只要还没有其它页面复用，就把这层编排留在路由附近。
+- 共享组件应接收已经整理好的 props 或聚焦的 callback。组件可以展示业务状态，但不要直接 fetch；除非它是 `src/components/business/` 下有明确跨页面用途的 app-aware 组件。
+- `src/components/ui/` 下的 UI 基础件必须与数据来源无关。不要导入 `src/api/`、route model、storage client、realtime client 或页面模块。
+- 实时事件、轮询和共享订阅放在 `src/shared/realtime/`；如果只有一个页面消费，放在页面拥有的 hook 里。能复用 HTTP 数据的 model helper 时，实时 payload 也通过同一套 helper 归一化。
+- mutation 流程保持显式：在页面/controller 层调用 API，在一个明确位置更新本地或共享状态，并通过 props 暴露 loading、disabled 和 error 状态。只有回滚行为清晰时才使用 optimistic update。
+- 只有状态确实需要跨远距离路由或布局区域共享时，才引入全局 store 或 context。单一可见 owner 的数据优先使用页面本地 hook 和派生 props。
+- 优先测试数据流中的纯逻辑：API shape adapter、model normalizer、serializer、routing helper 和状态流转 helper。组件测试只补用户可观察的 wiring。
 
 ## i18n 与文案
 

--- a/web/app/src/components/README.md
+++ b/web/app/src/components/README.md
@@ -6,4 +6,4 @@ This directory is only for components shared outside a single page.
 - `business/` contains shared app-aware components.
 - Page-private components belong under `src/pages/<PageName>/components/`.
 
-See [docs/web/FRONTEND.md](../../../../docs/web/FRONTEND.md) for the full frontend rules.
+See [docs/web/development.md](../../../../docs/web/development.md) for the full frontend rules.


### PR DESCRIPTION
Summary:
- add docs/web README describing each frontend documentation file
- add English and Chinese frontend architecture diagrams
- rename frontend development guides to development.md and development.zh.md
- update documentation references to the new frontend guide path

Verification:
- checked Markdown content
- git diff --check