### PR TITLE
docs: add codex feishu integration design

### DIFF
--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -1,228 +1,269 @@
-# Codex 对接飞书设计说明
+# Codex 对接飞书实现设计
 
-本文说明现有 PicoClaw 如何对接飞书，以及在 CSGClaw 中为 Codex runtime 增加飞书通道时推荐的模块边界、消息流和接口映射。
+本文梳理在 CSGClaw 中为 Codex runtime 增加飞书 channel 的实现方案。重点是：不破坏现有 Web UI、本地 IM、PicoClaw sandbox 和 Codex ACP 架构；飞书协议仍归 `internal/channel/feishu`，Codex 只通过 `codexbridge.BotClient` 抽象收发消息。
 
-## 背景
+## 结论
 
-CSGClaw 目前同时支持 PicoClaw runtime 和 Codex runtime。PicoClaw 已经可以接入飞书群聊，但它的飞书连接发生在 PicoClaw runtime 内部；Codex runtime 目前通过 ACP 与 CSGClaw 交互，并不直接连接飞书。
-
-推荐方案是：由 CSGClaw server 作为 Codex 与飞书之间的适配层，一边连接飞书 WebSocket/REST API，一边通过现有 `codexbridge` 将消息转换为 Codex ACP prompt。
-
-## 现有 PicoClaw 飞书接入
-
-PicoClaw 的飞书接入是 runtime 自己完成的：
+推荐方案是：CSGClaw server 作为 Codex 与飞书之间的 channel adapter。
 
 ```mermaid
 flowchart LR
     Feishu[飞书]
-    FeishuChannel[PicoClaw Feishu Channel]
-    MessageBus[PicoClaw MessageBus]
-    AgentLoop[PicoClaw AgentLoop]
-    CSGClaw[CSGClaw LLM/API]
+    FeishuService[internal/channel/feishu]
+    FeishuClient[internal/channel/feishu/codexbridgeclient]
+    CodexBridge[internal/channel/codexbridge]
+    CodexRuntime[internal/runtime/codex ACP]
 
-    Feishu <-->|WebSocket 入站和 REST 出站| FeishuChannel
-    FeishuChannel <-->|InboundMessage 和 OutboundMessage| MessageBus
-    MessageBus <-->|消费和发布| AgentLoop
-    AgentLoop <-->|LLM API| CSGClaw
+    Feishu <-->|WebSocket 入站 / REST 出站| FeishuService
+    FeishuService <-->|MessageEvent / SendMessage| FeishuClient
+    FeishuClient <-->|BotEvent / SendMessageRequest| CodexBridge
+    CodexBridge <-->|ACP Prompt / session events| CodexRuntime
 ```
 
-### 入站消息流
+关键原则：
 
-```mermaid
-sequenceDiagram
-    participant Feishu as 飞书平台 群聊私聊
-    participant Channel as PicoClaw FeishuChannel
-    participant Bus as PicoClaw MessageBus
-    participant Agent as PicoClaw AgentLoop
+- Codex runtime 不直接连接飞书。
+- `codexbridge` 不直接持有飞书 SDK client。
+- 飞书 WebSocket、REST、凭证、open_id 缓存和重连都放在 `internal/channel/feishu`。
+- `internal/channel/feishu/codexbridgeclient` 只做模型转换，不读配置文件，不创建飞书 SDK client。
+- Channel 路由是 CSGClaw server 内部路由，不是新增 HTTP URL。
 
-    Feishu->>Channel: WebSocket im.message.receive_v1
-    Channel->>Channel: handleMessageReceive event
-    Channel->>Channel: 解析 text mention chat_id
-    Channel->>Bus: PublishInbound InboundMessage
-    Bus-->>Agent: InboundChan
-    Agent->>Agent: processMessage ctx msg
-```
+## 当前状态
 
-关键模块：
+CSGClaw 当前已有三块相关能力：
 
-| 职责 | 模块 |
-| --- | --- |
-| 飞书通道实现 | `picoclaw/pkg/channels/feishu/feishu_64.go` |
-| 建立飞书 WebSocket | `FeishuChannel.Start` |
-| 注册飞书消息事件 | `OnP2MessageReceiveV1(c.handleMessageReceive)` |
-| 通道通用接口 | `picoclaw/pkg/channels/base.go` |
-| 消息总线 | `picoclaw/pkg/bus/bus.go` |
-| Agent 主循环 | `picoclaw/pkg/agent/loop.go` |
+| 能力 | 当前模块 | 说明 |
+| --- | --- | --- |
+| Codex ACP runtime | `internal/runtime/codex` | 管理 Codex ACP session 和 session event sink |
+| Codex bridge | `internal/channel/codexbridge` | 把 bot event 转为 ACP prompt，把 Codex session event 渲染为 bot message |
+| 飞书 REST 管理能力 | `internal/channel/feishu` | 配置、bot info、建群、加人、拉消息、发送消息 |
 
-### 出站消息流
+当前缺口：
 
-```mermaid
-sequenceDiagram
-    participant Agent as PicoClaw AgentLoop
-    participant Bus as PicoClaw MessageBus
-    participant Manager as PicoClaw ChannelManager
-    participant Channel as PicoClaw FeishuChannel
-    participant Feishu as 飞书平台 群聊私聊
+- CSGClaw server 还没有飞书 WebSocket 入站 listener。
+- `codexbridge.Service` 目前只有一个 `BotClient`，默认是本地 IM 的 HTTP SSE client。
+- `codexbridge.Binding` 目前没有 `Channel` 字段，worker key 也只按 `BotID` 区分。
+- Codex bridge manager 当前按 running Codex agent 启动本地 bridge worker，还没有按 bot record 的 channel 启动不同 channel worker。
 
-    Agent->>Bus: PublishOutbound OutboundMessage
-    Bus-->>Manager: OutboundChan
-    Manager->>Channel: dispatchOutbound msg
-    Channel->>Channel: Send ctx msg
-    Channel->>Feishu: REST message create chat_id content
-    Feishu-->>Channel: message_id
-```
+## HTTP 接口边界
 
-PicoClaw 的 `FeishuChannel.Send` 会优先发送 interactive card，失败时回退为文本消息。
+### 是否新增 HTTP
 
-### 配置流
+本期 Codex 对接飞书**不新增 Codex 专用 HTTP API**。
 
-飞书凭证由 CSGClaw 管理，然后在启动 PicoClaw sandbox runtime 时注入环境变量：
+新增 HTTP 汇总：
 
-```mermaid
-flowchart LR
-    Config[channels/feishu.toml]
-    Provider[feishu.Provider]
-    RuntimeWiring[runtimewiring.addFeishuBoxEnvVars]
-    Env[PicoClaw env]
-    Pico[PicoClaw Feishu Channel]
+| URL | 方法 | 请求参数 | 响应 | 说明 |
+| --- | --- | --- | --- | --- |
+| 无 | 无 | 无 | 无 | Codex-Feishu runtime path 全部走进程内接口、飞书 WebSocket 和飞书 REST |
 
-    Config --> Provider
-    Provider -->|BotConfig by botID| RuntimeWiring
-    RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_ID| Env
-    RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_SECRET| Env
-    Env --> Pico
-```
-
-注入的关键环境变量：
+不新增：
 
 ```text
-PICOCLAW_CHANNELS_FEISHU_APP_ID
-PICOCLAW_CHANNELS_FEISHU_APP_SECRET
+POST /api/v1/codex/feishu/...
+GET  /api/v1/codex/feishu/...
+POST /api/v1/channels/feishu/codex/...
 ```
 
-PicoClaw 读取这些环境变量后，自己创建飞书 SDK client 和 WebSocket client。因此，PicoClaw 并不是通过 CSGClaw server 的 HTTP/SSE 接口来收发飞书群聊消息。
+原因：
 
-## CSGClaw 当前飞书能力
+- 飞书实时入站使用飞书 WebSocket，由 CSGClaw server 主动连接飞书平台。
+- 飞书出站使用飞书 REST，由 `internal/channel/feishu.Service.SendMessage` 调用。
+- Codex bridge 和 Feishu adapter 都在 CSGClaw server 进程内，二者之间不需要 HTTP。
 
-CSGClaw server 目前已有飞书 REST 能力，主要用于配置和管理操作：
+### 现有本地 bot HTTP 保持不变
+
+本地 `csgclaw` channel 继续使用现有 PicoClaw 兼容接口。这些接口不为飞书新增，也不改变 URL。
+
+#### `GET /api/bots/{bot_id}/events`
+
+用途：本地 `csgclaw` channel 的 bot event SSE。
+
+调用方：
+
+- 当前 `codexbridge.HTTPClient`
+- PicoClaw 兼容客户端
+
+请求：
+
+```http
+GET /api/bots/u-dev/events HTTP/1.1
+Authorization: Bearer <access_token>
+Last-Event-ID: msg-xxx
+Accept: text/event-stream
+```
+
+响应：
 
 ```text
-CSGClaw server
-  -> 飞书 REST API
+id: msg-xxx
+event: message
+data: {"message_id":"msg-xxx","room_id":"room-1","chat_type":"group","text":"hello","mentions":["u-dev"]}
 ```
 
-已有能力包括：
+说明：
 
-- 保存和加载飞书 bot 配置
-- 获取 bot 信息
-- 创建群聊
-- 添加群成员
-- 拉取群成员和群消息
-- 发送管理类消息
+- 只用于本地 `csgclaw` channel。
+- Feishu channel 不通过这个接口接收飞书消息。
 
-主要模块：
+#### `POST /api/bots/{bot_id}/messages/send`
 
-| 职责 | 模块 |
-| --- | --- |
-| 飞书配置文件 | `internal/channel/feishu/store.go` |
-| 飞书配置 provider | `internal/channel/feishu/provider.go` |
-| 飞书 REST service | `internal/channel/feishu/service.go` |
-| 飞书 API handler | `internal/api/feishu.go` |
-| 飞书配置 API handler | `internal/api/feishu_config.go` |
+用途：本地 `csgclaw` channel 的 bot 回复发送。
 
-当前缺少的是：
+请求：
 
-```mermaid
-flowchart LR
-    Feishu[飞书 WebSocket]
-    CSGClaw[CSGClaw server 当前缺少入口]
-    Feishu -.-> CSGClaw
+```http
+POST /api/bots/u-dev/messages/send HTTP/1.1
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "room_id": "room-1",
+  "text": "收到，我来处理。",
+  "message_id": "activity-xxx",
+  "thread_root_id": "msg-root"
+}
 ```
 
-也就是说，CSGClaw server 当前不是飞书实时群聊消息入口。
+响应：
 
-## Codex 对接飞书推荐方案
-
-Codex 不直接连接飞书，`codexbridge` 也不直接持有飞书 SDK client。飞书协议连接由 `internal/channel/feishu` 统一持有；Codex 只通过一个 Feishu-to-Codex bridge client 消费抽象事件并发送抽象回复。
-
-```mermaid
-flowchart LR
-    Feishu[飞书]
-    FeishuService[CSGClaw internal channel feishu]
-    FeishuAdapter[CSGClaw feishu codexbridgeclient]
-    CodexBridge[CSGClaw codexbridge]
-    CodexRuntime[Codex ACP runtime]
-
-    Feishu <-->|WebSocket 入站和 REST 出站| FeishuService
-    FeishuService <-->|MessageEvent 和 SendMessage| FeishuAdapter
-    FeishuAdapter <-->|BotEvent 和 SendMessageRequest| CodexBridge
-    CodexBridge <-->|ACP Prompt 和 session events| CodexRuntime
+```json
+{
+  "message_id": "msg-created"
+}
 ```
 
-### 入站消息流
+说明：
 
-```mermaid
-sequenceDiagram
-    participant Feishu as 飞书平台 群聊私聊
-    participant Service as CSGClaw feishu Service
-    participant Bus as CSGClaw feishu MessageBus
-    participant Adapter as CSGClaw feishu codexbridgeclient
-    participant Bridge as CSGClaw codexbridge Service
-    participant Session as CSGClaw Codex SessionManager
-    participant Codex as Codex ACP runtime
+- 只用于本地 `csgclaw` channel。
+- Feishu channel 的发送走 `feishu.Service.SendMessage`，不经过该 HTTP URL。
 
-    Adapter->>Bus: Subscribe channel botID
-    Feishu->>Service: WebSocket im.message.receive_v1
-    Service->>Service: parse text mention chat_id open_id
-    Service->>Bus: Publish MessageEvent
-    Bus-->>Adapter: MessageEvent
-    Adapter->>Adapter: map to BotEvent no thread
-    Adapter-->>Bridge: StreamEvents returns BotEvent
-    Bridge->>Bridge: enqueue dedupe
-    Bridge->>Session: EnsureSession runtimeID conversationKey
-    Session-->>Bridge: sessionID
-    Bridge->>Codex: ACP PromptRequest sessionID text
-    Codex-->>Bridge: ACP PromptResponse session events
-```
+### 现有 Feishu 管理 HTTP 保持不变
 
-### 出站消息流
+现有 `/api/v1/channels/feishu/...` 管理接口继续保留，用于配置、建群、加成员、拉消息、发送管理类消息。Codex 飞书运行时不依赖新增管理 URL。
 
-```mermaid
-sequenceDiagram
-    participant Codex as Codex ACP runtime
-    participant Sink as CSGClaw Codex EventSink
-    participant Bridge as CSGClaw codexbridge Service
-    participant Adapter as CSGClaw feishu codexbridgeclient
-    participant Service as CSGClaw feishu Service
-    participant Feishu as 飞书平台 群聊私聊
-
-    Codex->>Sink: ACP session events
-    Sink-->>Bridge: Subscribe runtimeID
-    Bridge->>Bridge: TurnRenderer 汇总文本
-    Bridge->>Adapter: SendMessage botID request
-    Adapter->>Service: SendMessage roomID senderID content
-    Service->>Feishu: REST message create chat_id text uuid
-    Feishu-->>Service: message_id
-    Service-->>Adapter: im.Message
-    Adapter-->>Bridge: SendMessageResponse
-```
-
-### 新增和调整模块
-
-`internal/channel/feishu` 继续作为飞书 channel 的协议所有者：
-
-- 持有 `feishu.Provider` 和 `channels/feishu.toml` 中的 `app_id`、`app_secret`。
-- 持有飞书 WebSocket listener、REST sender、bot open_id cache。
-- 处理配置 reload、WebSocket 重连、消息去重、自触发规避。
-- 对外提供事件订阅和发送能力，例如 `MessageBus()`、`SendMessage(req im.CreateMessageRequest)`、`ResolveBotOpenID(ctx, botID)`。
-
-新增：
+示例：
 
 ```text
-internal/channel/feishu/codexbridgeclient
+GET  /api/v1/channels/feishu/users
+POST /api/v1/channels/feishu/rooms
+POST /api/v1/channels/feishu/rooms/{room_id}/members
+GET  /api/v1/channels/feishu/messages?room_id={chat_id}
+POST /api/v1/channels/feishu/messages
 ```
 
-该模块实现现有的 `codexbridge.BotClient` 接口，但不直接创建飞书 WebSocket client，也不直接调用飞书 REST API：
+这些接口面向 CLI/Web 管理操作，不是 Codex bridge 内部事件通道。
+
+### 飞书平台接口
+
+Feishu channel 使用的是飞书平台接口，不是 CSGClaw 新增 HTTP。
+
+| 方向 | 协议 | 飞书能力 | CSGClaw 模块 |
+| --- | --- | --- | --- |
+| 入站 | WebSocket | `im.message.receive_v1` | `internal/channel/feishu` |
+| 出站 | REST | message create | `internal/channel/feishu.Service.SendMessage` |
+
+如果未来改成飞书 HTTP callback 模式，才需要新增对外 callback URL，例如：
+
+```text
+POST /api/v1/channels/feishu/events
+```
+
+该 callback 不属于本期方案。
+
+## Channel 路由
+
+Channel 路由不是 HTTP 路由。它是 CSGClaw server 内部把一个 Codex worker bot 绑定到具体 channel client 的过程。
+
+路由依据：
+
+```go
+bot.Bot{
+    ID:        "u-dev",
+    Channel:   "feishu",
+    AgentID:   "u-dev",
+    RuntimeKind: "codex",
+}
+```
+
+规则：
+
+- `Channel == "csgclaw"`：使用现有 `codexbridge.HTTPClient`，走 `/api/bots/{id}/events` 和 `/api/bots/{id}/messages/send`。
+- `Channel == "feishu"`：使用新增 `feishu/codexbridgeclient.Client`，订阅 `feishu.MessageBus()` 并调用 `feishu.Service.SendMessage`。
+- 不用 `feishu.Provider.BotConfig(botID)` 决定路由。飞书 app 凭证只能说明这个 bot 可以连接飞书，不能说明某个 Codex worker 当前应该消费哪个 channel。
+
+兼容策略：
+
+- 对已经存在但没有 bot record 的本地 Codex worker，可继续按 `agent.ID` 启动 `csgclaw` channel bridge。
+- 对 Feishu channel，建议要求存在明确 bot record，避免 app config 和 worker 绑定关系不清晰。
+
+## 新增接口汇总
+
+| 接口 | 所在模块 | 用途 |
+| --- | --- | --- |
+| `FeishuChannel` | `internal/channel/feishu/codexbridgeclient` | 隔离 Feishu adapter 与 Feishu service 的依赖边界 |
+| `ClientForChannel` 或 `SetChannelClient` | `internal/channel/codexbridge` | 让 bridge 按 binding channel 选择不同 `BotClient` |
+| `Binding.Channel` | `internal/channel/codexbridge` | 把 channel 作为 worker 身份和 prompt meta 的一部分 |
+
+## 新增和调整模块
+
+### `internal/channel/feishu`
+
+继续作为飞书协议所有者。
+
+新增职责：
+
+- 管理每个 configured bot 的飞书 WebSocket listener。
+- 处理 WebSocket 生命周期：启动、停止、配置 reload、断线重连。
+- 解析 `im.message.receive_v1`：`message_id`、`chat_id`、chat type、sender open_id、mentions、text。
+- 过滤 bot 自己发送的消息，避免自触发。
+- 将入站消息发布为 `MessageEvent`。
+
+建议新增文件：
+
+```text
+internal/channel/feishu/listener.go
+internal/channel/feishu/listener_supervisor.go
+internal/channel/feishu/message_event.go
+internal/channel/feishu/message_parser.go
+```
+
+建议扩展事件模型：
+
+```go
+type MessageEvent struct {
+    Type         string
+    BotID        string
+    RoomID       string
+    ChatType     string
+    MessageID    string
+    Text         string
+    SenderOpenID string
+    Mentions     []Mention
+    Message      *im.Message
+}
+
+type Mention struct {
+    ID     string
+    Name   string
+    OpenID string
+}
+```
+
+`Message.Message.SenderID` 可以继续按当前 Feishu service 使用 open_id；`BotID` 字段用于告诉 adapter 这是哪个飞书 bot listener 收到的事件。
+
+### `internal/channel/feishu/codexbridgeclient`
+
+新增模块，实现 `codexbridge.BotClient`。
+
+建议文件：
+
+```text
+internal/channel/feishu/codexbridgeclient/client.go
+internal/channel/feishu/codexbridgeclient/client_test.go
+```
+
+接口形态：
 
 ```go
 type FeishuChannel interface {
@@ -241,52 +282,220 @@ func (c *Client) StreamEvents(ctx context.Context, botID, lastEventID string) (<
 func (c *Client) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
 ```
 
