### PR TITLE
feat(manager): add agent-creator skill and hub-template worker proviioning

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -132,6 +132,7 @@ func (a *App) parseGlobalOptions(args []string) (GlobalOptions, []string, error)
 	fs.StringVar(&opts.Endpoint, "endpoint", opts.Endpoint, "HTTP server endpoint")
 	fs.StringVar(&opts.Token, "token", opts.Token, "API authentication token")
 	fs.StringVar(&opts.Output, "output", "", "output format: table or json")
+	fs.StringVar(&opts.Output, "o", "", "shorthand for --output")
 	fs.StringVar(&opts.Config, "config", "", "path to config file")
 	fs.BoolVar(&opts.Version, "version", false, "print version and exit")
 	fs.BoolVar(&opts.Version, "V", false, "print version and exit")
@@ -189,7 +190,7 @@ func isSpecialOutputCommand(rest []string) bool {
 
 func consumesValue(arg string) bool {
 	switch arg {
-	case "--endpoint", "--token", "--output", "--config":
+	case "--endpoint", "--token", "--output", "-o", "--config":
 		return true
 	default:
 		return false
@@ -224,7 +225,7 @@ func (a *App) usage() {
 	fmt.Fprintln(a.stderr, "Global flags:")
 	fmt.Fprintf(a.stderr, "  --endpoint string   HTTP server endpoint (default %s)\n", envBaseURL)
 	fmt.Fprintf(a.stderr, "  --token string      API authentication token (default %s)\n", envAccessToken)
-	fmt.Fprintln(a.stderr, "  --output string     Output format: table or json")
+	fmt.Fprintln(a.stderr, "  --output, -o string Output format: table or json")
 	fmt.Fprintln(a.stderr, "  --config string     Path to config file")
 	fmt.Fprintln(a.stderr, "  --version, -V       Print version and exit")
 }

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -349,6 +349,44 @@ func TestExecuteBotCreateUsesDefaultChannel(t *testing.T) {
 	assertTableHasRow(t, stdout.String(), "u-alice", "alice", "test-lead", "worker", "csgclaw")
 }
 
+func TestExecuteBotCreateSendsFromTemplateAndEnv(t *testing.T) {
+	var stdout bytes.Buffer
+	app := &App{
+		stdout: &stdout,
+		stderr: &bytes.Buffer{},
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodPost)
+			}
+			var payload bot.CreateRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if payload.FromTemplate != "builtin/gitlab-worker" {
+				t.Fatalf("payload.FromTemplate = %q, want builtin/gitlab-worker", payload.FromTemplate)
+			}
+			if payload.AgentProfile == nil || payload.AgentProfile.Env["GITLAB_TOKEN"] != "secret" {
+				t.Fatalf("payload.AgentProfile.Env = %#v, want GITLAB_TOKEN", payload.AgentProfile)
+			}
+			return jsonResponse(http.StatusCreated, `{"id":"u-gitlab","name":"gitlab","description":"gitlab worker","role":"worker","channel":"csgclaw","runtime_kind":"picoclaw_sandbox","agent_id":"u-gitlab","user_id":"u-gitlab","available":true,"created_at":"2026-04-12T09:00:00Z"}`), nil
+		}),
+	}
+
+	err := app.Execute(context.Background(), []string{
+		"--endpoint", "http://example.test",
+		"bot", "create",
+		"--name", "gitlab",
+		"--description", "gitlab worker",
+		"--role", "worker",
+		"--from-template", "builtin/gitlab-worker",
+		"--env", "GITLAB_TOKEN=secret",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertTableHasRow(t, stdout.String(), "u-gitlab", "gitlab", "gitlab worker", "worker", "csgclaw")
+}
+
 func TestExecuteBotCreateFeishuSendsChannelPayload(t *testing.T) {
 	var stdout bytes.Buffer
 	app := &App{

--- a/cli/bot/bot.go
+++ b/cli/bot/bot.go
@@ -100,6 +100,9 @@ func (c cmd) runCreate(ctx context.Context, run *command.Context, args []string,
 	channelName := fs.String("channel", "csgclaw", "channel name: csgclaw or feishu")
 	modelID := fs.String("model-id", "", "agent model identifier")
 	runtimeKind := fs.String("runtime", "", "agent runtime kind for worker bots (for example: picoclaw_sandbox, openclaw_sandbox, codex)")
+	fromTemplate := fs.String("from-template", "", "hub template to use as creation defaults and workspace overlay")
+	var envValues envFlag
+	fs.Var(&envValues, "env", "agent image environment variable as KEY=VALUE (repeatable)")
 	botType := fs.String("type", botdomain.BotTypeNormal, "bot type: normal or notification")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -114,21 +117,26 @@ func (c cmd) runCreate(ctx context.Context, run *command.Context, args []string,
 		return fmt.Errorf("bot create requires --role")
 	}
 
-	req := apitypes.CreateBotRequest{
-		ID:          *id,
-		Name:        *name,
-		Description: *description,
-		Type:        botdomain.NormalizeBotType(*botType),
-		Role:        *role,
-		Channel:     *channelName,
-		RuntimeKind: *runtimeKind,
+	envMap, err := parseEnvAssignments(envValues)
+	if err != nil {
+		return err
 	}
-	if strings.TrimSpace(*modelID) != "" {
-		req.AgentProfile = &apitypes.CreateAgentProfile{ModelID: *modelID}
+
+	req := apitypes.CreateBotRequest{
+		ID:           *id,
+		Name:         *name,
+		Description:  *description,
+		Type:         botdomain.NormalizeBotType(*botType),
+		Role:         *role,
+		Channel:      *channelName,
+		RuntimeKind:  *runtimeKind,
+		FromTemplate: *fromTemplate,
+	}
+	if strings.TrimSpace(*modelID) != "" || len(envMap) > 0 {
+		req.AgentProfile = &apitypes.CreateAgentProfile{ModelID: *modelID, Env: envMap}
 	}
 	client := run.APIClient(globals)
 	var created apitypes.Bot
-	var err error
 	if req.Type == botdomain.BotTypeNotification {
 		created, err = client.CreateNotificationBot(ctx, req)
 	} else {
@@ -163,4 +171,38 @@ func (c cmd) runDelete(ctx context.Context, run *command.Context, args []string,
 		Channel: *channelName,
 		Message: fmt.Sprintf("deleted %s bot %s", *channelName, rest[0]),
 	})
+}
+
+type envFlag []string
+
+func (e *envFlag) String() string {
+	return strings.Join(*e, ",")
+}
+
+func (e *envFlag) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+
+func parseEnvAssignments(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(raw, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid --env %q: expected KEY=VALUE", raw)
+		}
+		if _, exists := out[key]; exists {
+			return nil, fmt.Errorf("duplicate --env key %q", key)
+		}
+		out[key] = value
+	}
+	return out, nil
 }

--- a/cli/bot/bot_test.go
+++ b/cli/bot/bot_test.go
@@ -1,0 +1,31 @@
+package bot
+
+import "testing"
+
+func TestParseEnvAssignments(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseEnvAssignments([]string{"GITLAB_TOKEN=secret", "GITLAB_URL=https://gitlab.example.com"})
+	if err != nil {
+		t.Fatalf("parseEnvAssignments() error = %v", err)
+	}
+	if got["GITLAB_TOKEN"] != "secret" || got["GITLAB_URL"] != "https://gitlab.example.com" {
+		t.Fatalf("parseEnvAssignments() = %#v", got)
+	}
+}
+
+func TestParseEnvAssignmentsRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseEnvAssignments([]string{"NOT_A_PAIR"}); err == nil {
+		t.Fatal("parseEnvAssignments() error = nil, want invalid env")
+	}
+}
+
+func TestParseEnvAssignmentsRejectsDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseEnvAssignments([]string{"A=1", "A=2"}); err == nil {
+		t.Fatal("parseEnvAssignments() error = nil, want duplicate key")
+	}
+}

--- a/cli/completion/completion.go
+++ b/cli/completion/completion.go
@@ -102,6 +102,7 @@ func LiteSpec() CommandSpec {
 		Flags: liteGlobalFlags(),
 		Children: []CommandSpec{
 			botSpec(),
+			hubSpec(),
 			roomSpec(),
 			memberSpec(),
 			messageSpec(),
@@ -212,7 +213,7 @@ func liteGlobalFlags() []FlagSpec {
 	return []FlagSpec{
 		{Name: "endpoint", TakesValue: true},
 		{Name: "token", TakesValue: true},
-		{Name: "output", TakesValue: true, Values: []string{"table", "json"}},
+		{Name: "output", Short: "o", TakesValue: true, Values: []string{"table", "json"}},
 		{Name: "version", Short: "V"},
 	}
 }

--- a/cli/csgclawcli/app.go
+++ b/cli/csgclawcli/app.go
@@ -12,6 +12,7 @@ import (
 	"csgclaw/cli/bot"
 	"csgclaw/cli/command"
 	completioncmd "csgclaw/cli/completion"
+	hubcmd "csgclaw/cli/hub"
 	"csgclaw/cli/member"
 	"csgclaw/cli/message"
 	"csgclaw/cli/room"
@@ -68,6 +69,7 @@ func (a *App) AddCommand(commands ...command.Command) {
 func (a *App) registerDefaultCommands() {
 	a.AddCommand(
 		bot.NewCmd(),
+		hubcmd.NewCmd(),
 		room.NewCmd(),
 		member.NewCmd(),
 		message.NewCmd(),
@@ -118,6 +120,7 @@ func (a *App) parseGlobalOptions(args []string) (GlobalOptions, []string, error)
 	fs.StringVar(&opts.Endpoint, "endpoint", opts.Endpoint, "HTTP server endpoint")
 	fs.StringVar(&opts.Token, "token", opts.Token, "API authentication token")
 	fs.StringVar(&opts.Output, "output", "", "output format: table or json")
+	fs.StringVar(&opts.Output, "o", "", "shorthand for --output")
 	fs.BoolVar(&opts.Version, "version", false, "print version and exit")
 	fs.BoolVar(&opts.Version, "V", false, "print version and exit")
 
@@ -160,7 +163,7 @@ func (a *App) defaultOutput(opts GlobalOptions, rest []string) string {
 
 func consumesValue(arg string) bool {
 	switch arg {
-	case "--endpoint", "--token", "--output":
+	case "--endpoint", "--token", "--output", "-o":
 		return true
 	default:
 		return false
@@ -190,7 +193,7 @@ func (a *App) usage() {
 	fmt.Fprintln(a.stderr, "Global flags:")
 	fmt.Fprintf(a.stderr, "  --endpoint string   HTTP server endpoint (default %s)\n", envBaseURL)
 	fmt.Fprintf(a.stderr, "  --token string      API authentication token (default %s)\n", envAccessToken)
-	fmt.Fprintln(a.stderr, "  --output string     Output format: table or json")
+	fmt.Fprintln(a.stderr, "  --output, -o string Output format: table or json")
 	fmt.Fprintln(a.stderr, "  --version, -V       Print version and exit")
 }
 

--- a/cli/csgclawcli/app_test.go
+++ b/cli/csgclawcli/app_test.go
@@ -31,6 +31,7 @@ func TestExecuteExposesOnlyLiteCommands(t *testing.T) {
 	for _, want := range []string{
 		"Available Commands:",
 		"bot      Manage bots",
+		"hub      Discover agent templates.",
 		"room     Manage IM rooms",
 		"member   Manage IM room members",
 		"message  Manage IM messages.",
@@ -67,6 +68,30 @@ func TestExecuteCompletionFish(t *testing.T) {
 	}
 }
 
+func TestExecuteHubListAcceptsOutputShorthand(t *testing.T) {
+	var stdout bytes.Buffer
+	app := &App{
+		stdout: &stdout,
+		stderr: &bytes.Buffer{},
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodGet)
+			}
+			if req.URL.String() != "http://example.test/api/v1/hub/templates" {
+				t.Fatalf("url = %q, want hub templates route", req.URL.String())
+			}
+			return jsonResponse(http.StatusOK, `[{"id":"builtin/gitlab-worker","name":"gitlab-worker","source":{"name":"builtin","kind":"builtin"}}]`), nil
+		}),
+	}
+
+	if err := app.Execute(context.Background(), []string{"--endpoint", "http://example.test", "-o", "json", "hub", "list"}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"id": "builtin/gitlab-worker"`) {
+		t.Fatalf("stdout = %q, want JSON hub template payload", stdout.String())
+	}
+}
+
 func TestExecuteHiddenCompleteUsesLiteCommandSet(t *testing.T) {
 	var stdout bytes.Buffer
 	app := &App{
@@ -79,7 +104,7 @@ func TestExecuteHiddenCompleteUsesLiteCommandSet(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	got := stdout.String()
-	for _, want := range []string{"bot\n", "room\n", "member\n", "message\n", "team\n", "completion\n"} {
+	for _, want := range []string{"bot\n", "hub\n", "room\n", "member\n", "message\n", "team\n", "completion\n"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stdout = %q, want substring %q", got, want)
 		}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,8 @@ Both CLIs are thin HTTP clients over the local API. They do not talk to BoxLite,
 
 - `--output table` prints human-readable tables or plain text.
 - `--output json` prints structured JSON.
+- `-o` is a shorthand for `--output`.
+- Global flags such as `--output`, `-o`, `--endpoint`, and `--token` must appear **before** the subcommand (for example `csgclaw-cli --output json hub list`, not `csgclaw-cli hub list --output json`).
 - If `--output` is omitted:
   - terminal output defaults to `table`
   - piped or redirected output defaults to `json`

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -16,6 +16,8 @@
 
 - `--output table` 输出适合人读的表格或纯文本。
 - `--output json` 输出结构化 JSON。
+- `-o` 是 `--output` 的简写。
+- 全局参数（`--output`、`-o`、`--endpoint`、`--token`）必须写在子命令**之前**（例如 `csgclaw-cli --output json hub list`，不要写成 `csgclaw-cli hub list --output json`）。
 - 如果不显式传入 `--output`：
   - 输出到终端时，默认是 `table`
   - 输出被管道或重定向时，默认是 `json`

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -789,6 +789,7 @@ func (s *Service) resolveTemplateCreateSpec(ctx context.Context, spec CreateAgen
 
 	cleanup := templateWorkspaceCleanup(item.Source.Kind, workspace)
 	spec = applyTemplateDefaults(spec, item)
+	spec = applyTemplateEnvDefaults(spec, item)
 	if strings.TrimSpace(workspace.Kind) == hub.WorkspaceKindDir {
 		spec.FromTemplate = strings.TrimSpace(workspace.Path)
 	}
@@ -855,6 +856,30 @@ func applyTemplateDefaults(spec CreateAgentSpec, item hub.Template) CreateAgentS
 	if strings.TrimSpace(spec.RuntimeKind) == "" {
 		spec.RuntimeKind = item.RuntimeKind
 	}
+	return spec
+}
+
+func applyTemplateEnvDefaults(spec CreateAgentSpec, item hub.Template) CreateAgentSpec {
+	if len(item.ImageEnv) == 0 {
+		return spec
+	}
+	env := spec.AgentProfile.Env
+	if env == nil {
+		env = make(map[string]string)
+	}
+	for _, contract := range item.ImageEnv {
+		name := strings.TrimSpace(contract.Name)
+		if name == "" {
+			continue
+		}
+		if _, exists := env[name]; exists {
+			continue
+		}
+		if defaultValue := strings.TrimSpace(contract.Default); defaultValue != "" {
+			env[name] = defaultValue
+		}
+	}
+	spec.AgentProfile.Env = env
 	return spec
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"csgclaw/internal/apitypes"
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/config"
 	"csgclaw/internal/hub"
@@ -3706,6 +3707,84 @@ func TestCreateWorkerFromTemplateAppliesDefaultsAndOverlaysWorkspace(t *testing.
 	}
 	if _, err := os.Stat(filepath.Join(workspaceRoot, "skills", "custom", "SKILL.md")); err != nil {
 		t.Fatalf("template skill missing after overlay: %v", err)
+	}
+}
+
+func TestApplyTemplateEnvDefaults(t *testing.T) {
+	t.Parallel()
+
+	got := applyTemplateEnvDefaults(CreateAgentSpec{
+		AgentProfile: AgentProfile{
+			Env: map[string]string{"GITLAB_TOKEN": "user-token"},
+		},
+	}, hub.Template{
+		ImageEnv: []apitypes.ImageEnvContract{
+			{Name: "GITLAB_TOKEN", Required: true, Secret: true},
+			{Name: "GITLAB_URL", Default: "https://gitlab.example.com"},
+		},
+	})
+	if got.AgentProfile.Env["GITLAB_TOKEN"] != "user-token" {
+		t.Fatalf("GITLAB_TOKEN = %q, want user-token", got.AgentProfile.Env["GITLAB_TOKEN"])
+	}
+	if got.AgentProfile.Env["GITLAB_URL"] != "https://gitlab.example.com" {
+		t.Fatalf("GITLAB_URL = %q, want default url", got.AgentProfile.Env["GITLAB_URL"])
+	}
+}
+
+func TestCreateWorkerFromTemplateAppliesImageEnvToSandbox(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
+
+	var capturedEnv map[string]string
+	restoreHook := testCreateGatewayBoxHook
+	testCreateGatewayBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, _, _, _ string, profile AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+		capturedEnv = profile.Env
+		return nil, sandbox.Info{ID: "box-gitlab", State: sandbox.StateRunning}, nil
+	}
+	t.Cleanup(func() { testCreateGatewayBoxHook = restoreHook })
+
+	hubSvc := mustNewLocalTemplateHubService(t, "gitlab-assistant", hub.Template{
+		ID:          "gitlab-assistant",
+		Name:        "gitlab-assistant",
+		Description: "GitLab assistant",
+		Role:        hub.TemplateRoleWorker,
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		Image:       "worker-image:1",
+		ImageEnv: []apitypes.ImageEnvContract{
+			{Name: "GITLAB_TOKEN", Required: true, Secret: true},
+			{Name: "GITLAB_URL", Default: "https://gitlab.example.com"},
+		},
+	})
+
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		WithHubService(hubSvc),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			Name:         "gitlab",
+			FromTemplate: "local/gitlab-assistant",
+			AgentProfile: AgentProfile{
+				Env: map[string]string{"GITLAB_TOKEN": "secret-token"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if capturedEnv["GITLAB_TOKEN"] != "secret-token" {
+		t.Fatalf("sandbox GITLAB_TOKEN = %q, want secret-token", capturedEnv["GITLAB_TOKEN"])
+	}
+	if capturedEnv["GITLAB_URL"] != "https://gitlab.example.com" {
+		t.Fatalf("sandbox GITLAB_URL = %q, want default url", capturedEnv["GITLAB_URL"])
 	}
 }
 

--- a/internal/templates/embed/openclaw-manager/workspace/AGENTS.md
+++ b/internal/templates/embed/openclaw-manager/workspace/AGENTS.md
@@ -23,6 +23,40 @@ You are an OpenClaw manager bot connected to CSGClaw. Orchestrate work,
 dispatch to workers when appropriate, and handle direct requests when manager
 execution is the right path. Stay practical, accurate, and concise.
 
+## Casual messages and CSGClaw onboarding
+
+When the user sends a greeting, small talk, or a vague message with **no clear
+task or command** (for example: "你好", "hi", "hello", "help", "你能做什么",
+"怎么用"):
+
+1. Do **not** run `csgclaw-cli`, load dispatch skills, or start tool-heavy
+   work yet.
+2. Reply warmly and briefly in the **user's language**.
+3. Introduce yourself as the **CSGClaw manager** — the coordinator for bots,
+   workers, rooms, and task handoff in this workspace.
+4. Summarize what you can help with, with **short example prompts** the user
+   can copy or adapt.
+5. End with one open question: what would they like to do next?
+
+Suggested capability bullets (pick 3–4 that fit; keep the whole reply concise):
+
+- **Create workers** from hub templates (GitLab, frontend, QA, review, etc.) —
+  e.g. "帮我创建一个 GitLab worker"
+- **Assign work** to existing workers in IM rooms and track multi-step handoffs —
+  e.g. "把登录页 UI 交给 frontend worker 做"
+- **Manage bots and rooms** — list workers, create rooms or Feishu groups, add
+  members — e.g. "列出当前所有 worker"
+- **Answer CSGClaw usage questions** — explain the manager vs worker model when
+  asked
+
+Do **not** list skill search or install in the welcome message. Workers install
+skills themselves via `skill-installer`; manager only dispatches that work when
+the user asks.
+
+Keep the intro to roughly **6–10 lines** unless the user asks for more detail.
+This is welcome guidance in response to the user, not OpenClaw first-run hatch
+or identity onboarding.
+
 ## CSGClaw Runtime
 
 - CSGClaw provides the channel bridge and LLM bridge through runtime config.
@@ -39,12 +73,16 @@ execution is the right path. Stay practical, accurate, and concise.
 - Before using a skill, check the local `skills/` directory and read the
   matching `SKILL.md`.
 - Prefer local workspace skills over external discovery.
+- **Agent creation first:** if the user wants to create/add/set up/provision an
+  agent, bot, robot, or worker—or needs a new capability-specific worker—read
+  `skills/agent-creator/SKILL.md` immediately. Never run `bot create` without
+  `--from-template` for a new worker.
+- **Dispatch second:** for task handoff when workers exist (or after
+  `agent-creator` finishes), read `skills/manager-worker-dispatch/SKILL.md`.
 - For CSGClaw room, bot, member, Feishu group/chat creation, or adding bots to
   Feishu groups, read and use `skills/basics/SKILL.md` first and run
   `csgclaw-cli`. Do not conclude group creation is unsupported just because the
   native OpenClaw `feishu_chat` tool only supports read/query actions.
-- Treat `skills/manager-worker-dispatch/SKILL.md` as the manager routing
-  contract when dispatching worker-owned tasks.
 - For registry skill search, inspect, or list versions, read
   `skills/skill-installer/SKILL.md` and run `csgclaw-cli skill`. Install skills
   by dispatching the target worker to follow `skill-installer` in its own

--- a/internal/templates/embed/openclaw-manager/workspace/skills/agent-creator/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/agent-creator/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent-creator
+description: Mandatory skill for provisioning any new CSGClaw agent, bot, robot, or worker. Use immediately when the user asks to create, add, set up, or provision an agent/bot/worker (including GitLab, frontend, QA, or other specialized workers), when dispatch needs a missing worker, or when asking which hub template fits. Always hub list + match + hub get + bot create --from-template with --env for secrets. Never run bot create without --from-template for a new worker. Do NOT use for task dispatch to existing workers or todo.json tracking only.
+---
+
+# Agent Creator
+
+Guide users through hub template selection and agent creation. This skill owns **all new worker provisioning**.
+
+Use `basics` only after create for room membership or IM mentions. Use `manager-worker-dispatch` only after the worker exists and the user wants task handoff.
+
+## Routing Gate (mandatory)
+
+Before running **any** `csgclaw-cli bot create` for a **new** worker:
+
+1. Read this skill first.
+2. Run `csgclaw-cli --output json hub list` and pick a template (do not skip even if the user named a capability like GitLab).
+3. Run `csgclaw-cli --output json hub get <template-id>`.
+4. Create with `--from-template` and required `--env` values.
+
+If dispatch or any other skill says "create a worker", that means **this skill**, not `basics`.
+
+## When to Use
+
+Use this skill when:
+
+- the user asks to create, add, set up, or provision an agent, bot, robot, or worker
+- the user names a capability (GitLab, frontend, QA, review, etc.) and needs a matching worker
+- `bot list` shows no suitable available worker for the required capability
+- dispatch needs a new worker (pause dispatch, complete provisioning here, then resume with `basics` + dispatch)
+
+Do **not** use this skill when:
+
+- reusing an existing available worker (use `basics` + dispatch)
+- only dispatching a task to workers that already exist
+- only room/member/message CLI without creating anyone new
+
+## Forbidden
+
+Never run a bare worker create like:
+
+```bash
+# FORBIDDEN for new workers
+csgclaw-cli bot create --name gitlab-worker --role worker --runtime openclaw_sandbox
+```
+
+Never tell the worker secrets in chat instead of `--env`.
+
+Never skip `hub list` / `hub get` because you think you already know the template id.
+
+## Workflow
+
+1. Confirm the user wants a **new** worker (or dispatch lacks one). If an available worker already matches, stop and reuse it.
+2. `csgclaw-cli bot list --channel <current_channel>` — avoid duplicate names; ask reuse vs new if ambiguous.
+3. `csgclaw-cli --output json hub list` — match by `name`, `description`, and `role`.
+4. No match → say so plainly; do not fall back to bare `bot create`.
+5. Multiple matches → short comparison; let the user choose.
+6. `csgclaw-cli --output json hub get <template-id>` — read `image_env`.
+7. Collect every `required=true` env with no `default`; never echo `secret=true` values.
+8. Confirm `name`, optional `--id`, and `--description` (template description is a good default).
+9. Create:
+
+```bash
+csgclaw-cli bot create \
+  --name gitlab-worker \
+  --description "GitLab issue and MR worker" \
+  --role worker \
+  --from-template <matched-template-id> \
+  --env GITLAB_TOKEN=<user-provided> \
+  --channel <current_channel>
+```
+
+10. Report bot id, template id, and env status. Use `basics` for `member create` if the user wants the worker in the room. Do **not** auto-dispatch unless asked.
+
+## Commands
+
+```bash
+csgclaw-cli --output json hub list
+csgclaw-cli --output json hub get builtin/gitlab-worker
+csgclaw-cli bot list --channel <current_channel>
+csgclaw-cli bot create --from-template <id> --env KEY=VALUE ... --channel <current_channel>
+```
+
+Template env vars with `default` are injected by the server; pass `--env` only for secrets and overrides.
+
+## Operating Rules
+
+- `--from-template` is **required** for every new worker created through this skill.
+- Prefer `csgclaw-cli` over ad hoc HTTP.
+- Put global flags (`--output json`, `--endpoint`, `--token`) **before** the subcommand, e.g. `csgclaw-cli --output json hub list` (not after `hub list`).
+- Do not use `manager-worker-dispatch` until provisioning finishes.
+- Creation success is not dispatch success.

--- a/internal/templates/embed/openclaw-manager/workspace/skills/agent-creator/agents/openai.yaml
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/agent-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Creator"
+  short_description: "Mandatory hub-template worker provisioning"
+  default_prompt: "Use $agent-creator before any new bot create. Hub list, hub get, then bot create --from-template with --env."

--- a/internal/templates/embed/openclaw-manager/workspace/skills/basics/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/basics/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: basics
-description: Handle the most common basic CSGClaw CLI administration tasks. Use when the Manager needs to create a room or Feishu group/chat, list bots, create a bot, inspect room members, add a bot into a room, or perform similar direct `csgclaw-cli` operations for routine room, bot, and membership management.
+description: Handle routine CSGClaw CLI administration for rooms, Feishu group/chat creation, bot listing, room members, and IM mentions. Use for list bots, member create, message create, and room operations. Do NOT use for creating a new worker—use agent-creator instead (hub list + bot create --from-template).
 ---
 
 # CSGClaw CLI Basics
 
 Execute common `csgclaw-cli` operations directly and keep the flow simple.
-Prefer this skill whenever the user is asking for basic room, bot, or member management.
+Prefer this skill for room, member, and message operations after workers already exist.
 
 ## Scope
 
@@ -16,17 +16,21 @@ This skill covers direct CLI actions such as:
 - create a Feishu group/chat through CSGClaw
 - list rooms
 - list all bots
-- create a bot
 - list room members
 - add a bot as a room member
 - send a message, including a message with a mention
 - check command help for the current CLI surface before assuming flags
+
+Do **not** use this skill to **create a new worker**. For any new agent/bot/worker provisioning, use `agent-creator` (`hub list`, `hub get`, `bot create --from-template`).
 
 Do not use this skill when the task requires any of the following:
 
 - break a request into multiple worker-owned tasks
 - orchestrate a multi-worker workflow
 - manage cross-worker sequencing or tracking state
+- create an agent from a hub template with required image env vars
+
+For hub template selection and `--from-template` creation, use `agent-creator` instead.
 
 ## Workflow
 
@@ -61,7 +65,7 @@ csgclaw-cli bot list --channel <current_channel>
 Create a bot. Always include `--description`:
 
 ```bash
-csgclaw-cli bot create --id u-alex --name alex --description "frontend worker for settings tasks" --role worker --channel <current_channel>
+# Do not use this for new workers. Use agent-creator with --from-template instead.
 ```
 
 List members in a room:
@@ -138,7 +142,7 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 
 - Prefer direct `csgclaw-cli` commands over ad hoc HTTP calls.
 - Use `bot list` before creating a new bot if the user may be referring to an existing one.
-- When creating a bot, always pass a meaningful `--description` so later matching and reuse remain clear.
+- When a **new** worker is needed, use `agent-creator`; do not run bare `bot create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added bot as a new member. Create a new room with `--member-ids` containing the existing DM bots and the new bot.
 - For Feishu, prefer `room create --member-ids` for new groups after bot configs exist. Use `member create` only for an existing Feishu group; that path requires manager app scopes such as `im:chat.members:write_only` or `im:chat`.

--- a/internal/templates/embed/openclaw-manager/workspace/skills/manager-worker-dispatch/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/manager-worker-dispatch/SKILL.md
@@ -13,6 +13,18 @@ Check the current CLI surface through the `basics` skill instead of writing ad h
 
 If the user only needs a direct CLI action and there is no real dispatch workflow, use the `basics` skill instead of this skill.
 
+If the user wants to create or provision a new agent from hub templates (not execute a task), use the `agent-creator` skill instead of this skill.
+
+## Out of Scope
+
+Do not use this skill for:
+
+- hub template listing, matching, or selection
+- collecting template `image_env` values
+- creating agents with `--from-template`
+
+For those flows, use `agent-creator`. Never create a new worker with bare `bot create` from dispatch.
+
 ## Mandatory Dispatch Order
 
 When a user asks for manager-led coordination (especially GitLab planning, issue queries, breakdown, assignment, or execution handoff), follow this order and do not skip steps:
@@ -20,7 +32,9 @@ When a user asks for manager-led coordination (especially GitLab planning, issue
 1. Read this skill first before any domain execution.
 2. Check existing workers first (`bot list`) and prefer reusing a capable available worker.
 3. Ensure the selected worker is a member of the target room (add if missing).
-4. If no suitable worker exists or the matching one is `unavailable`, create or recreate the worker first, then add to the room.
+4. If no suitable worker exists or the matching one is `unavailable`:
+   - **New worker needed:** stop dispatch, follow `agent-creator` (hub list → hub get → `bot create --from-template` + `--env`), then use `basics` to add the worker to the room.
+   - **Existing worker unavailable:** use `basics` / recreate paths for that bot id only; do not bare-create a replacement.
 5. Dispatch the task to the worker in-room after membership is confirmed.
 
 Do not start with repo/code exploration, web fetch/search, or manager self-execution when the task is delegable to an existing or creatable worker.
@@ -33,7 +47,7 @@ If the admin explicitly asks the manager to arrange or reuse workers such as `ux
 1. Do not do the implementation work yourself.
 2. Do not use `message` for progress chatter or to restate the request.
 3. Do not use `spawn` or `subagent`.
-4. Use the `basics` skill to inspect existing workers, reuse matching available workers, and create a worker only if a required capability is missing or the matching worker is `unavailable`.
+4. Use the `basics` skill to inspect existing workers, reuse matching available workers, and use `agent-creator` only if a required capability is missing or the matching worker is `unavailable` and must be replaced with a new hub-template worker.
 5. Use the `basics` skill to ensure every chosen worker has joined the target room and verify room membership.
 6. Only after all required workers are present in the room, write `todo.json` under `~/.openclaw/workspace/projects/<slug>/todo.json`.
 7. Only after that room-membership check passes, start tracking with `scripts/manager_worker_api.py start-tracking`.
@@ -47,7 +61,7 @@ Do not inspect or modify project implementation files before dispatch unless you
 
 1. Break the admin request into concrete deliverables.
 2. Match each task to the needed capability; use the `basics` skill to inspect existing workers first (`bot list`) and reuse by matching `description`.
-3. If a suitable worker does not exist or is `unavailable`, create or recreate it before dispatch.
+3. If a suitable worker does not exist or is `unavailable`, provision via `agent-creator` (new) or recreate the existing bot (unavailable) before dispatch.
 4. Use the `basics` skill to ensure every required worker has joined the target room, then verify the full required worker set.
 5. Dispatch the user task to selected workers in-room after membership checks pass.
 6. Choose a suitable project directory under `~/.openclaw/workspace/projects`; create a short slug directory if none fits.
@@ -150,11 +164,10 @@ Use the `basics` skill whenever this workflow needs any of these supporting oper
 
 - create the target room
 - list workers or bots
-- create or recreate a worker bot
 - add a worker into the room
 - verify room membership before tracking
 
-If a listed worker is `unavailable`, use the `basics` skill to recreate that bot with the same original parameters so the backing agent becomes available again before dispatch.
+When a **new** worker is required, use `agent-creator` instead of bare `bot create`. Use `basics` here only for recreate when an existing listed worker is `unavailable`.
 
 ## Tracking Script Usage
 
@@ -173,7 +186,7 @@ python scripts/manager_worker_api.py start-tracking --channel <current_channel> 
 Dispatch delivery verification (mandatory, immediately after start):
 
 ```bash
-csgclaw-cli message list --room-id <target_room_id> --channel <current_channel> --output json
+csgclaw-cli --output json message list --room-id <target_room_id> --channel <current_channel>
 ```
 
 Success criteria:
@@ -209,7 +222,7 @@ Use this when exactly one worker should act (for example install a registry skil
 ## Operating Rules
 
 - Reuse available workers before creating new ones.
-- If a matching worker is listed as `unavailable`, use the `basics` skill to recreate it with the original parameters so the backing agent is created before joining or dispatching work to it.
+- If a matching worker is listed as `unavailable`, recreate that existing bot; do not bare-create a different replacement worker.
 - Before writing the final `todo.json` or running `start-tracking`, use the `basics` skill to verify all required workers are already members of the target room.
 - Treat missing room membership as a blocker: add the worker, verify again, and only then continue with `todo.json` and tracking.
 - Keep `todo.json` aligned with the actual assignment being dispatched.

--- a/internal/templates/embed/openclaw-manager/workspace/skills/skill-installer/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/skill-installer/SKILL.md
@@ -55,5 +55,5 @@ Use `--skills-dir` only when the workspace layout is non-standard.
 
 - Never guess or change slug casing.
 - Prefer `skill get` / `skill versions` before install when version or moderation matters.
-- Add `-o json` when structured output is needed.
+- Add `--output json` when structured output is needed (place global flags before the subcommand, e.g. `csgclaw-cli --output json skill search gitlab`).
 - Run `csgclaw-cli skill -h` or `csgclaw-cli skill <subcommand> -h` for flags.

--- a/internal/templates/embed/openclaw-worker/workspace/skills/skill-installer/SKILL.md
+++ b/internal/templates/embed/openclaw-worker/workspace/skills/skill-installer/SKILL.md
@@ -55,5 +55,5 @@ Use `--skills-dir` only when the workspace layout is non-standard.
 
 - Never guess or change slug casing.
 - Prefer `skill get` / `skill versions` before install when version or moderation matters.
-- Add `-o json` when structured output is needed.
+- Add `--output json` when structured output is needed (place global flags before the subcommand, e.g. `csgclaw-cli --output json skill search gitlab`).
 - Run `csgclaw-cli skill -h` or `csgclaw-cli skill <subcommand> -h` for flags.

--- a/internal/templates/embed/picoclaw-manager/workspace/AGENT.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/AGENT.md
@@ -42,12 +42,33 @@ be practical, accurate, and efficient.
 - Manager may execute domain work directly only when no suitable worker is available, or when the human explicitly requires manager-only execution.
 - When direct execution is used as fallback, manager should explain why dispatch was not possible.
 - Dispatch means waking a worker with a real IM mention (`csgclaw-cli message create --mention-id <worker-bot-id>` so the message contains `<at user_id="...">...</at>`). Do **not** type plain-text `@worker-name` in the room or PicoClaw `message` tool content; workers use `mention_only` and will ignore it. Manager-side `subagent` calls are not valid worker dispatch.
-- For work that should be **handed off to a worker** (actionable, tool-heavy, or clearly matching a worker’s skills from `bot list` / descriptions): do **not** open with `web_fetch` or `web_search` to do the worker’s job yourself. Follow `manager-worker-dispatch` first—list or create a worker, then IM-dispatch. Use web tools only for manager-only questions, lightweight clarification, or after you have explained why dispatch is blocked.
+- For work that should be **handed off to a worker** (actionable, tool-heavy, or clearly matching a worker’s skills from `bot list` / descriptions): do **not** open with `web_fetch` or `web_search` to do the worker’s job yourself. Follow `manager-worker-dispatch` for task routing—but if a **new** worker is needed, use `agent-creator` to provision from hub templates before dispatch continues. Use web tools only for manager-only questions, lightweight clarification, or after you have explained why dispatch is blocked.
+
+## Casual messages and CSGClaw onboarding
+
+When the user sends a greeting, small talk, or a vague message with **no clear task or command** (for example: "你好", "hi", "hello", "help", "你能做什么", "怎么用"):
+
+1. Do **not** run `csgclaw-cli`, load dispatch skills, or start tool-heavy work yet.
+2. Reply warmly and briefly in the **user's language**.
+3. Introduce yourself as the **CSGClaw manager** (PicoClaw manager) — the coordinator for bots, workers, rooms, and task handoff in this workspace.
+4. Summarize what you can help with, with **short example prompts** the user can copy or adapt.
+5. End with one open question: what would they like to do next?
+
+Suggested capability bullets (pick 3–4 that fit; keep the whole reply concise):
+
+- **Create workers** from hub templates (GitLab, frontend, QA, review, etc.) — e.g. "帮我创建一个 GitLab worker"
+- **Assign work** to existing workers in IM rooms and track multi-step handoffs — e.g. "把登录页 UI 交给 frontend worker 做"
+- **Manage bots and rooms** — list workers, create rooms, add members — e.g. "列出当前所有 worker"
+- **Answer CSGClaw usage questions** — explain the manager vs worker model when asked
+
+Do **not** list skill search or install in the welcome message. Workers install skills themselves via `skill-installer`; manager only dispatches that work when the user asks.
+
+Keep the intro to roughly **6–10 lines** unless the user asks for more detail. This is welcome guidance, not OpenClaw first-run hatch or identity onboarding.
 
 ## Skill loading priority
 
-- Manager routing bootstrap (mandatory): before selecting any domain skill, first read and apply `workspace/skills/manager-worker-dispatch/SKILL.md` as the routing contract.
-- If the dispatch skill exists locally, treat it as the default entrypoint for manager task planning, worker selection, and handoff decisions.
+1. **Agent creation first.** If the user wants to create/add/set up/provision an agent, bot, robot, or worker—or names a capability that needs a new worker (GitLab, frontend, QA, etc.)—read `workspace/skills/agent-creator/SKILL.md` **immediately** and follow it. Do **not** run `bot create` without `--from-template`. Skip dispatch until provisioning completes or an existing worker is reused.
+2. **Dispatch second.** For executable task handoff when workers already exist (or after `agent-creator` finishes), read `workspace/skills/manager-worker-dispatch/SKILL.md`.
 - Only after dispatch routing decides execution mode may manager read a domain skill (for worker dispatch constraints or fallback direct execution).
 - Before planning or dispatching a task, first list local skills under `workspace/skills` and choose from them.
 - If a matching local skill exists, read its `SKILL.md` and follow it as the primary execution contract.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/agent-creator/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/agent-creator/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent-creator
+description: Mandatory skill for provisioning any new CSGClaw agent, bot, robot, or worker. Use immediately when the user asks to create, add, set up, or provision an agent/bot/worker (including GitLab, frontend, QA, or other specialized workers), when dispatch needs a missing worker, or when asking which hub template fits. Always hub list + match + hub get + bot create --from-template with --env for secrets. Never run bot create without --from-template for a new worker. Do NOT use for task dispatch to existing workers or todo.json tracking only.
+---
+
+# Agent Creator
+
+Guide users through hub template selection and agent creation. This skill owns **all new worker provisioning**.
+
+Use `basics` only after create for room membership or IM mentions. Use `manager-worker-dispatch` only after the worker exists and the user wants task handoff.
+
+## Routing Gate (mandatory)
+
+Before running **any** `csgclaw-cli bot create` for a **new** worker:
+
+1. Read this skill first.
+2. Run `csgclaw-cli --output json hub list` and pick a template (do not skip even if the user named a capability like GitLab).
+3. Run `csgclaw-cli --output json hub get <template-id>`.
+4. Create with `--from-template` and required `--env` values.
+
+If dispatch or any other skill says "create a worker", that means **this skill**, not `basics`.
+
+## When to Use
+
+Use this skill when:
+
+- the user asks to create, add, set up, or provision an agent, bot, robot, or worker
+- the user names a capability (GitLab, frontend, QA, review, etc.) and needs a matching worker
+- `bot list` shows no suitable available worker for the required capability
+- dispatch needs a new worker (pause dispatch, complete provisioning here, then resume with `basics` + dispatch)
+
+Do **not** use this skill when:
+
+- reusing an existing available worker (use `basics` + dispatch)
+- only dispatching a task to workers that already exist
+- only room/member/message CLI without creating anyone new
+
+## Forbidden
+
+Never run a bare worker create like:
+
+```bash
+# FORBIDDEN for new workers
+csgclaw-cli bot create --name gitlab-worker --role worker --runtime picoclaw_sandbox
+```
+
+Never tell the worker secrets in chat instead of `--env`.
+
+Never skip `hub list` / `hub get` because you think you already know the template id.
+
+## Workflow
+
+1. Confirm the user wants a **new** worker (or dispatch lacks one). If an available worker already matches, stop and reuse it.
+2. `csgclaw-cli bot list --channel <current_channel>` — avoid duplicate names; ask reuse vs new if ambiguous.
+3. `csgclaw-cli --output json hub list` — match by `name`, `description`, and `role`.
+4. No match → say so plainly; do not fall back to bare `bot create`.
+5. Multiple matches → short comparison; let the user choose.
+6. `csgclaw-cli --output json hub get <template-id>` — read `image_env`.
+7. Collect every `required=true` env with no `default`; never echo `secret=true` values.
+8. Confirm `name`, optional `--id`, and `--description` (template description is a good default).
+9. Create:
+
+```bash
+csgclaw-cli bot create \
+  --name gitlab-worker \
+  --description "GitLab issue and MR worker" \
+  --role worker \
+  --from-template <matched-template-id> \
+  --env GITLAB_TOKEN=<user-provided> \
+  --channel <current_channel>
+```
+
+10. Report bot id, template id, and env status. Use `basics` for `member create` if the user wants the worker in the room. Do **not** auto-dispatch unless asked.
+
+## Commands
+
+```bash
+csgclaw-cli --output json hub list
+csgclaw-cli --output json hub get builtin/gitlab-worker
+csgclaw-cli bot list --channel <current_channel>
+csgclaw-cli bot create --from-template <id> --env KEY=VALUE ... --channel <current_channel>
+```
+
+Template env vars with `default` are injected by the server; pass `--env` only for secrets and overrides.
+
+## Operating Rules
+
+- `--from-template` is **required** for every new worker created through this skill.
+- Prefer `csgclaw-cli` over ad hoc HTTP.
+- Put global flags (`--output json`, `--endpoint`, `--token`) **before** the subcommand, e.g. `csgclaw-cli --output json hub list` (not after `hub list`).
+- Do not use `manager-worker-dispatch` until provisioning finishes.
+- Creation success is not dispatch success.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/agent-creator/agents/openai.yaml
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/agent-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Creator"
+  short_description: "Mandatory hub-template worker provisioning"
+  default_prompt: "Use $agent-creator before any new bot create. Hub list, hub get, then bot create --from-template with --env."

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: basics
-description: Handle the most common basic CSGClaw CLI administration tasks. Use when the Manager needs to create a room, list bots, create a bot, inspect room members, add a bot into a room, or notify a worker in IM.
+description: Handle routine CSGClaw CLI administration for rooms, bot listing, room members, and IM mentions. Use for list bots, member create, message create, and room operations. Do NOT use for creating a new worker—use agent-creator instead (hub list + bot create --from-template).
 ---
 
 # CSGClaw CLI Basics
 
 Execute common `csgclaw-cli` operations directly and keep the flow simple.
-Prefer this skill whenever the user is asking for basic room, bot, or member management.
+Prefer this skill for room, member, and message operations after workers already exist.
 
 ## Scope
 
@@ -15,17 +15,21 @@ This skill covers direct CLI actions such as:
 - create a room
 - list rooms
 - list all bots
-- create a bot
 - list room members
 - add a bot as a room member
 - send a message, including a message with a mention
 - check command help for the current CLI surface before assuming flags
+
+Do **not** use this skill to **create a new worker**. For any new agent/bot/worker provisioning, use `agent-creator` (`hub list`, `hub get`, `bot create --from-template`).
 
 Do not use this skill when the task requires any of the following:
 
 - break a request into multiple worker-owned tasks
 - orchestrate a multi-worker workflow
 - manage cross-worker sequencing or tracking state
+- create an agent from a hub template with required image env vars
+
+For hub template selection and `--from-template` creation, use `agent-creator` instead.
 
 ## Workflow
 
@@ -60,7 +64,7 @@ csgclaw-cli bot list --channel <current_channel>
 Create a bot. Always include `--description`:
 
 ```bash
-csgclaw-cli bot create --id u-alex --name alex --description "frontend worker for settings tasks" --role worker --channel <current_channel>
+# Do not use this for new workers. Use agent-creator with --from-template instead.
 ```
 
 List members in a room:
@@ -137,7 +141,7 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 
 - Prefer direct `csgclaw-cli` commands over ad hoc HTTP calls.
 - Use `bot list` before creating a new bot if the user may be referring to an existing one.
-- When creating a bot, always pass a meaningful `--description` so later matching and reuse remain clear.
+- When a **new** worker is needed, use `agent-creator`; do not run bare `bot create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added bot as a new member. Create a new room with `--member-ids` containing the existing DM bots and the new bot.
 - Keep `csgclaw-cli` parameters bot-facing across channels: use bot IDs such as `u-manager`, `u-dev`, and `u-alex`.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/manager-worker-dispatch/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/manager-worker-dispatch/SKILL.md
@@ -13,6 +13,18 @@ Check the current CLI surface through the `basics` skill instead of writing ad h
 
 If the user only needs a direct CLI action and there is no real dispatch workflow, use the `basics` skill instead of this skill.
 
+If the user wants to create or provision a new agent from hub templates (not execute a task), use the `agent-creator` skill instead of this skill.
+
+## Out of Scope
+
+Do not use this skill for:
+
+- hub template listing, matching, or selection
+- collecting template `image_env` values
+- creating agents with `--from-template`
+
+For those flows, use `agent-creator`. Never create a new worker with bare `bot create` from dispatch.
+
 ## Mandatory Dispatch Order
 
 When a user asks for manager-led coordination (especially GitLab planning, issue queries, breakdown, assignment, or execution handoff), follow this order and do not skip steps:
@@ -20,7 +32,9 @@ When a user asks for manager-led coordination (especially GitLab planning, issue
 1. Read this skill first before any domain execution.
 2. Check existing workers first (`bot list`) and prefer reusing a capable available worker.
 3. Ensure the selected worker is a member of the target room (add if missing).
-4. If no suitable worker exists or the matching one is `unavailable`, create or recreate the worker first, then add to the room.
+4. If no suitable worker exists or the matching one is `unavailable`:
+   - **New worker needed:** stop dispatch, follow `agent-creator` (hub list → hub get → `bot create --from-template` + `--env`), then use `basics` to add the worker to the room.
+   - **Existing worker unavailable:** use `basics` / recreate paths for that bot id only; do not bare-create a replacement.
 5. Dispatch the task to the worker in-room after membership is confirmed.
 
 Do not start with repo/code exploration, web fetch/search, or manager self-execution when the task is delegable to an existing or creatable worker.
@@ -33,7 +47,7 @@ If the admin explicitly asks the manager to arrange or reuse workers such as `ux
 1. Do not do the implementation work yourself.
 2. Do not use `message` for progress chatter or to restate the request.
 3. Do not use `spawn` or `subagent`.
-4. Use the `basics` skill to inspect existing workers, reuse matching available workers, and create a worker only if a required capability is missing or the matching worker is `unavailable`.
+4. Use the `basics` skill to inspect existing workers, reuse matching available workers, and use `agent-creator` only if a required capability is missing or the matching worker is `unavailable` and must be replaced with a new hub-template worker.
 5. Use the `basics` skill to ensure every chosen worker has joined the target room and verify room membership.
 6. Only after all required workers are present in the room, write `todo.json` under `~/.picoclaw/workspace/projects/<slug>/todo.json`.
 7. Only after that room-membership check passes, start tracking with `scripts/manager_worker_api.py start-tracking`.
@@ -47,7 +61,7 @@ Do not inspect or modify project implementation files before dispatch unless you
 
 1. Break the admin request into concrete deliverables.
 2. Match each task to the needed capability; use the `basics` skill to inspect existing workers first (`bot list`) and reuse by matching `description`.
-3. If a suitable worker does not exist or is `unavailable`, create or recreate it before dispatch.
+3. If a suitable worker does not exist or is `unavailable`, provision via `agent-creator` (new) or recreate the existing bot (unavailable) before dispatch.
 4. Use the `basics` skill to ensure every required worker has joined the target room, then verify the full required worker set.
 5. Dispatch the user task to selected workers in-room after membership checks pass.
 6. Choose a suitable project directory under `~/.picoclaw/workspace/projects`; create a short slug directory if none fits.
@@ -150,11 +164,10 @@ Use the `basics` skill whenever this workflow needs any of these supporting oper
 
 - create the target room
 - list workers or bots
-- create or recreate a worker bot
 - add a worker into the room
 - verify room membership before tracking
 
-If a listed worker is `unavailable`, use the `basics` skill to recreate that bot with the same original parameters so the backing agent becomes available again before dispatch.
+When a **new** worker is required, use `agent-creator` instead of bare `bot create`. Use `basics` here only for recreate when an existing listed worker is `unavailable`.
 
 ## Tracking Script Usage
 
@@ -173,7 +186,7 @@ python scripts/manager_worker_api.py start-tracking --channel <current_channel> 
 Dispatch delivery verification (mandatory, immediately after start):
 
 ```bash
-csgclaw-cli message list --room-id <target_room_id> --channel <current_channel> --output json
+csgclaw-cli --output json message list --room-id <target_room_id> --channel <current_channel>
 ```
 
 Success criteria:
@@ -209,7 +222,7 @@ Use this when exactly one worker should act (for example install a registry skil
 ## Operating Rules
 
 - Reuse available workers before creating new ones.
-- If a matching worker is listed as `unavailable`, use the `basics` skill to recreate it with the original parameters so the backing agent is created before joining or dispatching work to it.
+- If a matching worker is listed as `unavailable`, recreate that existing bot; do not bare-create a different replacement worker.
 - Before writing the final `todo.json` or running `start-tracking`, use the `basics` skill to verify all required workers are already members of the target room.
 - Treat missing room membership as a blocker: add the worker, verify again, and only then continue with `todo.json` and tracking.
 - Keep `todo.json` aligned with the actual assignment being dispatched.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/skill-installer/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/skill-installer/SKILL.md
@@ -55,5 +55,5 @@ Use `--skills-dir` only when the workspace layout is non-standard.
 
 - Never guess or change slug casing.
 - Prefer `skill get` / `skill versions` before install when version or moderation matters.
-- Add `-o json` when structured output is needed.
+- Add `--output json` when structured output is needed (place global flags before the subcommand, e.g. `csgclaw-cli --output json skill search gitlab`).
 - Run `csgclaw-cli skill -h` or `csgclaw-cli skill <subcommand> -h` for flags.

--- a/internal/templates/embed/picoclaw-worker/workspace/skills/skill-installer/SKILL.md
+++ b/internal/templates/embed/picoclaw-worker/workspace/skills/skill-installer/SKILL.md
@@ -55,5 +55,5 @@ Use `--skills-dir` only when the workspace layout is non-standard.
 
 - Never guess or change slug casing.
 - Prefer `skill get` / `skill versions` before install when version or moderation matters.
-- Add `-o json` when structured output is needed.
+- Add `--output json` when structured output is needed (place global flags before the subcommand, e.g. `csgclaw-cli --output json skill search gitlab`).
 - Run `csgclaw-cli skill -h` or `csgclaw-cli skill <subcommand> -h` for flags.


### PR DESCRIPTION
- Guide manager provisioning through hub list/get and bot create --from-template, expose hub on csgclaw-cli with --env support, apply template image_env defaults on create, add casual onboarding guidance, and fix global --output/-o flag usage in CLI docs and embedded skills.