### PR TITLE
CI: Update pr-message via Conventional Commits v1.0.0 guidance

### DIFF
--- a/.github/workflows/pr-message.yml
+++ b/.github/workflows/pr-message.yml
@@ -24,18 +24,25 @@ jobs:
               .replace(/\r\n/g, "\n")
               .trim();
 
+            // Conventional Commits v1.0.0 title/header:
+            // <type>[optional scope][optional !]: <description>
             const titleRe =
-              /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9._-]+\))?!?: .+$/;
+              /^[a-z][a-z0-9-]*(\([a-z0-9._-]+\))?!?: \S.*$/i;
 
             if (!titleRe.test(title)) {
               core.setFailed(
                 [
                   "Invalid PR title.",
                   "",
-                  "Expected Conventional Commit format:",
-                  "  feat(scope): summary",
-                  "  fix(scope): summary",
-                  "  docs: summary",
+                  "Expected Conventional Commit title format:",
+                  "  <type>[optional scope][optional !]: <description>",
+                  "",
+                  "Examples:",
+                  "  feat(scope): add agent picker",
+                  "  fix(api)!: reject bad token",
+                  "  docs: update README",
+                  "",
+                  "Types are case-insensitive and custom types are allowed.",
                   "",
                   `Actual: ${title}`,
                 ].join("\n")

--- a/.github/workflows/pr-message.yml
+++ b/.github/workflows/pr-message.yml
@@ -24,10 +24,26 @@ jobs:
               .replace(/\r\n/g, "\n")
               .trim();
 
-            // Conventional Commits v1.0.0 title/header:
+            const allowedTypes = [
+              "feat",
+              "fix",
+              "docs",
+              "style",
+              "refactor",
+              "perf",
+              "test",
+              "build",
+              "ci",
+              "chore",
+              "revert",
+            ];
+
+            // Conventional Commits v1.0.0 title/header with this repo's type allowlist:
             // <type>[optional scope][optional !]: <description>
-            const titleRe =
-              /^[a-z][a-z0-9-]*(\([a-z0-9._-]+\))?!?: \S.*$/i;
+            const titleRe = new RegExp(
+              `^(${allowedTypes.join("|")})(\\([a-z0-9._-]+\\))?!?: \\S.*$`,
+              "i"
+            );
 
             if (!titleRe.test(title)) {
               core.setFailed(
@@ -37,12 +53,13 @@ jobs:
                   "Expected Conventional Commit title format:",
                   "  <type>[optional scope][optional !]: <description>",
                   "",
+                  `Allowed types: ${allowedTypes.join(", ")}`,
+                  "Type matching is case-insensitive.",
+                  "",
                   "Examples:",
                   "  feat(scope): add agent picker",
                   "  fix(api)!: reject bad token",
                   "  docs: update README",
-                  "",
-                  "Types are case-insensitive and custom types are allowed.",
                   "",
                   `Actual: ${title}`,
                 ].join("\n")


### PR DESCRIPTION
- Use https://www.conventionalcommits.org/en/v1.0.0/#summary , allow a tolerant title. If we want a definitive range of titles, I could revert line#30 with case-insensitive title matching.