### PR TITLE
Align PicoClaw runtime workspace layout

### DIFF
--- a/internal/agent/manager_config.go
+++ b/internal/agent/manager_config.go
@@ -30,11 +30,7 @@ func managerPicoClawRoot() (string, error) {
 }
 
 func agentWorkspacePicoClawConfigRoot(agentName string) (string, error) {
-	workspaceRoot, err := agentWorkspaceRoot(agentName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(workspaceRoot, filepath.FromSlash(picoclawsandbox.HostPicoClawStateDir)), nil
+	return agentPicoClawRoot(agentName)
 }
 
 func agentPicoClawRoot(agentName string) (string, error) {

--- a/internal/agent/manager_config_test.go
+++ b/internal/agent/manager_config_test.go
@@ -95,7 +95,7 @@ func TestPicoclawBridgeModelIDPrefixesOpenAIForSlashModelNames(t *testing.T) {
 	}
 }
 
-func TestEnsureAgentPicoClawConfigUsesWorkspaceStateDir(t *testing.T) {
+func TestEnsureAgentPicoClawConfigUsesRuntimeRoot(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
@@ -109,7 +109,7 @@ func TestEnsureAgentPicoClawConfigUsesWorkspaceStateDir(t *testing.T) {
 		t.Fatalf("ensureAgentPicoClawConfig() error = %v", err)
 	}
 
-	wantRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "ux", hostWorkspaceDir, filepath.FromSlash(picoclawsandbox.HostPicoClawStateDir))
+	wantRoot := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "ux", picoclawsandbox.HostDir)
 	if root != wantRoot {
 		t.Fatalf("ensureAgentPicoClawConfig() = %q, want %q", root, wantRoot)
 	}
@@ -119,8 +119,8 @@ func TestEnsureAgentPicoClawConfigUsesWorkspaceStateDir(t *testing.T) {
 		t.Fatalf("config root %q is not a directory", root)
 	}
 	for _, path := range []string{
-		filepath.Join(root, picoclawsandbox.HostPicoClawConfig),
-		filepath.Join(root, picoclawsandbox.HostPicoClawSecurity),
+		filepath.Join(root, picoclawsandbox.HostConfig),
+		filepath.Join(root, picoclawsandbox.HostSecurity),
 	} {
 		if info, err := os.Stat(path); err != nil {
 			t.Fatalf("os.Stat(%q) error = %v", path, err)

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,6 +18,7 @@ import (
 	"csgclaw/internal/config"
 	"csgclaw/internal/hub"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/picoclawsandbox"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/utils"
 )
@@ -1686,11 +1686,11 @@ func (s *Service) StreamLogs(ctx context.Context, id string, follow bool, lines 
 }
 
 func streamHostGatewayLog(ctx context.Context, agentName string, follow bool, lines int, w io.Writer) error {
-	logPaths, err := agentGatewayLogPaths(agentName)
+	logPath, err := agentGatewayLogPath(agentName)
 	if err != nil {
 		return err
 	}
-	return streamHostGatewayLogPaths(ctx, logPaths, follow, lines, w)
+	return streamHostGatewayLogPaths(ctx, []string{logPath}, follow, lines, w)
 }
 
 func streamHostGatewayLogPaths(ctx context.Context, logPaths []string, follow bool, lines int, w io.Writer) error {
@@ -1707,34 +1707,11 @@ func streamHostGatewayLogPaths(ctx context.Context, logPaths []string, follow bo
 }
 
 func agentGatewayLogPath(agentName string) (string, error) {
-	root, err := agentWorkspaceRoot(agentName)
+	agentHome, err := agentHomeDir(agentName)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(root, "gateway.log"), nil
-}
-
-func agentGatewayLogPaths(agentName string) ([]string, error) {
-	primary, err := agentGatewayLogPath(agentName)
-	if err != nil {
-		return nil, err
-	}
-	legacy, err := legacyAgentGatewayLogPath(agentName)
-	if err != nil {
-		return nil, err
-	}
-	if legacy == primary {
-		return []string{primary}, nil
-	}
-	return []string{primary, legacy}, nil
-}
-
-func legacyAgentGatewayLogPath(agentName string) (string, error) {
-	root, err := agentPicoClawRoot(agentName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(root, "gateway.log"), nil
+	return picoclawsandbox.HostGatewayLogPath(agentHome), nil
 }
 
 func streamGatewayLogFile(ctx context.Context, logPaths []string, follow bool, lines int, w io.Writer) error {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -194,7 +194,7 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 	if !ok {
 		return hub.PublishSpec{}, fmt.Errorf("agent %q not found", strings.TrimSpace(agentID))
 	}
-	workspaceRoot, err := agentWorkspaceRoot(got.Name)
+	workspaceRoot, err := agentWorkspaceRoot(got.Name, got.RuntimeKind)
 	if err != nil {
 		return hub.PublishSpec{}, err
 	}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1777,7 +1777,7 @@ func TestCreateReplaceManagerReprovisionsWorkspaceAfterHomeRemoval(t *testing.T)
 	if replaced.Image != "manager-image:2" {
 		t.Fatalf("Create() image = %q, want requested image", replaced.Image)
 	}
-	workspaceRoot, err := agentWorkspaceRoot(ManagerName)
+	workspaceRoot, err := agentWorkspaceRoot(ManagerName, RuntimeKindPicoClawSandbox)
 	if err != nil {
 		t.Fatalf("agentWorkspaceRoot() error = %v", err)
 	}
@@ -3531,7 +3531,7 @@ func TestCreateWorkerFromTemplateAppliesDefaultsAndOverlaysWorkspace(t *testing.
 		t.Fatalf("RuntimeKind = %q, want %q", got.RuntimeKind, RuntimeKindPicoClawSandbox)
 	}
 
-	workspaceRoot, err := agentWorkspaceRoot("alice")
+	workspaceRoot, err := agentWorkspaceRoot("alice", RuntimeKindPicoClawSandbox)
 	if err != nil {
 		t.Fatalf("agentWorkspaceRoot() error = %v", err)
 	}
@@ -3637,7 +3637,7 @@ func TestCreateWorkerUsesConfiguredDefaultTemplate(t *testing.T) {
 		t.Fatalf("RuntimeKind = %q, want %q", got.RuntimeKind, RuntimeKindPicoClawSandbox)
 	}
 
-	workspaceRoot, err := agentWorkspaceRoot("alice")
+	workspaceRoot, err := agentWorkspaceRoot("alice", RuntimeKindPicoClawSandbox)
 	if err != nil {
 		t.Fatalf("agentWorkspaceRoot() error = %v", err)
 	}
@@ -3797,7 +3797,7 @@ func TestCreateWorkerAppliesTemplateDefaultsWithoutWorkspace(t *testing.T) {
 		t.Fatalf("Image = %q, want %q", got.Image, "worker-image:1")
 	}
 
-	workspaceRoot, err := agentWorkspaceRoot("alice")
+	workspaceRoot, err := agentWorkspaceRoot("alice", RuntimeKindPicoClawSandbox)
 	if err != nil {
 		t.Fatalf("agentWorkspaceRoot() error = %v", err)
 	}
@@ -3864,7 +3864,7 @@ func TestHubPublishSpecUsesAgentWorkspaceSnapshot(t *testing.T) {
 		t.Fatalf("Create() error = %v", err)
 	}
 
-	workspaceRoot, err := agentWorkspaceRoot(created.Name)
+	workspaceRoot, err := agentWorkspaceRoot(created.Name, created.RuntimeKind)
 	if err != nil {
 		t.Fatalf("agentWorkspaceRoot() error = %v", err)
 	}
@@ -3896,6 +3896,50 @@ func TestHubPublishSpecUsesAgentWorkspaceSnapshot(t *testing.T) {
 	}
 	if spec.WorkspaceRef.Path != workspaceRoot {
 		t.Fatalf("WorkspaceRef.Path = %q, want %q", spec.WorkspaceRef.Path, workspaceRoot)
+	}
+}
+
+func TestHubPublishSpecUsesOpenClawWorkspaceSnapshot(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:1", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	created, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			ID:          "u-alice",
+			Name:        "alice",
+			Description: "openclaw worker",
+			RuntimeKind: RuntimeKindOpenClawSandbox,
+			Image:       "openclaw-image:1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	agentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, created.Name)
+	workspaceRoot := openclawsandbox.WorkspaceRoot(agentHome)
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "PLAYBOOK.md"), []byte("openclaw workspace snapshot\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(PLAYBOOK.md) error = %v", err)
+	}
+
+	spec, err := svc.HubPublishSpec(created.ID)
+	if err != nil {
+		t.Fatalf("HubPublishSpec() error = %v", err)
+	}
+	if spec.RuntimeKind != RuntimeKindOpenClawSandbox {
+		t.Fatalf("RuntimeKind = %q, want %q", spec.RuntimeKind, RuntimeKindOpenClawSandbox)
+	}
+	if spec.WorkspaceRef.Path != workspaceRoot {
+		t.Fatalf("WorkspaceRef.Path = %q, want %q", spec.WorkspaceRef.Path, workspaceRoot)
+	}
+	if spec.WorkspaceRef.Path == picoclawsandbox.WorkspaceRoot(agentHome) {
+		t.Fatalf("WorkspaceRef.Path = %q, want OpenClaw workspace root", spec.WorkspaceRef.Path)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -3369,7 +3369,7 @@ func TestStartRefreshesCompleteWorkerGatewayConfig(t *testing.T) {
 	if _, err := svc.Start(context.Background(), "u-alice"); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", hostWorkspaceDir, filepath.FromSlash(picoclawsandbox.HostPicoClawStateDir), picoclawsandbox.HostPicoClawConfig)
+	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice", picoclawsandbox.HostDir, picoclawsandbox.HostConfig)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("ReadFile(worker config) error = %v", err)
@@ -4340,6 +4340,13 @@ func TestEnsureBootstrapStateForceRecreateResetsManagerHomeBeforeCreate(t *testi
 	if err := os.WriteFile(stalePath, []byte("stale"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+	currentSkillPath := filepath.Join(picoclawsandbox.WorkspaceRoot(managerHome), "skills", "say-hello", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(currentSkillPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(current skill) error = %v", err)
+	}
+	if err := os.WriteFile(currentSkillPath, []byte("# Say Hello\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(current skill) error = %v", err)
+	}
 
 	var ensuredHomes []string
 	var closeRuntimeCalls int
@@ -4356,6 +4363,9 @@ func TestEnsureBootstrapStateForceRecreateResetsManagerHomeBeforeCreate(t *testi
 	testCreateGatewayBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string, name, _ string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
 		if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
 			t.Fatalf("stale manager file still exists before recreate: err=%v", err)
+		}
+		if _, err := os.Stat(currentSkillPath); !os.IsNotExist(err) {
+			t.Fatalf("current skill still exists before recreate: err=%v", err)
 		}
 		return &fakeInstance{}, sandbox.Info{
 			ID:        "box-new",
@@ -4788,26 +4798,27 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	}
 
 	wantAgentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")
-	wantWorkspaceRoot := filepath.Join(wantAgentHome, hostWorkspaceDir)
-	wantConfigRoot := filepath.Join(wantWorkspaceRoot, filepath.FromSlash(picoclawsandbox.HostPicoClawStateDir))
+	wantPicoClawRoot := picoclawsandbox.Root(wantAgentHome)
+	wantWorkspaceRoot := picoclawsandbox.WorkspaceRoot(wantAgentHome)
+	wantConfigRoot := wantPicoClawRoot
 	wantProjectsRoot := filepath.Join(homeDir, config.AppDirName, hostProjectsDir)
 	if len(spec.Mounts) != 2 {
 		t.Fatalf("gatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
 	}
-	if spec.Mounts[0].HostPath != wantWorkspaceRoot || spec.Mounts[0].GuestPath != picoclawsandbox.BoxWorkspaceDir {
-		t.Fatalf("workspace mount = %+v, want host %q guest %q", spec.Mounts[0], wantWorkspaceRoot, picoclawsandbox.BoxWorkspaceDir)
+	if spec.Mounts[0].HostPath != wantPicoClawRoot || spec.Mounts[0].GuestPath != picoclawsandbox.BoxDir {
+		t.Fatalf("runtime root mount = %+v, want host %q guest %q", spec.Mounts[0], wantPicoClawRoot, picoclawsandbox.BoxDir)
 	}
 	if spec.Mounts[1].HostPath != wantProjectsRoot || spec.Mounts[1].GuestPath != picoclawsandbox.BoxProjectsDir {
 		t.Fatalf("projects mount = %+v, want host %q guest %q", spec.Mounts[1], wantProjectsRoot, picoclawsandbox.BoxProjectsDir)
 	}
-	if _, err := os.Stat(filepath.Join(wantConfigRoot, picoclawsandbox.HostPicoClawConfig)); err != nil {
+	if _, err := os.Stat(filepath.Join(wantConfigRoot, picoclawsandbox.HostConfig)); err != nil {
 		t.Fatalf("worker PicoClaw config was not written: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(wantWorkspaceRoot, "AGENT.md")); err != nil {
 		t.Fatalf("worker workspace was not written: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(wantAgentHome, picoclawsandbox.HostPicoClawDir)); !os.IsNotExist(err) {
-		t.Fatalf("picoclaw host dir stat error = %v, want not exist", err)
+	if _, err := os.Stat(filepath.Join(wantAgentHome, hostWorkspaceDir)); !os.IsNotExist(err) {
+		t.Fatalf("legacy workspace stat error = %v, want not exist", err)
 	}
 }
 

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"csgclaw/internal/runtime/picoclawsandbox"
 	"csgclaw/internal/templates"
 )
 
@@ -70,7 +71,7 @@ func agentWorkspaceRoot(agentName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(agentHome, hostWorkspaceDir), nil
+	return picoclawsandbox.WorkspaceRoot(agentHome), nil
 }
 
 func copyEmbeddedTree(templateRoot, dstRoot string) error {

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	runtimecodex "csgclaw/internal/runtime/codex"
+	"csgclaw/internal/runtime/openclawsandbox"
 	"csgclaw/internal/runtime/picoclawsandbox"
 	"csgclaw/internal/templates"
 )
@@ -46,7 +48,7 @@ func runtimeTemplateWorkspacePath(templateRoot string) string {
 }
 
 func ensureAgentWorkspace(agentName, template string) (string, error) {
-	hostRoot, err := agentWorkspaceRoot(agentName)
+	hostRoot, err := agentWorkspaceRoot(agentName, RuntimeKindPicoClawSandbox)
 	if err != nil {
 		return "", err
 	}
@@ -66,12 +68,21 @@ func ensureWorkspaceAtRoot(hostRoot, template string) (string, error) {
 	return hostRoot, nil
 }
 
-func agentWorkspaceRoot(agentName string) (string, error) {
+func agentWorkspaceRoot(agentName, runtimeKind string) (string, error) {
 	agentHome, err := agentHomeDir(agentName)
 	if err != nil {
 		return "", err
 	}
-	return picoclawsandbox.WorkspaceRoot(agentHome), nil
+	switch strings.TrimSpace(runtimeKind) {
+	case RuntimeKindPicoClawSandbox:
+		return picoclawsandbox.WorkspaceRoot(agentHome), nil
+	case RuntimeKindOpenClawSandbox:
+		return openclawsandbox.WorkspaceRoot(agentHome), nil
+	case RuntimeKindCodex:
+		return runtimecodex.WorkspaceRoot(agentHome), nil
+	default:
+		return "", fmt.Errorf("unsupported runtime_kind %q for agent workspace", runtimeKind)
+	}
 }
 
 func copyEmbeddedTree(templateRoot, dstRoot string) error {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"csgclaw/internal/im"
 	"csgclaw/internal/llm"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/picoclawsandbox"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/sandbox/sandboxtest"
 )
@@ -1244,7 +1245,7 @@ func TestHandleAgentLogsStreamsGatewayLog(t *testing.T) {
 	if gotCmd != "tail" {
 		t.Fatalf("command = %q, want %q", gotCmd, "tail")
 	}
-	if strings.Join(gotArgs, " ") != "-n 80 /home/picoclaw/.picoclaw/workspace/gateway.log" {
+	if strings.Join(gotArgs, " ") != "-n 80 "+picoclawsandbox.BoxGatewayLogPath {
 		t.Fatalf("args = %q", gotArgs)
 	}
 	if rec.Body.String() != "hello\nworld\n" {

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -152,6 +152,10 @@ func (r *Runtime) Kind() string {
 	return agentruntime.KindCodex
 }
 
+func WorkspaceRoot(agentHome string) string {
+	return filepath.Join(agentHome, filepath.FromSlash(hostStateDirName), workspaceDirName)
+}
+
 func (r *Runtime) SessionManager() Manager {
 	return r.sessionManager()
 }

--- a/internal/runtime/openclawsandbox/config.go
+++ b/internal/runtime/openclawsandbox/config.go
@@ -15,17 +15,15 @@ import (
 var defaultOpenClawGatewayConfig []byte
 
 const (
-	HostDir                 = ".openclaw"
-	HostConfig              = "openclaw.json"
-	HostExecApproval        = "exec-approvals.json"
-	HostLogs                = "logs"
-	HostWorkspaceDir        = "workspace"
-	WorkspaceTemplateWorker = "embed/openclaw-worker"
-	BoxUserHome             = "/home/node"
-	BoxDir                  = "/home/node/.openclaw"
-	BoxWorkspaceDir         = BoxDir + "/workspace"
-	BoxProjectsDir          = BoxDir + "/workspace/projects"
-	BoxGatewayLogPath       = BoxDir + "/gateway.log"
+	HostDir           = ".openclaw"
+	HostConfig        = "openclaw.json"
+	HostExecApproval  = "exec-approvals.json"
+	HostWorkspaceDir  = "workspace"
+	BoxUserHome       = "/home/node"
+	BoxDir            = "/home/node/.openclaw"
+	BoxWorkspaceDir   = BoxDir + "/workspace"
+	BoxProjectsDir    = BoxDir + "/workspace/projects"
+	BoxGatewayLogPath = BoxDir + "/gateway.log"
 
 	openClawBridgeProviderID = "csgclaw-llm"
 )
@@ -46,8 +44,8 @@ func HostGatewayLogPath(agentHome string) string {
 
 func EnsureConfig(agentHome, botID string, server config.ServerConfig, model config.ModelConfig, resolveBaseURL BaseURLResolver) (string, error) {
 	hostRoot := Root(agentHome)
-	if err := os.MkdirAll(filepath.Join(hostRoot, HostLogs), 0o755); err != nil {
-		return "", fmt.Errorf("create openclaw logs dir: %w", err)
+	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
+		return "", fmt.Errorf("create openclaw config dir: %w", err)
 	}
 	data, err := renderConfig(botID, server, model, resolveBaseURL)
 	if err != nil {

--- a/internal/runtime/openclawsandbox/runtime.go
+++ b/internal/runtime/openclawsandbox/runtime.go
@@ -74,7 +74,7 @@ func (r *Runtime) Provision(_ context.Context, req agentruntime.ProvisionRequest
 }
 
 func GatewayRunCommand() string {
-	return "node /app/openclaw.mjs gateway stop 2>/dev/null; sleep 2; exec node /app/openclaw.mjs gateway --allow-unconfigured --bind lan --port 18789 1>>" + BoxGatewayLogPath + " 2>&1"
+	return "exec node /app/openclaw.mjs gateway --allow-unconfigured --bind lan --port 18789 1>" + BoxGatewayLogPath + " 2>&1"
 }
 
 func fixedBaseURL(baseURL string) BaseURLResolver {

--- a/internal/runtime/openclawsandbox/runtime_test.go
+++ b/internal/runtime/openclawsandbox/runtime_test.go
@@ -1,0 +1,26 @@
+package openclawsandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGatewayRunCommandWritesGatewayOutputToSingleLog(t *testing.T) {
+	cmd := GatewayRunCommand()
+
+	if !strings.Contains(cmd, "1>"+BoxGatewayLogPath) {
+		t.Fatalf("GatewayRunCommand() = %q, want stdout written to gateway log", cmd)
+	}
+	if !strings.Contains(cmd, " 2>&1") {
+		t.Fatalf("GatewayRunCommand() = %q, want stderr written to gateway log", cmd)
+	}
+	if strings.Contains(cmd, "gateway.err.pipe") || strings.Contains(cmd, "mkfifo") || strings.Contains(cmd, "tee ") {
+		t.Fatalf("GatewayRunCommand() = %q, want direct logging without stderr pipe", cmd)
+	}
+	if strings.Contains(cmd, "mkdir -p ") {
+		t.Fatalf("GatewayRunCommand() = %q, want directory creation handled during provisioning", cmd)
+	}
+	if strings.Contains(cmd, "gateway stop") || strings.Contains(cmd, "sleep ") {
+		t.Fatalf("GatewayRunCommand() = %q, want first-start command without pre-stop delay", cmd)
+	}
+}

--- a/internal/runtime/picoclawsandbox/config.go
+++ b/internal/runtime/picoclawsandbox/config.go
@@ -17,18 +17,38 @@ var defaultGatewayConfig []byte
 //go:embed defaults/manager-security.yml
 var defaultSecurityConfig string
 
+const (
+	HostDir           = ".picoclaw"
+	HostConfig        = "config.json"
+	HostSecurity      = ".security.yml"
+	HostWorkspaceDir  = "workspace"
+	BoxUserHome       = "/home/picoclaw"
+	BoxDir            = BoxUserHome + "/.picoclaw"
+	BoxWorkspaceDir   = BoxDir + "/workspace"
+	BoxProjectsDir    = BoxDir + "/workspace/projects"
+	BoxGatewayLogPath = BoxDir + "/gateway.log"
+)
+
 type BaseURLResolver func(config.ServerConfig) string
 
 func Root(agentHome string) string {
-	return filepath.Join(agentHome, HostPicoClawDir)
+	return filepath.Join(agentHome, HostDir)
+}
+
+func WorkspaceRoot(agentHome string) string {
+	return filepath.Join(Root(agentHome), HostWorkspaceDir)
+}
+
+func HostGatewayLogPath(agentHome string) string {
+	return filepath.Join(Root(agentHome), "gateway.log")
 }
 
 func WorkspaceConfigRoot(agentHome string) string {
-	return filepath.Join(filepath.Join(agentHome, "workspace"), filepath.FromSlash(HostPicoClawStateDir))
+	return Root(agentHome)
 }
 
 func EnsureConfig(agentHome, botID string, server config.ServerConfig, model config.ModelConfig, resolveBaseURL BaseURLResolver) (string, error) {
-	hostRoot := WorkspaceConfigRoot(agentHome)
+	hostRoot := Root(agentHome)
 	if err := os.MkdirAll(hostRoot, 0o755); err != nil {
 		return "", fmt.Errorf("create picoclaw config dir: %w", err)
 	}
@@ -37,12 +57,12 @@ func EnsureConfig(agentHome, botID string, server config.ServerConfig, model con
 	if err != nil {
 		return "", err
 	}
-	configPath := filepath.Join(hostRoot, HostPicoClawConfig)
+	configPath := filepath.Join(hostRoot, HostConfig)
 	if err := os.WriteFile(configPath, append(data, '\n'), 0o600); err != nil {
 		return "", fmt.Errorf("write manager picoclaw config: %w", err)
 	}
 	securityData := RenderSecurityConfig(server, model)
-	securityPath := filepath.Join(hostRoot, HostPicoClawSecurity)
+	securityPath := filepath.Join(hostRoot, HostSecurity)
 	if err := os.WriteFile(securityPath, []byte(securityData), 0o600); err != nil {
 		return "", fmt.Errorf("write manager security config: %w", err)
 	}

--- a/internal/runtime/picoclawsandbox/provision_test.go
+++ b/internal/runtime/picoclawsandbox/provision_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/config"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/templates"
@@ -39,17 +40,64 @@ func TestProvisionPreparesGatewayAssets(t *testing.T) {
 		t.Fatalf("Provision() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(agentHome, "workspace", HostPicoClawStateDir, HostPicoClawConfig)); err != nil {
+	if _, err := os.Stat(filepath.Join(Root(agentHome), HostConfig)); err != nil {
 		t.Fatalf("stat picoclaw config: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(agentHome, "workspace", HostPicoClawStateDir, HostPicoClawSecurity)); err != nil {
+	if _, err := os.Stat(filepath.Join(Root(agentHome), HostSecurity)); err != nil {
 		t.Fatalf("stat picoclaw security config: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(agentHome, "workspace", "USER.md"))
+	data, err := os.ReadFile(filepath.Join(WorkspaceRoot(agentHome), "USER.md"))
 	if err != nil {
 		t.Fatalf("ReadFile(USER.md) error = %v", err)
 	}
 	if got, want := string(data), "overlay user\n"; got != want {
 		t.Fatalf("USER.md = %q, want %q", got, want)
+	}
+}
+
+func TestGatewayCreateSpecMountsPicoClawRuntimeRoot(t *testing.T) {
+	agentHome := t.TempDir()
+	projectsRoot := t.TempDir()
+	rt := New(Dependencies{
+		BuildRuntimeEnv: func(_, _, _, _, _ string, _ feishu.BotCredentialProvider) map[string]string {
+			return map[string]string{}
+		},
+		AddProfileEnv: func(map[string]string, map[string]string) {},
+	})
+
+	if err := rt.Provision(context.Background(), agentruntime.ProvisionRequest{
+		RuntimeID: "rt-1",
+		AgentID:   "u-alice",
+		AgentName: "alice",
+		Gateway: &agentruntime.GatewayProvision{
+			ModelFallback:     "fallback-model",
+			Server:            config.ServerConfig{AdvertiseBaseURL: "http://127.0.0.1:18080", AccessToken: "shared-token"},
+			ManagerBaseURL:    "http://127.0.0.1:18080",
+			AgentHome:         agentHome,
+			ProjectsRoot:      projectsRoot,
+			WorkspaceTemplate: templates.PicoClawWorkerRoot,
+		},
+	}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	spec, err := rt.GatewayCreateSpec("picoclaw:test", "alice", "u-alice", agentruntime.Profile{})
+	if err != nil {
+		t.Fatalf("GatewayCreateSpec() error = %v", err)
+	}
+	if len(spec.Mounts) != 2 {
+		t.Fatalf("GatewayCreateSpec() mounts = %+v, want 2 mounts", spec.Mounts)
+	}
+	if got, want := spec.Mounts[0].HostPath, Root(agentHome); got != want {
+		t.Fatalf("runtime root mount host = %q, want %q", got, want)
+	}
+	if got, want := spec.Mounts[0].GuestPath, BoxDir; got != want {
+		t.Fatalf("runtime root mount guest = %q, want %q", got, want)
+	}
+	if got, want := spec.Mounts[1].HostPath, projectsRoot; got != want {
+		t.Fatalf("projects mount host = %q, want %q", got, want)
+	}
+	if got, want := spec.Mounts[1].GuestPath, BoxProjectsDir; got != want {
+		t.Fatalf("projects mount guest = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/picoclawsandbox/runtime.go
+++ b/internal/runtime/picoclawsandbox/runtime.go
@@ -3,24 +3,11 @@ package picoclawsandbox
 import (
 	"context"
 	"fmt"
-	"path"
-	"path/filepath"
 	"strings"
 
 	"csgclaw/internal/config"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/runtime/sandboxgateway"
-)
-
-const (
-	HostPicoClawDir      = ".picoclaw"
-	HostPicoClawConfig   = "config.json"
-	HostPicoClawSecurity = ".security.yml"
-	HostPicoClawStateDir = ".csgclaw/picoclaw"
-	BoxPicoClawDir       = "/home/picoclaw/.picoclaw"
-	BoxWorkspaceDir      = BoxPicoClawDir + "/workspace"
-	BoxProjectsDir       = "/home/picoclaw/.picoclaw/workspace/projects"
-	BoxGatewayLogPath    = BoxWorkspaceDir + "/gateway.log"
 )
 
 type AgentRef = sandboxgateway.AgentRef
@@ -36,8 +23,8 @@ var _ agentruntime.Provisioner = (*Runtime)(nil)
 
 func New(deps Dependencies) *Runtime {
 	deps.RuntimeKind = agentruntime.KindPicoClawSandbox
-	deps.HomeEnv = "/home/picoclaw"
-	deps.MountGuestPath = BoxWorkspaceDir
+	deps.HomeEnv = BoxUserHome
+	deps.MountGuestPath = BoxDir
 	deps.WorkspaceGuestPath = BoxWorkspaceDir
 	deps.ProjectsGuestPath = BoxProjectsDir
 	deps.GatewayLogPath = BoxGatewayLogPath
@@ -69,13 +56,13 @@ func (r *Runtime) Provision(_ context.Context, req agentruntime.ProvisionRequest
 	if _, err := EnsureConfig(agentHome, req.AgentID, gateway.Server, configModelFromProfile(profile), fixedBaseURL(gateway.ManagerBaseURL)); err != nil {
 		return err
 	}
-	workspaceRoot := filepath.Join(agentHome, "workspace")
+	workspaceRoot := WorkspaceRoot(agentHome)
 	if err := sandboxgateway.EnsureEmbeddedWorkspace(gateway.WorkspaceTemplate, workspaceRoot); err != nil {
 		return err
 	}
 	prepared, err := sandboxgateway.FinalizePreparedGatewayProvision(req, WorkspaceLayout{
-		MountHostPath:      workspaceRoot,
-		MountGuestPath:     BoxWorkspaceDir,
+		MountHostPath:      Root(agentHome),
+		MountGuestPath:     BoxDir,
 		WorkspaceHostPath:  workspaceRoot,
 		WorkspaceGuestPath: BoxWorkspaceDir,
 	})
@@ -87,18 +74,7 @@ func (r *Runtime) Provision(_ context.Context, req agentruntime.ProvisionRequest
 }
 
 func GatewayRunCommand() string {
-	// Use path (not filepath): this string runs inside the Linux container's /bin/sh.
-	// On Windows hosts filepath.Join emits '\' which breaks the shell and mangles cp paths.
-	configPath := boxWorkspaceConfigPath(HostPicoClawConfig)
-	securityPath := boxWorkspaceConfigPath(HostPicoClawSecurity)
-	return "mkdir -p " + BoxPicoClawDir +
-		" && cp " + configPath + " " + path.Join(BoxPicoClawDir, HostPicoClawConfig) +
-		" && cp " + securityPath + " " + path.Join(BoxPicoClawDir, HostPicoClawSecurity) +
-		" && /usr/local/bin/picoclaw gateway -d 1>" + BoxGatewayLogPath + " 2>/dev/null"
-}
-
-func boxWorkspaceConfigPath(name string) string {
-	return path.Join(BoxWorkspaceDir, HostPicoClawStateDir, name)
+	return "exec /usr/local/bin/picoclaw gateway -d 1>" + BoxGatewayLogPath + " 2>&1"
 }
 
 func fixedBaseURL(baseURL string) BaseURLResolver {

--- a/internal/runtime/picoclawsandbox/runtime_test.go
+++ b/internal/runtime/picoclawsandbox/runtime_test.go
@@ -1,0 +1,23 @@
+package picoclawsandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGatewayRunCommandWritesGatewayOutputToSingleLog(t *testing.T) {
+	cmd := GatewayRunCommand()
+
+	if !strings.Contains(cmd, "1>"+BoxGatewayLogPath) {
+		t.Fatalf("GatewayRunCommand() = %q, want stdout written to gateway log", cmd)
+	}
+	if !strings.Contains(cmd, " 2>&1") {
+		t.Fatalf("GatewayRunCommand() = %q, want stderr written to gateway log", cmd)
+	}
+	if strings.Contains(cmd, "gateway.err.pipe") || strings.Contains(cmd, "mkfifo") || strings.Contains(cmd, "tee ") {
+		t.Fatalf("GatewayRunCommand() = %q, want direct logging without stderr pipe", cmd)
+	}
+	if strings.Contains(cmd, "mkdir -p ") {
+		t.Fatalf("GatewayRunCommand() = %q, want directory creation handled during provisioning", cmd)
+	}
+}


### PR DESCRIPTION
Align the PicoClaw sandbox creation flow with OpenClaw by using a consistent runtime-root layout, mount structure, and gateway logging behavior across both runtimes.