### PR TITLE
ci: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+- Title format: `<type>[optional scope][optional !]: <description>`; allowed types are feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
+- Summary: describe the behavior change and why reviewers should accept it.
+- Validation: list commands or checks you ran, or say N/A when verification is not applicable.
+- Impact: describe user-facing, compatibility, API, deployment, configuration, or documentation impact, or say N/A.
+- Related issues: link issues with Fixes #123, Closes #123, or say N/A.
+- Notes: add review context, migration notes, or say N/A.
+- Do not add `Co-authored-by:` trailers in the PR body.


### PR DESCRIPTION
- Add a default GitHub PR template that is compatible with the repository PR message validation.
- Document the required Conventional Commit title format in the generated PR body.
- Keep every template line in `- ...` form so newly opened PRs do not fail body validation because of the template itself.
- Validation: `node -e` simulation of `.github/workflows/pr-message.yml` title and body checks.
