### PR TITLE
Fix workspace top bar asset paths

### DIFF
--- a/docs/web/development.md
+++ b/docs/web/development.md
@@ -33,6 +33,13 @@ pnpm --dir web/app install
 - Treat `web/static-dist` as generated output for Go embedding.
 - Prefer local conventions already present in `web/app` before adding new patterns or dependencies.
 
+## Static Assets And Deployment Paths
+
+- Reference `web/app/public` assets with deployment-relative paths, for example `brand/logo.svg` or `icons/users.svg`.
+- Do not use root-absolute public asset URLs such as `/brand/...`, `/icons/...`, or `/favicon.ico`; cloud deployments may serve the Web UI from a subpath.
+- For bundled `src` assets, use ESM imports or `new URL("./asset.svg", import.meta.url)`.
+- After changing asset paths, run the temporary Vite build and check that no new root-absolute public asset URL was introduced.
+
 ## Top-Level Structure
 
 - `src/api/`: HTTP request wrappers and API boundary code.

--- a/docs/web/development.zh.md
+++ b/docs/web/development.zh.md
@@ -33,6 +33,13 @@ pnpm --dir web/app install
 - `web/static-dist` 是给 Go embed 使用的构建产物。
 - 新增模式或依赖前，优先沿用 `web/app` 里已有的约定。
 
+## 静态资源与部署路径
+
+- 引用 `web/app/public` 资源时用部署相对路径，例如 `brand/logo.svg` 或 `icons/users.svg`。
+- 不要写 `/brand/...`、`/icons/...`、`/favicon.ico` 这类根路径 public 资源；云端可能挂在子路径。
+- `src` 里的打包资源用 ESM import 或 `new URL("./asset.svg", import.meta.url)`。
+- 改资源路径后跑一次临时 Vite build，确认没有新增根路径 public 资源引用。
+
 ## 顶层结构
 
 - `src/api/`: HTTP 请求封装和 API 边界代码。

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceLayout/WorkspaceTopBar.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceLayout/WorkspaceTopBar.tsx
@@ -4,13 +4,13 @@ export function WorkspaceTopBar() {
       <div className="workspace-topbar-brand" aria-label="CSGClaw">
         <img
           className="workspace-topbar-logo workspace-topbar-logo-light"
-          src="/brand/csgclaw-logo-light.svg"
+          src="brand/csgclaw-logo-light.svg"
           alt=""
           aria-hidden="true"
         />
         <img
           className="workspace-topbar-logo workspace-topbar-logo-dark"
-          src="/brand/csgclaw-logo-dark.svg"
+          src="brand/csgclaw-logo-dark.svg"
           alt=""
           aria-hidden="true"
         />


### PR DESCRIPTION
Summary:
- Update workspace top bar logos to use deployment-relative public asset paths.
- Document the public asset path convention for web development in English and Chinese.

Test:
- pnpm --dir web/app build