### PR TITLE
feat(hub): thread template env through stores and agent drafts

### DIFF
--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -162,7 +162,11 @@ func normalizeStringMap(values map[string]string) map[string]string {
 		if key == "" {
 			continue
 		}
-		out[key] = strings.TrimSpace(value)
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out[key] = value
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1008,6 +1008,7 @@ func presentHubTemplate(item hub.Template) apitypes.HubTemplate {
 		Role:        item.Role,
 		RuntimeKind: item.RuntimeKind,
 		Image:       item.Image,
+		ImageEnv:    append([]apitypes.ImageEnvContract(nil), item.ImageEnv...),
 		UpdatedAt:   item.UpdatedAt,
 		Source: apitypes.HubTemplateSource{
 			Name: item.Source.Name,

--- a/internal/apitypes/hub.go
+++ b/internal/apitypes/hub.go
@@ -7,6 +7,18 @@ type CreateHubTemplateRequest struct {
 	Registry string `json:"registry,omitempty"`
 }
 
+type ImageEnvContract struct {
+	Name        string   `json:"name"`
+	Required    bool     `json:"required,omitempty"`
+	Secret      bool     `json:"secret,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Choices     []string `json:"choices,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
+	Example     string   `json:"example,omitempty"`
+	Placeholder string   `json:"placeholder,omitempty"`
+}
+
 type HubTemplate struct {
 	ID          string               `json:"id"`
 	Name        string               `json:"name"`
@@ -14,6 +26,7 @@ type HubTemplate struct {
 	Role        string               `json:"role,omitempty"`
 	RuntimeKind string               `json:"runtime_kind,omitempty"`
 	Image       string               `json:"image,omitempty"`
+	ImageEnv    []ImageEnvContract   `json:"image_env,omitempty"`
 	Source      HubTemplateSource    `json:"source"`
 	UpdatedAt   time.Time            `json:"updated_at,omitempty"`
 	Workspace   HubTemplateWorkspace `json:"workspace,omitempty"`

--- a/internal/app/runtimewiring/picoclaw.go
+++ b/internal/app/runtimewiring/picoclaw.go
@@ -141,7 +141,8 @@ func addFeishuBoxEnvVars(envVars map[string]string, botID string, provider feish
 func agentAddProfileEnv(envVars map[string]string, profileEnv map[string]string) {
 	for key, value := range profileEnv {
 		key = strings.TrimSpace(key)
-		if key == "" || isReservedSandboxEnvKey(key) {
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || isReservedSandboxEnvKey(key) {
 			continue
 		}
 		envVars[key] = value

--- a/internal/hub/builtin_store.go
+++ b/internal/hub/builtin_store.go
@@ -64,7 +64,8 @@ func (s *BuiltinStore) Get(_ context.Context, id string) (Template, error) {
 		Description:  manifest.Description,
 		Role:         normalizeTemplateRole(manifest.Role),
 		RuntimeKind:  manifest.RuntimeKind,
-		Image:        manifest.Image,
+		Image:        manifestImageRef(manifest.Image),
+		ImageEnv:     manifestImageEnv(manifest.Image),
 		WorkspaceRef: s.workspaceRef(id),
 		UpdatedAt:    updatedAt,
 	}, nil

--- a/internal/hub/local_store.go
+++ b/internal/hub/local_store.go
@@ -86,7 +86,8 @@ func (s *LocalStore) Get(_ context.Context, id string) (Template, error) {
 		Description:  manifest.Description,
 		Role:         normalizeTemplateRole(manifest.Role),
 		RuntimeKind:  manifest.RuntimeKind,
-		Image:        manifest.Image,
+		Image:        manifestImageRef(manifest.Image),
+		ImageEnv:     manifestImageEnv(manifest.Image),
 		WorkspaceRef: s.workspaceRef(id),
 		UpdatedAt:    updatedAt,
 	}, nil
@@ -195,8 +196,10 @@ func (s *LocalStore) writeManifest(path string, spec PublishSpec) error {
 		Description: spec.Description,
 		Role:        spec.Role,
 		RuntimeKind: spec.RuntimeKind,
-		Image:       spec.Image,
-		UpdatedAt:   spec.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		Image: templateImageSection{
+			Ref: spec.Image,
+		},
+		UpdatedAt: spec.UpdatedAt.UTC().Format(time.RFC3339Nano),
 	}
 	data, err := toml.Marshal(manifest)
 	if err != nil {
@@ -232,7 +235,7 @@ func normalizePublishSpec(spec PublishSpec) (PublishSpec, error) {
 		return PublishSpec{}, ErrRuntimeKindRequired
 	}
 	if requiresTemplateImage(spec.RuntimeKind) && spec.Image == "" {
-		return PublishSpec{}, fmt.Errorf("image is required for runtime_kind %q", spec.RuntimeKind)
+		return PublishSpec{}, fmt.Errorf("image.ref is required for runtime_kind %q", spec.RuntimeKind)
 	}
 	spec.WorkspaceRef.Kind = strings.TrimSpace(spec.WorkspaceRef.Kind)
 	spec.WorkspaceRef.Path = strings.TrimSpace(spec.WorkspaceRef.Path)

--- a/internal/hub/local_store_test.go
+++ b/internal/hub/local_store_test.go
@@ -186,7 +186,7 @@ func TestLocalStorePublishRequiresImageForGatewayRuntime(t *testing.T) {
 		RuntimeKind:  runtime.KindPicoClawSandbox,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	})
-	if err == nil || err.Error() != `image is required for runtime_kind "picoclaw_sandbox"` {
+	if err == nil || err.Error() != `image.ref is required for runtime_kind "picoclaw_sandbox"` {
 		t.Fatalf("Publish() error = %v, want missing image error", err)
 	}
 }
@@ -204,7 +204,7 @@ func TestLocalStoreGetRejectsGatewayRuntimeWithoutImage(t *testing.T) {
 
 	store := NewLocalStore(registryRoot)
 	_, err := store.Get(context.Background(), "gateway-worker")
-	if err == nil || err.Error() != `validate local hub manifest "gateway-worker": image is required for runtime_kind "picoclaw_sandbox"` {
+	if err == nil || err.Error() != `validate local hub manifest "gateway-worker": image.ref is required for runtime_kind "picoclaw_sandbox"` {
 		t.Fatalf("Get() error = %v, want missing image validation error", err)
 	}
 }

--- a/internal/hub/remote_store.go
+++ b/internal/hub/remote_store.go
@@ -181,6 +181,7 @@ func templateFromAPI(item apitypes.HubTemplate) Template {
 		Role:         normalizeTemplateRole(item.Role),
 		RuntimeKind:  strings.TrimSpace(item.RuntimeKind),
 		Image:        strings.TrimSpace(item.Image),
+		ImageEnv:     append([]apitypes.ImageEnvContract(nil), item.ImageEnv...),
 		WorkspaceRef: WorkspaceRef{Kind: kind},
 		UpdatedAt:    item.UpdatedAt,
 	}

--- a/internal/hub/template_manifest.go
+++ b/internal/hub/template_manifest.go
@@ -2,19 +2,126 @@ package hub
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
+	"csgclaw/internal/apitypes"
 	"csgclaw/internal/runtime"
 )
 
 type templateManifest struct {
-	Name        string `toml:"name"`
-	Description string `toml:"description,omitempty"`
-	Role        string `toml:"role"`
-	RuntimeKind string `toml:"runtime_kind"`
-	Image       string `toml:"image,omitempty"`
-	UpdatedAt   string `toml:"updated_at,omitempty"`
+	Name        string               `toml:"name"`
+	Description string               `toml:"description,omitempty"`
+	Role        string               `toml:"role"`
+	RuntimeKind string               `toml:"runtime_kind"`
+	Image       templateImageSection `toml:"image"`
+	UpdatedAt   string               `toml:"updated_at,omitempty"`
+}
+
+type templateImageSection struct {
+	Ref       string                 `toml:"ref"`
+	Digest    string                 `toml:"digest,omitempty"`
+	Platforms []string               `toml:"platforms,omitempty"`
+	Env       []templateImageEnvItem `toml:"env"`
+}
+
+type templateImageEnvItem struct {
+	Name        string   `toml:"name"`
+	Required    bool     `toml:"required"`
+	Secret      bool     `toml:"secret"`
+	Default     string   `toml:"default,omitempty"`
+	Description string   `toml:"description,omitempty"`
+	Choices     []string `toml:"choices,omitempty"`
+	Pattern     string   `toml:"pattern,omitempty"`
+	Example     string   `toml:"example,omitempty"`
+	Placeholder string   `toml:"placeholder,omitempty"`
+}
+
+func manifestImageRef(image templateImageSection) string {
+	return strings.TrimSpace(image.Ref)
+}
+
+func manifestImageEnv(image templateImageSection) []apitypes.ImageEnvContract {
+	items := normalizeImageEnvContracts(image.Env)
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+func normalizeImageEnvContracts(raw []templateImageEnvItem) []apitypes.ImageEnvContract {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]apitypes.ImageEnvContract, 0, len(raw))
+	for _, item := range raw {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		contract := apitypes.ImageEnvContract{
+			Name:        name,
+			Required:    item.Required,
+			Secret:      item.Secret,
+			Default:     strings.TrimSpace(item.Default),
+			Description: strings.TrimSpace(item.Description),
+			Pattern:     strings.TrimSpace(item.Pattern),
+			Example:     strings.TrimSpace(item.Example),
+			Placeholder: strings.TrimSpace(item.Placeholder),
+		}
+		if len(item.Choices) > 0 {
+			contract.Choices = append([]string(nil), item.Choices...)
+		}
+		out = append(out, contract)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func validateImageEnvContracts(items []templateImageEnvItem) error {
+	seen := make(map[string]struct{}, len(items))
+	for index, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			return fmt.Errorf("image.env[%d].name is required", index)
+		}
+		normalized := strings.ToUpper(name)
+		if _, ok := seen[normalized]; ok {
+			return fmt.Errorf("duplicate image.env name %q", name)
+		}
+		seen[normalized] = struct{}{}
+
+		if item.Secret && strings.TrimSpace(item.Default) != "" {
+			return fmt.Errorf("image.env[%d] secret entries cannot set default", index)
+		}
+		if len(item.Choices) == 0 {
+			continue
+		}
+		if strings.TrimSpace(item.Default) != "" {
+			defaultValue := strings.TrimSpace(item.Default)
+			found := false
+			for _, choice := range item.Choices {
+				if choice == defaultValue {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("image.env[%d].default must appear in choices", index)
+			}
+		}
+		pattern := strings.TrimSpace(item.Pattern)
+		if pattern == "" {
+			continue
+		}
+		if _, err := regexp.Compile(pattern); err != nil {
+			return fmt.Errorf("image.env[%d].pattern is invalid: %w", index, err)
+		}
+	}
+	return nil
 }
 
 func validateManifest(manifest templateManifest) error {
@@ -32,8 +139,12 @@ func validateManifest(manifest templateManifest) error {
 	default:
 		return fmt.Errorf("%w: %s", ErrRuntimeKindRequired, manifest.RuntimeKind)
 	}
-	if requiresTemplateImage(manifest.RuntimeKind) && strings.TrimSpace(manifest.Image) == "" {
-		return fmt.Errorf("image is required for runtime_kind %q", manifest.RuntimeKind)
+	imageRef := manifestImageRef(manifest.Image)
+	if requiresTemplateImage(manifest.RuntimeKind) && imageRef == "" {
+		return fmt.Errorf("image.ref is required for runtime_kind %q", manifest.RuntimeKind)
+	}
+	if err := validateImageEnvContracts(manifest.Image.Env); err != nil {
+		return err
 	}
 	if _, err := parseManifestUpdatedAt(manifest.UpdatedAt); err != nil {
 		return err

--- a/internal/hub/template_manifest_test.go
+++ b/internal/hub/template_manifest_test.go
@@ -1,0 +1,68 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"csgclaw/internal/runtime"
+)
+
+func TestLoadManifestImageEnv(t *testing.T) {
+	registryRoot := t.TempDir()
+	manifestPath := filepath.Join(registryRoot, "templates", "gitlab-assistant", "agent.toml")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	manifest := `
+name = "gitlab-assistant"
+description = "GitLab assistant"
+role = "worker"
+runtime_kind = "picoclaw_sandbox"
+
+[image]
+ref = "picoclaw:test"
+
+[[image.env]]
+name = "GITLAB_TOKEN"
+required = true
+secret = true
+
+[[image.env]]
+name = "GITLAB_URL"
+default = "https://gitlab.example.com"
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	store := NewLocalStore(registryRoot)
+	got, err := store.Get(t.Context(), "gitlab-assistant")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.RuntimeKind != runtime.KindPicoClawSandbox {
+		t.Fatalf("RuntimeKind = %q, want %q", got.RuntimeKind, runtime.KindPicoClawSandbox)
+	}
+	if got.Image != "picoclaw:test" {
+		t.Fatalf("Image = %q, want picoclaw:test", got.Image)
+	}
+	if len(got.ImageEnv) != 2 {
+		t.Fatalf("ImageEnv = %#v, want 2 entries", got.ImageEnv)
+	}
+	if got.ImageEnv[0].Name != "GITLAB_TOKEN" || !got.ImageEnv[0].Required || !got.ImageEnv[0].Secret {
+		t.Fatalf("ImageEnv[0] = %#v, want GITLAB_TOKEN required secret", got.ImageEnv[0])
+	}
+	if got.ImageEnv[1].Name != "GITLAB_URL" || got.ImageEnv[1].Default != "https://gitlab.example.com" {
+		t.Fatalf("ImageEnv[1] = %#v, want GITLAB_URL default url", got.ImageEnv[1])
+	}
+}
+
+func TestValidateImageEnvRejectsSecretDefault(t *testing.T) {
+	err := validateImageEnvContracts([]templateImageEnvItem{
+		{Name: "API_KEY", Secret: true, Default: "secret"},
+	})
+	if err == nil {
+		t.Fatal("validateImageEnvContracts() error = nil, want secret default rejection")
+	}
+}

--- a/internal/hub/types.go
+++ b/internal/hub/types.go
@@ -1,6 +1,10 @@
 package hub
 
-import "time"
+import (
+	"time"
+
+	"csgclaw/internal/apitypes"
+)
 
 const (
 	RegistryKindBuiltin = "builtin"
@@ -18,6 +22,7 @@ type Template struct {
 	Role         string
 	RuntimeKind  string
 	Image        string
+	ImageEnv     []apitypes.ImageEnvContract
 	WorkspaceRef WorkspaceRef
 	Source       RegistryRef
 	UpdatedAt    time.Time

--- a/internal/templates/embed/openclaw-manager/agent.toml
+++ b/internal/templates/embed/openclaw-manager/agent.toml
@@ -2,5 +2,7 @@ name = "openclaw-manager"
 description = "Builtin OpenClaw manager template"
 role = "manager"
 runtime_kind = "openclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260527.2-csgclaw"
 updated_at = "2026-05-18T10:39:05Z"
+
+[image]
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260527.2-csgclaw"

--- a/internal/templates/embed/openclaw-worker/agent.toml
+++ b/internal/templates/embed/openclaw-worker/agent.toml
@@ -2,5 +2,7 @@ name = "openclaw-worker"
 description = "Builtin OpenClaw worker template"
 role = "worker"
 runtime_kind = "openclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260527.2-csgclaw"
 updated_at = "2026-05-18T10:39:05Z"
+
+[image]
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260527.2-csgclaw"

--- a/internal/templates/embed/picoclaw-manager/agent.toml
+++ b/internal/templates/embed/picoclaw-manager/agent.toml
@@ -2,5 +2,7 @@ name = "picoclaw-manager"
 description = "Builtin PicoClaw manager template"
 role = "manager"
 runtime_kind = "picoclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"
 updated_at = "2026-05-27T00:00:00Z"
+
+[image]
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"

--- a/internal/templates/embed/picoclaw-worker/agent.toml
+++ b/internal/templates/embed/picoclaw-worker/agent.toml
@@ -2,5 +2,7 @@ name = "picoclaw-worker"
 description = "Builtin PicoClaw worker template"
 role = "worker"
 runtime_kind = "picoclaw_sandbox"
-image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"
 updated_at = "2026-05-27T00:00:00Z"
+
+[image]
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -26,6 +26,18 @@ export type EnvKeyValueRow = {
   value: string;
 };
 
+export type ImageEnvContract = {
+  name: string;
+  required?: boolean;
+  secret?: boolean;
+  default?: string | null;
+  description?: string | null;
+  choices?: string[] | null;
+  pattern?: string | null;
+  example?: string | null;
+  placeholder?: string | null;
+};
+
 export type AgentProfileLike = {
   api_key_preview?: string | null;
   api_key_set?: boolean | null;
@@ -104,6 +116,7 @@ export type AgentTemplateLike = {
   description?: string | null;
   id?: string | null;
   image?: string | null;
+  image_env?: ImageEnvContract[] | null;
   name?: string | null;
   role?: string | null;
   runtime_kind?: string | null;
@@ -701,6 +714,7 @@ export function applyTemplateToDraft(
     image:
       template.image || runtimeImageForKind(runtimeKind, bootstrapConfig, fallbackImage || draft.default_image || ""),
     description: template.description || draft.description || "",
+    envRows: mapImageEnvToRows(template.image_env),
   };
 }
 
@@ -838,6 +852,16 @@ export function mapToEnvRows(value: unknown): EnvKeyValueRow[] {
   return entries.map(([key, val]) => ({ key, value: String(val ?? "") }));
 }
 
+export function mapImageEnvToRows(contracts: readonly ImageEnvContract[] | null | undefined): EnvKeyValueRow[] {
+  if (!contracts?.length) {
+    return [{ key: "", value: "" }];
+  }
+  return contracts.map((contract) => ({
+    key: String(contract.name || "").trim(),
+    value: contract.secret ? "" : String(contract.default ?? ""),
+  }));
+}
+
 export function envRowsToMap(rows: readonly EnvKeyValueRow[] | null | undefined): Record<string, string> {
   const result: Record<string, string> = {};
   const seen = new Set();
@@ -849,6 +873,9 @@ export function envRowsToMap(rows: readonly EnvKeyValueRow[] | null | undefined)
     }
     if (!key) {
       throw new Error("Environment variable key is required");
+    }
+    if (!value.trim()) {
+      continue;
     }
     const normalized = key.toUpperCase();
     if (seen.has(normalized)) {

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -76,7 +76,7 @@ describe("agent model helpers", () => {
         { key: "", value: "" },
         { key: "BAR", value: "" },
       ]),
-    ).toEqual({ FOO: "one", BAR: "" });
+    ).toEqual({ FOO: "one" });
 
     expect(() => envRowsToMap([{ key: "", value: "set" }])).toThrow("Environment variable key is required");
     expect(() =>
@@ -168,6 +168,40 @@ describe("agent model helpers", () => {
       runtime_kind: "openclaw_sandbox",
       template_name: "openclaw-worker",
     });
+  });
+
+  it("applies template image_env contracts to draft env rows", () => {
+    expect(
+      applyTemplateToDraft(
+        {
+          api_key: "",
+          api_key_preview: "",
+          api_key_set: false,
+          base_url: "",
+          enable_fast_mode: false,
+          envRows: [{ key: "OLD", value: "keep" }],
+          headersText: "{}",
+          model_id: "",
+          provider: "csghub_lite",
+          reasoning_effort: "medium",
+          requestOptionsText: "{}",
+          runtime_kind: "picoclaw_sandbox",
+        },
+        {
+          id: "custom/gitlab",
+          name: "gitlab-assistant",
+          runtime_kind: "picoclaw_sandbox",
+          image_env: [
+            { name: "GITLAB_TOKEN", required: true, secret: true },
+            { name: "GITLAB_URL", default: "https://gitlab.example.com" },
+          ],
+        },
+        null,
+      )?.envRows,
+    ).toEqual([
+      { key: "GITLAB_TOKEN", value: "" },
+      { key: "GITLAB_URL", value: "https://gitlab.example.com" },
+    ]);
   });
 
   it("filters manager rebuild runtime options to gateway runtimes", () => {


### PR DESCRIPTION
- Parse env from hub template manifests and expose it on builtin, local, and remote template listings. 
- Apply template env to agent create drafts, skip empty env values in profile maps and sandbox wiring, and add tests.