-`StreamEvents` 只订阅 Feishu channel 事件并做模型转换：
+`StreamEvents` 行为：
 
-```text
-feishu.MessageEvent
-  -> codexbridge.BotEvent
-```
+- 订阅 `Feishu.MessageBus().Subscribe()`。
+- 只接受 `evt.BotID == botID` 的事件。
+- 群聊中 `MentionOnly == true` 时，只接受 mention 当前 bot 的消息。
+- 将飞书 mention 文本清理后写入 `codexbridge.BotEvent.Text`。
+- `ThreadRootID` 保持空，`ThreadContext` 保持 nil。
+- `lastEventID` 只作为本地去重参考，不表示可以从飞书恢复历史消息。
 
-`SendMessage` 只把 Codex 回复转换为 Feishu channel 的发送请求：
-
-```text
-codexbridge.SendMessageRequest
-  -> im.CreateMessageRequest
-  -> feishu.Service.SendMessage
-```
-
-### Channel 路由
-
-路由依据是 bot 记录上的 `Channel`，不是 `feishu.Provider.BotConfig(botID)` 是否存在。`app_id`、`app_secret` 只能说明某个 bot 有飞书凭证，不能说明某个 Codex bridge worker 应该消费哪个 channel。
-
-CSGClaw 已有 channel-scoped bot 模型：
+转换结果：
 
 ```go
-type Bot struct {
-    ID      string
-    Channel string
-    AgentID string
+codexbridge.BotEvent{
+    MessageID: evt.MessageID,
+    RoomID:    evt.RoomID,
+    ChatType:  evt.ChatType,
+    Text:      cleanedText,
+    Mentions:  mentionBotIDs,
 }
 ```
 
-Codex bridge manager 启动 worker 时应解析对应 bot record，并把 channel 写入 binding：
+`SendMessage` 行为：
+
+```go
+message, err := c.Feishu.SendMessage(im.CreateMessageRequest{
+    RoomID:   req.RoomID,
+    SenderID: botID,
+    Content:  req.Text,
+})
+```
+
+返回：
+
+```go
+codexbridge.SendMessageResponse{
+    MessageID: message.ID,
+}
+```
+
+说明：
+
+- `req.MessageID` 不映射到飞书。
+- `req.ThreadRootID` 不映射到飞书。
+- Feishu 回复统一发送为普通 `chat_id` 文本消息。
+
+### `internal/channel/codexbridge`
+
+需要保持现有接口兼容，同时增加 channel-aware worker。
+
+调整 `Binding`：
 
 ```go
 type Binding struct {
-    Channel   string
-    BotID     string
-    RuntimeID string
-    SessionID string
+    Channel    string
+    BotID      string
+    RuntimeID  string
+    SessionID  string
     PromptMeta map[string]any
 }
 ```
 
-worker key 使用 `channel + "\x00" + botID`，避免同一个 bot ID 同时绑定 `csgclaw` 和 `feishu` 时互相覆盖。`PromptMeta.channel` 使用真实 channel，例如 `feishu` 或 `csgclaw`。
+新增 client registry：
 
-### 核心字段模型
+```go
+type ClientRegistry interface {
+    ClientForChannel(channel string) (BotClient, bool)
+}
+```
 
-当前 `channels/feishu.toml` 中与飞书 channel 相关的字段是：
+一种低侵入实现：
+
+```go
+type Service struct {
+    clients map[string]BotClient
+    // existing fields...
+}
+
+func NewService(defaultClient BotClient, prompter SessionPrompter, events runtimecodex.SessionEventSubscriber) *Service
+func (s *Service) SetChannelClient(channel string, client BotClient)
+```
+
+默认行为：
+
+- `NewService(defaultClient, ...)` 把 default client 注册到 `csgclaw`。
+- 未设置 `Binding.Channel` 时默认 `csgclaw`，兼容现有测试和调用方。
+
+worker key：
+
+```go
+func workerKey(channel, botID string) string {
+    return strings.TrimSpace(channel) + "\x00" + strings.TrimSpace(botID)
+}
+```
+
+需要同步调整：
+
+- `StartBot`
+- `StopBot`
+- `sameBinding`
+- worker 内部调用 `StreamEvents` 和 `SendMessage` 时使用当前 binding 的 channel client
+
+### `cli/serve`
+
+调整 Codex bridge manager 的依赖。
+
+当前：
+
+```go
+newCodexBridgeManager(cfg config.Config, svc *agent.Service)
+```
+
+建议：
+
+```go
+newCodexBridgeManager(
+    cfg config.Config,
+    agentSvc *agent.Service,
+    botSvc *bot.Service,
+    feishuSvc *feishu.Service,
+)
+```
+
+职责：
+
+- 创建 `codexbridge.Service`。
+- 注册 `csgclaw` channel client。
+- 如果 `feishuSvc != nil`，注册 `feishu` channel client。
+- 启动 bridge worker 时读取 bot record，按 `bot.Channel` 选择 channel。
+- 对旧本地 Codex worker 保留 fallback。
+
+启动流程：
+
+```mermaid
+sequenceDiagram
+    participant Serve as cli/serve
+    participant Agent as agent.Service
+    participant Bot as bot.Service
+    participant Feishu as feishu.Service
+    participant Bridge as codexbridge.Service
+
+    Serve->>Bridge: NewService(csgclaw HTTPClient)
+    Serve->>Bridge: SetChannelClient("feishu", feishu codexbridgeclient)
+    Serve->>Agent: List running codex agents
+    Serve->>Bot: List bot records
+    Serve->>Bridge: StartBot(Binding{Channel, BotID, RuntimeID})
+```
+
+## 入站流程
+
+```mermaid
+sequenceDiagram
+    participant Feishu as 飞书平台
+    participant Listener as feishu listener
+    participant Bus as feishu.MessageBus
+    participant Client as feishu/codexbridgeclient
+    participant Bridge as codexbridge worker
+    participant Codex as Codex ACP runtime
+
+    Feishu->>Listener: WebSocket im.message.receive_v1
+    Listener->>Listener: parse message_id chat_id text mentions
+    Listener->>Bus: Publish MessageEvent
+    Client->>Bus: Subscribe
+    Bus-->>Client: MessageEvent
+    Client->>Client: filter botID mention self-message dedupe
+    Client-->>Bridge: BotEvent
+    Bridge->>Codex: ACP PromptRequest
+```
+
+`BotEvent` 字段映射：
+
+| 字段 | Feishu 来源 |
+| --- | --- |
+| `MessageID` | 飞书 `message_id` |
+| `RoomID` | 飞书 `chat_id` |
+| `ChatType` | 飞书 chat type，映射为 `p2p` 或 `group` |
+| `Text` | 飞书文本内容，群聊中去掉当前 bot mention |
+| `Mentions` | mention 到的 CSGClaw bot IDs |
+| `ThreadRootID` | 空 |
+| `ThreadContext` | nil |
+
+## 出站流程
+
+```mermaid
+sequenceDiagram
+    participant Codex as Codex ACP runtime
+    participant Sink as Codex EventSink
+    participant Bridge as codexbridge worker
+    participant Client as feishu/codexbridgeclient
+    participant Service as feishu.Service
+    participant Feishu as 飞书 REST
+
+    Codex->>Sink: session events
+    Sink-->>Bridge: runtime session event
+    Bridge->>Bridge: TurnRenderer
+    Bridge->>Client: SendMessage(botID, request)
+    Client->>Service: SendMessage(CreateMessageRequest)
+    Service->>Feishu: message create
+    Feishu-->>Service: message_id
+    Service-->>Client: im.Message
+    Client-->>Bridge: SendMessageResponse
+```
+
+`SendMessageRequest` 字段映射：
+
+| Codex bridge 字段 | Feishu 发送字段 |
+| --- | --- |
+| `RoomID` | `im.CreateMessageRequest.RoomID`，对应飞书 `chat_id` |
+| `Text` | `im.CreateMessageRequest.Content` |
+| `MessageID` | 不映射 |
+| `ThreadRootID` | 不映射 |
+
+## 配置和凭证
+
+配置文件保持现有结构：
 
 ```toml
 [global]
@@ -297,204 +506,165 @@ app_id = "cli_xxx"
 app_secret = "xxx"
 ```
 
-`app_id` 和 `app_secret` 由 `internal/channel/feishu` 使用，用于创建飞书 SDK client、WebSocket listener 和 REST sender。`codexbridgeclient` 不直接读取配置文件，也不直接持有 app 凭证。
+使用方：
 
-Codex bridge 的入站事件模型保持不变：
-
-```go
-type BotEvent struct {
-    MessageID     string
-    RoomID        string
-    ChatType      string
-    Text          string
-    Mentions      []string
-    ThreadRootID  string
-    ThreadContext *BotThreadContext
-}
-```
-
-Feishu 路径的字段使用：
-
-| 字段 | Feishu 路径含义 |
+| 字段 | 使用方 |
 | --- | --- |
-| `MessageID` | 飞书 `message_id`，用于本地去重 |
-| `RoomID` | 飞书 `chat_id` |
-| `ChatType` | 飞书 chat type，映射为 `p2p` 或 `group` |
-| `Text` | 送给 Codex 的文本，群聊中去掉 bot mention |
-| `Mentions` | 飞书 mentions |
-| `ThreadRootID` | 不映射，保持空值 |
-| `ThreadContext` | 不映射，保持 nil |
+| `app_id` | `internal/channel/feishu` 创建 REST/WebSocket client |
+| `app_secret` | `internal/channel/feishu` 创建 REST/WebSocket client |
+| `admin_open_id` | 现有 Feishu 管理能力 |
 
-Codex bridge 的出站模型保持不变：
+`codexbridgeclient` 不读取该文件，只依赖注入进来的 `FeishuChannel`。
 
-```go
-type SendMessageRequest struct {
-    RoomID       string
-    Text         string
-    MessageID    string
-    ThreadRootID string
-}
-```
+## 映射持久化和重启恢复
 
-Feishu 路径的出站字段使用：
+Codex-Feishu 不需要新增一份单独的映射文件。映射由已有持久化状态组合出来，server 启动时重建运行时 binding。
 
-| Codex bridge 字段 | Feishu channel 字段 |
-| --- | --- |
-| `RoomID` | `im.CreateMessageRequest.RoomID`，对应飞书 `chat_id` |
-| `Text` | `im.CreateMessageRequest.Content` |
-| `MessageID` | 不映射 |
-| `ThreadRootID` | 不映射 |
+持久化来源：
 
-Feishu 路径不支持 thread/reply 映射，和 PicoClaw 当前行为保持一致：回复统一作为普通 `chat_id` 消息发送，不调用飞书 reply/thread API，也不注入 `ThreadContext`。
-
-### 函数流程设计
-
-Server 启动流程：
-
-```mermaid
-sequenceDiagram
-    participant Serve as serve.Start
-    participant Feishu as buildFeishuComponents
-    participant Manager as newCodexBridgeManager
-    participant Bots as bot.Service
-    participant Runtime as Codex runtime
-    participant Bridge as codexbridge.Service
-
-    Serve->>Feishu: buildFeishuComponents configPath
-    Feishu->>Feishu: feishu.NewProvider store
-    Feishu->>Feishu: feishu.NewServiceWithProvider provider
-    Serve->>Manager: newCodexBridgeManager cfg agentService botService feishuService
-    Manager->>Runtime: Runtime KindCodex
-    Manager->>Runtime: EventSink
-    Manager->>Manager: New local HTTPClient
-    Manager->>Manager: New feishu codexbridgeclient
-    Manager->>Bridge: NewService per channel
-    Manager->>Bots: resolve bot records by channel
-    Bridge->>Bridge: StartBot Binding with channel
-```
-
-入站函数调用链：
-
-```mermaid
-sequenceDiagram
-    participant Service as CSGClaw feishu Service
-    participant Bus as CSGClaw feishu MessageBus
-    participant Adapter as CSGClaw feishu codexbridgeclient
-    participant Bridge as CSGClaw codexbridge worker
-    participant Session as CSGClaw SessionManager
-    participant Codex as Codex ACP runtime
-
-    Bridge->>Adapter: StreamEvents botID lastEventID
-    Adapter->>Bus: Subscribe
-    Service->>Bus: Publish MessageEvent
-    Bus-->>Adapter: MessageEvent
-    Adapter->>Adapter: filter channel botID mention dedupe
-    Adapter-->>Bridge: BotEvent
-    Bridge->>Session: EnsureSession runtimeID conversationKey
-    Session-->>Bridge: sessionID
-    Bridge->>Codex: Prompt acp PromptRequest
-```
-
-出站函数调用链：
-
-```mermaid
-sequenceDiagram
-    participant Codex as Codex ACP runtime
-    participant Events as CSGClaw EventSink
-    participant Bridge as CSGClaw codexbridge worker
-    participant Adapter as CSGClaw feishu codexbridgeclient
-    participant Service as CSGClaw feishu Service
-    participant Feishu as 飞书平台 REST API
-
-    Codex->>Events: ACP session events
-    Events-->>Bridge: Subscribe runtimeID
-    Bridge->>Bridge: TurnRenderer 汇总文本
-    Bridge->>Adapter: SendMessage botID req
-    Adapter->>Service: SendMessage im CreateMessageRequest
-    Service->>Feishu: message create chat_id text uuid
-    Feishu-->>Service: message_id
-    Service-->>Adapter: im.Message
-    Adapter-->>Bridge: SendMessageResponse
-```
-
-### Feishu 入站和出站参数
-
-飞书 WebSocket 和 REST 参数由 `internal/channel/feishu` 处理：
-
-| 参数 | 来源 | 用途 |
+| 映射内容 | 持久化位置 | 说明 |
 | --- | --- | --- |
-| `app_id` | `feishu.AppConfig.AppID` | 创建飞书 SDK client 和 WebSocket listener |
-| `app_secret` | `feishu.AppConfig.AppSecret` | 创建飞书 SDK client 和 WebSocket listener |
-| `chat_id` | 飞书消息事件或 `RoomID` | 入站会话和出站目标 |
-| `message_id` | 飞书消息事件或发送结果 | 本地去重和返回值 |
-| `uuid` | Feishu service 生成或传入 | 发送幂等 |
+| bot 属于哪个 channel | `bots.json` | `bot.ID`、`bot.Channel`、`bot.AgentID` 持久化在 bot store |
+| bot 绑定哪个 agent/runtime | `agents.json` | `agent.ID`、`agent.RuntimeID`、`agent.RuntimeKind` 持久化在 agent store |
+| 飞书 bot 凭证 | `channels/feishu.toml` | `botID -> app_id/app_secret` |
+| 飞书群聊 ID | 飞书平台 | `chat_id` 由飞书事件带入，也可通过现有 room/message API 查询 |
+| Codex conversation session | 进程内 | `conversationKey -> ACP session_id` 当前由 Codex runtime live session 维护 |
 
