### PR TITLE
ci(gitlab): build picoclaw manager/worker images on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,8 @@
 .cursor
 .vscode
 .agents
-bin
+bin/**
+!bin/csgclaw-cli
 dist
 manager-data
 tmp

--- a/.gitlab/ci-picoclaw-image.sh
+++ b/.gitlab/ci-picoclaw-image.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: ci-picoclaw-image.sh <goarch> <dockerfile> <image-name>" >&2
+  exit 1
+fi
+
+goarch="$1"
+dockerfile="$2"
+image_name="$3"
+
+: "${CI_PROJECT_DIR:?CI_PROJECT_DIR must be set}"
+: "${CI_COMMIT_TAG:?CI_COMMIT_TAG must be set}"
+: "${ACR_REGISTRY:?ACR_REGISTRY must be set}"
+
+archive="${CI_PROJECT_DIR}/dist/csgclaw-cli_${CI_COMMIT_TAG}_linux_${goarch}.tar.gz"
+staging_dir="${CI_PROJECT_DIR}/bin"
+cli_path="${staging_dir}/csgclaw-cli"
+
+if [ ! -f "${archive}" ]; then
+  echo "missing release artifact: ${archive}" >&2
+  echo "picoclaw image builds reuse csgclaw-cli from release-build (scripts/release-build-all.sh)" >&2
+  exit 1
+fi
+
+mkdir -p "${staging_dir}"
+rm -f "${cli_path}"
+tar -xzf "${archive}" -C "${staging_dir}" csgclaw-cli
+chmod 755 "${cli_path}"
+
+if [ ! -f "${cli_path}" ]; then
+  echo "failed to stage ${cli_path} from ${archive}" >&2
+  exit 1
+fi
+
+export PICOCLAW_BASE_TAG="${PICOCLAW_BASE_TAG:-2026.5.27}"
+
+/kaniko/executor \
+  --context "${CI_PROJECT_DIR}" \
+  --dockerfile "${CI_PROJECT_DIR}/${dockerfile}" \
+  --custom-platform "linux/${goarch}" \
+  --destination "${ACR_REGISTRY}/opencsghq/${image_name}:${CI_COMMIT_TAG}-${goarch}" \
+  --build-arg PICOCLAW_IMAGE="${ACR_REGISTRY}/opencsghq/picoclaw:${PICOCLAW_BASE_TAG}"

--- a/.gitlab/ci-picoclaw-manifest.sh
+++ b/.gitlab/ci-picoclaw-manifest.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: ci-picoclaw-manifest.sh <image-name>" >&2
+  exit 1
+fi
+
+image_name="$1"
+
+: "${ACR_REGISTRY:?ACR_REGISTRY must be set}"
+: "${ACR_USERNAME:?ACR_USERNAME must be set}"
+: "${ACR_PASSWORD:?ACR_PASSWORD must be set}"
+: "${CI_COMMIT_TAG:?CI_COMMIT_TAG must be set}"
+
+repo="${ACR_REGISTRY}/opencsghq/${image_name}"
+amd64_ref="${repo}:${CI_COMMIT_TAG}-amd64"
+arm64_ref="${repo}:${CI_COMMIT_TAG}-arm64"
+target_ref="${repo}:${CI_COMMIT_TAG}"
+
+crane auth login "$ACR_REGISTRY" -u "$ACR_USERNAME" -p "$ACR_PASSWORD"
+
+for ref in "$amd64_ref" "$arm64_ref"; do
+  if ! crane manifest "$ref" >/dev/null; then
+    echo "missing pushed image manifest: ${ref}" >&2
+    exit 1
+  fi
+done
+
+crane index append \
+  -m "$amd64_ref" \
+  -m "$arm64_ref" \
+  -t "$target_ref"

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -4,12 +4,16 @@
 #
 # Trigger: tags matching v* (e.g. pull mirror with "Trigger pipelines for mirror updates").
 #
-# Implementation: scripts/release-build-all.sh (per matrix cell); .gitlab/ci-gitlab-release-upload.sh (upload only); .gitlab/bookworm-mirror.sh (apt sources).
+# Implementation: scripts/release-build-all.sh (per matrix cell); .gitlab/ci-gitlab-release-upload.sh (upload only);
+# .gitlab/ci-picoclaw-image.sh (stage csgclaw-cli from dist/ into picoclaw manager/worker images); .gitlab/bookworm-mirror.sh (apt sources).
 #
 # Required CI/CD variables:
 #   REMOTE_SSH – e.g. root@cdn.example.com
-#   ACR_REGISTRY – registry hostname only (no scheme); CI images are mirrored under ${ACR_REGISTRY}/opencsg_public/ and ${ACR_REGISTRY}/opencsghq/
+#   ACR_REGISTRY – registry hostname only (no scheme)
+#   Toolchain mirrors: ${ACR_REGISTRY}/opencsg_public/ (golang, alpine, kaniko)
+#   Product images: ${ACR_REGISTRY}/opencsghq/ (csgclaw, picoclaw-*, node, crane-ci)
 #   ACR_USERNAME / ACR_PASSWORD – credentials with push access to ${ACR_REGISTRY}/opencsghq/csgclaw
+#   and ${ACR_REGISTRY}/opencsghq/picoclaw-{manager,worker}
 #
 # Recommended:
 #   SSH_PRIVATE_KEY – PEM text (Variable) OR GitLab “File” variable (value is a path in the job; script copies to ~/.ssh/id_rsa)
@@ -18,6 +22,7 @@
 # Optional:
 #   SSH_PORT – default 22
 #   REMOTE_BASE_DIR – default /data/csgclaw (releases under .../releases/<tag>/)
+#   PICOCLAW_BASE_TAG – upstream picoclaw base image tag; default 2026.5.27
 #   BOXLITE_CLI_VERSION – default v0.9.0
 #   BOXLITE_CLI_BASE_URL – boxlite-cli tarballs; default mirrors https://csgclaw.opencsg.com/boxlite-cli/{version}/{filename} (matches fetch-boxlite-cli.sh)
 #   BOXLITE_CURL_INSECURE – default 1 (TLS inspection); set 0 if csgclaw.opencsg.com is trusted as-is
@@ -43,6 +48,7 @@
 #   docker push ${ACR_REGISTRY}/opencsghq/node:22.13.0-alpine
 #   docker tag gcr.io/kaniko-project/executor:debug ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
 #   docker push ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
+#   # picoclaw manifest jobs require ${ACR_REGISTRY}/opencsghq/crane-ci:${CRANE_VERSION} (one-time manual push).
 
 variables:
   GIT_STRATEGY: clone
@@ -54,6 +60,8 @@ variables:
   GOPROXY: "https://goproxy.cn,direct"
   DEBIAN_APT_MIRROR_DEB: "http://mirrors.aliyun.com/debian"
   DEBIAN_APT_MIRROR_SEC: "http://mirrors.aliyun.com/debian-security"
+  PICOCLAW_BASE_TAG: "2026.5.27"
+  CRANE_VERSION: "v0.20.6"
 
 stages:
   - web
@@ -77,6 +85,37 @@ stages:
   image:
     name: ${ACR_REGISTRY}/opencsg_public/kaniko-executor:debug
     entrypoint: [""]
+
+.crane_image:
+  image:
+    name: ${ACR_REGISTRY}/opencsghq/crane-ci:${CRANE_VERSION}
+    entrypoint: [""]
+
+.kaniko_acr_auth:
+  before_script:
+    - test -n "${ACR_REGISTRY}"
+    - test -n "${ACR_USERNAME}"
+    - test -n "${ACR_PASSWORD}"
+    - mkdir -p /kaniko/.docker
+    - export ACR_AUTH="$(printf '%s:%s' "$ACR_USERNAME" "$ACR_PASSWORD" | base64 | tr -d '\n')"
+    - printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$ACR_REGISTRY" "$ACR_AUTH" > /kaniko/.docker/config.json
+
+.picoclaw_image_build:
+  extends:
+    - .kaniko_image
+    - .kaniko_acr_auth
+    - .release_rules
+  stage: image
+  needs:
+    - job: release-build
+      artifacts: true
+  parallel:
+    matrix:
+      - GOARCH: amd64
+      - GOARCH: arm64
+  script:
+    - chmod +x .gitlab/ci-picoclaw-image.sh
+    - sh .gitlab/ci-picoclaw-image.sh "${GOARCH}" "${PICOCLAW_DOCKERFILE}" "${PICOCLAW_IMAGE_NAME}"
 
 web-build:
   extends:
@@ -139,15 +178,10 @@ release-build:
 docker-build-amd64:
   extends:
     - .kaniko_image
+    - .kaniko_acr_auth
     - .release_rules
   stage: image
   script:
-    - test -n "${ACR_REGISTRY}"
-    - test -n "${ACR_USERNAME}"
-    - test -n "${ACR_PASSWORD}"
-    - mkdir -p /kaniko/.docker
-    - export ACR_AUTH="$(printf '%s:%s' "$ACR_USERNAME" "$ACR_PASSWORD" | base64 | tr -d '\n')"
-    - printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$ACR_REGISTRY" "$ACR_AUTH" > /kaniko/.docker/config.json
     - export COMMIT="$(git rev-parse --short HEAD)"
     - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     - |
@@ -163,6 +197,45 @@ docker-build-amd64:
         --build-arg VERSION="${CI_COMMIT_TAG}" \
         --build-arg COMMIT="${COMMIT}" \
         --build-arg BUILD_TIME="${BUILD_TIME}"
+
+picoclaw-manager-image:
+  extends: .picoclaw_image_build
+  variables:
+    PICOCLAW_DOCKERFILE: internal/templates/embed/picoclaw-manager/Dockerfile
+    PICOCLAW_IMAGE_NAME: picoclaw-manager
+
+picoclaw-worker-image:
+  extends: .picoclaw_image_build
+  variables:
+    PICOCLAW_DOCKERFILE: internal/templates/embed/picoclaw-worker/Dockerfile
+    PICOCLAW_IMAGE_NAME: picoclaw-worker
+
+.picoclaw_manifest:
+  extends:
+    - .crane_image
+    - .release_rules
+  stage: image
+  before_script:
+    - chmod +x .gitlab/ci-picoclaw-manifest.sh
+    - crane version
+  script:
+    - sh .gitlab/ci-picoclaw-manifest.sh "${PICOCLAW_IMAGE_NAME}"
+
+picoclaw-manager-manifest:
+  extends: .picoclaw_manifest
+  needs:
+    - job: picoclaw-manager-image
+      artifacts: false
+  variables:
+    PICOCLAW_IMAGE_NAME: picoclaw-manager
+
+picoclaw-worker-manifest:
+  extends: .picoclaw_manifest
+  needs:
+    - job: picoclaw-worker-image
+      artifacts: false
+  variables:
+    PICOCLAW_IMAGE_NAME: picoclaw-worker
 
 release-upload:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,15 @@ CLI_BIN ?= $(BIN_DIR)/csgclaw-cli
 IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw
 TAG ?= 2026.5.27
 LOCAL_IMAGE ?= picoclaw:local
+PICOCLAW_BASE_IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:$(TAG)
+PICOCLAW_MANAGER_IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager
+PICOCLAW_WORKER_IMAGE ?= opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker
+PICOCLAW_DOCKER_GOOS ?= linux
+PICOCLAW_DOCKER_GOARCH ?= $(TARGET_ARCH)
 
 .DEFAULT_GOAL := build-all
 
-.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw build-all run clean package package-all release tag push publish
+.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-picoclaw-docker-cli build-all run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
 
 help:
 	@printf '%s\n' \
@@ -42,6 +47,8 @@ help:
 		'make build-csgclaw - alias for build-server' \
 		'make build-csgclaw-cli - build $(CLI_BIN) for TARGET_OS/TARGET_ARCH (defaults to current platform)' \
 		'make build-csgclaw-cli-for-picoclaw - build PicoClaw CLI binaries for linux/amd64 and linux/arm64' \
+		'make build-picoclaw-manager-image - build picoclaw-manager Docker image (repo root context)' \
+		'make build-picoclaw-worker-image - build picoclaw-worker Docker image (repo root context)' \
 		'make build-all - build Web UI, bin/csgclaw, and bin/csgclaw-cli' \
 		'make run       - run the server in foreground' \
 		'make package   - package APP binary into dist/' \
@@ -126,6 +133,19 @@ build-csgclaw-cli:
 build-csgclaw-cli-for-picoclaw:
 	$(MAKE) build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=$(BIN_DIR)/csgclaw-cli_linux_amd64
 	$(MAKE) build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=arm64 CLI_BIN=$(BIN_DIR)/csgclaw-cli_linux_arm64
+
+stage-picoclaw-docker-cli:
+	$(MAKE) build-csgclaw-cli TARGET_OS=$(PICOCLAW_DOCKER_GOOS) TARGET_ARCH=$(PICOCLAW_DOCKER_GOARCH) CLI_BIN=$(BIN_DIR)/csgclaw-cli
+
+build-picoclaw-manager-image: stage-picoclaw-docker-cli
+	docker build -f internal/templates/embed/picoclaw-manager/Dockerfile \
+	  --build-arg PICOCLAW_IMAGE=$(PICOCLAW_BASE_IMAGE) \
+	  -t $(PICOCLAW_MANAGER_IMAGE):$(TAG) .
+
+build-picoclaw-worker-image: stage-picoclaw-docker-cli
+	docker build -f internal/templates/embed/picoclaw-worker/Dockerfile \
+	  --build-arg PICOCLAW_IMAGE=$(PICOCLAW_BASE_IMAGE) \
+	  -t $(PICOCLAW_WORKER_IMAGE):$(TAG) .
 
 build-all: build-web
 	$(MAKE) build-server APP=csgclaw

--- a/internal/hub/builtin_store_test.go
+++ b/internal/hub/builtin_store_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	testBuiltinPicoClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"
+	testBuiltinPicoClawManagerImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:2026.5.27"
+	testBuiltinPicoClawWorkerImage  = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:2026.5.27"
 	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260529.2-csgclaw"
 )
 
@@ -49,8 +50,16 @@ func TestBuiltinStoreListGetAndFetchWorkspace(t *testing.T) {
 	if got, want := item.Role, TemplateRoleWorker; got != want {
 		t.Fatalf("Get().Role = %q, want %q", got, want)
 	}
-	if got, want := item.Image, testBuiltinPicoClawImage; got != want {
+	if got, want := item.Image, testBuiltinPicoClawWorkerImage; got != want {
 		t.Fatalf("Get().Image = %q, want %q", got, want)
+	}
+
+	managerItem, err := store.Get(context.Background(), "picoclaw-manager")
+	if err != nil {
+		t.Fatalf("Get(picoclaw-manager) error = %v", err)
+	}
+	if got, want := managerItem.Image, testBuiltinPicoClawManagerImage; got != want {
+		t.Fatalf("Get(picoclaw-manager).Image = %q, want %q", got, want)
 	}
 	if got, want := item.WorkspaceRef.Kind, WorkspaceKindDir; got != want {
 		t.Fatalf("Get().WorkspaceRef.Kind = %q, want %q", got, want)

--- a/internal/templates/embed/picoclaw-manager/Dockerfile
+++ b/internal/templates/embed/picoclaw-manager/Dockerfile
@@ -1,0 +1,21 @@
+# PicoClaw manager sandbox image: upstream picoclaw base + prebuilt csgclaw-cli.
+#
+# Build context must include bin/csgclaw-cli (see Makefile or .gitlab/ci-picoclaw-image.sh).
+#
+# Local build from repository root:
+#   make build-picoclaw-manager-image
+#
+# Manual build:
+#   make build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=bin/csgclaw-cli
+#   docker build -f internal/templates/embed/picoclaw-manager/Dockerfile \
+#     --build-arg PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27 \
+#     -t picoclaw-manager:local .
+
+ARG PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27
+
+FROM ${PICOCLAW_IMAGE}
+
+USER root
+
+COPY bin/csgclaw-cli /usr/local/bin/csgclaw-cli
+RUN chmod 755 /usr/local/bin/csgclaw-cli

--- a/internal/templates/embed/picoclaw-manager/agent.toml
+++ b/internal/templates/embed/picoclaw-manager/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "picoclaw_sandbox"
 updated_at = "2026-05-27T00:00:00Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:2026.5.27"

--- a/internal/templates/embed/picoclaw-worker/Dockerfile
+++ b/internal/templates/embed/picoclaw-worker/Dockerfile
@@ -1,0 +1,21 @@
+# PicoClaw worker sandbox image: upstream picoclaw base + prebuilt csgclaw-cli.
+#
+# Build context must include bin/csgclaw-cli (see Makefile or .gitlab/ci-picoclaw-image.sh).
+#
+# Local build from repository root:
+#   make build-picoclaw-worker-image
+#
+# Manual build:
+#   make build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=bin/csgclaw-cli
+#   docker build -f internal/templates/embed/picoclaw-worker/Dockerfile \
+#     --build-arg PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27 \
+#     -t picoclaw-worker:local .
+
+ARG PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27
+
+FROM ${PICOCLAW_IMAGE}
+
+USER root
+
+COPY bin/csgclaw-cli /usr/local/bin/csgclaw-cli
+RUN chmod 755 /usr/local/bin/csgclaw-cli

--- a/internal/templates/embed/picoclaw-worker/agent.toml
+++ b/internal/templates/embed/picoclaw-worker/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "picoclaw_sandbox"
 updated_at = "2026-05-27T00:00:00Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:2026.5.27"


### PR DESCRIPTION
- Add embedded Dockerfiles, Kaniko/crane CI jobs, and split builtin template image refs. 