### PR TITLE
[codex] Refine hub template detail layout

### DIFF
--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -145,16 +145,18 @@ export function HubDetailPane({ t, locale, hub, onCreateFromTemplate }) {
                       <div className="hub-inspector-copy">
                         <h2>{selectedTemplate.name || selectedTemplate.id}</h2>
                         <p>{selectedTemplate.description || selectedTemplate.id}</p>
-                        <span className="mini-badge template-role-badge">
-                          {localizeRole(selectedTemplate.role || "worker", t)}
-                        </span>
-                        <span className="mini-badge template-runtime-badge">
-                          {selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}
-                        </span>
-                        <span className="mini-badge template-source-badge">
-                          <span className="template-source-badge-dot" aria-hidden="true"></span>
-                          {localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}
-                        </span>
+                        <div className="hub-inspector-badge-row">
+                          <span className="mini-badge template-role-badge">
+                            {localizeRole(selectedTemplate.role || "worker", t)}
+                          </span>
+                          <span className="mini-badge template-runtime-badge">
+                            {selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}
+                          </span>
+                          <span className="mini-badge template-source-badge">
+                            <span className="template-source-badge-dot" aria-hidden="true"></span>
+                            {localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}
+                          </span>
+                        </div>
                       </div>
                     </div>
                     <div className="hub-template-actions">
@@ -190,11 +192,6 @@ export function HubDetailPane({ t, locale, hub, onCreateFromTemplate }) {
                     <span>{t("hubUpdatedAtLabel")}</span>
                     <strong>{formatHubDateTime(selectedTemplate.updated_at, locale)}</strong>
                   </div>
-                </div>
-
-                <div className="hub-description-block">
-                  <span className="hub-section-label">{t("hubDescriptionLabel")}</span>
-                  <p>{selectedTemplate.description || selectedTemplate.id}</p>
                 </div>
 
                 <div className="hub-workspace-block">

--- a/web/app/src/shared/styles/globals.css
+++ b/web/app/src/shared/styles/globals.css
@@ -2821,20 +2821,24 @@ body::after {
 
 .template-runtime-badge {
   width: fit-content;
+  display: inline-flex;
+  align-items: center;
   padding: 2px 8px;
-  border: 1px solid #e9eaeb;
+  border: 1px solid #d5d7da;
   border-radius: 6px;
-  background: #fafafa;
+  background: #fff;
   color: #414651;
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 :root[data-theme="dark"] .template-runtime-badge {
   border-color: #333741;
-  background: #161b26;
+  background: #0c111d;
   color: #cecfd2;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 .template-role-badge {
@@ -3183,9 +3187,17 @@ body::after {
   font-size: 12px;
 }
 
+.hub-inspector-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .hub-inspector-panel {
+  container-type: inline-size;
   display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   align-content: stretch;
   gap: 20px;
   min-height: 0;
@@ -3227,7 +3239,7 @@ body::after {
 
 .hub-inspector-grid {
   display: grid;
-  grid-template-columns: minmax(180px, 0.8fr) minmax(280px, 1.8fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   padding: 22px;
   border: 1px solid var(--line);
@@ -3271,6 +3283,12 @@ body::after {
 
 .hub-field-value-multiline {
   word-break: break-word;
+}
+
+@container (max-width: 620px) {
+  .hub-inspector-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hub-description-block,
@@ -5204,7 +5222,6 @@ body::after {
     border-bottom: 1px solid var(--line);
   }
 
-  .hub-inspector-grid,
   .entity-grid,
   .metric-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -5011,9 +5011,11 @@ function HubDetailPane({
                           <div className="hub-inspector-copy">
                             <h2>${selectedTemplate.name || selectedTemplate.id}</h2>
                             <p>${selectedTemplate.description || selectedTemplate.id}</p>
-                            <span className="mini-badge template-role-badge">${localizeRole(selectedTemplate.role || "worker", t)}</span>
-                            <span className="mini-badge template-runtime-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
-                            <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
+                            <div className="hub-inspector-badge-row">
+                              <span className="mini-badge template-role-badge">${localizeRole(selectedTemplate.role || "worker", t)}</span>
+                              <span className="mini-badge template-runtime-badge">${selectedTemplate.runtime_kind || selectedTemplate.workspace?.kind || "-"}</span>
+                              <span className="mini-badge template-source-badge"><span className="template-source-badge-dot" aria-hidden="true"></span>${localizeTemplateSourceTag(selectedTemplate.source?.name, locale)}</span>
+                            </div>
                           </div>
                         </div>
                         <div className="hub-template-actions">
@@ -5049,11 +5051,6 @@ function HubDetailPane({
                         <span>${t("hubUpdatedAtLabel")}</span>
                         <strong>${formatHubDateTime(selectedTemplate.updated_at, locale)}</strong>
                       </div>
-                    </div>
-
-                    <div className="hub-description-block">
-                      <span className="hub-section-label">${t("hubDescriptionLabel")}</span>
-                      <p>${selectedTemplate.description || selectedTemplate.id}</p>
                     </div>
 
                     <div className="hub-workspace-block">

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -2909,20 +2909,24 @@ body::after {
 
 .template-runtime-badge {
   width: fit-content;
+  display: inline-flex;
+  align-items: center;
   padding: 2px 8px;
-  border: 1px solid #e9eaeb;
+  border: 1px solid #d5d7da;
   border-radius: 6px;
-  background: #fafafa;
+  background: #fff;
   color: #414651;
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 :root[data-theme="dark"] .template-runtime-badge {
   border-color: #333741;
-  background: #161b26;
+  background: #0c111d;
   color: #cecfd2;
+  box-shadow: 0 1px 2px 0 rgba(10, 13, 18, 0.05);
 }
 
 .mini-badge.warn,
@@ -3238,6 +3242,13 @@ body::after {
   max-width: 100%;
 }
 
+.hub-inspector-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .hub-template-card-title-row h2 {
   margin: 0;
   color: color-mix(in srgb, var(--text) 78%, var(--muted) 22%);
@@ -3276,8 +3287,9 @@ body::after {
 }
 
 .hub-inspector-panel {
+  container-type: inline-size;
   display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   align-content: stretch;
   gap: 20px;
   max-height: calc(100dvh - 166px);
@@ -3322,7 +3334,7 @@ body::after {
 
 .hub-inspector-grid {
   display: grid;
-  grid-template-columns: minmax(180px, 0.8fr) minmax(280px, 1.8fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   padding: 22px;
   border: 1px solid var(--line);
@@ -3362,6 +3374,12 @@ body::after {
 
 :root[data-theme="dark"] .hub-inspector-field strong {
   color: color-mix(in srgb, var(--text) 78%, var(--muted) 22%);
+}
+
+@container (max-width: 620px) {
+  .hub-inspector-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hub-field-value-multiline {
@@ -5313,7 +5331,6 @@ body::after {
     border-bottom: 1px solid var(--line);
   }
 
-  .hub-inspector-grid,
   .entity-grid,
   .metric-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

- Apply the hub template detail layout refinement from PR #73.
- Keep the current role badge while grouping role, runtime, and source badges into one responsive row.
- Remove the duplicated description block and make the inspector grid use balanced responsive columns in both Vite source and legacy static assets.

## Validation

- PATH=/Users/shenyongfan/.nvm/versions/node/v22.13.0/bin:$PATH pnpm --dir web/app typecheck
- make test was attempted, but the local sandbox blocks test HTTP listeners (bind: operation not permitted) and the environment is missing boxlite for existing serve tests.