### PR TITLE
feat(im): spill oversized session messages to blob files

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1,11 +1,9 @@
 package im
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -313,36 +311,8 @@ func loadRoomMessages(statePath, roomID, relativePath string) ([]Message, error)
 	if filepath.Ext(relativePath) != ".jsonl" {
 		return nil, fmt.Errorf("decode room %s messages: expected jsonl session path", roomID)
 	}
-	return loadMessagesJSONL(filepath.Join(filepath.Dir(statePath), filepath.FromSlash(relativePath)))
-}
-
-func loadMessagesJSONL(path string) ([]Message, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("open im session: %w", err)
-	}
-	defer file.Close()
-
-	var messages []Message
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		var message Message
-		if err := json.Unmarshal([]byte(line), &message); err != nil {
-			return nil, fmt.Errorf("decode im session line: %w", err)
-		}
-		messages = append(messages, message)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read im session: %w", err)
-	}
-	return messages, nil
+	sessionPath := filepath.Join(filepath.Dir(statePath), filepath.FromSlash(relativePath))
+	return loadMessagesJSONL(sessionPath, roomID)
 }
 
 func savePersistedBootstrap(statePath string, state Bootstrap) (persistedBootstrap, error) {
@@ -372,7 +342,7 @@ func savePersistedRooms(statePath string, rooms []Room) ([]persistedRoom, error)
 	persisted := make([]persistedRoom, 0, len(rooms))
 	for _, room := range rooms {
 		relativePath := sessionRelativePath(room.ID)
-		if err := saveMessagesJSONL(filepath.Join(filepath.Dir(statePath), filepath.FromSlash(relativePath)), room.Messages); err != nil {
+		if err := saveMessagesJSONL(filepath.Join(filepath.Dir(statePath), filepath.FromSlash(relativePath)), room.ID, room.Messages); err != nil {
 			return nil, err
 		}
 		persisted = append(persisted, persistedRoom{
@@ -387,32 +357,6 @@ func savePersistedRooms(statePath string, rooms []Room) ([]persistedRoom, error)
 		})
 	}
 	return persisted, nil
-}
-
-func saveMessagesJSONL(path string, messages []Message) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create im session dir: %w", err)
-	}
-
-	file, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("create im session: %w", err)
-	}
-	defer file.Close()
-
-	for _, message := range messages {
-		data, err := json.Marshal(message)
-		if err != nil {
-			return fmt.Errorf("encode im session message: %w", err)
-		}
-		if _, err := file.Write(data); err != nil {
-			return fmt.Errorf("write im session: %w", err)
-		}
-		if _, err := io.WriteString(file, "\n"); err != nil {
-			return fmt.Errorf("write im session newline: %w", err)
-		}
-	}
-	return nil
 }
 
 func cleanupSessionFiles(statePath string, rooms []persistedRoom) error {
@@ -437,8 +381,41 @@ func cleanupSessionFiles(statePath string, rooms []persistedRoom) error {
 		if _, ok := keep[entry.Name()]; ok {
 			continue
 		}
+		roomID := strings.TrimSuffix(entry.Name(), ".jsonl")
 		if err := os.Remove(filepath.Join(sessionsDir, entry.Name())); err != nil {
 			return fmt.Errorf("remove stale im session: %w", err)
+		}
+		if err := removeRoomSessionBlobs(sessionsDir, roomID); err != nil {
+			return err
+		}
+	}
+	return cleanupStaleSessionBlobRooms(sessionsDir, rooms)
+}
+
+func cleanupStaleSessionBlobRooms(sessionsDir string, rooms []persistedRoom) error {
+	blobsRoot := filepath.Join(sessionsDir, sessionBlobsDirName)
+	entries, err := os.ReadDir(blobsRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read im session blobs dir: %w", err)
+	}
+
+	keepRooms := make(map[string]struct{}, len(rooms))
+	for _, room := range rooms {
+		keepRooms[room.ID] = struct{}{}
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, ok := keepRooms[entry.Name()]; ok {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(blobsRoot, entry.Name())); err != nil {
+			return fmt.Errorf("remove stale im session blobs dir: %w", err)
 		}
 	}
 	return nil

--- a/internal/im/session_store.go
+++ b/internal/im/session_store.go
@@ -1,0 +1,350 @@
+package im
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Keep each jsonl line safely under bufio.Scanner's default 64KiB token limit.
+	maxSessionJSONLLineBytes = 56 * 1024
+	// Upper bound when reading a line (legacy oversized rows or manual edits).
+	maxSessionReadLineBytes = 16 * 1024 * 1024
+	sessionBlobsDirName     = "blobs"
+)
+
+// sessionMessageLine is the on-disk jsonl shape. blob_ref points at spillover payload.
+type sessionMessageLine struct {
+	ID        string           `json:"id"`
+	SenderID  string           `json:"sender_id"`
+	Kind      string           `json:"kind,omitempty"`
+	Content   string           `json:"content"`
+	Event     *EventPayload    `json:"event,omitempty"`
+	CreatedAt string           `json:"created_at"`
+	Mentions  []Mention        `json:"mentions"`
+	RelatesTo *MessageRelation `json:"relates_to,omitempty"`
+	Thread    *ThreadSummary   `json:"thread,omitempty"`
+	BlobRef   string           `json:"blob_ref,omitempty"`
+}
+
+type sessionMessageBlob struct {
+	Content string         `json:"content,omitempty"`
+	Event   *EventPayload  `json:"event,omitempty"`
+	Thread  *ThreadSummary `json:"thread,omitempty"`
+}
+
+func messageToSessionLine(message Message) sessionMessageLine {
+	return sessionMessageLine{
+		ID:        message.ID,
+		SenderID:  message.SenderID,
+		Kind:      message.Kind,
+		Content:   message.Content,
+		Event:     message.Event,
+		CreatedAt: message.CreatedAt.UTC().Format(timeRFC3339Nano),
+		Mentions:  message.Mentions,
+		RelatesTo: message.RelatesTo,
+		Thread:    message.Thread,
+	}
+}
+
+func sessionLineToMessage(line sessionMessageLine) (Message, error) {
+	createdAt, err := parseSessionCreatedAt(line.CreatedAt)
+	if err != nil {
+		return Message{}, err
+	}
+	return Message{
+		ID:        line.ID,
+		SenderID:  line.SenderID,
+		Kind:      line.Kind,
+		Content:   line.Content,
+		Event:     line.Event,
+		CreatedAt: createdAt,
+		Mentions:  line.Mentions,
+		RelatesTo: line.RelatesTo,
+		Thread:    line.Thread,
+	}, nil
+}
+
+const timeRFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+
+func parseSessionCreatedAt(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("missing created_at")
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		parsed, err = time.Parse(time.RFC3339, raw)
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse created_at %q: %w", raw, err)
+	}
+	return parsed.UTC(), nil
+}
+
+func validateSessionPathSegment(segment string) error {
+	segment = strings.TrimSpace(segment)
+	switch {
+	case segment == "":
+		return fmt.Errorf("empty session path segment")
+	case segment == "." || segment == "..":
+		return fmt.Errorf("invalid session path segment %q", segment)
+	case strings.Contains(segment, "/"), strings.Contains(segment, "\\"):
+		return fmt.Errorf("invalid session path segment %q", segment)
+	default:
+		return nil
+	}
+}
+
+func sessionBlobRelativePath(roomID, messageID string) (string, error) {
+	if err := validateSessionPathSegment(roomID); err != nil {
+		return "", err
+	}
+	if err := validateSessionPathSegment(messageID); err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(filepath.Join(sessionBlobsDirName, roomID, messageID+".json")), nil
+}
+
+func loadMessagesJSONL(path, roomID string) ([]Message, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open im session: %w", err)
+	}
+	defer file.Close()
+
+	lines, err := readSessionJSONLLines(file)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionsRoot := filepath.Dir(path)
+	messages := make([]Message, 0, len(lines))
+	for _, line := range lines {
+		message, err := decodeSessionMessageLine(sessionsRoot, line)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	return messages, nil
+}
+
+func readSessionJSONLLines(r io.Reader) ([][]byte, error) {
+	reader := bufio.NewReader(r)
+	var lines [][]byte
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			trimmed := bytes.TrimSpace(line)
+			if len(trimmed) == 0 {
+				if err == io.EOF {
+					break
+				}
+				continue
+			}
+			if len(trimmed) > maxSessionReadLineBytes {
+				return nil, fmt.Errorf("im session line exceeds %d bytes", maxSessionReadLineBytes)
+			}
+			lines = append(lines, bytes.Clone(trimmed))
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read im session: %w", err)
+		}
+	}
+	return lines, nil
+}
+
+func decodeSessionMessageLine(sessionsRoot string, line []byte) (Message, error) {
+	var record sessionMessageLine
+	if err := json.Unmarshal(line, &record); err != nil {
+		// Legacy rows are plain Message JSON without blob_ref.
+		var legacy Message
+		if legacyErr := json.Unmarshal(line, &legacy); legacyErr != nil {
+			return Message{}, fmt.Errorf("decode im session line: %w", err)
+		}
+		return legacy, nil
+	}
+
+	message, err := sessionLineToMessage(record)
+	if err != nil {
+		return Message{}, fmt.Errorf("decode im session line: %w", err)
+	}
+	if strings.TrimSpace(record.BlobRef) == "" {
+		return message, nil
+	}
+
+	blob, err := loadSessionMessageBlob(sessionsRoot, record.BlobRef)
+	if err != nil {
+		return Message{}, err
+	}
+	message.Content = blob.Content
+	message.Event = blob.Event
+	message.Thread = blob.Thread
+	return message, nil
+}
+
+func loadSessionMessageBlob(sessionsRoot, relativeRef string) (sessionMessageBlob, error) {
+	relativeRef = strings.TrimSpace(relativeRef)
+	if relativeRef == "" {
+		return sessionMessageBlob{}, fmt.Errorf("empty blob_ref")
+	}
+	if filepath.IsAbs(relativeRef) {
+		return sessionMessageBlob{}, fmt.Errorf("blob_ref must be relative")
+	}
+	path := filepath.Join(sessionsRoot, filepath.FromSlash(relativeRef))
+	sessionsRootClean := filepath.Clean(sessionsRoot)
+	pathClean := filepath.Clean(path)
+	if !strings.HasPrefix(pathClean, sessionsRootClean+string(os.PathSeparator)) && pathClean != sessionsRootClean {
+		return sessionMessageBlob{}, fmt.Errorf("blob_ref escapes sessions dir")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sessionMessageBlob{}, fmt.Errorf("read im session blob: %w", err)
+	}
+	var blob sessionMessageBlob
+	if err := json.Unmarshal(data, &blob); err != nil {
+		return sessionMessageBlob{}, fmt.Errorf("decode im session blob: %w", err)
+	}
+	return blob, nil
+}
+
+func saveMessagesJSONL(path, roomID string, messages []Message) error {
+	if err := validateSessionPathSegment(roomID); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create im session dir: %w", err)
+	}
+
+	sessionsRoot := filepath.Dir(path)
+	blobDir := filepath.Join(sessionsRoot, sessionBlobsDirName, roomID)
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		return fmt.Errorf("create im session blobs dir: %w", err)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create im session: %w", err)
+	}
+	defer file.Close()
+
+	keepBlobs := make(map[string]struct{}, len(messages))
+	for _, message := range messages {
+		line, blobRef, err := encodeSessionMessageLine(sessionsRoot, roomID, message)
+		if err != nil {
+			return err
+		}
+		if blobRef != "" {
+			keepBlobs[filepath.Base(blobRef)] = struct{}{}
+		}
+		if _, err := file.Write(line); err != nil {
+			return fmt.Errorf("write im session: %w", err)
+		}
+		if _, err := io.WriteString(file, "\n"); err != nil {
+			return fmt.Errorf("write im session newline: %w", err)
+		}
+	}
+
+	if err := cleanupRoomSessionBlobs(blobDir, keepBlobs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encodeSessionMessageLine(sessionsRoot, roomID string, message Message) ([]byte, string, error) {
+	if err := validateSessionPathSegment(message.ID); err != nil {
+		return nil, "", fmt.Errorf("encode im session message: %w", err)
+	}
+
+	line := messageToSessionLine(message)
+	data, err := json.Marshal(line)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode im session message: %w", err)
+	}
+	if len(data) <= maxSessionJSONLLineBytes {
+		return data, "", nil
+	}
+
+	relativeRef, err := sessionBlobRelativePath(roomID, message.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	blob := sessionMessageBlob{
+		Content: message.Content,
+		Event:   message.Event,
+		Thread:  message.Thread,
+	}
+	blobData, err := json.Marshal(blob)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode im session blob: %w", err)
+	}
+	blobPath := filepath.Join(sessionsRoot, filepath.FromSlash(relativeRef))
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o755); err != nil {
+		return nil, "", fmt.Errorf("create im session blob dir: %w", err)
+	}
+	if err := os.WriteFile(blobPath, blobData, 0o600); err != nil {
+		return nil, "", fmt.Errorf("write im session blob: %w", err)
+	}
+
+	line.Content = ""
+	line.Event = nil
+	line.Thread = nil
+	line.BlobRef = relativeRef
+	data, err = json.Marshal(line)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode im session message: %w", err)
+	}
+	if len(data) > maxSessionJSONLLineBytes {
+		return nil, "", fmt.Errorf("encode im session message: metadata exceeds %d bytes for message %s", maxSessionJSONLLineBytes, message.ID)
+	}
+	return data, relativeRef, nil
+}
+
+func cleanupRoomSessionBlobs(blobDir string, keep map[string]struct{}) error {
+	entries, err := os.ReadDir(blobDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read im session blobs dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if _, ok := keep[entry.Name()]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(blobDir, entry.Name())); err != nil {
+			return fmt.Errorf("remove stale im session blob: %w", err)
+		}
+	}
+	return nil
+}
+
+func removeRoomSessionBlobs(sessionsDir, roomID string) error {
+	if err := validateSessionPathSegment(roomID); err != nil {
+		return err
+	}
+	blobDir := filepath.Join(sessionsDir, sessionBlobsDirName, roomID)
+	if err := os.RemoveAll(blobDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove im session blobs dir: %w", err)
+	}
+	return nil
+}