-`lastEventID` 在 Feishu 路径中只作为本地去重参考，不表示可以从飞书 WebSocket 按 message id 恢复历史事件。
-
-## 与 PicoClaw 方案的对齐关系
+启动恢复流程：
 
 ```mermaid
-flowchart LR
-    subgraph PicoClawPath[PicoClaw 路径]
-        PFeishu[飞书]
-        PChannel[PicoClaw Feishu Channel]
-        PBus[MessageBus]
-        PAgent[AgentLoop]
-        PFeishu <-->|WS 和 REST| PChannel
-        PChannel <--> PBus
-        PBus <--> PAgent
-    end
+sequenceDiagram
+    participant Serve as CSGClaw serve
+    participant BotStore as bots.json
+    participant AgentStore as agents.json
+    participant FeishuConfig as channels/feishu.toml
+    participant Bridge as codexbridge
+    participant Feishu as Feishu listener
 
-    subgraph CodexPath[Codex 路径]
-        CFeishu[飞书]
-        CService[CSGClaw feishu Service]
-        CAdapter[feishu codexbridgeclient]
-        CBridge[CodexBridge]
-        CACP[Codex ACP runtime]
-        CFeishu <-->|WS 和 REST| CService
-        CService <--> CAdapter
-        CAdapter <--> CBridge
-        CBridge <-->|ACP| CACP
-    end
+    Serve->>BotStore: load bot records
+    Serve->>AgentStore: load agents and runtime records
+    Serve->>FeishuConfig: load bot app credentials
+    Serve->>Feishu: start listeners for configured Feishu bots
+    Serve->>Bridge: StartBot(Binding{Channel:"feishu", BotID, RuntimeID})
 ```
 
-| 层面 | PicoClaw | Codex 推荐方案 |
-| --- | --- | --- |
-| 飞书入站 | PicoClaw runtime 的 FeishuChannel 连接 WebSocket | CSGClaw 的 `internal/channel/feishu` 连接 WebSocket |
-| 飞书出站 | PicoClaw runtime 的 FeishuChannel 调 REST | CSGClaw 的 `internal/channel/feishu` 调 REST |
-| 消息抽象 | `bus.InboundMessage` | `codexbridge.BotEvent` |
-| 回复抽象 | `bus.OutboundMessage` | `codexbridge.SendMessageRequest` |
-| Agent 执行 | PicoClaw `AgentLoop` | Codex ACP runtime |
-| 配置来源 | CSGClaw `channels/feishu.toml` | CSGClaw `channels/feishu.toml` |
-| 凭证使用方 | PicoClaw runtime | CSGClaw `internal/channel/feishu` |
-| Thread 支持 | 暂不支持，普通 `chat_id` 发送 | 暂不支持，普通 `chat_id` 发送 |
+重启后不会丢失：
 
-两套方案在飞书协议层面对齐：都是 WebSocket 入站、REST 出站；也都暂不支持飞书 thread/reply。差异在 runtime 边界：PicoClaw 自己持有飞书连接；Codex 由 CSGClaw 的 Feishu channel 持有飞书连接，`codexbridge` 只消费抽象事件。
+- `botID -> channel -> agentID` 的绑定。
+- `agentID -> runtimeID -> runtimeKind` 的绑定。
+- `botID -> feishu app_id/app_secret` 的凭证绑定。
+- 已存在飞书群聊本身，因为群聊在飞书平台。
 
-## 为什么不放到 Codex 插件里
+重启后会重建或变化：
 
-Codex 插件或 MCP server 更适合作为会话内工具，例如查询飞书消息、发送飞书消息、查询用户信息等。它们不适合作为飞书 WebSocket 的常驻入站网关，因为飞书事件到达时仍然需要有一个外部进程接住事件并触发 Codex turn。
+- Feishu WebSocket 连接会重新建立。
+- `codexbridge` worker 会重新启动。
+- `conversationKey(chat_id) -> ACP session_id` 当前是进程内关系，server 重启后会重新创建 Codex ACP session。
 
-因此，设计为：
+因此，首期语义是：
 
 ```text
-飞书入站和出站适配：放在 CSGClaw server
-Codex 推理和执行：继续走 ACP
+持久化稳定关系：bot/channel/agent/runtime/config
+运行时临时关系：WebSocket connection、bridge worker、ACP session_id
 ```
+
+这意味着重启后仍然知道哪个飞书 bot 对应哪个 Codex worker；但某个飞书 `chat_id` 对应的 Codex ACP session 会重新建立，不保证继续复用重启前同一个 ACP `session_id`。
+
+如需后续增强连续会话，可新增持久化索引：
+
+```text
+channel + bot_id + room_id + thread_root_id -> codex conversation/session metadata
+```
+
+但这不是打通 Codex-Feishu 首期的必需项。
+
+### 与 PicoClaw 的一致性
+
+PicoClaw 路径也不是由 CSGClaw 保存一份 `chat_id -> agent session` 映射。当前 PicoClaw 的飞书凭证由 CSGClaw 从 `channels/feishu.toml` 读取，并在启动 sandbox runtime 时注入：
+
+```text
+PICOCLAW_CHANNELS_FEISHU_APP_ID
+PICOCLAW_CHANNELS_FEISHU_APP_SECRET
+```
+
+然后 PicoClaw runtime 自己建立飞书 WebSocket、处理消息和维护它自己的运行时状态。
+
+一致点：
+
+- 飞书凭证都来自 `channels/feishu.toml`。
+- bot 与 worker 的稳定关系都来自 CSGClaw 的 bot/agent 状态。
+- 飞书 `chat_id` 都来自飞书事件，不需要 CSGClaw 预先保存才能收到消息。
+
+差异点：
+
+- PicoClaw 的飞书连接和消息循环在 PicoClaw runtime 内部。
+- Codex 的飞书连接和消息转换在 CSGClaw server 内部，再通过 ACP 调 Codex runtime。
+- Codex 的 `conversationKey -> ACP session_id` 是 CSGClaw server 内部运行时关系，首期不单独持久化。
+
+## 可靠性和去重
+
+本地 `csgclaw` channel 继续使用现有 HTTP SSE 的 ack/requeue/replay。
+
+Feishu channel 本期建议采用进程内 best-effort：
+
+- WebSocket listener 收到事件后发布到 `MessageBus`。
+- `codexbridge` worker 使用 `MessageID + RoomID` 做本地去重。
+- `lastEventID` 只用于 adapter/worker 本地去重。
+- 进程重启后不从飞书历史消息自动 replay。
+
+如果需要更强可靠性，后续可扩展 `feishu.MessageBus`：
+
+```go
+Subscribe(botID string, lastEventID string) (<-chan MessageEvent, func())
+Ack(botID, messageID string)
+Requeue(botID string, evt MessageEvent)
+```
+
+该增强不是 Codex-Feishu 打通的首期必需条件。
 
 ## 实施步骤
 
-1. 扩展 `internal/channel/feishu`，让它持有飞书 WebSocket listener，并把入站消息发布到现有或扩展后的 Feishu `MessageBus`。
-2. 复用 `internal/channel/feishu/service.go` 的发送能力，保持 REST 出站、JSON content、`uuid`、bot info 和错误处理在 Feishu channel 内部。
-3. 新增 `internal/channel/feishu/codexbridgeclient`，实现 `codexbridge.BotClient`，只负责订阅 Feishu channel 事件和做模型转换。
-4. 修改 Codex bridge manager，按 bot record 的 `Channel` 选择本地 IM client 或 Feishu bridge client，不用 `BotConfig(botID)` 存在性做路由。
-5. 扩展 `codexbridge.Binding` 和 worker key，携带 `Channel`，避免同一个 bot ID 在 `csgclaw` 与 `feishu` 下冲突。
-6. 将飞书入站事件转换为 `codexbridge.BotEvent`，其中 `ThreadRootID` 保持空值，`ThreadContext` 保持 nil。
-7. 将 `codexbridge.SendMessageRequest` 转换为 `im.CreateMessageRequest`，通过 Feishu service 发送普通 `chat_id` 文本消息，忽略 `ThreadRootID`。
-8. 增加测试覆盖 channel 路由、重复 bot ID、WebSocket 生命周期、群聊 mention 过滤、`lastEventID` 本地去重，以及 thread 字段不映射。
+1. 扩展 `internal/channel/feishu.MessageEvent`，补齐 `BotID`、`MessageID`、`ChatType`、`Text`、`SenderOpenID`、`Mentions`。
+2. 在 `internal/channel/feishu` 新增 WebSocket listener 和 supervisor，按 configured bot 启动、停止和 reload。
+3. 新增 `internal/channel/feishu/codexbridgeclient`，实现 `codexbridge.BotClient`。
+4. 扩展 `codexbridge.Binding.Channel`，并将 worker key 改为 `channel + "\x00" + botID`。
+5. 为 `codexbridge.Service` 增加 channel client registry，默认兼容 `csgclaw`。
+6. 调整 `cli/serve.newCodexBridgeManager`，注入 `bot.Service` 和 `feishu.Service`。
+7. Codex bridge manager 启动时按 bot record 的 `Channel` 创建 binding；本地旧 agent 保留 fallback。
+8. 为 Feishu path 增加 mention-only、自触发过滤、去重和普通文本发送测试。
 
-## 最终结论
+## 测试清单
 
-PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入由 CSGClaw 的 Feishu channel 代 Codex 连飞书。
+需要覆盖：
 
-这样可以复用现有 Codex ACP bridge，不需要修改 Codex runtime，也不需要新增一套 Codex 专用 HTTP API。CSGClaw server 内部新增的是 Feishu-backed `BotClient` 适配器，不是新的飞书协议所有者；thread/reply 暂不进入本期范围，和 PicoClaw 当前行为保持一致。
+- `codexbridge` 未设置 `Binding.Channel` 时仍默认使用 `csgclaw`。
+- 同一个 `BotID` 分别绑定 `csgclaw` 和 `feishu` 时 worker 不互相覆盖。
+- `StopBot(channel, botID)` 或兼容 wrapper 能正确停止指定 channel worker。
+- Feishu adapter 只消费匹配 `BotID` 的 `MessageEvent`。
+- 群聊 `MentionOnly` 开启时，未 mention 当前 bot 的消息不会触发 Codex。
+- Feishu adapter 发送消息时使用 botID 作为 `SenderID` 调用 `feishu.Service.SendMessage`。
+- `ThreadRootID` 和 `ThreadContext` 在 Feishu path 不映射。
+- Feishu listener 不把 bot 自己发送的消息重新投递给 Codex。
+
+## 与 PicoClaw 的关系
+
+PicoClaw 飞书路径保持不变：
+
+```text
+Feishu -> PicoClaw runtime FeishuChannel -> PicoClaw MessageBus -> PicoClaw AgentLoop
+```
+
+Codex 飞书路径新增在 CSGClaw server 内：
+
+```text
+Feishu -> CSGClaw feishu channel -> feishu codexbridgeclient -> codexbridge -> Codex ACP runtime
+```
+
+两条路径共享 `channels/feishu.toml` 的凭证来源，但飞书连接所有者不同：
+
+| Runtime | 飞书连接所有者 |
+| --- | --- |
+| PicoClaw sandbox | PicoClaw runtime 内部 |
+| Codex ACP | CSGClaw server 的 `internal/channel/feishu` |
+
+这样能复用现有 Codex ACP bridge，不新增 Codex 专用 HTTP API，也不把飞书协议细节泄漏到 Codex runtime。

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -87,7 +87,7 @@ flowchart LR
     Pico[PicoClaw Feishu Channel]
 
     Config --> Provider
-    Provider -->|BotConfig(botID)| RuntimeWiring
+    Provider -->|BotConfig by botID| RuntimeWiring
     RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_ID| Env
     RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_SECRET| Env
     Env --> Pico

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -176,6 +176,316 @@ SendMessage
   = codexbridge.SendMessageRequest -> 飞书 message create
 ```
 
+如果需要同时支持 CSGClaw 本地 IM 和 Feishu 两种 Codex bot，可以再加一个轻量路由 client：
+
+```text
+internal/channel/codexbridge/routing_client.go
+```
+
+它仍然实现 `codexbridge.BotClient`，按 `botID` 选择真实 client：
+
+```go
+type RoutingClient struct {
+    Local  codexbridge.BotClient
+    Feishu codexbridge.BotClient
+    Route  func(botID string) string
+}
+
+func (c *RoutingClient) StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan codexbridge.BotEvent, <-chan error)
+func (c *RoutingClient) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
+```
+
+第一版路由规则可以很简单：
+
+```text
+如果 feishu.Provider.BotConfig(botID) 存在 -> 使用 FeishuCodexClient
+否则 -> 使用现有 codexbridge.HTTPClient
+```
+
+这样 `codexbridge.Service` 仍然只依赖一个 `BotClient`，不用改动 Codex ACP 主流程。
+
+## 核心字段模型
+
+### 现有 Feishu 配置模型
+
+CSGClaw 已有飞书配置 provider：
+
+```go
+type BotCredentialProvider interface {
+    BotConfig(botID string) (AppConfig, bool)
+}
+
+type AppConfig struct {
+    AppID       string
+    AppSecret   string
+    AdminOpenID string
+}
+```
+
+`FeishuCodexClient` 通过 `BotConfig(botID)` 获取该 bot 对应的飞书凭证。
+
+第一版只需要 `app_id` 和 `app_secret`。如果飞书应用开启事件加密，后续需要在 `channels/feishu.toml` 中补充 `encrypt_key` 和 `verification_token`，并扩展 `AppConfig` 或新增运行时选项。
+
+### 现有 Codex bridge 入站模型
+
+Codex bridge 已经定义了入站事件：
+
+```go
+type BotEvent struct {
+    MessageID     string
+    RoomID        string
+    ChatType      string
+    Text          string
+    Mentions      []string
+    ThreadRootID  string
+    ThreadContext *BotThreadContext
+}
+```
+
+字段含义：
+
+| 字段 | 含义 |
+| --- | --- |
+| `MessageID` | 外部平台消息 ID，用于去重和 `Last-Event-ID` |
+| `RoomID` | 会话 ID；飞书中对应 `chat_id` |
+| `ChatType` | `p2p` 或 `group` |
+| `Text` | 送给 Codex 的用户文本，群聊中应去掉 bot mention |
+| `Mentions` | 被 mention 的用户或 bot ID 列表 |
+| `ThreadRootID` | thread/reply 根消息 ID |
+| `ThreadContext` | 首次进入 thread 时注入给 Codex 的上下文 |
+
+### 现有 Codex bridge 出站模型
+
+```go
+type SendMessageRequest struct {
+    RoomID       string
+    Text         string
+    MessageID    string
+    ThreadRootID string
+}
+
+type SendMessageResponse struct {
+    MessageID string
+}
+```
+
+字段含义：
+
+| 字段 | 含义 |
+| --- | --- |
+| `RoomID` | 目标会话；飞书中对应 `chat_id` |
+| `Text` | Codex 要发送的内容 |
+| `MessageID` | activity/update 场景中的消息 ID；第一版可忽略 |
+| `ThreadRootID` | thread/reply 目标；第一版可按普通群消息处理 |
+
+### 新增 FeishuCodexClient 模型
+
+建议模型：
+
+```go
+type Options struct {
+    Provider    feishu.BotCredentialProvider
+    MentionOnly bool
+    IsLark      bool
+    QueueSize   int
+    Logger      *slog.Logger
+}
+
+type Client struct {
+    provider    feishu.BotCredentialProvider
+    mentionOnly bool
+    isLark      bool
+    queueSize   int
+    logger      *slog.Logger
+}
+
+func New(options Options) *Client
+```
+
+`Client` 实现：
+
+```go
+func (c *Client) StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan codexbridge.BotEvent, <-chan error)
+
+func (c *Client) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
+```
+
+内部可以拆成几个小函数，便于测试：
+
+```go
+func (c *Client) appConfig(botID string) (feishu.AppConfig, error)
+func (c *Client) resolveBotOpenID(ctx context.Context, app feishu.AppConfig) (string, error)
+func (c *Client) startWebSocket(ctx context.Context, botID string, app feishu.AppConfig, events chan<- codexbridge.BotEvent) error
+func (c *Client) handleMessageReceive(botID string, botOpenID string, events chan<- codexbridge.BotEvent) func(context.Context, *larkim.P2MessageReceiveV1) error
+func (c *Client) mapMessageEvent(botID string, botOpenID string, event *larkim.P2MessageReceiveV1) (codexbridge.BotEvent, bool)
+func (c *Client) shouldAccept(event codexbridge.BotEvent, botOpenID string) bool
+func (c *Client) stripBotMention(text string, botOpenID string) string
+```
+
+## 函数流程设计
+
+### Server 启动流程
+
+当前 Codex bridge manager 在 `newCodexBridgeManager` 中创建 `codexbridge.Service`。接入飞书后，推荐流程如下：
+
+```text
+serve.Start
+  -> buildFeishuComponents
+      -> feishu.NewProvider
+      -> feishu.NewServiceWithProvider
+  -> newCodexBridgeManager
+      -> 获取 codex runtime
+      -> 获取 codex runtime EventSink
+      -> 创建 local HTTPClient
+      -> 创建 FeishuCodexClient
+      -> 创建 RoutingClient
+      -> codexbridge.NewService(RoutingClient, SessionManager, EventSink)
+  -> codexBridgeMgr.Start
+      -> 遍历 runtime_kind=codex 的 agent
+      -> ensureSession
+      -> bridge.StartBot(Binding)
+```
+
+`Binding` 参数：
+
+```go
+codexbridge.Binding{
+    BotID:     a.ID,
+    RuntimeID: strings.TrimSpace(a.RuntimeID),
+    SessionID: session.SessionID,
+    PromptMeta: map[string]any{
+        "channel": "feishu",
+    },
+}
+```
+
+其中 `PromptMeta` 第一版可以不填；如果后续希望 Codex 知道消息来自飞书，可以注入 `channel`、`chat_type`、`bot_id` 等元信息。
+
+### 入站函数调用链
+
+```text
+codexbridge.Service.StartBot
+  -> worker.run
+  -> worker.pumpEvents
+  -> RoutingClient.StreamEvents(botID, lastEventID)
+  -> FeishuCodexClient.StreamEvents(botID, lastEventID)
+  -> provider.BotConfig(botID)
+  -> resolveBotOpenID(app)
+  -> larkws.NewClient(appID, appSecret, WithEventHandler(dispatcher))
+  -> dispatcher.OnP2MessageReceiveV1(handleMessageReceive)
+  -> mapMessageEvent
+  -> events <- codexbridge.BotEvent
+  -> worker.enqueue
+  -> worker.handleEvent
+  -> SessionManager.EnsureSession
+  -> acp.PromptRequest
+  -> codex runtime Prompt
+```
+
+`acp.PromptRequest` 的关键参数：
+
+```go
+acp.PromptRequest{
+    SessionId: acp.SessionId(sessionID),
+    Prompt: []acp.ContentBlock{
+        acp.TextBlock(event.Text),
+    },
+    Meta: binding.PromptMeta,
+}
+```
+
+### 飞书入站接口参数
+
+飞书 WebSocket client 参数：
+
+| 参数 | 来源 | 用途 |
+| --- | --- | --- |
+| `app_id` | `feishu.AppConfig.AppID` | 创建飞书 WS client |
+| `app_secret` | `feishu.AppConfig.AppSecret` | 创建飞书 WS client |
+| `domain` | `Options.IsLark` | 选择飞书或 Lark 域名 |
+| `verification_token` | 后续可扩展 | 事件校验 |
+| `encrypt_key` | 后续可扩展 | 事件解密 |
+
+启动 WebSocket 前建议先调用 bot info API 获取当前 bot 的 `open_id`，并在内存中缓存：
+
+```text
+resolveBotOpenID(app)
+  -> 飞书 bot info API
+  -> botOpenID
+```
+
+`botOpenID` 用于两件事：
+
+- 群聊 mention 判断
+- 忽略 bot 自己发送的消息，避免自触发循环
+
+飞书消息事件中需要读取的字段：
+
+| Feishu 事件字段 | 用途 |
+| --- | --- |
+| `event.message.message_id` | 映射为 `BotEvent.MessageID` |
+| `event.message.chat_id` | 映射为 `BotEvent.RoomID` |
+| `event.message.chat_type` | 映射为 `BotEvent.ChatType` |
+| `event.message.message_type` | 判断是否支持，第一版建议只处理 `text` |
+| `event.message.content` | 解析文本内容 |
+| `event.message.mentions` | mention 判断和 `BotEvent.Mentions` |
+| `event.sender.sender_id.open_id` | 忽略 bot 自己发出的消息，记录用户来源 |
+
+群聊过滤建议：
+
+```text
+如果 chat_type != group -> 接收
+如果 MentionOnly=false -> 接收
+如果 mentions 包含 bot open_id -> 接收
+否则忽略
+```
+
+### 出站函数调用链
+
+```text
+codex runtime 输出 session events
+  -> codexbridge worker 监听 EventSink
+  -> runtimebridge.TurnRenderer 汇总文本
+  -> worker.flushTurn
+  -> worker.sendMessageRequest
+  -> RoutingClient.SendMessage(botID, req)
+  -> FeishuCodexClient.SendMessage(botID, req)
+  -> provider.BotConfig(botID)
+  -> 飞书 REST API message create
+  -> 返回飞书 message_id
+```
+
+飞书 REST 发送参数：
+
+| 参数 | 值 |
+| --- | --- |
+| `receive_id_type` | `chat_id` |
+| `receive_id` | `req.RoomID` |
+| `msg_type` | `text` |
+| `content` | `{"text": req.Text}` |
+| `uuid` | 可选，建议使用稳定请求 ID 做幂等 |
+
+第一版 `SendMessage` 示例：
+
+```go
+req := larkim.NewCreateMessageReqBuilder().
+    ReceiveIdType(larkim.ReceiveIdTypeChatId).
+    Body(larkim.NewCreateMessageReqBodyBuilder().
+        ReceiveId(sendReq.RoomID).
+        MsgType(larkim.MsgTypeText).
+        Content(`{"text": "...escaped text..."}`).
+        Build()).
+    Build()
+```
+
+返回值：
+
+```go
+codexbridge.SendMessageResponse{
+    MessageID: feishuMessageID,
+}
+```
+
 ### 事件映射
 
 飞书事件应映射为 `codexbridge.BotEvent`：

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -12,24 +12,35 @@ CSGClaw 目前同时支持 PicoClaw runtime 和 Codex runtime。PicoClaw 已经�
 
 PicoClaw 的飞书接入是 runtime 自己完成的：
 
-```text
-飞书
-  <-> PicoClaw Feishu Channel
-  <-> PicoClaw MessageBus
-  <-> PicoClaw AgentLoop
-  <-> CSGClaw LLM/API
+```mermaid
+flowchart LR
+    Feishu[飞书]
+    FeishuChannel[PicoClaw Feishu Channel]
+    MessageBus[PicoClaw MessageBus]
+    AgentLoop[PicoClaw AgentLoop]
+    CSGClaw[CSGClaw LLM/API]
+
+    Feishu <-->|WebSocket 入站 / REST 出站| FeishuChannel
+    FeishuChannel <-->|InboundMessage / OutboundMessage| MessageBus
+    MessageBus <-->|消费 / 发布| AgentLoop
+    AgentLoop <-->|LLM API| CSGClaw
 ```
 
 ### 入站消息流
 
