### PR TITLE
fix(web): support sandbox deployment routing

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -866,8 +866,11 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) handleHubTemplateByID(w http.ResponseWriter, r *http.Request) {
-	id := hubTemplateIDFromPathValues(r)
+func (h *Handler) handleHubTemplateByRegistryName(w http.ResponseWriter, r *http.Request) {
+	h.handleHubTemplateByResolvedID(w, r, hubTemplateIDFromRegistryNamePathValues(r))
+}
+
+func (h *Handler) handleHubTemplateByResolvedID(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -901,8 +904,8 @@ func (h *Handler) handleHubTemplateByID(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, presented)
 }
 
-func (h *Handler) handleHubTemplateWorkspaceFileByID(w http.ResponseWriter, r *http.Request) {
-	id := hubTemplateIDFromPathValues(r)
+func (h *Handler) handleHubTemplateWorkspaceFileByRegistryName(w http.ResponseWriter, r *http.Request) {
+	id := hubTemplateIDFromRegistryNamePathValues(r)
 	h.handleHubTemplateWorkspaceFile(w, r, id)
 }
 
@@ -1545,8 +1548,13 @@ func (r addRoomMembersRequest) toServiceRequest() (im.AddRoomMembersRequest, err
 	}, nil
 }
 
-func hubTemplateIDFromPathValues(r *http.Request) string {
-	return pathValue(r, "id")
+func hubTemplateIDFromRegistryNamePathValues(r *http.Request) string {
+	registry := pathValue(r, "registry")
+	name := pathValue(r, "name")
+	if registry == "" || name == "" {
+		return ""
+	}
+	return registry + "/" + name
 }
 
 func (h *Handler) reloadIM() error {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1820,7 +1820,7 @@ func TestHandleHubTemplatesListsAggregatedTemplates(t *testing.T) {
 	}
 }
 
-func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
+func TestHandleHubTemplateByRegistryNameReturnsTemplate(t *testing.T) {
 	hubSvc := mustNewLocalTemplateHubService(t, "review-bot", hub.Template{
 		ID:          "review-bot",
 		Name:        "review-bot",
@@ -1830,7 +1830,7 @@ func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
 	})
 	srv := &Handler{}
 	srv.SetHubService(hubSvc)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local%2Freview-bot", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local/review-bot", nil)
 	rec := httptest.NewRecorder()
 
 	srv.Routes().ServeHTTP(rec, req)
@@ -1844,9 +1844,6 @@ func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
 	}
 	if got.ID != "local/review-bot" {
 		t.Fatalf("template id = %q, want %q", got.ID, "local/review-bot")
-	}
-	if got.Role != hub.TemplateRoleWorker {
-		t.Fatalf("template role = %q, want %q", got.Role, hub.TemplateRoleWorker)
 	}
 	if got.Source.Name != "local" || got.Source.Kind != "local" {
 		t.Fatalf("template source = %+v, want local/local", got.Source)
@@ -1872,7 +1869,7 @@ func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
 	}
 }
 
