### PR TITLE
ci: use docker buildx for release image

### DIFF
--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -41,12 +41,13 @@
 #   docker pull --platform linux/amd64 node:22.13.0-alpine
 #   docker tag node:22.13.0-alpine ${ACR_REGISTRY}/opencsghq/node:22.13.0-alpine
 #   docker push ${ACR_REGISTRY}/opencsghq/node:22.13.0-alpine
-#   docker tag gcr.io/kaniko-project/executor:debug ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
-#   docker push ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
 
 variables:
   GIT_STRATEGY: clone
   GIT_DEPTH: "0"
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_TLS_CERTDIR: ""
+  DOCKER_DRIVER: overlay2
   BOXLITE_CLI_VERSION: "v0.9.0"
   BOXLITE_CLI_BASE_URL: "https://csgclaw.opencsg.com/boxlite-cli"
   BOXLITE_CURL_INSECURE: "1"
@@ -73,10 +74,13 @@ stages:
   image:
     name: ${ACR_REGISTRY}/opencsghq/node:22.13.0-bookworm-slim
 
-.kaniko_image:
+.docker_image:
   image:
-    name: ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
-    entrypoint: [""]
+    name: ${ACR_REGISTRY}/opencsg_public/docker:27.3
+  services:
+    - name: ${ACR_REGISTRY}/opencsg_public/docker:27.3-dind
+      alias: docker
+      command: ["--tls=false", "--experimental"]
 
 web-build:
   extends:
@@ -138,31 +142,35 @@ release-build:
 
 docker-build-amd64:
   extends:
-    - .kaniko_image
+    - .docker_image
     - .release_rules
   stage: image
+  before_script:
+    - sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+    - apk add --no-cache git
+    - docker version
+    - docker buildx version
   script:
     - test -n "${ACR_REGISTRY}"
     - test -n "${ACR_USERNAME}"
     - test -n "${ACR_PASSWORD}"
-    - mkdir -p /kaniko/.docker
-    - export ACR_AUTH="$(printf '%s:%s' "$ACR_USERNAME" "$ACR_PASSWORD" | base64 | tr -d '\n')"
-    - printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$ACR_REGISTRY" "$ACR_AUTH" > /kaniko/.docker/config.json
+    - echo "${ACR_PASSWORD}" | docker login "${ACR_REGISTRY}" -u "${ACR_USERNAME}" --password-stdin
     - export COMMIT="$(git rev-parse --short HEAD)"
     - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     - |
-      /kaniko/executor \
-        --context "${CI_PROJECT_DIR}" \
-        --dockerfile "${CI_PROJECT_DIR}/Dockerfile" \
-        --custom-platform linux/amd64 \
-        --destination "${ACR_REGISTRY}/opencsghq/csgclaw:${CI_COMMIT_TAG}" \
+      docker buildx build \
+        --platform linux/amd64 \
+        --file "${CI_PROJECT_DIR}/Dockerfile" \
+        --tag "${ACR_REGISTRY}/opencsghq/csgclaw:${CI_COMMIT_TAG}" \
         --build-arg GO_IMAGE="${ACR_REGISTRY}/opencsg_public/golang:1.26.2-alpine" \
         --build-arg NODE_IMAGE="${ACR_REGISTRY}/opencsghq/node:22.13.0-alpine" \
         --build-arg RUNTIME_IMAGE="${ACR_REGISTRY}/opencsg_public/alpine:3.23" \
         --build-arg GOPROXY="${GOPROXY}" \
         --build-arg VERSION="${CI_COMMIT_TAG}" \
         --build-arg COMMIT="${COMMIT}" \
-        --build-arg BUILD_TIME="${BUILD_TIME}"
+        --build-arg BUILD_TIME="${BUILD_TIME}" \
+        --push \
+        "${CI_PROJECT_DIR}"
 
 release-upload:
   extends:


### PR DESCRIPTION
- Summary: Replaces the GitLab release Docker image job's kaniko executor image with ACR-mirrored docker:27.3 plus docker:27.3-dind.\n- Summary: Uses docker buildx build --platform linux/amd64 --push with the same release Dockerfile build args.\n- Root cause: The configured opencsg_public/kaniko-executor:debug image is not present in ACR, so the GitLab runner fails before job scripts run.\n- Validation: python3 -c 'import yaml; yaml.safe_load(open(".gitlab/ci.yml", encoding="utf-8")); print("ok")'\n- Validation: git diff --check\n- Impact: Tag release pipelines no longer depend on the missing kaniko image; ACR still needs docker:27.3 and docker:27.3-dind mirrors.\n- Related issues: N/A.\n- Notes: Existing local .vscode/settings.json change was left uncommitted.