### PR TITLE
fix(web): compact upgrade version menu

### DIFF
--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui";
 import { MoonIcon, SunIcon } from "@/components/ui/Icons";
 import type { LocaleCode, TranslateFn } from "@/models/conversations";
 import type { UpgradePhase, UpgradeStatus } from "@/models/upgradeStatus";
-import { formatSidebarVersionLabel, hasUpgradeAttention, isLocalBuildVersion, upgradeStatusLabel } from "@/models/upgradeStatus";
+import { formatSidebarVersionLabel, hasUpgradeAttention, isLocalBuildVersion } from "@/models/upgradeStatus";
 import { classNames } from "@/shared/lib/classNames";
 import type { ThemeMode } from "@/shared/theme/theme";
 
@@ -42,6 +42,7 @@ export function SidebarUserButton({
   const upgradeAttention = showUpgradeControls && hasUpgradeAttention(upgradeStatus, upgradePhase, upgradeBusy);
   const upgradeRunning = showUpgradeControls ? upgradeBusy || Boolean(upgradeStatus?.upgrading) : false;
   const upgradeIssue = showUpgradeControls ? upgradeError || upgradeStatus?.last_error || "" : "";
+  const currentVersion = upgradeStatus?.current_version || appVersion;
   const upgradeView = showUpgradeControls
     ? {
         actionLabel: upgradeMenuActionText({
@@ -52,18 +53,12 @@ export function SidebarUserButton({
           t,
         }),
         issue: upgradeIssue,
-        latestVersion: upgradeStatus?.latest_version || t("upgradeNoLatest"),
+        localBuild: isLocalBuildVersion(currentVersion),
         running: upgradeRunning,
-        status: upgradeStatusText({
-          phase: upgradePhase,
-          running: upgradeRunning,
-          issue: upgradeIssue,
-          known: Boolean(upgradeStatus),
-          currentVersion: upgradeStatus?.current_version || appVersion,
-          manualRestartRequired: Boolean(upgradeStatus?.manual_restart_required),
-          updateAvailable: Boolean(upgradeStatus?.update_available),
-          t,
-        }),
+        versionLabel:
+          upgradeStatus?.update_available && upgradeStatus.latest_version
+            ? `${formatSidebarVersionLabel(currentVersion)} -> ${formatSidebarVersionLabel(upgradeStatus.latest_version)}`
+            : formatSidebarVersionLabel(currentVersion),
       }
     : null;
 
@@ -162,85 +157,34 @@ export function SidebarUserButton({
           <div className="sidebar-menu-divider"></div>
           <div className="sidebar-version-panel">
             <div className="sidebar-version-heading">
-              <span className="sidebar-menu-label">{showUpgradeControls ? t("versionSettings") : t("versionInfo")}</span>
-              {upgradeAttention ? <span className="sidebar-version-alert-dot" aria-hidden="true"></span> : null}
+              <span className="sidebar-menu-label">{t("versionInfo")}</span>
+              {upgradeView?.localBuild ? (
+                <span className="sidebar-version-status">{t("upgradeLocalBuild")}</span>
+              ) : upgradeAttention && upgradeView ? (
+                <Button
+                  variant={upgradePhase === "done" ? "secondaryColor" : "secondaryGray"}
+                  size="sm"
+                  className={classNames(
+                    "sidebar-version-action",
+                    upgradeView.running && "is-running",
+                    upgradePhase === "done" && "is-done",
+                  )}
+                  onClick={handleOpenUpgrade}
+                >
+                  <span className="sidebar-upgrade-menu-dot" aria-hidden="true"></span>
+                  <span>{upgradeView.actionLabel}</span>
+                </Button>
+              ) : null}
             </div>
-            <div className="sidebar-version-row">
-              <span>{t("upgradeCurrentVersion")}</span>
-              <strong>{formatSidebarVersionLabel(appVersion)}</strong>
-            </div>
-            {upgradeView ? (
-              <>
-                <div className="sidebar-version-row">
-                  <span>{t("upgradeLatestVersion")}</span>
-                  <strong>{upgradeView.latestVersion}</strong>
-                </div>
-                <div className="sidebar-version-row">
-                  <span>{t("upgradeStatus")}</span>
-                  <strong>{upgradeView.status}</strong>
-                </div>
-                {upgradeView.issue ? <div className="sidebar-version-error">{upgradeView.issue}</div> : null}
-                {upgradeAttention ? (
-                  <Button
-                    variant={upgradePhase === "done" ? "secondaryColor" : "secondaryGray"}
-                    className={classNames(
-                      "sidebar-upgrade-menu-button",
-                      upgradeView.running && "is-running",
-                      upgradePhase === "done" && "is-done",
-                    )}
-                    onClick={handleOpenUpgrade}
-                  >
-                    <span className="sidebar-upgrade-menu-dot" aria-hidden="true"></span>
-                    <span>{upgradeView.actionLabel}</span>
-                  </Button>
-                ) : null}
-              </>
-            ) : null}
+            <strong className="sidebar-version-value">
+              {upgradeView ? upgradeView.versionLabel : formatSidebarVersionLabel(appVersion)}
+            </strong>
+            {upgradeView?.issue ? <div className="sidebar-version-error">{upgradeView.issue}</div> : null}
           </div>
         </div>
       ) : null}
     </div>
   );
-}
-
-function upgradeStatusText({
-  phase,
-  running,
-  issue,
-  known,
-  currentVersion,
-  manualRestartRequired,
-  updateAvailable,
-  t,
-}: {
-  phase: UpgradePhase;
-  running: boolean;
-  issue: string;
-  known: boolean;
-  currentVersion: string;
-  manualRestartRequired: boolean;
-  updateAvailable: boolean;
-  t: TranslateFn;
-}): string {
-  if (issue || phase === "error") {
-    return t("upgradeStatusError");
-  }
-  if (phase === "manual_restart" || manualRestartRequired) {
-    return t("upgradeStatusManualRestart");
-  }
-  if (phase === "done") {
-    return t("upgradeStatusDone");
-  }
-  if (running || phase === "starting" || phase === "restarting") {
-    return upgradeStatusLabel(phase === "idle" ? "restarting" : phase, t);
-  }
-  if (!known) {
-    return t("upgradeNoLatest");
-  }
-  if (isLocalBuildVersion(currentVersion)) {
-    return t("upgradeStatusLocal");
-  }
-  return updateAvailable ? t("upgradeAction") : t("upgradeUpToDate");
 }
 
 function upgradeMenuActionText({

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
@@ -2136,35 +2136,23 @@
   gap: 8px;
 }
 
-.sidebar-version-alert-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--danger);
-  box-shadow: 0 0 0 4px color-mix(in oklab, var(--danger) 14%, transparent);
-  flex: 0 0 auto;
-}
-
-.sidebar-version-row {
+.sidebar-version-status {
   min-width: 0;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
   color: var(--muted);
-  font-size: 12px;
-  line-height: 1.35;
-}
-
-.sidebar-version-row strong {
-  min-width: 0;
-  max-width: 170px;
-  color: var(--text);
   font-size: 12px;
   font-weight: 700;
   line-height: 1.35;
-  overflow-wrap: anywhere;
   text-align: right;
+}
+
+.sidebar-version-value {
+  min-width: 0;
+  color: var(--text);
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .sidebar-version-error {
@@ -2174,13 +2162,18 @@
   overflow-wrap: anywhere;
 }
 
-.sidebar-upgrade-menu-button {
-  width: 100%;
+.sidebar-version-action {
+  max-width: 150px;
+  min-width: 0;
+  height: 28px;
+  padding-inline: 8px;
   justify-content: center;
   gap: 8px;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
-.sidebar-upgrade-menu-button.is-running {
+.sidebar-version-action.is-running {
   cursor: progress;
 }
 
@@ -2193,13 +2186,13 @@
   flex: 0 0 auto;
 }
 
-.sidebar-upgrade-menu-button.is-running .sidebar-upgrade-menu-dot {
+.sidebar-version-action.is-running .sidebar-upgrade-menu-dot {
   background: var(--primary);
   box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 16%, transparent);
   animation: upgrade-pulse 1.4s ease-in-out infinite;
 }
 
-.sidebar-upgrade-menu-button.is-done .sidebar-upgrade-menu-dot {
+.sidebar-version-action.is-done .sidebar-upgrade-menu-dot {
   background: var(--portal-success-700);
   box-shadow: 0 0 0 4px color-mix(in oklab, var(--portal-success-700) 16%, transparent);
 }

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -292,6 +292,7 @@ export const messages = {
     upgradeStatusDone: "升级完成",
     upgradeStatusError: "升级失败",
     upgradeStatusLocal: "本地构建，不检查更新",
+    upgradeLocalBuild: "本地构建",
     upgradeConfirmBody: "点击更新后会运行 csgclaw upgrade，并在完成后重启本地服务。",
     upgradeRestartingBody: "升级 helper 已启动。页面会自动等待服务恢复，期间连接短暂中断是正常现象。",
     upgradeManualRestartBody:
@@ -621,6 +622,7 @@ export const messages = {
     upgradeStatusDone: "Upgrade complete",
     upgradeStatusError: "Upgrade failed",
     upgradeStatusLocal: "Local build, update check skipped",
+    upgradeLocalBuild: "Local build",
     upgradeConfirmBody: "Updating runs csgclaw upgrade and restarts the local service when it finishes.",
     upgradeRestartingBody:
       "The upgrade helper has started. This page will wait for the service to come back; a brief disconnect is normal.",

--- a/web/app/tests/components/SidebarUserButton.test.tsx
+++ b/web/app/tests/components/SidebarUserButton.test.tsx
@@ -11,11 +11,7 @@ const labels: Record<string, string> = {
   themeLight: "Light",
   themeSwitcher: "Theme",
   upgradeAction: "Update & Restart",
-  upgradeCurrentVersion: "Current version",
-  upgradeLatestVersion: "Latest version",
-  upgradeNoLatest: "Unknown",
-  upgradeStatus: "Status",
-  upgradeUpToDate: "Up to date",
+  upgradeLocalBuild: "Local build",
   versionInfo: "Version",
   versionSettings: "Version and updates",
 };
@@ -56,13 +52,64 @@ describe("SidebarUserButton", () => {
 
     await user.click(screen.getByRole("button", { name: "Settings" }));
 
-    expect(screen.getByText("Current version")).toBeInTheDocument();
     expect(screen.getByText("v0.3.0")).toBeInTheDocument();
     expect(screen.getByText("Version")).toBeInTheDocument();
     expect(screen.queryByText("Version and updates")).not.toBeInTheDocument();
-    expect(screen.queryByText("Latest version")).not.toBeInTheDocument();
-    expect(screen.queryByText("Status")).not.toBeInTheDocument();
     expect(screen.queryByText("Update & Restart")).not.toBeInTheDocument();
     expect(onOpenUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("shows a compact version summary when updates are available", async () => {
+    const user = userEvent.setup();
+    const onOpenUpgrade = vi.fn();
+
+    render(
+      <SidebarUserButton
+        appVersion="v0.3.0"
+        showUpgradeControls={true}
+        locale="en"
+        onOpenUpgrade={onOpenUpgrade}
+        onLocaleChange={() => {}}
+        onThemeChange={() => {}}
+        t={t}
+        theme="light"
+        upgradeStatus={updateAvailableStatus}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(screen.getByText("v0.3.0 -> v0.3.1")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Update & Restart" }));
+    expect(onOpenUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows local build state without upgrade actions", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SidebarUserButton
+        appVersion="v0.3.5+local"
+        showUpgradeControls={true}
+        locale="en"
+        onOpenUpgrade={() => {}}
+        onLocaleChange={() => {}}
+        onThemeChange={() => {}}
+        t={t}
+        theme="light"
+        upgradeStatus={{
+          ...updateAvailableStatus,
+          current_version: "v0.3.5+local",
+          latest_version: "",
+          update_available: false,
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(screen.getByText("Local build")).toBeInTheDocument();
+    expect(screen.getByText("v0.3.5+local")).toBeInTheDocument();
+    expect(screen.queryByText("Update & Restart")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Show a compact version row in the settings menu, with update actions only when an update is available.
- Keep local builds and hidden upgrade controls focused on the current version only.