### PR TITLE
docs: update agent collaboration guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
-- Title format: `<type>[optional scope][optional !]: <description>`; allowed types are feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
-- Summary: describe the behavior change and why reviewers should accept it.
-- Validation: list commands or checks you ran, or say N/A when verification is not applicable.
-- Impact: describe user-facing, compatibility, API, deployment, configuration, or documentation impact, or say N/A.
-- Related issues: link issues with Fixes #123, Closes #123, or say N/A.
-- Notes: add review context, migration notes, or say N/A.
-- Do not add `Co-authored-by:` trailers in the PR body.
+- Summary:
+- Validation:
+- Impact:
+- Related issues: N/A
+- Notes: N/A

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-- Title format: `<type>[optional scope][optional !]: <description>`; allowed types are feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
-- Summary: describe the behavior change and why reviewers should accept it.
-- Validation: list commands or checks you ran, or say N/A when verification is not applicable.
-- Impact: describe user-facing, compatibility, API, deployment, configuration, or documentation impact, or say N/A.
-- Related issues: link issues with Fixes #123, Closes #123, or say N/A.
-- Notes: add review context, migration notes, or say N/A.
-- Do not add `Co-authored-by:` trailers in the PR body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+- Title format: `<type>[optional scope][optional !]: <description>`; allowed types are feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
+- Summary: describe the behavior change and why reviewers should accept it.
+- Validation: list commands or checks you ran, or say N/A when verification is not applicable.
+- Impact: describe user-facing, compatibility, API, deployment, configuration, or documentation impact, or say N/A.
+- Related issues: link issues with Fixes #123, Closes #123, or say N/A.
+- Notes: add review context, migration notes, or say N/A.
+- Do not add `Co-authored-by:` trailers in the PR body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
-- Summary:
-- Validation:
-- Impact:
-- Related issues: N/A
-- Notes: N/A
+- Title format: `<type>[optional scope][optional !]: <description>`; allowed types are feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
+- Summary: describe the behavior change and why reviewers should accept it.
+- Validation: list commands or checks you ran, or say N/A when verification is not applicable.
+- Impact: describe user-facing, compatibility, API, deployment, configuration, or documentation impact, or say N/A.
+- Related issues: link issues with Fixes #123, Closes #123, or say N/A.
+- Notes: add review context, migration notes, or say N/A.
+- Do not add `Co-authored-by:` trailers in the PR body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ make release
 
 - Use Conventional Commits for commit messages and PR titles.
 - Keep PR bodies compatible with `.github/workflows/pr-message.yml`: each line starts with `- `, no blank lines, no `Co-authored-by:` trailers.
-- Use `.github/pull_request_template.md`; keep entries short and focused on summary, validation, impact, related issues, and notes.
+- Keep PR bodies short and focused on summary, validation, impact, related issues, and notes.
 - Check PR CI before requesting review or merge.
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # CSGCLAW KNOWLEDGE BASE
 
-## Reply Format (Required)
+## Communication
 
-- Every first reply must begin with: "I have followed the instructions in AGENTS.md."
-- Immediately follow with a concise, natural-English refinement of the user's query to aid English learning.
+- Reply in the user's language unless asked otherwise.
+- Keep responses concise and task-focused.
 
 ## Overview
 
@@ -47,6 +47,13 @@ make release
 - Do not change BoxLite sandbox integration or packaging paths unless the task is about sandbox/runtime integration.
 - When changing config fields or defaults, update loader, saver, onboard flow, tests, and docs together.
 - Never hardcode or print real secrets; startup and logs must keep tokens redacted.
+
+## Git And PR Workflow
+
+- Base feature branches on the latest `origin/main` unless the user asks for a different base.
+- Use Conventional Commits for commit messages, such as `fix(feishu): allow open_id mentions`.
+- Keep PR titles and descriptions focused on the technical change, tests run, and known limitations.
+- Before asking for review or merge, inspect PR CI checks and address failing checks when possible.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,10 @@ make release
 
 - Base feature branches on the latest `origin/main` unless the user asks for a different base.
 - Use Conventional Commits for commit messages, such as `fix(feishu): allow open_id mentions`.
-- Keep PR titles and descriptions focused on the technical change, tests run, and known limitations.
+- Use `.github/pull_request_template.md` when creating or updating PR descriptions.
+- PR titles must use Conventional Commit format: `<type>[optional scope][optional !]: <description>`.
+- PR descriptions must follow `.github/workflows/pr-message.yml`: every non-empty body line starts with `- `, blank lines are not allowed, and `Co-authored-by:` trailers must not appear in the body.
+- Keep PR descriptions focused on the technical change, tests run, impact, related issues, and known limitations.
 - Before asking for review or merge, inspect PR CI checks and address failing checks when possible.
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,15 +48,12 @@ make release
 - When changing config fields or defaults, update loader, saver, onboard flow, tests, and docs together.
 - Never hardcode or print real secrets; startup and logs must keep tokens redacted.
 
-## Git And PR Workflow
+## Git And PRs
 
-- Base feature branches on the latest `origin/main` unless the user asks for a different base.
-- Use Conventional Commits for commit messages, such as `fix(feishu): allow open_id mentions`.
-- Use `.github/pull_request_template.md` when creating or updating PR descriptions.
-- PR titles must use Conventional Commit format: `<type>[optional scope][optional !]: <description>`.
-- PR descriptions must follow `.github/workflows/pr-message.yml`: every non-empty body line starts with `- `, blank lines are not allowed, and `Co-authored-by:` trailers must not appear in the body.
-- Keep PR descriptions focused on the technical change, tests run, impact, related issues, and known limitations.
-- Before asking for review or merge, inspect PR CI checks and address failing checks when possible.
+- Use Conventional Commits for commit messages and PR titles.
+- Keep PR bodies compatible with `.github/workflows/pr-message.yml`: each line starts with `- `, no blank lines, no `Co-authored-by:` trailers.
+- Use `.github/pull_request_template.md`; keep entries short and focused on summary, validation, impact, related issues, and notes.
+- Check PR CI before requesting review or merge.
 
 ## Verification
 


### PR DESCRIPTION
- Summary: Simplify agent communication guidance and make PR guidance match the PR message CI rules.
- Validation: Ran `git diff --check`; confirmed `validate-pr-message` passes.
- Impact: Documentation only.
- Related issues: N/A
- Notes: N/A