--- a/internal/im/session_store_test.go
+++ b/internal/im/session_store_test.go
@@ -1,0 +1,155 @@
+package im
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSaveLargeMessageSpillsToBlob(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	roomID := "room-large"
+	large := strings.Repeat("Z", 70*1024)
+
+	state := Bootstrap{
+		CurrentUserID: "u-admin",
+		Users:         []User{{ID: "u-admin", Name: "admin", Handle: "admin"}},
+		Rooms: []Room{{
+			ID:      roomID,
+			Title:   "large",
+			Members: []string{"u-admin"},
+			Messages: []Message{{
+				ID:        "msg-large-1",
+				SenderID:  "u-admin",
+				Kind:      MessageKindMessage,
+				Content:   large,
+				CreatedAt: time.Date(2026, 5, 25, 3, 0, 0, 0, time.UTC),
+			}},
+		}},
+	}
+	if err := SaveBootstrap(statePath, state); err != nil {
+		t.Fatalf("SaveBootstrap() error = %v", err)
+	}
+
+	sessionPath := filepath.Join(dir, "sessions", roomID+".jsonl")
+	sessionData, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("ReadFile(session) error = %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(sessionData)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("session lines = %d, want 1", len(lines))
+	}
+	if len(lines[0]) > maxSessionJSONLLineBytes {
+		t.Fatalf("jsonl line bytes = %d, want <= %d", len(lines[0]), maxSessionJSONLLineBytes)
+	}
+
+	var record sessionMessageLine
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatalf("Unmarshal(session line) error = %v", err)
+	}
+	if record.BlobRef == "" {
+		t.Fatal("blob_ref is empty, want spillover reference")
+	}
+	if record.Content != "" {
+		t.Fatalf("inline content = %d bytes, want empty with blob_ref", len(record.Content))
+	}
+
+	blobPath := filepath.Join(dir, "sessions", filepath.FromSlash(record.BlobRef))
+	blobData, err := os.ReadFile(blobPath)
+	if err != nil {
+		t.Fatalf("ReadFile(blob) error = %v", err)
+	}
+	var blob sessionMessageBlob
+	if err := json.Unmarshal(blobData, &blob); err != nil {
+		t.Fatalf("Unmarshal(blob) error = %v", err)
+	}
+	if blob.Content != large {
+		t.Fatalf("blob content len = %d, want %d", len(blob.Content), len(large))
+	}
+
+	loaded, err := LoadBootstrap(statePath)
+	if err != nil {
+		t.Fatalf("LoadBootstrap() error = %v", err)
+	}
+	if len(loaded.Rooms) != 1 || len(loaded.Rooms[0].Messages) != 1 {
+		t.Fatalf("loaded rooms = %+v, want one large message", loaded.Rooms)
+	}
+	if loaded.Rooms[0].Messages[0].Content != large {
+		t.Fatalf("loaded content len = %d, want %d", len(loaded.Rooms[0].Messages[0].Content), len(large))
+	}
+}
+
+func TestLoadLegacyOversizedInlineLine(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	roomID := "room-legacy"
+	large := strings.Repeat("L", 70*1024)
+
+	if err := os.MkdirAll(filepath.Join(dir, "sessions"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	legacy := Message{
+		ID:        "msg-legacy-fat",
+		SenderID:  "u-admin",
+		Kind:      MessageKindMessage,
+		Content:   large,
+		CreatedAt: time.Date(2026, 5, 25, 4, 0, 0, 0, time.UTC),
+	}
+	line, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("Marshal(legacy) error = %v", err)
+	}
+	if len(line) <= maxSessionJSONLLineBytes {
+		t.Fatalf("legacy line bytes = %d, want > %d for repro", len(line), maxSessionJSONLLineBytes)
+	}
+	sessionPath := filepath.Join(dir, "sessions", roomID+".jsonl")
+	if err := os.WriteFile(sessionPath, append(line, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile(session) error = %v", err)
+	}
+
+	stateJSON := `{
+  "current_user_id": "u-admin",
+  "users": [{"id": "u-admin", "name": "admin", "handle": "admin"}],
+  "rooms": [{
+    "id": "` + roomID + `",
+    "title": "legacy",
+    "members": ["u-admin"],
+    "messages": "sessions/` + roomID + `.jsonl"
+  }]
+}`
+	if err := os.WriteFile(statePath, []byte(stateJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile(state.json) error = %v", err)
+	}
+
+	loaded, err := LoadBootstrap(statePath)
+	if err != nil {
+		t.Fatalf("LoadBootstrap() error = %v", err)
+	}
+	if len(loaded.Rooms[0].Messages) != 1 || loaded.Rooms[0].Messages[0].Content != large {
+		t.Fatalf("loaded message = %+v, want legacy fat content", loaded.Rooms[0].Messages[0])
+	}
+
+	if err := SaveBootstrap(statePath, loaded); err != nil {
+		t.Fatalf("SaveBootstrap(migrate) error = %v", err)
+	}
+	sessionData, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("ReadFile(session after migrate) error = %v", err)
+	}
+	migratedLine := strings.TrimSpace(strings.Split(string(sessionData), "\n")[0])
+	if len(migratedLine) > maxSessionJSONLLineBytes {
+		t.Fatalf("migrated jsonl line bytes = %d, want <= %d", len(migratedLine), maxSessionJSONLLineBytes)
+	}
+	var record sessionMessageLine
+	if err := json.Unmarshal([]byte(migratedLine), &record); err != nil {
+		t.Fatalf("Unmarshal(migrated line) error = %v", err)
+	}
+	if record.BlobRef == "" {
+		t.Fatal("migrated line missing blob_ref")
+	}
+}


### PR DESCRIPTION
https://github.com/OpenCSGs/csgclaw/issues/58 Store large message payloads outside jsonl lines so sessions stay readable under the 64KiB scanner limit while preserving full content.