### PR TITLE
feat(sandbox): add podman container runtime support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ CLI_BIN ?= $(BIN_DIR)/csgclaw-cli
 IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw
 TAG ?= 2026.5.27
 LOCAL_IMAGE ?= picoclaw:local
+CONTAINER_TOOL ?= docker
 
 .DEFAULT_GOAL := build-all
 
@@ -156,9 +157,9 @@ clean:
 	rm -rf $(BIN_DIR) $(DIST_DIR) $(GOCACHE)
 
 tag:
-	docker tag $(LOCAL_IMAGE) $(IMAGE):$(TAG)
+	$(CONTAINER_TOOL) tag $(LOCAL_IMAGE) $(IMAGE):$(TAG)
 
 push:
-	docker push $(IMAGE):$(TAG)
+	$(CONTAINER_TOOL) push $(IMAGE):$(TAG)
 
 publish: tag push

--- a/internal/app/runtimewiring/picoclaw.go
+++ b/internal/app/runtimewiring/picoclaw.go
@@ -108,6 +108,7 @@ func UpdatePicoClawFeishuProvider(svc *agent.Service, provider feishu.BotCredent
 
 func picoClawBoxEnvVars(baseURL, accessToken, botID, llmBaseURL, modelID string) map[string]string {
 	env := bridgeLLMEnvVars(llmBaseURL, accessToken, modelID)
+	env["NO_PROXY"] = "127.0.0.1,localhost"
 	picoclawModelID := picoclawBridgeModelID(modelID)
 	env["CSGCLAW_BASE_URL"] = baseURL
 	env["CSGCLAW_ACCESS_TOKEN"] = accessToken

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -222,12 +223,26 @@ func (c SandboxConfig) EffectiveDebianRegistries() []string {
 	return append([]string(nil), c.DebianRegistriesOverride...)
 }
 
-// EffectiveDockerCLIPath returns the docker binary path for [sandbox].provider = docker.
+// EffectiveDockerCLIPath returns the container CLI binary path for [sandbox].provider = docker.
 // When unset, it defaults to "docker" (PATH lookup).
+// If docker is not found on PATH, it falls back to "podman".
 func (c SandboxConfig) EffectiveDockerCLIPath() string {
 	p := strings.TrimSpace(c.DockerCLIPath)
 	if p != "" {
 		return p
+	}
+	return defaultContainerCLIPath()
+}
+
+// defaultContainerCLIPath is a test-overridable variable that resolves the
+// container CLI binary path when none is explicitly configured. It tries
+// "docker" first, then "podman", falling back to "docker".
+var defaultContainerCLIPath = func() string {
+	if _, err := exec.LookPath("docker"); err == nil {
+		return "docker"
+	}
+	if _, err := exec.LookPath("podman"); err == nil {
+		return "podman"
 	}
 	return "docker"
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -460,8 +460,21 @@ models = ["minimax-m2.7"]
 }
 
 func TestSandboxEffectiveDockerCLIPathDefault(t *testing.T) {
+	defer func(orig func() string) { defaultContainerCLIPath = orig }(defaultContainerCLIPath)
+	defaultContainerCLIPath = func() string { return "docker" }
+
 	cfg := SandboxConfig{Provider: DockerProvider}.Resolved()
 	if got, want := cfg.EffectiveDockerCLIPath(), "docker"; got != want {
+		t.Fatalf("EffectiveDockerCLIPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSandboxEffectiveDockerCLIPathDefaultsToPodmanWhenDockerNotFound(t *testing.T) {
+	defer func(orig func() string) { defaultContainerCLIPath = orig }(defaultContainerCLIPath)
+	defaultContainerCLIPath = func() string { return "podman" }
+
+	cfg := SandboxConfig{Provider: DockerProvider}.Resolved()
+	if got, want := cfg.EffectiveDockerCLIPath(), "podman"; got != want {
 		t.Fatalf("EffectiveDockerCLIPath() = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/picoclawsandbox/runtime.go
+++ b/internal/runtime/picoclawsandbox/runtime.go
@@ -33,8 +33,8 @@ func New(deps Dependencies) *Runtime {
 	}
 	if strings.TrimSpace(deps.ReadinessProbe.Name) == "" {
 		deps.ReadinessProbe = sandboxgateway.GatewayReadinessProbe{
-			Name: "wget",
-			Args: []string{"-q", "--spider", "-T", "2", "http://127.0.0.1:18790/health"},
+			Name: "curl",
+			Args: []string{"-sf", "-o", "/dev/null", "--max-time", "2", "http://127.0.0.1:18790/health"},
 		}
 	}
 	return &Runtime{

--- a/internal/runtime/picoclawsandbox/runtime_test.go
+++ b/internal/runtime/picoclawsandbox/runtime_test.go
@@ -28,16 +28,16 @@ func TestNewDefaultsReadinessProbeToHealthEndpoint(t *testing.T) {
 		t.Fatal("New() = nil")
 	}
 	probe := rt.deps.ReadinessProbe
-	if probe.Name != "wget" {
-		t.Fatalf("ReadinessProbe.Name = %q, want wget", probe.Name)
+	if probe.Name != "curl" {
+		t.Fatalf("ReadinessProbe.Name = %q, want curl", probe.Name)
 	}
 	if got := strings.Join(probe.Args, " "); !strings.Contains(got, "http://127.0.0.1:18790/health") {
 		t.Fatalf("ReadinessProbe.Args = %q, want /health endpoint", got)
 	}
-	if got := strings.Join(probe.Args, " "); !strings.Contains(got, "--spider") {
-		t.Fatalf("ReadinessProbe.Args = %q, want wget spider probe", got)
+	if got := strings.Join(probe.Args, " "); !strings.Contains(got, "-sf") {
+		t.Fatalf("ReadinessProbe.Args = %q, want curl -sf probe", got)
 	}
 	if got := strings.Join(probe.Args, " "); strings.Contains(got, "/ready") {
-		t.Fatalf("ReadinessProbe.Args = %q, want docker health endpoint rather than /ready", got)
+		t.Fatalf("ReadinessProbe.Args = %q, want container health endpoint rather than /ready", got)
 	}
 }

--- a/internal/sandbox/dockercli/errors.go
+++ b/internal/sandbox/dockercli/errors.go
@@ -22,9 +22,9 @@ func (e *ExitError) Error() string {
 		msg = "command failed"
 	}
 	if e.Op == "" {
-		return fmt.Sprintf("docker exited with code %d: %s", e.ExitCode, msg)
+		return fmt.Sprintf("container exited with code %d: %s", e.ExitCode, msg)
 	}
-	return fmt.Sprintf("%s: docker exited with code %d: %s", e.Op, e.ExitCode, msg)
+	return fmt.Sprintf("%s: container exited with code %d: %s", e.Op, e.ExitCode, msg)
 }
 
 func (e *ExitError) Unwrap() error {

--- a/internal/sandbox/dockercli/parse.go
+++ b/internal/sandbox/dockercli/parse.go
@@ -22,7 +22,7 @@ type inspectContainer struct {
 func parseInspect(data []byte) (sandbox.Info, error) {
 	var containers []inspectContainer
 	if err := json.Unmarshal(data, &containers); err != nil {
-		return sandbox.Info{}, fmt.Errorf("parse docker inspect json: %w", err)
+		return sandbox.Info{}, fmt.Errorf("parse container inspect json: %w", err)
 	}
 	if len(containers) == 0 {
 		return sandbox.Info{}, sandbox.ErrNotFound
@@ -54,7 +54,7 @@ func parseCreatedAt(value string) (time.Time, error) {
 		createdAt, err = time.Parse(time.RFC3339, value)
 	}
 	if err != nil {
-		return time.Time{}, fmt.Errorf("parse docker created time %q: %w", value, err)
+		return time.Time{}, fmt.Errorf("parse container created time %q: %w", value, err)
 	}
 	return createdAt, nil
 }

--- a/internal/sandbox/dockercli/provider.go
+++ b/internal/sandbox/dockercli/provider.go
@@ -62,7 +62,7 @@ func (r *Runtime) Create(ctx context.Context, spec sandbox.CreateSpec) (sandbox.
 	}
 	result, err := r.run(ctx, args, nil, nil)
 	if err != nil {
-		return nil, wrapRunError("docker run", result, err)
+		return nil, wrapRunError("container run", result, err)
 	}
 	id := strings.TrimSpace(string(result.Stdout))
 	if id == "" {
@@ -91,7 +91,7 @@ func (r *Runtime) Remove(ctx context.Context, idOrName string, opts sandbox.Remo
 		return err
 	}
 	if strings.TrimSpace(idOrName) == "" {
-		return fmt.Errorf("docker container id or name is required")
+		return fmt.Errorf("container id or name is required")
 	}
 	args := []string{"rm"}
 	if opts.Force {
@@ -99,7 +99,7 @@ func (r *Runtime) Remove(ctx context.Context, idOrName string, opts sandbox.Remo
 	}
 	args = append(args, idOrName)
 	result, err := r.run(ctx, args, nil, nil)
-	return wrapRunError("docker rm", result, err)
+	return wrapRunError("container rm", result, err)
 }
 
 func (r *Runtime) Close() error {
@@ -108,26 +108,26 @@ func (r *Runtime) Close() error {
 
 func (r *Runtime) valid() error {
 	if r == nil || r.runner == nil {
-		return fmt.Errorf("invalid docker runtime")
+		return fmt.Errorf("invalid container runtime")
 	}
 	if strings.TrimSpace(r.path) == "" {
-		return fmt.Errorf("docker path is required")
+		return fmt.Errorf("container runtime path is required")
 	}
 	return nil
 }
 
 func (r *Runtime) inspect(ctx context.Context, idOrName string) (sandbox.Info, error) {
 	if strings.TrimSpace(idOrName) == "" {
-		return sandbox.Info{}, fmt.Errorf("docker container id or name is required")
+		return sandbox.Info{}, fmt.Errorf("container id or name is required")
 	}
 	result, err := r.run(ctx, []string{"inspect", idOrName}, nil, nil)
 	if err != nil {
-		return sandbox.Info{}, wrapRunError("docker inspect", result, err)
+		return sandbox.Info{}, wrapRunError("container inspect", result, err)
 	}
 	info, err := parseInspect(result.Stdout)
 	if err != nil {
 		if sandbox.IsNotFound(err) {
-			return sandbox.Info{}, fmt.Errorf("docker inspect: %w", err)
+			return sandbox.Info{}, fmt.Errorf("container inspect: %w", err)
 		}
 		return sandbox.Info{}, err
 	}
@@ -156,7 +156,7 @@ func (i *Instance) Start(ctx context.Context) error {
 		return err
 	}
 	result, err := i.runtime.run(ctx, []string{"start", i.idOrName}, nil, nil)
-	return wrapRunError("docker start", result, err)
+	return wrapRunError("container start", result, err)
 }
 
 func (i *Instance) Stop(ctx context.Context, opts sandbox.StopOptions) error {
@@ -165,7 +165,7 @@ func (i *Instance) Stop(ctx context.Context, opts sandbox.StopOptions) error {
 	}
 	if opts.Force {
 		result, err := i.runtime.run(ctx, []string{"kill", i.idOrName}, nil, nil)
-		return wrapRunError("docker kill", result, err)
+		return wrapRunError("container kill", result, err)
 	}
 	args := []string{"stop"}
 	if opts.Timeout > 0 {
@@ -177,7 +177,7 @@ func (i *Instance) Stop(ctx context.Context, opts sandbox.StopOptions) error {
 	}
 	args = append(args, i.idOrName)
 	result, err := i.runtime.run(ctx, args, nil, nil)
-	return wrapRunError("docker stop", result, err)
+	return wrapRunError("container stop", result, err)
 }
 
 func (i *Instance) Info(ctx context.Context) (sandbox.Info, error) {
@@ -199,7 +199,7 @@ func (i *Instance) Run(ctx context.Context, spec sandbox.CommandSpec) (sandbox.C
 	result, err := i.runtime.run(ctx, args, spec.Stdout, spec.Stderr)
 	out := sandbox.CommandResult{ExitCode: result.ExitCode}
 	if err != nil {
-		return out, wrapRunError("docker exec", result, err)
+		return out, wrapRunError("container exec", result, err)
 	}
 	return out, nil
 }
@@ -210,13 +210,13 @@ func (i *Instance) Close() error {
 
 func (i *Instance) valid() error {
 	if i == nil || i.runtime == nil {
-		return fmt.Errorf("invalid docker container")
+		return fmt.Errorf("invalid container instance")
 	}
 	if err := i.runtime.valid(); err != nil {
 		return err
 	}
 	if strings.TrimSpace(i.idOrName) == "" {
-		return fmt.Errorf("docker container id or name is required")
+		return fmt.Errorf("container id or name is required")
 	}
 	return nil
 }

--- a/internal/sandbox/dockercli/runner.go
+++ b/internal/sandbox/dockercli/runner.go
@@ -31,14 +31,14 @@ type execRunner struct{}
 
 func (execRunner) Run(ctx context.Context, req CommandRequest) (CommandResult, error) {
 	if req.Path == "" {
-		return CommandResult{ExitCode: -1}, fmt.Errorf("docker path is required")
+		return CommandResult{ExitCode: -1}, fmt.Errorf("container runtime path is required")
 	}
 
 	cmd := exec.CommandContext(ctx, req.Path, req.Args...)
 	if len(req.Env) > 0 {
 		cmd.Env = append(cmd.Environ(), req.Env...)
 	}
-	slog.DebugContext(ctx, fmt.Sprintf("running docker command: %s", cmd.String()))
+	slog.DebugContext(ctx, fmt.Sprintf("running container command: %s", cmd.String()))
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -64,7 +64,7 @@ func (execRunner) Run(ctx context.Context, req CommandRequest) (CommandResult, e
 		if result.ExitCode == 0 {
 			result.ExitCode = -1
 		}
-		return result, fmt.Errorf("docker command canceled: %w", ctxErr)
+		return result, fmt.Errorf("container command canceled: %w", ctxErr)
 	}
 	if err != nil {
 		if result.ExitCode == 0 {

--- a/internal/sandboxproviders/docker_provider_test.go
+++ b/internal/sandboxproviders/docker_provider_test.go
@@ -40,7 +40,10 @@ func TestDockerProviderFactoryUsesConfiguredPath(t *testing.T) {
 
 func TestDockerProviderFactoryDefaultsPath(t *testing.T) {
 	factory := factories[config.DockerProvider]
-	opt, err := factory(config.SandboxConfig{Provider: config.DockerProvider})
+	opt, err := factory(config.SandboxConfig{
+		Provider:      config.DockerProvider,
+		DockerCLIPath: "docker",
+	})
 	if err != nil {
 		t.Fatalf("factory() error = %v", err)
 	}


### PR DESCRIPTION
- add podman support and continue to use docker the default runtime options
- for the readinessprobe, replace to use curl since in some case we will pass the `NO_PROXY` variable.
- add `NO_PROXY` env variable in `picoClawBoxEnvVars`