### PR TITLE
fix(web): preserve PicoClaw tool feedback rendering

### DIFF
--- a/web/app/src/components/business/MessageContent/structuredMessages.ts
+++ b/web/app/src/components/business/MessageContent/structuredMessages.ts
@@ -12,6 +12,9 @@ export function parseStructuredMessage(content: unknown): ParsedStructuredMessag
   if (!cleaned) {
     return null;
   }
+  if (isLegacyToolFeedback(cleaned)) {
+    return null;
+  }
 
   const fencedJSON = cleaned.match(/^```(?:json|javascript|js)?\s*([\s\S]+?)\s*```$/i);
   const rawJSON = fencedJSON ? fencedJSON[1].trim() : cleaned;
@@ -21,7 +24,7 @@ export function parseStructuredMessage(content: unknown): ParsedStructuredMessag
   }
 
   const extracted = extractTopLevelJSONObject(cleaned);
-  const fromExtracted = structuredPayloadFromParsed(tryParseJSON(extracted));
+  const fromExtracted = structuredEnvelopePayloadFromParsed(tryParseJSON(extracted));
   if (fromExtracted) {
     return fromExtracted;
   }
@@ -38,16 +41,31 @@ export function structuredPayloadFromParsed(parsed: unknown): ParsedStructuredMe
   if (!parsed) {
     return null;
   }
+  const envelope = structuredEnvelopePayloadFromParsed(parsed);
+  if (envelope) {
+    return envelope;
+  }
+  if (isStructuredPayload(parsed)) {
+    return buildStructuredPayload(parsed);
+  }
+  return null;
+}
+
+function structuredEnvelopePayloadFromParsed(parsed: unknown): ParsedStructuredMessage | null {
+  if (!parsed) {
+    return null;
+  }
   if (isNotifyCardPayload(parsed)) {
     return buildNotifyCardPayload(parsed);
   }
   if (isActionCardPayload(parsed)) {
     return buildActionCardPayload(parsed);
   }
-  if (isStructuredPayload(parsed)) {
-    return buildStructuredPayload(parsed);
-  }
   return null;
+}
+
+function isLegacyToolFeedback(content: string): boolean {
+  return content.trimStart().startsWith("🔧 ");
 }
 
 export function tryParseJSON(input: string | null): unknown | null {

--- a/web/app/tests/components/MessageContent.test.tsx
+++ b/web/app/tests/components/MessageContent.test.tsx
@@ -103,6 +103,20 @@ describe("MessageContent", () => {
     expect(screen.getByText("feature -> main")).toBeInTheDocument();
   });
 
+  it("keeps PicoClaw legacy tool feedback in markdown form", () => {
+    render(
+      <MessageContent
+        content={`🔧 \`read_file\`
+\`\`\`json
+{"path":"README.md"}
+\`\`\``}
+      />,
+    );
+
+    expect(screen.getByText("read_file")).toBeInTheDocument();
+    expect(screen.queryByText("查看原始 JSON · 1 个字段")).not.toBeInTheDocument();
+  });
+
   it("renders Codex tool activity in the structured tool output style", () => {
     render(
       <MessageContent

--- a/web/app/tests/components/MessageContent/structuredMessages.test.ts
+++ b/web/app/tests/components/MessageContent/structuredMessages.test.ts
@@ -37,16 +37,42 @@ describe("structured message helpers", () => {
     });
   });
 
-  it("extracts a top-level JSON object from surrounding assistant text", () => {
+  it("does not promote embedded generic JSON into a structured payload", () => {
     const extracted = extractTopLevelJSONObject('Before {"tool":"read_file","arguments":{"path":"README.md"}} after');
 
     expect(extracted).toBe('{"tool":"read_file","arguments":{"path":"README.md"}}');
-    expect(parseStructuredMessage(`Assistant result: ${extracted}`)).toMatchObject({
-      badge: "Tool",
-      payloadSummary: "查看原始 JSON · 2 个字段",
-      summary: "参数: path",
-      title: "read_file",
+    expect(parseStructuredMessage(`Assistant result: ${extracted}`)).toBeNull();
+  });
+
+  it("extracts action-card JSON from surrounding assistant text", () => {
+    const parsed = parseStructuredMessage(`Manager setup complete:
+{
+  "type": "${CSGCLAW_ACTION_CARD_TYPE}",
+  "title": "Manager needs rebuild",
+  "actions": [
+    { "id": "${ACTION_REBUILD_MANAGER}", "label": "Rebuild manager" }
+  ]
+}`);
+
+    expect(parsed).toMatchObject({
+      actions: [
+        {
+          id: ACTION_REBUILD_MANAGER,
+          label: "Rebuild manager",
+        },
+      ],
+      kind: "action_card",
+      title: "Manager needs rebuild",
     });
+  });
+
+  it("leaves legacy PicoClaw tool feedback as markdown", () => {
+    expect(
+      parseStructuredMessage(`🔧 \`read_file\`
+\`\`\`json
+{"path":"README.md"}
+\`\`\``),
+    ).toBeNull();
   });
 
   it("parses notifier notify-card payloads with links and meta rows", () => {


### PR DESCRIPTION
- Keep legacy PicoClaw tool feedback messages in Markdown rendering when they start with the wrench prefix.
- Limit extracted JSON promotion to explicit CSGClaw envelope payloads such as `csgclaw.action_card` and `csgclaw.notify_card`.
- Add regression coverage for action-card extraction and PicoClaw tool feedback rendering.
- Root cause: generic JSON extraction promoted PicoClaw tool feedback JSON into structured cards and hid the wrench-style rendering.
- Validation: `pnpm --dir web/app test -- tests/components/MessageContent.test.tsx tests/components/MessageContent/structuredMessages.test.ts`.
- Validation: `pnpm --dir web/app typecheck`.
- Note: local validation emitted the existing Node engine warning because this environment ran Node v26 while the package declares `>=22.13.0 <25`.