-```text
-飞书群聊 / 私聊
-  -> 飞书 WebSocket 推送 message event
-  -> picoclaw/pkg/channels/feishu
-  -> 转成 bus.InboundMessage
-  -> MessageBus.PublishInbound
-  -> AgentLoop 消费 InboundChan
-  -> AgentLoop 处理消息
+```mermaid
+sequenceDiagram
+    participant Feishu as 飞书群聊/私聊
+    participant Channel as PicoClaw Feishu Channel
+    participant Bus as PicoClaw MessageBus
+    participant Agent as PicoClaw AgentLoop
+
+    Feishu->>Channel: WebSocket 推送 message event
+    Channel->>Channel: handleMessageReceive
+    Channel->>Channel: 解析文本、mention、chat_id
+    Channel->>Bus: PublishInbound(bus.InboundMessage)
+    Bus-->>Agent: InboundChan()
+    Agent->>Agent: processMessage
 ```
 
 关键模块：
@@ -45,13 +56,19 @@ PicoClaw 的飞书接入是 runtime 自己完成的：
 
 ### 出站消息流
 
-```text
-AgentLoop
-  -> MessageBus.PublishOutbound
-  -> ChannelManager.dispatchOutbound
-  -> FeishuChannel.Send
-  -> 飞书 REST API message create
-  -> 飞书群聊 / 私聊
+```mermaid
+sequenceDiagram
+    participant Agent as PicoClaw AgentLoop
+    participant Bus as PicoClaw MessageBus
+    participant Manager as PicoClaw ChannelManager
+    participant Channel as PicoClaw Feishu Channel
+    participant Feishu as 飞书群聊/私聊
+
+    Agent->>Bus: PublishOutbound(bus.OutboundMessage)
+    Bus-->>Manager: OutboundChan()
+    Manager->>Channel: dispatchOutbound -> Send
+    Channel->>Feishu: REST message create
+    Feishu-->>Channel: message_id
 ```
 
 PicoClaw 的 `FeishuChannel.Send` 会优先发送 interactive card，失败时回退为文本消息。
@@ -60,11 +77,19 @@ PicoClaw 的 `FeishuChannel.Send` 会优先发送 interactive card，失败时�
 
 飞书凭证由 CSGClaw 管理，然后在启动 PicoClaw sandbox runtime 时注入环境变量：
 
-```text
-CSGClaw channels/feishu.toml
-  -> feishu.Provider.BotConfig(botID)
-  -> runtimewiring.addFeishuBoxEnvVars
-  -> PicoClaw env
+```mermaid
+flowchart LR
+    Config[channels/feishu.toml]
+    Provider[feishu.Provider]
+    RuntimeWiring[runtimewiring.addFeishuBoxEnvVars]
+    Env[PicoClaw env]
+    Pico[PicoClaw Feishu Channel]
+
+    Config --> Provider
+    Provider -->|BotConfig(botID)| RuntimeWiring
+    RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_ID| Env
+    RuntimeWiring -->|PICOCLAW_CHANNELS_FEISHU_APP_SECRET| Env
+    Env --> Pico
 ```
 
 注入的关键环境变量：
@@ -106,9 +131,9 @@ CSGClaw server
 
 当前缺少的是：
 
-```text
-飞书 WebSocket
-  -> CSGClaw server
+```mermaid
+flowchart LR
+    Feishu[飞书 WebSocket] -. 当前缺少 .-> CSGClaw[CSGClaw server]
 ```
 
 也就是说，CSGClaw server 当前不是飞书实时群聊消息入口。
@@ -117,34 +142,55 @@ CSGClaw server
 
 Codex 不直接连接飞书。推荐由 CSGClaw server 代表 Codex 连接飞书：
 
-```text
-飞书
-  <-> CSGClaw FeishuCodexClient
-  <-> CSGClaw codexbridge
-  <-> Codex ACP runtime
+```mermaid
+flowchart LR
+    Feishu[飞书]
+    FeishuClient[CSGClaw FeishuCodexClient]
+    CodexBridge[CSGClaw codexbridge]
+    CodexRuntime[Codex ACP runtime]
+
+    Feishu <-->|WebSocket 入站 / REST 出站| FeishuClient
+    FeishuClient <-->|BotEvent / SendMessageRequest| CodexBridge
+    CodexBridge <-->|ACP Prompt / session events| CodexRuntime
 ```
 
 ### 入站消息流
 
-```text
-飞书群聊 / 私聊
-  -> 飞书 WebSocket 推送 message event
-  -> CSGClaw FeishuCodexClient.StreamEvents
-  -> 转成 codexbridge.BotEvent
-  -> codexbridge.Service
-  -> 转成 ACP PromptRequest
-  -> Codex runtime
+```mermaid
+sequenceDiagram
+    participant Feishu as 飞书群聊/私聊
+    participant Client as FeishuCodexClient
+    participant Bridge as codexbridge.Service
+    participant Session as Codex SessionManager
+    participant Codex as Codex ACP runtime
+
+    Feishu->>Client: WebSocket message event
+    Client->>Client: mapMessageEvent
+    Client->>Bridge: StreamEvents -> BotEvent
+    Bridge->>Bridge: enqueue / dedupe
+    Bridge->>Session: EnsureSession(runtimeID, conversationKey)
+    Session-->>Bridge: sessionID
+    Bridge->>Codex: ACP PromptRequest(sessionID, Text)
+    Codex-->>Bridge: ACP PromptResponse / session events
 ```
 
 ### 出站消息流
 
-```text
-Codex runtime
-  -> ACP session events
-  -> codexbridge.Service
-  -> FeishuCodexClient.SendMessage
-  -> 飞书 REST API message create
-  -> 飞书群聊 / 私聊
+```mermaid
+sequenceDiagram
+    participant Codex as Codex ACP runtime
+    participant Sink as Codex EventSink
+    participant Bridge as codexbridge.Service
+    participant Client as FeishuCodexClient
+    participant Feishu as 飞书群聊/私聊
+
+    Codex->>Sink: session events
+    Sink-->>Bridge: Subscribe(runtimeID)
+    Bridge->>Bridge: TurnRenderer 汇总文本
+    Bridge->>Client: SendMessage(botID, SendMessageRequest)
+    Client->>Feishu: REST message create(chat_id, text)
+    Feishu-->>Client: message_id
+    Client-->>Bridge: SendMessageResponse
 ```
 
 ### 新增模块
@@ -337,22 +383,27 @@ func (c *Client) stripBotMention(text string, botOpenID string) string
 
 当前 Codex bridge manager 在 `newCodexBridgeManager` 中创建 `codexbridge.Service`。接入飞书后，推荐流程如下：
 
-```text
-serve.Start
-  -> buildFeishuComponents
-      -> feishu.NewProvider
-      -> feishu.NewServiceWithProvider
-  -> newCodexBridgeManager
-      -> 获取 codex runtime
-      -> 获取 codex runtime EventSink
-      -> 创建 local HTTPClient
-      -> 创建 FeishuCodexClient
-      -> 创建 RoutingClient
-      -> codexbridge.NewService(RoutingClient, SessionManager, EventSink)
-  -> codexBridgeMgr.Start
-      -> 遍历 runtime_kind=codex 的 agent
-      -> ensureSession
-      -> bridge.StartBot(Binding)
+```mermaid
+sequenceDiagram
+    participant Serve as serve.Start
+    participant Feishu as buildFeishuComponents
+    participant Manager as newCodexBridgeManager
+    participant Runtime as Codex runtime
+    participant Bridge as codexbridge.Service
+    participant Agent as agent.Service
+
+    Serve->>Feishu: buildFeishuComponents(configPath)
+    Feishu->>Feishu: feishu.NewProvider(store)
+    Feishu->>Feishu: feishu.NewServiceWithProvider(provider)
+    Serve->>Manager: newCodexBridgeManager(cfg, agentService)
+    Manager->>Runtime: Runtime(KindCodex)
+    Manager->>Runtime: EventSink()
+    Manager->>Manager: New HTTPClient / FeishuCodexClient / RoutingClient
+    Manager->>Bridge: NewService(RoutingClient, SessionManager, EventSink)
+    Serve->>Bridge: Start()
+    Bridge->>Agent: List()
+    Bridge->>Runtime: ensureSession(agent)
+    Bridge->>Bridge: StartBot(Binding)
 ```
 
 `Binding` 参数：
