### PR TITLE
fix(templates): bump builtin picoclaw images to v0.3.7.1

### DIFF
--- a/internal/hub/builtin_store_test.go
+++ b/internal/hub/builtin_store_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	testBuiltinPicoClawManagerImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:2026.5.27"
-	testBuiltinPicoClawWorkerImage  = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:2026.5.27"
+	testBuiltinPicoClawManagerImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:v0.3.7.1"
+	testBuiltinPicoClawWorkerImage  = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:v0.3.7.1"
 	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260529.2-csgclaw"
 )
 

--- a/internal/templates/embed/picoclaw-manager/agent.toml
+++ b/internal/templates/embed/picoclaw-manager/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "picoclaw_sandbox"
 updated_at = "2026-05-27T00:00:00Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:2026.5.27"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-manager:v0.3.7.1"

--- a/internal/templates/embed/picoclaw-worker/agent.toml
+++ b/internal/templates/embed/picoclaw-worker/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "picoclaw_sandbox"
 updated_at = "2026-05-27T00:00:00Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:2026.5.27"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw-worker:v0.3.7.1"


### PR DESCRIPTION
- Align embedded manager/worker template refs with GitLab release tags so rebuild and upgrade use images published to ACR.