-func TestHandleHubTemplateWorkspaceFileReturnsContent(t *testing.T) {
+func TestHandleHubTemplateWorkspaceFileByRegistryNameReturnsContent(t *testing.T) {
 	hubSvc := mustNewLocalTemplateHubService(t, "review-bot", hub.Template{
 		ID:          "review-bot",
 		Name:        "review-bot",
@@ -1882,7 +1879,7 @@ func TestHandleHubTemplateWorkspaceFileReturnsContent(t *testing.T) {
 	})
 	srv := &Handler{}
 	srv.SetHubService(hubSvc)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local%2Freview-bot/workspace/file?path=skills/custom/SKILL.md", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local/review-bot/workspace/file?path=skills/custom/SKILL.md", nil)
 	rec := httptest.NewRecorder()
 
 	srv.Routes().ServeHTTP(rec, req)
@@ -1913,7 +1910,7 @@ func TestHandleHubTemplateWithoutWorkspaceOmitsEntriesAndFilePreview(t *testing.
 	srv := &Handler{}
 	srv.SetHubService(hubSvc)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local%2Freview-bot", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local/review-bot", nil)
 	rec := httptest.NewRecorder()
 	srv.Routes().ServeHTTP(rec, req)
 
@@ -1928,7 +1925,7 @@ func TestHandleHubTemplateWithoutWorkspaceOmitsEntriesAndFilePreview(t *testing.
 		t.Fatalf("workspace entries = %#v, want empty", detail.Workspace.Entries)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local%2Freview-bot/workspace/file?path=USER.md", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local/review-bot/workspace/file?path=USER.md", nil)
 	rec = httptest.NewRecorder()
 	srv.Routes().ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/internal/api/rest_handlers.go
+++ b/internal/api/rest_handlers.go
@@ -35,11 +35,11 @@ func (h *Handler) listHubTemplates(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) createHubTemplate(w http.ResponseWriter, r *http.Request) {
 	h.handleHubTemplates(w, r)
 }
-func (h *Handler) getHubTemplate(w http.ResponseWriter, r *http.Request) {
-	h.handleHubTemplateByID(w, r)
+func (h *Handler) getHubTemplateByRegistryName(w http.ResponseWriter, r *http.Request) {
+	h.handleHubTemplateByRegistryName(w, r)
 }
-func (h *Handler) getHubTemplateWorkspaceFile(w http.ResponseWriter, r *http.Request) {
-	h.handleHubTemplateWorkspaceFileByID(w, r)
+func (h *Handler) getHubTemplateWorkspaceFileByRegistryName(w http.ResponseWriter, r *http.Request) {
+	h.handleHubTemplateWorkspaceFileByRegistryName(w, r)
 }
 func (h *Handler) getBootstrapConfig(w http.ResponseWriter, r *http.Request) {
 	h.handleBootstrapConfig(w, r)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -38,8 +38,8 @@ func (h *Handler) registerCoreRoutes(router chi.Router) {
 		r.Route("/hub/templates", func(r chi.Router) {
 			r.Get("/", h.listHubTemplates)
 			r.Post("/", h.createHubTemplate)
-			r.Get("/{id}", h.getHubTemplate)
-			r.Get("/{id}/workspace/file", h.getHubTemplateWorkspaceFile)
+			r.Get("/{registry}/{name}", h.getHubTemplateByRegistryName)
+			r.Get("/{registry}/{name}/workspace/file", h.getHubTemplateWorkspaceFileByRegistryName)
 		})
 		r.Route("/cliproxy/auth", func(r chi.Router) {
 			r.Get("/status", h.handleCLIProxyAuthStatus)

--- a/web/app/index.html
+++ b/web/app/index.html
@@ -5,7 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark light" />
     <title>CSGClaw</title>
-    <base href="/" />
+    <script>
+      (() => {
+        const base = document.createElement("base");
+        const pathname = window.location.pathname || "/";
+        base.href = pathname.endsWith("/") ? pathname : `${pathname}/`;
+        document.head.appendChild(base);
+      })();
+    </script>
     <script>
       (() => {
         try {
@@ -19,8 +26,8 @@
         }
       })();
     </script>
-    <link rel="icon" href="/favicon.ico?v=20260507" type="image/x-icon" />
-    <link rel="shortcut icon" href="/favicon.ico?v=20260507" type="image/x-icon" />
+    <link rel="icon" href="favicon.ico?v=20260507" type="image/x-icon" />
+    <link rel="shortcut icon" href="favicon.ico?v=20260507" type="image/x-icon" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/app/src/api/client.ts
+++ b/web/app/src/api/client.ts
@@ -8,6 +8,8 @@ export type ApiRequestOptions = Omit<RequestInit, "body"> & {
   json?: unknown;
 };
 
+const absoluteURLPattern: RegExp = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
 export async function request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
   const { json, ...requestOptions } = options;
   const headers = new Headers(requestOptions.headers);
@@ -24,7 +26,7 @@ export async function request<T>(path: string, options: ApiRequestOptions = {}):
     headers.set("Accept", "application/json");
   }
 
-  const response = await fetch(path, {
+  const response = await fetch(resolveRequestPath(path), {
     ...requestOptions,
     body,
     headers,
@@ -44,6 +46,14 @@ export async function request<T>(path: string, options: ApiRequestOptions = {}):
     return undefined as T;
   }
   return JSON.parse(text) as T;
+}
+
+function resolveRequestPath(path: string): string {
+  const value = String(path || "").trim();
+  if (!value || value.startsWith("#") || value.startsWith("//") || absoluteURLPattern.test(value)) {
+    return value;
+  }
+  return value.replace(/^\/+/, "");
 }
 
 export function get<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {

--- a/web/app/src/api/hub.ts
+++ b/web/app/src/api/hub.ts
@@ -1,22 +1,37 @@
 import { get, post } from "@/api/client";
 import type { HubTemplate, HubWorkspaceFile } from "@/models/hubWorkspace";
 
+const HUB_TEMPLATES_PATH = "/api/v1/hub/templates";
+
+type PublishAgentTemplatePayload = {
+  agent_id: string;
+};
+
 export function fetchHubTemplates(): Promise<HubTemplate[]> {
-  return get("/api/v1/hub/templates");
+  return get<HubTemplate[]>(HUB_TEMPLATES_PATH);
 }
 
 export function fetchHubTemplate(templateID: string): Promise<HubTemplate> {
-  return get(`/api/v1/hub/templates/${encodeURIComponent(templateID)}`);
+  return get<HubTemplate>(hubTemplatePath(templateID));
 }
 
 export function fetchHubWorkspaceFile(templateID: string, workspacePath: string): Promise<HubWorkspaceFile> {
-  return get(
-    `/api/v1/hub/templates/${encodeURIComponent(templateID)}/workspace/file?path=${encodeURIComponent(workspacePath)}`,
+  return get<HubWorkspaceFile>(
+    `${hubTemplatePath(templateID)}/workspace/file?path=${encodeURIComponent(workspacePath)}`,
   );
 }
 
 export function publishAgentTemplateRequest(agentID: string): Promise<HubTemplate> {
-  return post("/api/v1/hub/templates", {
+  const payload: PublishAgentTemplatePayload = {
     agent_id: agentID,
-  });
+  };
+  return post<HubTemplate>(HUB_TEMPLATES_PATH, payload);
+}
+
+function hubTemplatePath(templateID: string): string {
+  const id = String(templateID || "");
+  const separator = id.indexOf("/");
+  const registry = id.slice(0, separator);
+  const name = id.slice(separator + 1);
+  return `${HUB_TEMPLATES_PATH}/${registry}/${name}`;
 }

--- a/web/app/src/components/ui/Icons/IconImage.tsx
+++ b/web/app/src/components/ui/Icons/IconImage.tsx
@@ -1,81 +1,78 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactElement } from "react";
 import "./Icons.css";
 
-export function IconImage(name: string) {
-  return (
-    <span
-      className="svg-icon"
-      aria-hidden="true"
-      style={
-        {
-          WebkitMaskImage: `url("/icons/${name}.svg")`,
-          maskImage: `url("/icons/${name}.svg")`,
-        } as CSSProperties
-      }
-    ></span>
-  );
+export function IconImage(name: string): ReactElement {
+  const iconURL = `icons/${name}.svg`;
+  return <span className="svg-icon" aria-hidden="true" style={iconMaskStyle(iconURL)}></span>;
 }
 
-export function GlobeIcon() {
+function iconMaskStyle(iconURL: string): CSSProperties {
+  return {
+    WebkitMaskImage: `url("${iconURL}")`,
+    maskImage: `url("${iconURL}")`,
+  };
+}
+
+export function GlobeIcon(): ReactElement {
   return IconImage("globe");
 }
 
-export function SunIcon() {
+export function SunIcon(): ReactElement {
   return IconImage("sun");
 }
 
-export function MoonIcon() {
+export function MoonIcon(): ReactElement {
   return IconImage("moon");
 }
 
-export function AddUserIcon() {
+export function AddUserIcon(): ReactElement {
   return IconImage("add-user");
 }
 
-export function UsersIcon() {
+export function UsersIcon(): ReactElement {
   return IconImage("users");
 }
 
-export function WrenchIcon() {
+export function WrenchIcon(): ReactElement {
   return IconImage("wrench");
 }
 
-export function SidebarToggleIcon() {
+export function SidebarToggleIcon(): ReactElement {
   return IconImage("sidebar-toggle");
 }
 
-export function ChevronIcon() {
+export function ChevronIcon(): ReactElement {
   return IconImage("chevron");
 }
 
-export function RoomPlusIcon() {
+export function RoomPlusIcon(): ReactElement {
   return IconImage("room-plus");
 }
 
-export function TrashIcon() {
+export function TrashIcon(): ReactElement {
   return IconImage("trash");
 }
 
-export function RoomsIcon() {
+export function RoomsIcon(): ReactElement {
   return IconImage("rooms");
 }
 
-export function AgentIcon() {
+export function AgentIcon(): ReactElement {
   return IconImage("agent");
 }
 
-export function ComputerIcon() {
+export function ComputerIcon(): ReactElement {
   return IconImage("computer");
 }
 
-export function HubIcon() {
+export function HubIcon(): ReactElement {
   return IconImage("hub");
 }
 
-export function PlayIcon() {
+export function PlayIcon(): ReactElement {
   return IconImage("play");
 }
 
-export function StopIcon() {
+export function StopIcon(): ReactElement {
   return IconImage("stop");
 }

--- a/web/app/src/routes/AppRouter.tsx
+++ b/web/app/src/routes/AppRouter.tsx
@@ -1,11 +1,13 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import type { ReactElement } from "react";
+import { createHashRouter, RouterProvider } from "react-router-dom";
+import type { RouteObject } from "react-router-dom";
 import { AgentPage } from "@/pages/AgentPage";
 import { ComputerPage } from "@/pages/ComputerPage";
 import { ConversationPage } from "@/pages/ConversationPage";
 import { HubPage } from "@/pages/HubPage";
 import { WorkspacePage } from "@/pages/WorkspacePage/WorkspacePage";
 
-const router = createBrowserRouter([
+const routes: RouteObject[] = [
   {
     path: "/",
     element: <WorkspacePage />,
@@ -26,8 +28,10 @@ const router = createBrowserRouter([
       { path: "*", element: <ConversationPage /> },
     ],
   },
-]);
+];
 
-export function AppRouter() {
+const router = createHashRouter(routes);
+
+export function AppRouter(): ReactElement {
   return <RouterProvider router={router} />;
 }

--- a/web/app/src/shared/constants/api.ts
+++ b/web/app/src/shared/constants/api.ts
@@ -1,4 +1,4 @@
-export const API_BASE_PATH = "/api/v1";
+export const API_BASE_PATH = "api/v1";
 
 export const ApiEndpoints = {
   imEvents: `${API_BASE_PATH}/events`,
@@ -8,4 +8,4 @@ export const ApiEndpoints = {
   notifierRelayWebhookIngress: `${API_BASE_PATH}/webhooks/ingress`,
 } as const;
 
-export const IM_EVENTS_SHARED_WORKER_PATH = "/sse-shared-worker.js";
+export const IM_EVENTS_SHARED_WORKER_PATH = "sse-shared-worker.js";

--- a/web/app/tests/api/hub.test.ts
+++ b/web/app/tests/api/hub.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { fetchHubTemplate, fetchHubWorkspaceFile } from "@/api/hub";
+
+function mockFetch(): Mock<typeof fetch> {
+  const fetchMock = vi.fn<typeof fetch>(async (_input, _init) => new Response("{}", { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("hub API", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses registry/name paths for namespaced template detail requests", async () => {
+    const fetchMock = mockFetch();
+
+    await fetchHubTemplate("builtin/openclaw-manager");
+
+    expect(fetchMock).toHaveBeenCalledWith("api/v1/hub/templates/builtin/openclaw-manager", expect.any(Object));
+  });
+
+  it("uses registry/name paths for namespaced workspace file requests", async () => {
+    const fetchMock = mockFetch();
+
+    await fetchHubWorkspaceFile("builtin/openclaw-manager", "skills/custom/SKILL.md");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "api/v1/hub/templates/builtin/openclaw-manager/workspace/file?path=skills%2Fcustom%2FSKILL.md",
+      expect.any(Object),
+    );
+  });
+});

--- a/web/app/tests/legacy-contract.test.ts
+++ b/web/app/tests/legacy-contract.test.ts
@@ -13,7 +13,7 @@ function readSourceTree(dir: string): string {
     .join("\n");
 }
 
-const source = readSourceTree(resolve(process.cwd(), "src"));
+const source: string = readSourceTree(resolve(process.cwd(), "src"));
 
 describe("legacy UI contract", () => {
   it("keeps the manager rebuild action card contract", () => {
@@ -72,7 +72,8 @@ describe("legacy UI contract", () => {
     expect(source).toContain('agentPublish: "发布"');
     expect(source).toContain("async function publishAgentPage()");
     expect(source).toContain("function publishAgentTemplateRequest");
-    expect(source).toContain('post("/api/v1/hub/templates", {');
+    expect(source).toContain('const HUB_TEMPLATES_PATH = "/api/v1/hub/templates";');
+    expect(source).toContain("post<HubTemplate>(HUB_TEMPLATES_PATH, payload)");
     expect(source).toContain("publishAgentTemplateRequest(selectedAgentForPage.id)");
     expect(source).toContain("agent_id: agentID");
     expect(source).toContain("setSelectedHubTemplateId(published.id);");

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -1,21 +1,21 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import type { PluginOption } from "vite";
 import path from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
 
+const keepStaticDistPlaceholderPlugin: PluginOption = {
+  name: "keep-static-dist-placeholder",
+  closeBundle(): void {
+    const outDir = path.resolve(__dirname, "../static-dist");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(outDir, ".gitkeep"), "");
+  },
+};
+
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: "keep-static-dist-placeholder",
-      closeBundle() {
-        const outDir = path.resolve(__dirname, "../static-dist");
-        mkdirSync(outDir, { recursive: true });
-        writeFileSync(path.join(outDir, ".gitkeep"), "");
-      },
-    },
-  ],
-  base: "/",
+  plugins: [react(), keepStaticDistPlaceholderPlugin],
+  base: "./",
   publicDir: "public",
   resolve: {
     alias: {

--- a/web/ui_test.go
+++ b/web/ui_test.go
@@ -88,7 +88,7 @@ func TestHandlerSetsCacheHeaders(t *testing.T) {
 		}
 		return
 	}
-	t.Fatal("index.html does not reference a Vite /assets/ file")
+	t.Fatal("index.html does not reference a Vite assets file")
 }
 
 func TestHandlerReportsMissingWebBuild(t *testing.T) {
@@ -135,6 +135,7 @@ func assetPaths(index string) []string {
 		if strings.HasPrefix(value, "#") {
 			continue
 		}
+		value = strings.TrimPrefix(value, "./")
 		if !strings.HasPrefix(value, "/") {
 			value = "/" + value
 		}


### PR DESCRIPTION
## Summary

- Resolve frontend assets, favicon, shared worker, and API requests relative to the current mount point so the web UI can run behind sandbox path prefixes.
- Switch the SPA to hash routing to avoid server-side route fallback assumptions in sandbox deployments.
- Use registry/name Hub template routes instead of encoded slash IDs so template detail and workspace file requests survive proxy and sandbox routing layers.

## Testing

- Not run by Codex in this PR creation step; user reports this branch was tested locally.