@@ -372,23 +423,31 @@ codexbridge.Binding{
 
 ### 入站函数调用链
 
-```text
-codexbridge.Service.StartBot
-  -> worker.run
-  -> worker.pumpEvents
-  -> RoutingClient.StreamEvents(botID, lastEventID)
-  -> FeishuCodexClient.StreamEvents(botID, lastEventID)
-  -> provider.BotConfig(botID)
-  -> resolveBotOpenID(app)
-  -> larkws.NewClient(appID, appSecret, WithEventHandler(dispatcher))
-  -> dispatcher.OnP2MessageReceiveV1(handleMessageReceive)
-  -> mapMessageEvent
-  -> events <- codexbridge.BotEvent
-  -> worker.enqueue
-  -> worker.handleEvent
-  -> SessionManager.EnsureSession
-  -> acp.PromptRequest
-  -> codex runtime Prompt
+```mermaid
+sequenceDiagram
+    participant Bridge as codexbridge.Service
+    participant Worker as bridge worker
+    participant Router as RoutingClient
+    participant Client as FeishuCodexClient
+    participant Provider as feishu.Provider
+    participant LarkWS as larkws.Client
+    participant Session as SessionManager
+    participant Codex as Codex runtime
+
+    Bridge->>Worker: StartBot(Binding)
+    Worker->>Router: StreamEvents(botID, lastEventID)
+    Router->>Client: StreamEvents(botID, lastEventID)
+    Client->>Provider: BotConfig(botID)
+    Provider-->>Client: AppConfig(app_id, app_secret)
+    Client->>Client: resolveBotOpenID(app)
+    Client->>LarkWS: NewClient(app_id, app_secret, handler)
+    LarkWS-->>Client: OnP2MessageReceiveV1(event)
+    Client->>Client: mapMessageEvent(event)
+    Client-->>Worker: BotEvent
+    Worker->>Worker: enqueue / accept / dedupe
+    Worker->>Session: EnsureSession(runtimeID, conversationKey)
+    Session-->>Worker: sessionID
+    Worker->>Codex: Prompt(acp.PromptRequest)
 ```
 
 `acp.PromptRequest` 的关键参数：
@@ -448,17 +507,27 @@ resolveBotOpenID(app)
 
 ### 出站函数调用链
 
-```text
-codex runtime 输出 session events
-  -> codexbridge worker 监听 EventSink
-  -> runtimebridge.TurnRenderer 汇总文本
-  -> worker.flushTurn
-  -> worker.sendMessageRequest
-  -> RoutingClient.SendMessage(botID, req)
-  -> FeishuCodexClient.SendMessage(botID, req)
-  -> provider.BotConfig(botID)
-  -> 飞书 REST API message create
-  -> 返回飞书 message_id
+```mermaid
+sequenceDiagram
+    participant Codex as Codex runtime
+    participant Events as EventSink
+    participant Worker as bridge worker
+    participant Router as RoutingClient
+    participant Client as FeishuCodexClient
+    participant Provider as feishu.Provider
+    participant Feishu as 飞书 REST API
+
+    Codex->>Events: session events
+    Events-->>Worker: Subscribe(runtimeID)
+    Worker->>Worker: TurnRenderer.RenderActivity / ApplyText
+    Worker->>Worker: flushTurn
+    Worker->>Router: SendMessage(botID, req)
+    Router->>Client: SendMessage(botID, req)
+    Client->>Provider: BotConfig(botID)
+    Provider-->>Client: AppConfig(app_id, app_secret)
+    Client->>Feishu: message create(chat_id, text)
+    Feishu-->>Client: message_id
+    Client-->>Worker: SendMessageResponse
 ```
 
 飞书 REST 发送参数：
@@ -525,12 +594,27 @@ codexbridge.SendMessageResponse{
 
 ## 与 PicoClaw 方案的对齐关系
 
-```text
-PicoClaw:
-飞书 WS -> PicoClaw Feishu Channel -> MessageBus -> AgentLoop -> 飞书 REST
+```mermaid
+flowchart LR
+    subgraph PicoClawPath[PicoClaw 路径]
+        PFeishu[飞书]
+        PChannel[PicoClaw Feishu Channel]
+        PBus[MessageBus]
+        PAgent[AgentLoop]
+        PFeishu <-->|WS / REST| PChannel
+        PChannel <--> PBus
+        PBus <--> PAgent
+    end
 
-Codex:
-飞书 WS -> CSGClaw FeishuCodexClient -> CodexBridge -> ACP -> 飞书 REST
+    subgraph CodexPath[Codex 路径]
+        CFeishu[飞书]
+        CClient[CSGClaw FeishuCodexClient]
+        CBridge[CodexBridge]
+        CACP[Codex ACP runtime]
+        CFeishu <-->|WS / REST| CClient
+        CClient <--> CBridge
+        CBridge <-->|ACP| CACP
+    end
 ```
 
 | 层面 | PicoClaw | Codex 推荐方案 |

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -1,0 +1,260 @@
+# Codex 对接飞书设计说明
+
+本文说明现有 PicoClaw 如何对接飞书，以及在 CSGClaw 中为 Codex runtime 增加飞书通道时推荐的模块边界、消息流和接口映射。
+
+## 背景
+
+CSGClaw 目前同时支持 PicoClaw runtime 和 Codex runtime。PicoClaw 已经可以接入飞书群聊，但它的飞书连接发生在 PicoClaw runtime 内部；Codex runtime 目前通过 ACP 与 CSGClaw 交互，并不直接连接飞书。
+
+推荐方案是：由 CSGClaw server 作为 Codex 与飞书之间的适配层，一边连接飞书 WebSocket/REST API，一边通过现有 `codexbridge` 将消息转换为 Codex ACP prompt。
+
+## 现有 PicoClaw 飞书接入
+
+PicoClaw 的飞书接入是 runtime 自己完成的：
+
+```text
+飞书
+  <-> PicoClaw Feishu Channel
+  <-> PicoClaw MessageBus
+  <-> PicoClaw AgentLoop
+  <-> CSGClaw LLM/API
+```
+
+### 入站消息流
+
+```text
+飞书群聊 / 私聊
+  -> 飞书 WebSocket 推送 message event
+  -> picoclaw/pkg/channels/feishu
+  -> 转成 bus.InboundMessage
+  -> MessageBus.PublishInbound
+  -> AgentLoop 消费 InboundChan
+  -> AgentLoop 处理消息
+```
+
+关键模块：
+
+| 职责 | 模块 |
+| --- | --- |
+| 飞书通道实现 | `picoclaw/pkg/channels/feishu/feishu_64.go` |
+| 建立飞书 WebSocket | `FeishuChannel.Start` |
+| 注册飞书消息事件 | `OnP2MessageReceiveV1(c.handleMessageReceive)` |
+| 通道通用接口 | `picoclaw/pkg/channels/base.go` |
+| 消息总线 | `picoclaw/pkg/bus/bus.go` |
+| Agent 主循环 | `picoclaw/pkg/agent/loop.go` |
+
+### 出站消息流
+
+```text
+AgentLoop
+  -> MessageBus.PublishOutbound
+  -> ChannelManager.dispatchOutbound
+  -> FeishuChannel.Send
+  -> 飞书 REST API message create
+  -> 飞书群聊 / 私聊
+```
+
+PicoClaw 的 `FeishuChannel.Send` 会优先发送 interactive card，失败时回退为文本消息。
+
+### 配置流
+
+飞书凭证由 CSGClaw 管理，然后在启动 PicoClaw sandbox runtime 时注入环境变量：
+
+```text
+CSGClaw channels/feishu.toml
+  -> feishu.Provider.BotConfig(botID)
+  -> runtimewiring.addFeishuBoxEnvVars
+  -> PicoClaw env
+```
+
+注入的关键环境变量：
+
+```text
+PICOCLAW_CHANNELS_FEISHU_APP_ID
+PICOCLAW_CHANNELS_FEISHU_APP_SECRET
+```
+
+PicoClaw 读取这些环境变量后，自己创建飞书 SDK client 和 WebSocket client。因此，PicoClaw 并不是通过 CSGClaw server 的 HTTP/SSE 接口来收发飞书群聊消息。
+
+## CSGClaw 当前飞书能力
+
+CSGClaw server 目前已有飞书 REST 能力，主要用于配置和管理操作：
+
+```text
+CSGClaw server
+  -> 飞书 REST API
+```
+
+已有能力包括：
+
+- 保存和加载飞书 bot 配置
+- 获取 bot 信息
+- 创建群聊
+- 添加群成员
+- 拉取群成员和群消息
+- 发送管理类消息
+
+主要模块：
+
+| 职责 | 模块 |
+| --- | --- |
+| 飞书配置文件 | `internal/channel/feishu/store.go` |
+| 飞书配置 provider | `internal/channel/feishu/provider.go` |
+| 飞书 REST service | `internal/channel/feishu/service.go` |
+| 飞书 API handler | `internal/api/feishu.go` |
+| 飞书配置 API handler | `internal/api/feishu_config.go` |
+
+当前缺少的是：
+
+```text
+飞书 WebSocket
+  -> CSGClaw server
+```
+
+也就是说，CSGClaw server 当前不是飞书实时群聊消息入口。
+
+## Codex 对接飞书推荐方案
+
+Codex 不直接连接飞书。推荐由 CSGClaw server 代表 Codex 连接飞书：
+
+```text
+飞书
+  <-> CSGClaw FeishuCodexClient
+  <-> CSGClaw codexbridge
+  <-> Codex ACP runtime
+```
+
+### 入站消息流
+
+```text
+飞书群聊 / 私聊
+  -> 飞书 WebSocket 推送 message event
+  -> CSGClaw FeishuCodexClient.StreamEvents
+  -> 转成 codexbridge.BotEvent
+  -> codexbridge.Service
+  -> 转成 ACP PromptRequest
+  -> Codex runtime
+```
+
+### 出站消息流
+
+```text
+Codex runtime
+  -> ACP session events
+  -> codexbridge.Service
+  -> FeishuCodexClient.SendMessage
+  -> 飞书 REST API message create
+  -> 飞书群聊 / 私聊
+```
+
+### 推荐新增模块
+
+建议新增：
+
+```text
+internal/channel/feishu/codexclient
+```
+
+该模块实现现有的 `codexbridge.BotClient` 接口：
+
+```go
+type BotClient interface {
+    StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan BotEvent, <-chan error)
+    SendMessage(ctx context.Context, botID string, req SendMessageRequest) (SendMessageResponse, error)
+}
+```
+
+其中：
+
+```text
+StreamEvents
+  = 飞书 WebSocket 入站
+  = 飞书 message event -> codexbridge.BotEvent
+
+SendMessage
+  = 飞书 REST 出站
+  = codexbridge.SendMessageRequest -> 飞书 message create
+```
+
+### 事件映射
+
+飞书事件应映射为 `codexbridge.BotEvent`：
+
+| Feishu 字段 | Codex bridge 字段 |
+| --- | --- |
+| `message_id` | `MessageID` |
+| `chat_id` | `RoomID` |
+| chat type | `ChatType` |
+| text content | `Text` |
+| mentions | `Mentions` |
+| thread/root message | `ThreadRootID` / `ThreadContext` |
+
+群聊中建议沿用 PicoClaw 的处理语义：
+
+- 支持只响应 @bot 的消息
+- 收到消息后去除 bot mention
+- 使用 bot open_id 做可靠 mention 判断
+- 对重复事件做去重
+
+### 出站映射
+
+`codexbridge.SendMessageRequest` 应映射到飞书消息发送：
+
+| Codex bridge 字段 | Feishu 字段 |
+| --- | --- |
+| `RoomID` | `receive_id`，类型为 `chat_id` |
+| `Text` | message content |
+| `ThreadRootID` | thread/reply 目标，按飞书能力补齐 |
+| `MessageID` | activity/update 场景可映射为编辑或补充消息 |
+
+第一版可以只支持文本回复；后续再补 interactive card、消息编辑、占位消息和 reasoning/activity 消息。
+
+## 与 PicoClaw 方案的对齐关系
+
+```text
+PicoClaw:
+飞书 WS -> PicoClaw Feishu Channel -> MessageBus -> AgentLoop -> 飞书 REST
+
+Codex:
+飞书 WS -> CSGClaw FeishuCodexClient -> CodexBridge -> ACP -> 飞书 REST
+```
+
+| 层面 | PicoClaw | Codex 推荐方案 |
+| --- | --- | --- |
+| 飞书入站 | PicoClaw runtime 连接 WebSocket | CSGClaw server 连接 WebSocket |
+| 飞书出站 | PicoClaw runtime 调 REST | CSGClaw server 调 REST |
+| 消息抽象 | `bus.InboundMessage` | `codexbridge.BotEvent` |
+| 回复抽象 | `bus.OutboundMessage` | `codexbridge.SendMessageRequest` |
+| Agent 执行 | PicoClaw `AgentLoop` | Codex ACP runtime |
+| 配置来源 | CSGClaw `channels/feishu.toml` | CSGClaw `channels/feishu.toml` |
+| 凭证使用方 | PicoClaw runtime | CSGClaw server |
+
+两套方案在飞书协议层面对齐：都是 WebSocket 入站、REST 出站。差异在 runtime 边界：PicoClaw 自己持有飞书连接；Codex 由 CSGClaw server 持有飞书连接。
+
+## 为什么不放到 Codex 插件里
+
+Codex 插件或 MCP server 更适合作为会话内工具，例如查询飞书消息、发送飞书消息、查询用户信息等。它们不适合作为飞书 WebSocket 的常驻入站网关，因为飞书事件到达时仍然需要有一个外部进程接住事件并触发 Codex turn。
+
+因此，推荐：
+
+```text
+飞书入站和出站适配：放在 CSGClaw server
+Codex 推理和执行：继续走 ACP
+可选飞书工具能力：后续再通过 MCP/插件暴露给 Codex
+```
+
+## 实施步骤
+
+1. 新增 `internal/channel/feishu/codexclient`，实现 `codexbridge.BotClient`。
+2. 复用 `feishu.Provider.BotConfig(botID)` 获取 `app_id` 和 `app_secret`。
+3. 在 `StreamEvents` 中为 bot 启动飞书 WebSocket client。
+4. 将飞书消息事件转换为 `codexbridge.BotEvent`。
+5. 在 `SendMessage` 中调用飞书 REST message create API。
+6. 修改 Codex bridge manager，根据 agent/channel 选择 bot client。
+7. 为配置 reload、WebSocket 重连、消息去重和群聊 mention 过滤补测试。
+
+## 最终结论
+
+PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入建议由 CSGClaw server 代 Codex 连飞书。
+
+这样可以复用现有 Codex ACP bridge，不需要修改 Codex runtime，也不需要新增一套 Codex 专用 HTTP API。CSGClaw server 内部新增 Feishu-backed `BotClient` 即可完成协议适配。

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -30,17 +30,17 @@ flowchart LR
 
 ```mermaid
 sequenceDiagram
-    participant Feishu as 飞书群聊/私聊
-    participant Channel as PicoClaw Feishu Channel
-    participant Bus as PicoClaw MessageBus
-    participant Agent as PicoClaw AgentLoop
+    participant Feishu as 飞书平台<br/>群聊/私聊
+    participant Channel as PicoClaw 程序<br/>FeishuChannel
+    participant Bus as PicoClaw 程序<br/>MessageBus
+    participant Agent as PicoClaw 程序<br/>AgentLoop
 
-    Feishu->>Channel: WebSocket 推送 message event
-    Channel->>Channel: handleMessageReceive
-    Channel->>Channel: 解析文本、mention、chat_id
+    Feishu->>Channel: WebSocket: im.message.receive_v1
+    Channel->>Channel: handleMessageReceive(event)
+    Channel->>Channel: 解析 text / mention / chat_id
     Channel->>Bus: PublishInbound(bus.InboundMessage)
     Bus-->>Agent: InboundChan()
-    Agent->>Agent: processMessage
+    Agent->>Agent: processMessage(ctx, msg)
 ```
 
 关键模块：
@@ -58,16 +58,17 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Agent as PicoClaw AgentLoop
-    participant Bus as PicoClaw MessageBus
-    participant Manager as PicoClaw ChannelManager
-    participant Channel as PicoClaw Feishu Channel
-    participant Feishu as 飞书群聊/私聊
+    participant Agent as PicoClaw 程序<br/>AgentLoop
+    participant Bus as PicoClaw 程序<br/>MessageBus
+    participant Manager as PicoClaw 程序<br/>ChannelManager
+    participant Channel as PicoClaw 程序<br/>FeishuChannel
+    participant Feishu as 飞书平台<br/>群聊/私聊
 
     Agent->>Bus: PublishOutbound(bus.OutboundMessage)
     Bus-->>Manager: OutboundChan()
-    Manager->>Channel: dispatchOutbound -> Send
-    Channel->>Feishu: REST message create
+    Manager->>Channel: dispatchOutbound(msg)
+    Channel->>Channel: Send(ctx, msg)
+    Channel->>Feishu: REST: message create(chat_id, content)
     Feishu-->>Channel: message_id
 ```
 
@@ -158,19 +159,19 @@ flowchart LR
 
 ```mermaid
 sequenceDiagram
-    participant Feishu as 飞书群聊/私聊
-    participant Client as FeishuCodexClient
-    participant Bridge as codexbridge.Service
-    participant Session as Codex SessionManager
-    participant Codex as Codex ACP runtime
+    participant Feishu as 飞书平台<br/>群聊/私聊
+    participant Client as CSGClaw server<br/>FeishuCodexClient
+    participant Bridge as CSGClaw server<br/>codexbridge.Service
+    participant Session as CSGClaw server<br/>Codex SessionManager
+    participant Codex as Codex 进程<br/>ACP runtime
 
-    Feishu->>Client: WebSocket message event
-    Client->>Client: mapMessageEvent
-    Client->>Bridge: StreamEvents -> BotEvent
+    Feishu->>Client: WebSocket: im.message.receive_v1
+    Client->>Client: mapMessageEvent(event)
+    Client->>Bridge: StreamEvents(botID) -> BotEvent
     Bridge->>Bridge: enqueue / dedupe
     Bridge->>Session: EnsureSession(runtimeID, conversationKey)
     Session-->>Bridge: sessionID
-    Bridge->>Codex: ACP PromptRequest(sessionID, Text)
+    Bridge->>Codex: ACP PromptRequest(sessionID, text)
     Codex-->>Bridge: ACP PromptResponse / session events
 ```
 
@@ -178,17 +179,17 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Codex as Codex ACP runtime
-    participant Sink as Codex EventSink
-    participant Bridge as codexbridge.Service
-    participant Client as FeishuCodexClient
-    participant Feishu as 飞书群聊/私聊
+    participant Codex as Codex 进程<br/>ACP runtime
+    participant Sink as CSGClaw server<br/>Codex EventSink
+    participant Bridge as CSGClaw server<br/>codexbridge.Service
+    participant Client as CSGClaw server<br/>FeishuCodexClient
+    participant Feishu as 飞书平台<br/>群聊/私聊
 
-    Codex->>Sink: session events
+    Codex->>Sink: ACP session events
     Sink-->>Bridge: Subscribe(runtimeID)
     Bridge->>Bridge: TurnRenderer 汇总文本
     Bridge->>Client: SendMessage(botID, SendMessageRequest)
-    Client->>Feishu: REST message create(chat_id, text)
+    Client->>Feishu: REST: message create(chat_id, text)
     Feishu-->>Client: message_id
     Client-->>Bridge: SendMessageResponse
 ```
@@ -425,14 +426,14 @@ codexbridge.Binding{
 
 ```mermaid
 sequenceDiagram
-    participant Bridge as codexbridge.Service
-    participant Worker as bridge worker
-    participant Router as RoutingClient
-    participant Client as FeishuCodexClient
-    participant Provider as feishu.Provider
-    participant LarkWS as larkws.Client
-    participant Session as SessionManager
-    participant Codex as Codex runtime
+    participant Bridge as CSGClaw server<br/>codexbridge.Service
+    participant Worker as CSGClaw server<br/>bridge worker
+    participant Router as CSGClaw server<br/>RoutingClient
+    participant Client as CSGClaw server<br/>FeishuCodexClient
+    participant Provider as CSGClaw server<br/>feishu.Provider
+    participant LarkWS as CSGClaw server<br/>larkws.Client
+    participant Session as CSGClaw server<br/>SessionManager
+    participant Codex as Codex 进程<br/>ACP runtime
 
     Bridge->>Worker: StartBot(Binding)
     Worker->>Router: StreamEvents(botID, lastEventID)
@@ -509,15 +510,15 @@ resolveBotOpenID(app)
 
 ```mermaid
 sequenceDiagram
-    participant Codex as Codex runtime
-    participant Events as EventSink
-    participant Worker as bridge worker
-    participant Router as RoutingClient
-    participant Client as FeishuCodexClient
-    participant Provider as feishu.Provider
-    participant Feishu as 飞书 REST API
+    participant Codex as Codex 进程<br/>ACP runtime
+    participant Events as CSGClaw server<br/>EventSink
+    participant Worker as CSGClaw server<br/>bridge worker
+    participant Router as CSGClaw server<br/>RoutingClient
+    participant Client as CSGClaw server<br/>FeishuCodexClient
+    participant Provider as CSGClaw server<br/>feishu.Provider
+    participant Feishu as 飞书平台<br/>REST API
 
-    Codex->>Events: session events
+    Codex->>Events: ACP session events
     Events-->>Worker: Subscribe(runtimeID)
     Worker->>Worker: TurnRenderer.RenderActivity / ApplyText
     Worker->>Worker: flushTurn

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -147,9 +147,9 @@ Codex runtime
   -> 飞书群聊 / 私聊
 ```
 
-### 推荐新增模块
+### 新增模块
 
-建议新增：
+新增：
 
 ```text
 internal/channel/feishu/codexclient
@@ -176,7 +176,7 @@ SendMessage
   = codexbridge.SendMessageRequest -> 飞书 message create
 ```
 
-如果需要同时支持 CSGClaw 本地 IM 和 Feishu 两种 Codex bot，可以再加一个轻量路由 client：
+为同时支持 CSGClaw 本地 IM 和 Feishu 两种 Codex bot，增加一个轻量路由 client：
 
 ```text
 internal/channel/codexbridge/routing_client.go
@@ -195,7 +195,7 @@ func (c *RoutingClient) StreamEvents(ctx context.Context, botID, lastEventID str
 func (c *RoutingClient) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
 ```
 
-第一版路由规则可以很简单：
+路由规则：
 
 ```text
 如果 feishu.Provider.BotConfig(botID) 存在 -> 使用 FeishuCodexClient
@@ -224,7 +224,18 @@ type AppConfig struct {
 
 `FeishuCodexClient` 通过 `BotConfig(botID)` 获取该 bot 对应的飞书凭证。
 
-第一版只需要 `app_id` 和 `app_secret`。如果飞书应用开启事件加密，后续需要在 `channels/feishu.toml` 中补充 `encrypt_key` 和 `verification_token`，并扩展 `AppConfig` 或新增运行时选项。
+当前 `channels/feishu.toml` 中与 Codex 飞书桥接相关的字段是：
+
+```toml
+[global]
+admin_open_id = "ou_xxx"
+
+[bots.u-dev]
+app_id = "cli_xxx"
+app_secret = "xxx"
+```
+
+`app_id` 和 `app_secret` 用于创建飞书 SDK client、WebSocket client，以及调用飞书 REST API。`admin_open_id` 保持现有管理语义，Codex 飞书消息桥接不依赖该字段处理普通群聊收发。
 
 ### 现有 Codex bridge 入站模型
 
@@ -275,18 +286,17 @@ type SendMessageResponse struct {
 | --- | --- |
 | `RoomID` | 目标会话；飞书中对应 `chat_id` |
 | `Text` | Codex 要发送的内容 |
-| `MessageID` | activity/update 场景中的消息 ID；第一版可忽略 |
-| `ThreadRootID` | thread/reply 目标；第一版可按普通群消息处理 |
+| `MessageID` | activity/update 场景中的消息 ID |
+| `ThreadRootID` | thread/reply 目标 |
 
 ### 新增 FeishuCodexClient 模型
 
-建议模型：
+模型：
 
 ```go
 type Options struct {
     Provider    feishu.BotCredentialProvider
     MentionOnly bool
-    IsLark      bool
     QueueSize   int
     Logger      *slog.Logger
 }
@@ -294,7 +304,6 @@ type Options struct {
 type Client struct {
     provider    feishu.BotCredentialProvider
     mentionOnly bool
-    isLark      bool
     queueSize   int
     logger      *slog.Logger
 }
@@ -359,7 +368,7 @@ codexbridge.Binding{
 }
 ```
 
-其中 `PromptMeta` 第一版可以不填；如果后续希望 Codex 知道消息来自飞书，可以注入 `channel`、`chat_type`、`bot_id` 等元信息。
+`PromptMeta` 用于给 Codex prompt 附加来源信息。Feishu 路径可以注入 `channel=feishu`，并在需要时加入 `chat_type`、`bot_id` 等元信息。
 
 ### 入站函数调用链
 
@@ -402,11 +411,8 @@ acp.PromptRequest{
 | --- | --- | --- |
 | `app_id` | `feishu.AppConfig.AppID` | 创建飞书 WS client |
 | `app_secret` | `feishu.AppConfig.AppSecret` | 创建飞书 WS client |
-| `domain` | `Options.IsLark` | 选择飞书或 Lark 域名 |
-| `verification_token` | 后续可扩展 | 事件校验 |
-| `encrypt_key` | 后续可扩展 | 事件解密 |
 
-启动 WebSocket 前建议先调用 bot info API 获取当前 bot 的 `open_id`，并在内存中缓存：
+启动 WebSocket 前调用 bot info API 获取当前 bot 的 `open_id`，并在内存中缓存：
 
 ```text
 resolveBotOpenID(app)
@@ -426,12 +432,12 @@ resolveBotOpenID(app)
 | `event.message.message_id` | 映射为 `BotEvent.MessageID` |
 | `event.message.chat_id` | 映射为 `BotEvent.RoomID` |
 | `event.message.chat_type` | 映射为 `BotEvent.ChatType` |
-| `event.message.message_type` | 判断是否支持，第一版建议只处理 `text` |
+| `event.message.message_type` | 判断消息类型 |
 | `event.message.content` | 解析文本内容 |
 | `event.message.mentions` | mention 判断和 `BotEvent.Mentions` |
 | `event.sender.sender_id.open_id` | 忽略 bot 自己发出的消息，记录用户来源 |
 
-群聊过滤建议：
+群聊过滤：
 
 ```text
 如果 chat_type != group -> 接收
@@ -463,9 +469,9 @@ codex runtime 输出 session events
 | `receive_id` | `req.RoomID` |
 | `msg_type` | `text` |
 | `content` | `{"text": req.Text}` |
-| `uuid` | 可选，建议使用稳定请求 ID 做幂等 |
+| `uuid` | 使用稳定请求 ID 做幂等 |
 
-第一版 `SendMessage` 示例：
+`SendMessage` 示例：
 
 ```go
 req := larkim.NewCreateMessageReqBuilder().
@@ -499,7 +505,7 @@ codexbridge.SendMessageResponse{
 | mentions | `Mentions` |
 | thread/root message | `ThreadRootID` / `ThreadContext` |
 
-群聊中建议沿用 PicoClaw 的处理语义：
+群聊中沿用 PicoClaw 的处理语义：
 
 - 支持只响应 @bot 的消息
 - 收到消息后去除 bot mention
@@ -514,10 +520,8 @@ codexbridge.SendMessageResponse{
 | --- | --- |
 | `RoomID` | `receive_id`，类型为 `chat_id` |
 | `Text` | message content |
-| `ThreadRootID` | thread/reply 目标，按飞书能力补齐 |
-| `MessageID` | activity/update 场景可映射为编辑或补充消息 |
-
-第一版可以只支持文本回复；后续再补 interactive card、消息编辑、占位消息和 reasoning/activity 消息。
+| `ThreadRootID` | thread/reply 目标 |
+| `MessageID` | activity/update 场景中的消息 ID |
 
 ## 与 PicoClaw 方案的对齐关系
 
@@ -545,12 +549,11 @@ Codex:
 
 Codex 插件或 MCP server 更适合作为会话内工具，例如查询飞书消息、发送飞书消息、查询用户信息等。它们不适合作为飞书 WebSocket 的常驻入站网关，因为飞书事件到达时仍然需要有一个外部进程接住事件并触发 Codex turn。
 
-因此，推荐：
+因此，设计为：
 
 ```text
 飞书入站和出站适配：放在 CSGClaw server
 Codex 推理和执行：继续走 ACP
-可选飞书工具能力：后续再通过 MCP/插件暴露给 Codex
 ```
 
 ## 实施步骤
@@ -561,10 +564,10 @@ Codex 推理和执行：继续走 ACP
 4. 将飞书消息事件转换为 `codexbridge.BotEvent`。
 5. 在 `SendMessage` 中调用飞书 REST message create API。
 6. 修改 Codex bridge manager，根据 agent/channel 选择 bot client。
-7. 为配置 reload、WebSocket 重连、消息去重和群聊 mention 过滤补测试。
+7. 为配置 reload、WebSocket 重连、消息去重和群聊 mention 过滤增加测试。
 
 ## 最终结论
 
-PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入建议由 CSGClaw server 代 Codex 连飞书。
+PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入由 CSGClaw server 代 Codex 连飞书。
 
 这样可以复用现有 Codex ACP bridge，不需要修改 Codex runtime，也不需要新增一套 Codex 专用 HTTP API。CSGClaw server 内部新增 Feishu-backed `BotClient` 即可完成协议适配。

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -20,9 +20,9 @@ flowchart LR
     AgentLoop[PicoClaw AgentLoop]
     CSGClaw[CSGClaw LLM/API]
 
-    Feishu <-->|WebSocket 入站 / REST 出站| FeishuChannel
-    FeishuChannel <-->|InboundMessage / OutboundMessage| MessageBus
-    MessageBus <-->|消费 / 发布| AgentLoop
+    Feishu <-->|WebSocket 入站和 REST 出站| FeishuChannel
+    FeishuChannel <-->|InboundMessage 和 OutboundMessage| MessageBus
+    MessageBus <-->|消费和发布| AgentLoop
     AgentLoop <-->|LLM API| CSGClaw
 ```
 
@@ -30,17 +30,17 @@ flowchart LR
 
 ```mermaid
 sequenceDiagram
-    participant Feishu as 飞书平台<br/>群聊/私聊
-    participant Channel as PicoClaw 程序<br/>FeishuChannel
-    participant Bus as PicoClaw 程序<br/>MessageBus
-    participant Agent as PicoClaw 程序<br/>AgentLoop
+    participant Feishu as 飞书平台 群聊私聊
+    participant Channel as PicoClaw FeishuChannel
+    participant Bus as PicoClaw MessageBus
+    participant Agent as PicoClaw AgentLoop
 
-    Feishu->>Channel: WebSocket: im.message.receive_v1
-    Channel->>Channel: handleMessageReceive(event)
-    Channel->>Channel: 解析 text / mention / chat_id
-    Channel->>Bus: PublishInbound(bus.InboundMessage)
-    Bus-->>Agent: InboundChan()
-    Agent->>Agent: processMessage(ctx, msg)
+    Feishu->>Channel: WebSocket im.message.receive_v1
+    Channel->>Channel: handleMessageReceive event
+    Channel->>Channel: 解析 text mention chat_id
+    Channel->>Bus: PublishInbound InboundMessage
+    Bus-->>Agent: InboundChan
+    Agent->>Agent: processMessage ctx msg
 ```
 
 关键模块：
@@ -58,17 +58,17 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Agent as PicoClaw 程序<br/>AgentLoop
-    participant Bus as PicoClaw 程序<br/>MessageBus
-    participant Manager as PicoClaw 程序<br/>ChannelManager
-    participant Channel as PicoClaw 程序<br/>FeishuChannel
-    participant Feishu as 飞书平台<br/>群聊/私聊
+    participant Agent as PicoClaw AgentLoop
+    participant Bus as PicoClaw MessageBus
+    participant Manager as PicoClaw ChannelManager
+    participant Channel as PicoClaw FeishuChannel
+    participant Feishu as 飞书平台 群聊私聊
 
-    Agent->>Bus: PublishOutbound(bus.OutboundMessage)
-    Bus-->>Manager: OutboundChan()
-    Manager->>Channel: dispatchOutbound(msg)
-    Channel->>Channel: Send(ctx, msg)
-    Channel->>Feishu: REST: message create(chat_id, content)
+    Agent->>Bus: PublishOutbound OutboundMessage
+    Bus-->>Manager: OutboundChan
+    Manager->>Channel: dispatchOutbound msg
+    Channel->>Channel: Send ctx msg
+    Channel->>Feishu: REST message create chat_id content
     Feishu-->>Channel: message_id
 ```
 
@@ -134,7 +134,9 @@ CSGClaw server
 
 ```mermaid
 flowchart LR
-    Feishu[飞书 WebSocket] -. 当前缺少 .-> CSGClaw[CSGClaw server]
+    Feishu[飞书 WebSocket]
+    CSGClaw[CSGClaw server 当前缺少入口]
+    Feishu -.-> CSGClaw
 ```
 
 也就是说，CSGClaw server 当前不是飞书实时群聊消息入口。
@@ -150,46 +152,46 @@ flowchart LR
     CodexBridge[CSGClaw codexbridge]
     CodexRuntime[Codex ACP runtime]
 
-    Feishu <-->|WebSocket 入站 / REST 出站| FeishuClient
-    FeishuClient <-->|BotEvent / SendMessageRequest| CodexBridge
-    CodexBridge <-->|ACP Prompt / session events| CodexRuntime
+    Feishu <-->|WebSocket 入站和 REST 出站| FeishuClient
+    FeishuClient <-->|BotEvent 和 SendMessageRequest| CodexBridge
+    CodexBridge <-->|ACP Prompt 和 session events| CodexRuntime
 ```
 
 ### 入站消息流
 
 ```mermaid
 sequenceDiagram
-    participant Feishu as 飞书平台<br/>群聊/私聊
-    participant Client as CSGClaw server<br/>FeishuCodexClient
-    participant Bridge as CSGClaw server<br/>codexbridge.Service
-    participant Session as CSGClaw server<br/>Codex SessionManager
-    participant Codex as Codex 进程<br/>ACP runtime
+    participant Feishu as 飞书平台 群聊私聊
+    participant Client as CSGClaw FeishuCodexClient
+    participant Bridge as CSGClaw codexbridge Service
+    participant Session as CSGClaw Codex SessionManager
+    participant Codex as Codex ACP runtime
 
-    Feishu->>Client: WebSocket: im.message.receive_v1
-    Client->>Client: mapMessageEvent(event)
-    Client->>Bridge: StreamEvents(botID) -> BotEvent
-    Bridge->>Bridge: enqueue / dedupe
-    Bridge->>Session: EnsureSession(runtimeID, conversationKey)
+    Feishu->>Client: WebSocket im.message.receive_v1
+    Client->>Client: mapMessageEvent event
+    Client->>Bridge: StreamEvents botID returns BotEvent
+    Bridge->>Bridge: enqueue dedupe
+    Bridge->>Session: EnsureSession runtimeID conversationKey
     Session-->>Bridge: sessionID
-    Bridge->>Codex: ACP PromptRequest(sessionID, text)
-    Codex-->>Bridge: ACP PromptResponse / session events
+    Bridge->>Codex: ACP PromptRequest sessionID text
+    Codex-->>Bridge: ACP PromptResponse session events
 ```
 
 ### 出站消息流
 
 ```mermaid
 sequenceDiagram
-    participant Codex as Codex 进程<br/>ACP runtime
-    participant Sink as CSGClaw server<br/>Codex EventSink
-    participant Bridge as CSGClaw server<br/>codexbridge.Service
-    participant Client as CSGClaw server<br/>FeishuCodexClient
-    participant Feishu as 飞书平台<br/>群聊/私聊
+    participant Codex as Codex ACP runtime
+    participant Sink as CSGClaw Codex EventSink
+    participant Bridge as CSGClaw codexbridge Service
+    participant Client as CSGClaw FeishuCodexClient
+    participant Feishu as 飞书平台 群聊私聊
 
     Codex->>Sink: ACP session events
-    Sink-->>Bridge: Subscribe(runtimeID)
+    Sink-->>Bridge: Subscribe runtimeID
     Bridge->>Bridge: TurnRenderer 汇总文本
-    Bridge->>Client: SendMessage(botID, SendMessageRequest)
-    Client->>Feishu: REST: message create(chat_id, text)
+    Bridge->>Client: SendMessage botID request
+    Client->>Feishu: REST message create chat_id text
     Feishu-->>Client: message_id
     Client-->>Bridge: SendMessageResponse
 ```
@@ -393,18 +395,18 @@ sequenceDiagram
     participant Bridge as codexbridge.Service
     participant Agent as agent.Service
 
-    Serve->>Feishu: buildFeishuComponents(configPath)
-    Feishu->>Feishu: feishu.NewProvider(store)
-    Feishu->>Feishu: feishu.NewServiceWithProvider(provider)
-    Serve->>Manager: newCodexBridgeManager(cfg, agentService)
-    Manager->>Runtime: Runtime(KindCodex)
-    Manager->>Runtime: EventSink()
-    Manager->>Manager: New HTTPClient / FeishuCodexClient / RoutingClient
-    Manager->>Bridge: NewService(RoutingClient, SessionManager, EventSink)
-    Serve->>Bridge: Start()
-    Bridge->>Agent: List()
-    Bridge->>Runtime: ensureSession(agent)
-    Bridge->>Bridge: StartBot(Binding)
+    Serve->>Feishu: buildFeishuComponents configPath
+    Feishu->>Feishu: feishu.NewProvider store
+    Feishu->>Feishu: feishu.NewServiceWithProvider provider
+    Serve->>Manager: newCodexBridgeManager cfg agentService
+    Manager->>Runtime: Runtime KindCodex
+    Manager->>Runtime: EventSink
+    Manager->>Manager: New HTTPClient FeishuCodexClient RoutingClient
+    Manager->>Bridge: NewService RoutingClient SessionManager EventSink
+    Serve->>Bridge: Start
+    Bridge->>Agent: List
+    Bridge->>Runtime: ensureSession agent
+    Bridge->>Bridge: StartBot Binding
 ```
 
 `Binding` 参数：
@@ -426,29 +428,29 @@ codexbridge.Binding{
 
 ```mermaid
 sequenceDiagram
-    participant Bridge as CSGClaw server<br/>codexbridge.Service
-    participant Worker as CSGClaw server<br/>bridge worker
-    participant Router as CSGClaw server<br/>RoutingClient
-    participant Client as CSGClaw server<br/>FeishuCodexClient
-    participant Provider as CSGClaw server<br/>feishu.Provider
-    participant LarkWS as CSGClaw server<br/>larkws.Client
-    participant Session as CSGClaw server<br/>SessionManager
-    participant Codex as Codex 进程<br/>ACP runtime
+    participant Bridge as CSGClaw codexbridge Service
+    participant Worker as CSGClaw bridge worker
+    participant Router as CSGClaw RoutingClient
+    participant Client as CSGClaw FeishuCodexClient
+    participant Provider as CSGClaw feishu Provider
+    participant LarkWS as CSGClaw larkws Client
+    participant Session as CSGClaw SessionManager
+    participant Codex as Codex ACP runtime
 
-    Bridge->>Worker: StartBot(Binding)
-    Worker->>Router: StreamEvents(botID, lastEventID)
-    Router->>Client: StreamEvents(botID, lastEventID)
-    Client->>Provider: BotConfig(botID)
-    Provider-->>Client: AppConfig(app_id, app_secret)
-    Client->>Client: resolveBotOpenID(app)
-    Client->>LarkWS: NewClient(app_id, app_secret, handler)
-    LarkWS-->>Client: OnP2MessageReceiveV1(event)
-    Client->>Client: mapMessageEvent(event)
+    Bridge->>Worker: StartBot Binding
+    Worker->>Router: StreamEvents botID lastEventID
+    Router->>Client: StreamEvents botID lastEventID
+    Client->>Provider: BotConfig botID
+    Provider-->>Client: AppConfig app_id app_secret
+    Client->>Client: resolveBotOpenID app
+    Client->>LarkWS: NewClient app_id app_secret handler
+    LarkWS-->>Client: OnP2MessageReceiveV1 event
+    Client->>Client: mapMessageEvent event
     Client-->>Worker: BotEvent
-    Worker->>Worker: enqueue / accept / dedupe
-    Worker->>Session: EnsureSession(runtimeID, conversationKey)
+    Worker->>Worker: enqueue accept dedupe
+    Worker->>Session: EnsureSession runtimeID conversationKey
     Session-->>Worker: sessionID
-    Worker->>Codex: Prompt(acp.PromptRequest)
+    Worker->>Codex: Prompt acp PromptRequest
 ```
 
 `acp.PromptRequest` 的关键参数：
@@ -510,23 +512,23 @@ resolveBotOpenID(app)
 
 ```mermaid
 sequenceDiagram
-    participant Codex as Codex 进程<br/>ACP runtime
-    participant Events as CSGClaw server<br/>EventSink
-    participant Worker as CSGClaw server<br/>bridge worker
-    participant Router as CSGClaw server<br/>RoutingClient
-    participant Client as CSGClaw server<br/>FeishuCodexClient
-    participant Provider as CSGClaw server<br/>feishu.Provider
-    participant Feishu as 飞书平台<br/>REST API
+    participant Codex as Codex ACP runtime
+    participant Events as CSGClaw EventSink
+    participant Worker as CSGClaw bridge worker
+    participant Router as CSGClaw RoutingClient
+    participant Client as CSGClaw FeishuCodexClient
+    participant Provider as CSGClaw feishu Provider
+    participant Feishu as 飞书平台 REST API
 
     Codex->>Events: ACP session events
-    Events-->>Worker: Subscribe(runtimeID)
-    Worker->>Worker: TurnRenderer.RenderActivity / ApplyText
+    Events-->>Worker: Subscribe runtimeID
+    Worker->>Worker: TurnRenderer RenderActivity ApplyText
     Worker->>Worker: flushTurn
-    Worker->>Router: SendMessage(botID, req)
-    Router->>Client: SendMessage(botID, req)
-    Client->>Provider: BotConfig(botID)
-    Provider-->>Client: AppConfig(app_id, app_secret)
-    Client->>Feishu: message create(chat_id, text)
+    Worker->>Router: SendMessage botID req
+    Router->>Client: SendMessage botID req
+    Client->>Provider: BotConfig botID
+    Provider-->>Client: AppConfig app_id app_secret
+    Client->>Feishu: message create chat_id text
     Feishu-->>Client: message_id
     Client-->>Worker: SendMessageResponse
 ```
@@ -602,7 +604,7 @@ flowchart LR
         PChannel[PicoClaw Feishu Channel]
         PBus[MessageBus]
         PAgent[AgentLoop]
-        PFeishu <-->|WS / REST| PChannel
+        PFeishu <-->|WS 和 REST| PChannel
         PChannel <--> PBus
         PBus <--> PAgent
     end
@@ -612,7 +614,7 @@ flowchart LR
         CClient[CSGClaw FeishuCodexClient]
         CBridge[CodexBridge]
         CACP[Codex ACP runtime]
-        CFeishu <-->|WS / REST| CClient
+        CFeishu <-->|WS 和 REST| CClient
         CClient <--> CBridge
         CBridge <-->|ACP| CACP
     end

--- a/docs/channel/codex-feishu.zh.md
+++ b/docs/channel/codex-feishu.zh.md
@@ -143,17 +143,19 @@ flowchart LR
 
 ## Codex 对接飞书推荐方案
 
-Codex 不直接连接飞书。推荐由 CSGClaw server 代表 Codex 连接飞书：
+Codex 不直接连接飞书，`codexbridge` 也不直接持有飞书 SDK client。飞书协议连接由 `internal/channel/feishu` 统一持有；Codex 只通过一个 Feishu-to-Codex bridge client 消费抽象事件并发送抽象回复。
 
 ```mermaid
 flowchart LR
     Feishu[飞书]
-    FeishuClient[CSGClaw FeishuCodexClient]
+    FeishuService[CSGClaw internal channel feishu]
+    FeishuAdapter[CSGClaw feishu codexbridgeclient]
     CodexBridge[CSGClaw codexbridge]
     CodexRuntime[Codex ACP runtime]
 
-    Feishu <-->|WebSocket 入站和 REST 出站| FeishuClient
-    FeishuClient <-->|BotEvent 和 SendMessageRequest| CodexBridge
+    Feishu <-->|WebSocket 入站和 REST 出站| FeishuService
+    FeishuService <-->|MessageEvent 和 SendMessage| FeishuAdapter
+    FeishuAdapter <-->|BotEvent 和 SendMessageRequest| CodexBridge
     CodexBridge <-->|ACP Prompt 和 session events| CodexRuntime
 ```
 
@@ -162,14 +164,20 @@ flowchart LR
 ```mermaid
 sequenceDiagram
     participant Feishu as 飞书平台 群聊私聊
-    participant Client as CSGClaw FeishuCodexClient
+    participant Service as CSGClaw feishu Service
+    participant Bus as CSGClaw feishu MessageBus
+    participant Adapter as CSGClaw feishu codexbridgeclient
     participant Bridge as CSGClaw codexbridge Service
     participant Session as CSGClaw Codex SessionManager
     participant Codex as Codex ACP runtime
 
-    Feishu->>Client: WebSocket im.message.receive_v1
-    Client->>Client: mapMessageEvent event
-    Client->>Bridge: StreamEvents botID returns BotEvent
+    Adapter->>Bus: Subscribe channel botID
+    Feishu->>Service: WebSocket im.message.receive_v1
+    Service->>Service: parse text mention chat_id open_id
+    Service->>Bus: Publish MessageEvent
+    Bus-->>Adapter: MessageEvent
+    Adapter->>Adapter: map to BotEvent no thread
+    Adapter-->>Bridge: StreamEvents returns BotEvent
     Bridge->>Bridge: enqueue dedupe
     Bridge->>Session: EnsureSession runtimeID conversationKey
     Session-->>Bridge: sessionID
@@ -184,96 +192,101 @@ sequenceDiagram
     participant Codex as Codex ACP runtime
     participant Sink as CSGClaw Codex EventSink
     participant Bridge as CSGClaw codexbridge Service
-    participant Client as CSGClaw FeishuCodexClient
+    participant Adapter as CSGClaw feishu codexbridgeclient
+    participant Service as CSGClaw feishu Service
     participant Feishu as 飞书平台 群聊私聊
 
     Codex->>Sink: ACP session events
     Sink-->>Bridge: Subscribe runtimeID
     Bridge->>Bridge: TurnRenderer 汇总文本
-    Bridge->>Client: SendMessage botID request
-    Client->>Feishu: REST message create chat_id text
-    Feishu-->>Client: message_id
-    Client-->>Bridge: SendMessageResponse
+    Bridge->>Adapter: SendMessage botID request
+    Adapter->>Service: SendMessage roomID senderID content
+    Service->>Feishu: REST message create chat_id text uuid
+    Feishu-->>Service: message_id
+    Service-->>Adapter: im.Message
+    Adapter-->>Bridge: SendMessageResponse
 ```
 
-### 新增模块
+### 新增和调整模块
+
+`internal/channel/feishu` 继续作为飞书 channel 的协议所有者：
+
+- 持有 `feishu.Provider` 和 `channels/feishu.toml` 中的 `app_id`、`app_secret`。
+- 持有飞书 WebSocket listener、REST sender、bot open_id cache。
+- 处理配置 reload、WebSocket 重连、消息去重、自触发规避。
+- 对外提供事件订阅和发送能力，例如 `MessageBus()`、`SendMessage(req im.CreateMessageRequest)`、`ResolveBotOpenID(ctx, botID)`。
 
 新增：
 
 ```text
-internal/channel/feishu/codexclient
+internal/channel/feishu/codexbridgeclient
 ```
 
-该模块实现现有的 `codexbridge.BotClient` 接口：
+该模块实现现有的 `codexbridge.BotClient` 接口，但不直接创建飞书 WebSocket client，也不直接调用飞书 REST API：
 
 ```go
-type BotClient interface {
-    StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan BotEvent, <-chan error)
-    SendMessage(ctx context.Context, botID string, req SendMessageRequest) (SendMessageResponse, error)
+type FeishuChannel interface {
+    MessageBus() *feishu.MessageBus
+    SendMessage(req im.CreateMessageRequest) (im.Message, error)
+    ResolveBotOpenID(ctx context.Context, botID string) (string, string, error)
 }
+
+type Client struct {
+    Feishu     FeishuChannel
+    MentionOnly bool
+    QueueSize   int
+}
+
+func (c *Client) StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan codexbridge.BotEvent, <-chan error)
+func (c *Client) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
 ```
 
-其中：
+`StreamEvents` 只订阅 Feishu channel 事件并做模型转换：
 
 ```text
-StreamEvents
-  = 飞书 WebSocket 入站
-  = 飞书 message event -> codexbridge.BotEvent
-
-SendMessage
-  = 飞书 REST 出站
-  = codexbridge.SendMessageRequest -> 飞书 message create
+feishu.MessageEvent
+  -> codexbridge.BotEvent
 ```
 
-为同时支持 CSGClaw 本地 IM 和 Feishu 两种 Codex bot，增加一个轻量路由 client：
+`SendMessage` 只把 Codex 回复转换为 Feishu channel 的发送请求：
 
 ```text
-internal/channel/codexbridge/routing_client.go
+codexbridge.SendMessageRequest
+  -> im.CreateMessageRequest
+  -> feishu.Service.SendMessage
 ```
 
-它仍然实现 `codexbridge.BotClient`，按 `botID` 选择真实 client：
+### Channel 路由
+
+路由依据是 bot 记录上的 `Channel`，不是 `feishu.Provider.BotConfig(botID)` 是否存在。`app_id`、`app_secret` 只能说明某个 bot 有飞书凭证，不能说明某个 Codex bridge worker 应该消费哪个 channel。
+
+CSGClaw 已有 channel-scoped bot 模型：
 
 ```go
-type RoutingClient struct {
-    Local  codexbridge.BotClient
-    Feishu codexbridge.BotClient
-    Route  func(botID string) string
+type Bot struct {
+    ID      string
+    Channel string
+    AgentID string
 }
-
-func (c *RoutingClient) StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan codexbridge.BotEvent, <-chan error)
-func (c *RoutingClient) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
 ```
 
-路由规则：
-
-```text
-如果 feishu.Provider.BotConfig(botID) 存在 -> 使用 FeishuCodexClient
-否则 -> 使用现有 codexbridge.HTTPClient
-```
-
-这样 `codexbridge.Service` 仍然只依赖一个 `BotClient`，不用改动 Codex ACP 主流程。
-
-## 核心字段模型
-
-### 现有 Feishu 配置模型
-
-CSGClaw 已有飞书配置 provider：
+Codex bridge manager 启动 worker 时应解析对应 bot record，并把 channel 写入 binding：
 
 ```go
-type BotCredentialProvider interface {
-    BotConfig(botID string) (AppConfig, bool)
-}
-
-type AppConfig struct {
-    AppID       string
-    AppSecret   string
-    AdminOpenID string
+type Binding struct {
+    Channel   string
+    BotID     string
+    RuntimeID string
+    SessionID string
+    PromptMeta map[string]any
 }
 ```
 
-`FeishuCodexClient` 通过 `BotConfig(botID)` 获取该 bot 对应的飞书凭证。
+worker key 使用 `channel + "\x00" + botID`，避免同一个 bot ID 同时绑定 `csgclaw` 和 `feishu` 时互相覆盖。`PromptMeta.channel` 使用真实 channel，例如 `feishu` 或 `csgclaw`。
 
-当前 `channels/feishu.toml` 中与 Codex 飞书桥接相关的字段是：
+### 核心字段模型
+
+当前 `channels/feishu.toml` 中与飞书 channel 相关的字段是：
 
 ```toml
 [global]
@@ -284,11 +297,9 @@ app_id = "cli_xxx"
 app_secret = "xxx"
 ```
 
-`app_id` 和 `app_secret` 用于创建飞书 SDK client、WebSocket client，以及调用飞书 REST API。`admin_open_id` 保持现有管理语义，Codex 飞书消息桥接不依赖该字段处理普通群聊收发。
+`app_id` 和 `app_secret` 由 `internal/channel/feishu` 使用，用于创建飞书 SDK client、WebSocket listener 和 REST sender。`codexbridgeclient` 不直接读取配置文件，也不直接持有 app 凭证。
 
-### 现有 Codex bridge 入站模型
-
-Codex bridge 已经定义了入站事件：
+Codex bridge 的入站事件模型保持不变：
 
 ```go
 type BotEvent struct {
@@ -302,19 +313,19 @@ type BotEvent struct {
 }
 ```
 
-字段含义：
+Feishu 路径的字段使用：
 
-| 字段 | 含义 |
+| 字段 | Feishu 路径含义 |
 | --- | --- |
-| `MessageID` | 外部平台消息 ID，用于去重和 `Last-Event-ID` |
-| `RoomID` | 会话 ID；飞书中对应 `chat_id` |
-| `ChatType` | `p2p` 或 `group` |
-| `Text` | 送给 Codex 的用户文本，群聊中应去掉 bot mention |
-| `Mentions` | 被 mention 的用户或 bot ID 列表 |
-| `ThreadRootID` | thread/reply 根消息 ID |
-| `ThreadContext` | 首次进入 thread 时注入给 Codex 的上下文 |
+| `MessageID` | 飞书 `message_id`，用于本地去重 |
+| `RoomID` | 飞书 `chat_id` |
+| `ChatType` | 飞书 chat type，映射为 `p2p` 或 `group` |
+| `Text` | 送给 Codex 的文本，群聊中去掉 bot mention |
+| `Mentions` | 飞书 mentions |
+| `ThreadRootID` | 不映射，保持空值 |
+| `ThreadContext` | 不映射，保持 nil |
 
-### 现有 Codex bridge 出站模型
+Codex bridge 的出站模型保持不变：
 
 ```go
 type SendMessageRequest struct {
@@ -323,277 +334,102 @@ type SendMessageRequest struct {
     MessageID    string
     ThreadRootID string
 }
-
-type SendMessageResponse struct {
-    MessageID string
-}
 ```
 
-字段含义：
+Feishu 路径的出站字段使用：
 
-| 字段 | 含义 |
+| Codex bridge 字段 | Feishu channel 字段 |
 | --- | --- |
-| `RoomID` | 目标会话；飞书中对应 `chat_id` |
-| `Text` | Codex 要发送的内容 |
-| `MessageID` | activity/update 场景中的消息 ID |
-| `ThreadRootID` | thread/reply 目标 |
+| `RoomID` | `im.CreateMessageRequest.RoomID`，对应飞书 `chat_id` |
+| `Text` | `im.CreateMessageRequest.Content` |
+| `MessageID` | 不映射 |
+| `ThreadRootID` | 不映射 |
 
-### 新增 FeishuCodexClient 模型
+Feishu 路径不支持 thread/reply 映射，和 PicoClaw 当前行为保持一致：回复统一作为普通 `chat_id` 消息发送，不调用飞书 reply/thread API，也不注入 `ThreadContext`。
 
-模型：
+### 函数流程设计
 
-```go
-type Options struct {
-    Provider    feishu.BotCredentialProvider
-    MentionOnly bool
-    QueueSize   int
-    Logger      *slog.Logger
-}
-
-type Client struct {
-    provider    feishu.BotCredentialProvider
-    mentionOnly bool
-    queueSize   int
-    logger      *slog.Logger
-}
-
-func New(options Options) *Client
-```
-
-`Client` 实现：
-
-```go
-func (c *Client) StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan codexbridge.BotEvent, <-chan error)
-
-func (c *Client) SendMessage(ctx context.Context, botID string, req codexbridge.SendMessageRequest) (codexbridge.SendMessageResponse, error)
-```
-
-内部可以拆成几个小函数，便于测试：
-
-```go
-func (c *Client) appConfig(botID string) (feishu.AppConfig, error)
-func (c *Client) resolveBotOpenID(ctx context.Context, app feishu.AppConfig) (string, error)
-func (c *Client) startWebSocket(ctx context.Context, botID string, app feishu.AppConfig, events chan<- codexbridge.BotEvent) error
-func (c *Client) handleMessageReceive(botID string, botOpenID string, events chan<- codexbridge.BotEvent) func(context.Context, *larkim.P2MessageReceiveV1) error
-func (c *Client) mapMessageEvent(botID string, botOpenID string, event *larkim.P2MessageReceiveV1) (codexbridge.BotEvent, bool)
-func (c *Client) shouldAccept(event codexbridge.BotEvent, botOpenID string) bool
-func (c *Client) stripBotMention(text string, botOpenID string) string
-```
-
-## 函数流程设计
-
-### Server 启动流程
-
-当前 Codex bridge manager 在 `newCodexBridgeManager` 中创建 `codexbridge.Service`。接入飞书后，推荐流程如下：
+Server 启动流程：
 
 ```mermaid
 sequenceDiagram
     participant Serve as serve.Start
     participant Feishu as buildFeishuComponents
     participant Manager as newCodexBridgeManager
+    participant Bots as bot.Service
     participant Runtime as Codex runtime
     participant Bridge as codexbridge.Service
-    participant Agent as agent.Service
 
     Serve->>Feishu: buildFeishuComponents configPath
     Feishu->>Feishu: feishu.NewProvider store
     Feishu->>Feishu: feishu.NewServiceWithProvider provider
-    Serve->>Manager: newCodexBridgeManager cfg agentService
+    Serve->>Manager: newCodexBridgeManager cfg agentService botService feishuService
     Manager->>Runtime: Runtime KindCodex
     Manager->>Runtime: EventSink
-    Manager->>Manager: New HTTPClient FeishuCodexClient RoutingClient
-    Manager->>Bridge: NewService RoutingClient SessionManager EventSink
-    Serve->>Bridge: Start
-    Bridge->>Agent: List
-    Bridge->>Runtime: ensureSession agent
-    Bridge->>Bridge: StartBot Binding
+    Manager->>Manager: New local HTTPClient
+    Manager->>Manager: New feishu codexbridgeclient
+    Manager->>Bridge: NewService per channel
+    Manager->>Bots: resolve bot records by channel
+    Bridge->>Bridge: StartBot Binding with channel
 ```
 
-`Binding` 参数：
-
-```go
-codexbridge.Binding{
-    BotID:     a.ID,
-    RuntimeID: strings.TrimSpace(a.RuntimeID),
-    SessionID: session.SessionID,
-    PromptMeta: map[string]any{
-        "channel": "feishu",
-    },
-}
-```
-
-`PromptMeta` 用于给 Codex prompt 附加来源信息。Feishu 路径可以注入 `channel=feishu`，并在需要时加入 `chat_type`、`bot_id` 等元信息。
-
-### 入站函数调用链
+入站函数调用链：
 
 ```mermaid
 sequenceDiagram
-    participant Bridge as CSGClaw codexbridge Service
-    participant Worker as CSGClaw bridge worker
-    participant Router as CSGClaw RoutingClient
-    participant Client as CSGClaw FeishuCodexClient
-    participant Provider as CSGClaw feishu Provider
-    participant LarkWS as CSGClaw larkws Client
+    participant Service as CSGClaw feishu Service
+    participant Bus as CSGClaw feishu MessageBus
+    participant Adapter as CSGClaw feishu codexbridgeclient
+    participant Bridge as CSGClaw codexbridge worker
     participant Session as CSGClaw SessionManager
     participant Codex as Codex ACP runtime
 
-    Bridge->>Worker: StartBot Binding
-    Worker->>Router: StreamEvents botID lastEventID
-    Router->>Client: StreamEvents botID lastEventID
-    Client->>Provider: BotConfig botID
-    Provider-->>Client: AppConfig app_id app_secret
-    Client->>Client: resolveBotOpenID app
-    Client->>LarkWS: NewClient app_id app_secret handler
-    LarkWS-->>Client: OnP2MessageReceiveV1 event
-    Client->>Client: mapMessageEvent event
-    Client-->>Worker: BotEvent
-    Worker->>Worker: enqueue accept dedupe
-    Worker->>Session: EnsureSession runtimeID conversationKey
-    Session-->>Worker: sessionID
-    Worker->>Codex: Prompt acp PromptRequest
+    Bridge->>Adapter: StreamEvents botID lastEventID
+    Adapter->>Bus: Subscribe
+    Service->>Bus: Publish MessageEvent
+    Bus-->>Adapter: MessageEvent
+    Adapter->>Adapter: filter channel botID mention dedupe
+    Adapter-->>Bridge: BotEvent
+    Bridge->>Session: EnsureSession runtimeID conversationKey
+    Session-->>Bridge: sessionID
+    Bridge->>Codex: Prompt acp PromptRequest
 ```
 
-`acp.PromptRequest` 的关键参数：
-
-```go
-acp.PromptRequest{
-    SessionId: acp.SessionId(sessionID),
-    Prompt: []acp.ContentBlock{
-        acp.TextBlock(event.Text),
-    },
-    Meta: binding.PromptMeta,
-}
-```
-
-### 飞书入站接口参数
-
-飞书 WebSocket client 参数：
-
-| 参数 | 来源 | 用途 |
-| --- | --- | --- |
-| `app_id` | `feishu.AppConfig.AppID` | 创建飞书 WS client |
-| `app_secret` | `feishu.AppConfig.AppSecret` | 创建飞书 WS client |
-
-启动 WebSocket 前调用 bot info API 获取当前 bot 的 `open_id`，并在内存中缓存：
-
-```text
-resolveBotOpenID(app)
-  -> 飞书 bot info API
-  -> botOpenID
-```
-
-`botOpenID` 用于两件事：
-
-- 群聊 mention 判断
-- 忽略 bot 自己发送的消息，避免自触发循环
-
-飞书消息事件中需要读取的字段：
-
-| Feishu 事件字段 | 用途 |
-| --- | --- |
-| `event.message.message_id` | 映射为 `BotEvent.MessageID` |
-| `event.message.chat_id` | 映射为 `BotEvent.RoomID` |
-| `event.message.chat_type` | 映射为 `BotEvent.ChatType` |
-| `event.message.message_type` | 判断消息类型 |
-| `event.message.content` | 解析文本内容 |
-| `event.message.mentions` | mention 判断和 `BotEvent.Mentions` |
-| `event.sender.sender_id.open_id` | 忽略 bot 自己发出的消息，记录用户来源 |
-
-群聊过滤：
-
-```text
-如果 chat_type != group -> 接收
-如果 MentionOnly=false -> 接收
-如果 mentions 包含 bot open_id -> 接收
-否则忽略
-```
-
-### 出站函数调用链
+出站函数调用链：
 
 ```mermaid
 sequenceDiagram
     participant Codex as Codex ACP runtime
     participant Events as CSGClaw EventSink
-    participant Worker as CSGClaw bridge worker
-    participant Router as CSGClaw RoutingClient
-    participant Client as CSGClaw FeishuCodexClient
-    participant Provider as CSGClaw feishu Provider
+    participant Bridge as CSGClaw codexbridge worker
+    participant Adapter as CSGClaw feishu codexbridgeclient
+    participant Service as CSGClaw feishu Service
     participant Feishu as 飞书平台 REST API
 
     Codex->>Events: ACP session events
-    Events-->>Worker: Subscribe runtimeID
-    Worker->>Worker: TurnRenderer RenderActivity ApplyText
-    Worker->>Worker: flushTurn
-    Worker->>Router: SendMessage botID req
-    Router->>Client: SendMessage botID req
-    Client->>Provider: BotConfig botID
-    Provider-->>Client: AppConfig app_id app_secret
-    Client->>Feishu: message create chat_id text
-    Feishu-->>Client: message_id
-    Client-->>Worker: SendMessageResponse
+    Events-->>Bridge: Subscribe runtimeID
+    Bridge->>Bridge: TurnRenderer 汇总文本
+    Bridge->>Adapter: SendMessage botID req
+    Adapter->>Service: SendMessage im CreateMessageRequest
+    Service->>Feishu: message create chat_id text uuid
+    Feishu-->>Service: message_id
+    Service-->>Adapter: im.Message
+    Adapter-->>Bridge: SendMessageResponse
 ```
 
-飞书 REST 发送参数：
+### Feishu 入站和出站参数
 
-| 参数 | 值 |
-| --- | --- |
-| `receive_id_type` | `chat_id` |
-| `receive_id` | `req.RoomID` |
-| `msg_type` | `text` |
-| `content` | `{"text": req.Text}` |
-| `uuid` | 使用稳定请求 ID 做幂等 |
+飞书 WebSocket 和 REST 参数由 `internal/channel/feishu` 处理：
 
-`SendMessage` 示例：
+| 参数 | 来源 | 用途 |
+| --- | --- | --- |
+| `app_id` | `feishu.AppConfig.AppID` | 创建飞书 SDK client 和 WebSocket listener |
+| `app_secret` | `feishu.AppConfig.AppSecret` | 创建飞书 SDK client 和 WebSocket listener |
+| `chat_id` | 飞书消息事件或 `RoomID` | 入站会话和出站目标 |
+| `message_id` | 飞书消息事件或发送结果 | 本地去重和返回值 |
+| `uuid` | Feishu service 生成或传入 | 发送幂等 |
 
-```go
-req := larkim.NewCreateMessageReqBuilder().
-    ReceiveIdType(larkim.ReceiveIdTypeChatId).
-    Body(larkim.NewCreateMessageReqBodyBuilder().
-        ReceiveId(sendReq.RoomID).
-        MsgType(larkim.MsgTypeText).
-        Content(`{"text": "...escaped text..."}`).
-        Build()).
-    Build()
-```
-
-返回值：
-
-```go
-codexbridge.SendMessageResponse{
-    MessageID: feishuMessageID,
-}
-```
-
-### 事件映射
-
-飞书事件应映射为 `codexbridge.BotEvent`：
-
-| Feishu 字段 | Codex bridge 字段 |
-| --- | --- |
-| `message_id` | `MessageID` |
-| `chat_id` | `RoomID` |
-| chat type | `ChatType` |
-| text content | `Text` |
-| mentions | `Mentions` |
-| thread/root message | `ThreadRootID` / `ThreadContext` |
-
-群聊中沿用 PicoClaw 的处理语义：
-
-- 支持只响应 @bot 的消息
-- 收到消息后去除 bot mention
-- 使用 bot open_id 做可靠 mention 判断
-- 对重复事件做去重
-
-### 出站映射
-
-`codexbridge.SendMessageRequest` 应映射到飞书消息发送：
-
-| Codex bridge 字段 | Feishu 字段 |
-| --- | --- |
-| `RoomID` | `receive_id`，类型为 `chat_id` |
-| `Text` | message content |
-| `ThreadRootID` | thread/reply 目标 |
-| `MessageID` | activity/update 场景中的消息 ID |
+`lastEventID` 在 Feishu 路径中只作为本地去重参考，不表示可以从飞书 WebSocket 按 message id 恢复历史事件。
 
 ## 与 PicoClaw 方案的对齐关系
 
@@ -611,26 +447,29 @@ flowchart LR
 
     subgraph CodexPath[Codex 路径]
         CFeishu[飞书]
-        CClient[CSGClaw FeishuCodexClient]
+        CService[CSGClaw feishu Service]
+        CAdapter[feishu codexbridgeclient]
         CBridge[CodexBridge]
         CACP[Codex ACP runtime]
-        CFeishu <-->|WS 和 REST| CClient
-        CClient <--> CBridge
+        CFeishu <-->|WS 和 REST| CService
+        CService <--> CAdapter
+        CAdapter <--> CBridge
         CBridge <-->|ACP| CACP
     end
 ```
 
 | 层面 | PicoClaw | Codex 推荐方案 |
 | --- | --- | --- |
-| 飞书入站 | PicoClaw runtime 连接 WebSocket | CSGClaw server 连接 WebSocket |
-| 飞书出站 | PicoClaw runtime 调 REST | CSGClaw server 调 REST |
+| 飞书入站 | PicoClaw runtime 的 FeishuChannel 连接 WebSocket | CSGClaw 的 `internal/channel/feishu` 连接 WebSocket |
+| 飞书出站 | PicoClaw runtime 的 FeishuChannel 调 REST | CSGClaw 的 `internal/channel/feishu` 调 REST |
 | 消息抽象 | `bus.InboundMessage` | `codexbridge.BotEvent` |
 | 回复抽象 | `bus.OutboundMessage` | `codexbridge.SendMessageRequest` |
 | Agent 执行 | PicoClaw `AgentLoop` | Codex ACP runtime |
 | 配置来源 | CSGClaw `channels/feishu.toml` | CSGClaw `channels/feishu.toml` |
-| 凭证使用方 | PicoClaw runtime | CSGClaw server |
+| 凭证使用方 | PicoClaw runtime | CSGClaw `internal/channel/feishu` |
+| Thread 支持 | 暂不支持，普通 `chat_id` 发送 | 暂不支持，普通 `chat_id` 发送 |
 
-两套方案在飞书协议层面对齐：都是 WebSocket 入站、REST 出站。差异在 runtime 边界：PicoClaw 自己持有飞书连接；Codex 由 CSGClaw server 持有飞书连接。
+两套方案在飞书协议层面对齐：都是 WebSocket 入站、REST 出站；也都暂不支持飞书 thread/reply。差异在 runtime 边界：PicoClaw 自己持有飞书连接；Codex 由 CSGClaw 的 Feishu channel 持有飞书连接，`codexbridge` 只消费抽象事件。
 
 ## 为什么不放到 Codex 插件里
 
@@ -645,16 +484,17 @@ Codex 推理和执行：继续走 ACP
 
 ## 实施步骤
 
-1. 新增 `internal/channel/feishu/codexclient`，实现 `codexbridge.BotClient`。
-2. 复用 `feishu.Provider.BotConfig(botID)` 获取 `app_id` 和 `app_secret`。
-3. 在 `StreamEvents` 中为 bot 启动飞书 WebSocket client。
-4. 将飞书消息事件转换为 `codexbridge.BotEvent`。
-5. 在 `SendMessage` 中调用飞书 REST message create API。
-6. 修改 Codex bridge manager，根据 agent/channel 选择 bot client。
-7. 为配置 reload、WebSocket 重连、消息去重和群聊 mention 过滤增加测试。
+1. 扩展 `internal/channel/feishu`，让它持有飞书 WebSocket listener，并把入站消息发布到现有或扩展后的 Feishu `MessageBus`。
+2. 复用 `internal/channel/feishu/service.go` 的发送能力，保持 REST 出站、JSON content、`uuid`、bot info 和错误处理在 Feishu channel 内部。
+3. 新增 `internal/channel/feishu/codexbridgeclient`，实现 `codexbridge.BotClient`，只负责订阅 Feishu channel 事件和做模型转换。
+4. 修改 Codex bridge manager，按 bot record 的 `Channel` 选择本地 IM client 或 Feishu bridge client，不用 `BotConfig(botID)` 存在性做路由。
+5. 扩展 `codexbridge.Binding` 和 worker key，携带 `Channel`，避免同一个 bot ID 在 `csgclaw` 与 `feishu` 下冲突。
+6. 将飞书入站事件转换为 `codexbridge.BotEvent`，其中 `ThreadRootID` 保持空值，`ThreadContext` 保持 nil。
+7. 将 `codexbridge.SendMessageRequest` 转换为 `im.CreateMessageRequest`，通过 Feishu service 发送普通 `chat_id` 文本消息，忽略 `ThreadRootID`。
+8. 增加测试覆盖 channel 路由、重复 bot ID、WebSocket 生命周期、群聊 mention 过滤、`lastEventID` 本地去重，以及 thread 字段不映射。
 
 ## 最终结论
 
-PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入由 CSGClaw server 代 Codex 连飞书。
+PicoClaw 飞书接入是 runtime 自己连飞书；Codex 飞书接入由 CSGClaw 的 Feishu channel 代 Codex 连飞书。
 
-这样可以复用现有 Codex ACP bridge，不需要修改 Codex runtime，也不需要新增一套 Codex 专用 HTTP API。CSGClaw server 内部新增 Feishu-backed `BotClient` 即可完成协议适配。
+这样可以复用现有 Codex ACP bridge，不需要修改 Codex runtime，也不需要新增一套 Codex 专用 HTTP API。CSGClaw server 内部新增的是 Feishu-backed `BotClient` 适配器，不是新的飞书协议所有者；thread/reply 暂不进入本期范围，和 PicoClaw 当前行为保持一致。


### PR DESCRIPTION
Title:
docs: add codex feishu integration design

Body:
## Summary
- document the current PicoClaw Feishu message flow and module boundaries
- propose the Codex Feishu bridge architecture through CSGClaw server and ACP
- compare PicoClaw and Codex integration responsibilities and interface mappings

## Testing
- Not run; documentation-only change.