### PR TITLE
fix: static CLI builds and host UID alignment for sandboxes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,11 @@ web/static-dist/        generated Web UI assets for Go embed; run make web-build
 
 ## Commands
 
+See [docs/build.md](docs/build.md) or [docs/build.zh.md](docs/build.zh.md) for Makefile targets, embed dist staging, and optional Docker image builds.
+
 ```bash
-make                    # default build
+make                    # default build (no docker images)
+make build-all-with-docker-embed
 make fmt
 make test
 make run
@@ -65,7 +68,8 @@ make release
 ## References
 
 - `README.md`
-- `docs/README.go.md`
+- `docs/build.md`
+- `docs/build.zh.md`
 - `docs/web/development.md`
 - `Makefile`
 - `.github/workflows/release.yml`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ See [docs/build.md](docs/build.md) or [docs/build.zh.md](docs/build.zh.md) for M
 
 ```bash
 make                    # default build (no docker images)
-make build-all-with-docker-embed
+make build-all          # full build including embed docker images
 make fmt
 make test
 make run

--- a/Makefile
+++ b/Makefile
@@ -38,29 +38,25 @@ PICOCLAW_DOCKER_GOOS ?= $(DOCKER_EMBED_DOCKER_GOOS)
 PICOCLAW_DOCKER_GOARCH ?= $(DOCKER_EMBED_DOCKER_GOARCH)
 PICOCLAW_DOCKER_CLI ?= $(DOCKER_EMBED_CLI)
 
-# Set to 1 to docker-build all embed templates with a Dockerfile (slow; optional).
-BUILD_DOCKER_EMBED_IMAGES ?= 0
+.DEFAULT_GOAL := build
 
-.DEFAULT_GOAL := build-all
-
-.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist ensure-docker-embed-dist maybe-build-docker-embed-images build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all build-all-with-docker-embed run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
+.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist ensure-docker-embed-dist build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
 
 help:
 	@printf '%s\n' \
 		'make            - build Web UI, ensure embed dist, bin/csgclaw, bin/csgclaw-cli (no docker images)' \
-		'make build-all-with-docker-embed - like build-all, and docker-build embed template images' \
-		'make BUILD_DOCKER_EMBED_IMAGES=1 - same as build-all-with-docker-embed' \
+		'make build      - same as default goal' \
+		'make build-all  - build plus docker-build all embed template images and patch refs' \
 		'make fmt        - format Go files' \
 		'make test       - stage-docker-embed-dist (patched :dev refs), then go test ./...' \
 		'make web-install - install Web UI dependencies' \
 		'make web-dev    - run Vite Web UI dev server' \
 		'make build-web  - build Web UI app into web/static-dist' \
-		'make build      - alias for build-all' \
 		'make build-server-bin - build $(BIN) only (expects embed/*/dist patched; use stage-docker-embed-dist first)' \
 		'make stage-docker-embed-dist - prepare dist/ and patch dev image refs (no docker)' \
 		'make build-csgclaw-cli - build $(CLI_BIN) for current platform (CGO_ENABLED=0)' \
 		'make build-docker-embed-runtime-embed - stage cli, docker all embed templates with Dockerfile, patch refs' \
-		'make run        - build everything, then run the server' \
+		'make run        - build (no docker images), then run the server' \
 		'make clean      - remove local build outputs'
 
 fmt:
@@ -120,13 +116,15 @@ build-web: ensure-web-deps
 		exit 1; \
 	}
 
-build: build-all
+build: build-web ensure-docker-embed-dist
+	$(MAKE) build-server-bin APP=csgclaw
+	$(MAKE) build-csgclaw-cli TARGET_OS=$(TARGET_OS) TARGET_ARCH=$(TARGET_ARCH)
 
 build-server-bin:
 	mkdir -p $(BIN_DIR)
 	env GOCACHE=$(GOCACHE) $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN) $(CMD_PATH)
 
-build-server: ensure-docker-embed-dist maybe-build-docker-embed-images build-server-bin
+build-server: ensure-docker-embed-dist build-server-bin
 
 build-csgclaw:
 	$(MAKE) build-server APP=csgclaw
@@ -164,7 +162,7 @@ patch-picoclaw-embed-image-refs: patch-docker-embed-image-refs
 stage-docker-embed-dist: prepare-docker-embed-dist patch-docker-embed-image-refs
 stage-picoclaw-embed-dist: stage-docker-embed-dist
 
-# Stage embed/*/dist when missing; sets .docker-embed-dist-missing for maybe-build-docker-embed-images.
+# Stage embed/*/dist when missing (no docker).
 ensure-docker-embed-dist:
 	@mkdir -p "$(GOCACHE)"
 	@chmod +x scripts/list-docker-embed-templates.sh
@@ -179,16 +177,6 @@ ensure-docker-embed-dist:
 	if [ "$$dist_missing" -eq 1 ]; then \
 	  printf '%s\n' "docker embed dist/ missing or incomplete; running stage-docker-embed-dist"; \
 	  $(MAKE) stage-docker-embed-dist; \
-	  echo 1 > "$(GOCACHE)/.docker-embed-dist-missing"; \
-	else \
-	  rm -f "$(GOCACHE)/.docker-embed-dist-missing"; \
-	fi
-
-# Docker-build embed images when BUILD_DOCKER_EMBED_IMAGES=1 or dist/ was just staged.
-maybe-build-docker-embed-images:
-	@if [ "$(BUILD_DOCKER_EMBED_IMAGES)" = "1" ] || [ -f "$(GOCACHE)/.docker-embed-dist-missing" ]; then \
-	  $(MAKE) build-docker-embed-images patch-docker-embed-image-refs; \
-	  rm -f "$(GOCACHE)/.docker-embed-dist-missing"; \
 	fi
 
 build-docker-embed-images: stage-docker-embed-cli
@@ -214,14 +202,10 @@ build-picoclaw-worker-image: stage-docker-embed-cli
 		DOCKER_EMBED_IMAGE_TAG="$(DOCKER_EMBED_IMAGE_TAG)" \
 		scripts/build-docker-embed-images.sh picoclaw-worker
 
-build-all: build-web ensure-docker-embed-dist maybe-build-docker-embed-images
-	$(MAKE) build-server-bin APP=csgclaw
-	$(MAKE) build-csgclaw-cli TARGET_OS=$(TARGET_OS) TARGET_ARCH=$(TARGET_ARCH)
+build-all: build
+	$(MAKE) build-docker-embed-images patch-docker-embed-image-refs
 
-build-all-with-docker-embed:
-	$(MAKE) build-all BUILD_DOCKER_EMBED_IMAGES=1
-
-run: build-all
+run: build
 	$(BIN) serve
 
 package: build-web

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ PICOCLAW_DOCKER_CLI ?= $(DOCKER_EMBED_CLI)
 
 .DEFAULT_GOAL := build
 
-.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist ensure-docker-embed-dist build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
+.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist ensure-docker-embed-dist build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
 
 help:
 	@printf '%s\n' \
@@ -52,10 +52,9 @@ help:
 		'make web-install - install Web UI dependencies' \
 		'make web-dev    - run Vite Web UI dev server' \
 		'make build-web  - build Web UI app into web/static-dist' \
-		'make build-server-bin - build $(BIN) only (expects embed/*/dist patched; use stage-docker-embed-dist first)' \
+		'make build-server-bin - build bin/csgclaw and bin/csgclaw-cli (expects embed/*/dist; use stage-docker-embed-dist first)' \
 		'make stage-docker-embed-dist - prepare dist/ and patch dev image refs (no docker)' \
-		'make build-csgclaw-cli - build $(CLI_BIN) for current platform (CGO_ENABLED=0)' \
-		'make build-docker-embed-runtime-embed - stage cli, docker all embed templates with Dockerfile, patch refs' \
+		'make build-docker-embed-runtime-embed - stage linux cli, docker all embed templates with Dockerfile, patch refs' \
 		'make run        - build (no docker images), then run the server' \
 		'make clean      - remove local build outputs'
 
@@ -116,27 +115,15 @@ build-web: ensure-web-deps
 		exit 1; \
 	}
 
-build: build-web ensure-docker-embed-dist
-	$(MAKE) build-server-bin APP=csgclaw
-	$(MAKE) build-csgclaw-cli TARGET_OS=$(TARGET_OS) TARGET_ARCH=$(TARGET_ARCH)
+build: build-web ensure-docker-embed-dist build-server-bin
 
 build-server-bin:
 	mkdir -p $(BIN_DIR)
-	env GOCACHE=$(GOCACHE) $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN) $(CMD_PATH)
+	env GOCACHE=$(GOCACHE) $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/csgclaw ./cmd/csgclaw
+	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) \
+		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(BIN_DIR)/csgclaw-cli ./cmd/csgclaw-cli
 
 build-server: ensure-docker-embed-dist build-server-bin
-
-build-csgclaw:
-	$(MAKE) build-server APP=csgclaw
-
-build-csgclaw-cli:
-	mkdir -p $(BIN_DIR)
-	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) \
-		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(CLI_BIN) ./cmd/csgclaw-cli
-
-build-csgclaw-cli-for-picoclaw:
-	$(MAKE) build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=$(BIN_DIR)/csgclaw-cli_linux_amd64
-	$(MAKE) build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=arm64 CLI_BIN=$(BIN_DIR)/csgclaw-cli_linux_arm64
 
 $(DOCKER_EMBED_CLI): prepare-docker-embed-dist
 	mkdir -p $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ BOXLITE_CLI_BASE_URL ?= https://github.com/boxlite-ai/boxlite/releases/download
 
 GO ?= go
 GOFMT ?= gofmt
+# Static CLI for musl-based PicoClaw/BoxLite sandbox images (see release-build-all.sh).
+CGO_ENABLED ?= 0
 WEB_APP_DIR ?= web/app
 WEB_STATIC_DIST_DIR ?= web/static-dist
 WEB_PNPM ?= $(CURDIR)/scripts/web-pnpm.sh
@@ -36,22 +38,27 @@ PICOCLAW_DOCKER_GOOS ?= $(DOCKER_EMBED_DOCKER_GOOS)
 PICOCLAW_DOCKER_GOARCH ?= $(DOCKER_EMBED_DOCKER_GOARCH)
 PICOCLAW_DOCKER_CLI ?= $(DOCKER_EMBED_CLI)
 
+# Set to 1 to docker-build all embed templates with a Dockerfile (slow; optional).
+BUILD_DOCKER_EMBED_IMAGES ?= 0
+
 .DEFAULT_GOAL := build-all
 
-.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
+.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev build-web build build-server build-server-bin build-csgclaw build-csgclaw-cli build-csgclaw-cli-for-picoclaw stage-docker-embed-cli stage-picoclaw-docker-cli prepare-docker-embed-dist prepare-picoclaw-embed-dist patch-docker-embed-image-refs patch-picoclaw-embed-image-refs stage-docker-embed-dist stage-picoclaw-embed-dist ensure-docker-embed-dist maybe-build-docker-embed-images build-docker-embed-images build-docker-embed-runtime-embed build-picoclaw-runtime-embed build-all build-all-with-docker-embed run clean package package-all release tag push publish build-picoclaw-manager-image build-picoclaw-worker-image
 
 help:
 	@printf '%s\n' \
-		'make            - build Web UI, PicoClaw images + embed dist, bin/csgclaw, bin/csgclaw-cli' \
+		'make            - build Web UI, ensure embed dist, bin/csgclaw, bin/csgclaw-cli (no docker images)' \
+		'make build-all-with-docker-embed - like build-all, and docker-build embed template images' \
+		'make BUILD_DOCKER_EMBED_IMAGES=1 - same as build-all-with-docker-embed' \
 		'make fmt        - format Go files' \
 		'make test       - stage-docker-embed-dist (patched :dev refs), then go test ./...' \
 		'make web-install - install Web UI dependencies' \
 		'make web-dev    - run Vite Web UI dev server' \
 		'make build-web  - build Web UI app into web/static-dist' \
 		'make build      - alias for build-all' \
-		'make build-server-bin - build $(BIN) only (expects embed/*/dist patched; use build-docker-embed-runtime-embed or stage-docker-embed-dist first)' \
+		'make build-server-bin - build $(BIN) only (expects embed/*/dist patched; use stage-docker-embed-dist first)' \
 		'make stage-docker-embed-dist - prepare dist/ and patch dev image refs (no docker)' \
-		'make build-csgclaw-cli - build $(CLI_BIN) for current platform' \
+		'make build-csgclaw-cli - build $(CLI_BIN) for current platform (CGO_ENABLED=0)' \
 		'make build-docker-embed-runtime-embed - stage cli, docker all embed templates with Dockerfile, patch refs' \
 		'make run        - build everything, then run the server' \
 		'make clean      - remove local build outputs'
@@ -119,14 +126,15 @@ build-server-bin:
 	mkdir -p $(BIN_DIR)
 	env GOCACHE=$(GOCACHE) $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN) $(CMD_PATH)
 
-build-server: build-docker-embed-runtime-embed build-server-bin
+build-server: ensure-docker-embed-dist maybe-build-docker-embed-images build-server-bin
 
 build-csgclaw:
 	$(MAKE) build-server APP=csgclaw
 
 build-csgclaw-cli:
 	mkdir -p $(BIN_DIR)
-	env GOCACHE=$(GOCACHE) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) $(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(CLI_BIN) ./cmd/csgclaw-cli
+	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) \
+		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(CLI_BIN) ./cmd/csgclaw-cli
 
 build-csgclaw-cli-for-picoclaw:
 	$(MAKE) build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=$(BIN_DIR)/csgclaw-cli_linux_amd64
@@ -134,7 +142,8 @@ build-csgclaw-cli-for-picoclaw:
 
 $(DOCKER_EMBED_CLI): prepare-docker-embed-dist
 	mkdir -p $(BIN_DIR)
-	env GOCACHE=$(GOCACHE) GOOS=$(DOCKER_EMBED_DOCKER_GOOS) GOARCH=$(DOCKER_EMBED_DOCKER_GOARCH) $(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(DOCKER_EMBED_CLI) ./cmd/csgclaw-cli
+	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(DOCKER_EMBED_DOCKER_GOOS) GOARCH=$(DOCKER_EMBED_DOCKER_GOARCH) \
+		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(DOCKER_EMBED_CLI) ./cmd/csgclaw-cli
 
 stage-docker-embed-cli: $(DOCKER_EMBED_CLI)
 stage-picoclaw-docker-cli: stage-docker-embed-cli
@@ -154,6 +163,33 @@ patch-picoclaw-embed-image-refs: patch-docker-embed-image-refs
 
 stage-docker-embed-dist: prepare-docker-embed-dist patch-docker-embed-image-refs
 stage-picoclaw-embed-dist: stage-docker-embed-dist
+
+# Stage embed/*/dist when missing; sets .docker-embed-dist-missing for maybe-build-docker-embed-images.
+ensure-docker-embed-dist:
+	@mkdir -p "$(GOCACHE)"
+	@chmod +x scripts/list-docker-embed-templates.sh
+	@dist_missing=0; \
+	for name in $$(scripts/list-docker-embed-templates.sh); do \
+	  manifest="internal/templates/embed/$$name/dist/agent.toml"; \
+	  if [ ! -f "$$manifest" ] || ! grep -q '^ref = ' "$$manifest"; then \
+	    dist_missing=1; \
+	    break; \
+	  fi; \
+	done; \
+	if [ "$$dist_missing" -eq 1 ]; then \
+	  printf '%s\n' "docker embed dist/ missing or incomplete; running stage-docker-embed-dist"; \
+	  $(MAKE) stage-docker-embed-dist; \
+	  echo 1 > "$(GOCACHE)/.docker-embed-dist-missing"; \
+	else \
+	  rm -f "$(GOCACHE)/.docker-embed-dist-missing"; \
+	fi
+
+# Docker-build embed images when BUILD_DOCKER_EMBED_IMAGES=1 or dist/ was just staged.
+maybe-build-docker-embed-images:
+	@if [ "$(BUILD_DOCKER_EMBED_IMAGES)" = "1" ] || [ -f "$(GOCACHE)/.docker-embed-dist-missing" ]; then \
+	  $(MAKE) build-docker-embed-images patch-docker-embed-image-refs; \
+	  rm -f "$(GOCACHE)/.docker-embed-dist-missing"; \
+	fi
 
 build-docker-embed-images: stage-docker-embed-cli
 	chmod +x scripts/build-docker-embed-images.sh
@@ -178,10 +214,12 @@ build-picoclaw-worker-image: stage-docker-embed-cli
 		DOCKER_EMBED_IMAGE_TAG="$(DOCKER_EMBED_IMAGE_TAG)" \
 		scripts/build-docker-embed-images.sh picoclaw-worker
 
-build-all: build-web
-	$(MAKE) build-docker-embed-runtime-embed
+build-all: build-web ensure-docker-embed-dist maybe-build-docker-embed-images
 	$(MAKE) build-server-bin APP=csgclaw
 	$(MAKE) build-csgclaw-cli TARGET_OS=$(TARGET_OS) TARGET_ARCH=$(TARGET_ARCH)
+
+build-all-with-docker-embed:
+	$(MAKE) build-all BUILD_DOCKER_EMBED_IMAGES=1
 
 run: build-all
 	$(BIN) serve

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Official release bundles are also published for macOS amd64 and Windows amd64. W
 make build
 ```
 
+See [docs/build.md](docs/build.md) for embed dist staging, optional PicoClaw Docker image builds, and other Makefile targets.
+
 For most users, the install script above is the simpler option.
 
 ## Quick Start

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,6 +39,8 @@ curl.exe -fsSL https://csgclaw.opencsg.com/install.ps1 | powershell -ExecutionPo
 make build
 ```
 
+Makefile 详细说明（embed dist、可选 Docker 镜像构建等）见 [docs/build.zh.md](docs/build.zh.md)。
+
 对大多数用户来说，直接使用上面的安装脚本会更简单。
 
 ## 快速开始

--- a/docs/build.md
+++ b/docs/build.md
@@ -70,18 +70,10 @@ Frontend structure and verification details: [docs/web/development.md](web/devel
 
 | Target | Output | Notes |
 |--------|--------|-------|
-| `make build-server-bin` | `bin/csgclaw` | Server only; expects `embed/*/dist` already staged |
-| `make build-csgclaw-cli` | `bin/csgclaw-cli` | Current platform; `CGO_ENABLED=0` (static binary) |
-| `make build-csgclaw-cli-for-picoclaw` | `bin/csgclaw-cli_linux_amd64`, `bin/csgclaw-cli_linux_arm64` | Used before Docker embed image builds |
+| `make build-server-bin` | `bin/csgclaw`, `bin/csgclaw-cli` | Both binaries for the current platform; CLI uses `CGO_ENABLED=0` |
 | `make stage-docker-embed-cli` | `bin/csgclaw-cli` (linux, host arch) | Linux CLI copied into PicoClaw Docker images |
 
 `csgclaw-cli` is built with `CGO_ENABLED=0` so it runs inside musl-based PicoClaw and BoxLite sandbox images. Release CI uses the same setting (`scripts/release-build-all.sh`).
-
-Override statically if needed:
-
-```bash
-make build-csgclaw-cli CGO_ENABLED=0
-```
 
 ## Embed dist
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -19,13 +19,12 @@ make help
 
 ## Default build
 
-The default goal is `build-all`:
+The default goal is `build`:
 
 ```bash
 make
 # same as:
 make build
-make build-all
 ```
 
 This builds:
@@ -35,7 +34,7 @@ This builds:
 3. `bin/csgclaw` (server CLI)
 4. `bin/csgclaw-cli` for the current platform
 
-By default, **Docker images are not built**. This keeps day-to-day builds fast.
+**Docker images are not built.** Use `make build-all` for a full local build including embed template images.
 
 After a successful build:
 
@@ -44,6 +43,16 @@ After a successful build:
 # or
 make run
 ```
+
+## Full build
+
+`build-all` runs `build`, then docker-builds all embed templates with a `Dockerfile` and patches image refs:
+
+```bash
+make build-all
+```
+
+Use this when you need local `picoclaw-manager` / `picoclaw-worker` images. It can be slow.
 
 ## Web UI
 
@@ -95,23 +104,15 @@ make stage-docker-embed-dist
 
 ## Docker embed images (optional)
 
-Local Docker image builds are **optional** and can be slow. Use them when you need custom `picoclaw-manager` / `picoclaw-worker` images on your machine.
+Local Docker image builds are **optional** and can be slow. The usual entry point is `make build-all`. Use individual targets when you only need one image.
 
 ### When images are built
 
 | Command | Builds Docker images? |
 |---------|------------------------|
-| `make` / `make build-all` | No (unless dist was just created for the first time; see below) |
-| `make build-all-with-docker-embed` | Yes |
-| `BUILD_DOCKER_EMBED_IMAGES=1 make` | Yes |
-| `make build-docker-embed-runtime-embed` | Yes (full pipeline) |
-
-On a fresh clone, `ensure-docker-embed-dist` may stage missing `dist/` trees and then trigger a one-time image build so refs resolve to local `:dev` tags. To always skip Docker during default builds, stage dist first:
-
-```bash
-make stage-docker-embed-dist
-make build-all
-```
+| `make` / `make build` | No |
+| `make build-all` | Yes |
+| `make build-docker-embed-runtime-embed` | Yes (images + patch refs, without rebuilding binaries) |
 
 ### Image build targets
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,184 @@
+# Build Guide
+
+English | [中文](build.zh.md)
+
+This document describes the repository `Makefile` targets for local development, testing, packaging, and optional PicoClaw embed image builds.
+
+Run all commands from the repository root. For a quick summary at any time:
+
+```bash
+make help
+```
+
+## Prerequisites
+
+- Go toolchain (see `go.mod` for the required version)
+- `pnpm` for the Web UI (`scripts/web-pnpm.sh` wraps installation checks)
+- Docker, when building embed template images locally
+- `boxlite` CLI, when running or testing with the BoxLite sandbox provider (see [docs/config.md](config.md))
+
+## Default build
+
+The default goal is `build-all`:
+
+```bash
+make
+# same as:
+make build
+make build-all
+```
+
+This builds:
+
+1. Web UI assets into `web/static-dist/`
+2. Embed template `dist/` trees when missing (see [Embed dist](#embed-dist))
+3. `bin/csgclaw` (server CLI)
+4. `bin/csgclaw-cli` for the current platform
+
+By default, **Docker images are not built**. This keeps day-to-day builds fast.
+
+After a successful build:
+
+```bash
+./bin/csgclaw serve
+# or
+make run
+```
+
+## Web UI
+
+| Target | Description |
+|--------|-------------|
+| `make web-install` | Install Web UI dependencies (`pnpm install --frozen-lockfile`) |
+| `make web-dev` | Run the Vite dev server |
+| `make build-web` | Build the Web UI into `web/static-dist/` |
+
+`make build-web` auto-runs `web-install` when `node_modules` is missing.
+
+Frontend structure and verification details: [docs/web/development.md](web/development.md).
+
+## Go binaries
+
+| Target | Output | Notes |
+|--------|--------|-------|
+| `make build-server-bin` | `bin/csgclaw` | Server only; expects `embed/*/dist` already staged |
+| `make build-csgclaw-cli` | `bin/csgclaw-cli` | Current platform; `CGO_ENABLED=0` (static binary) |
+| `make build-csgclaw-cli-for-picoclaw` | `bin/csgclaw-cli_linux_amd64`, `bin/csgclaw-cli_linux_arm64` | Used before Docker embed image builds |
+| `make stage-docker-embed-cli` | `bin/csgclaw-cli` (linux, host arch) | Linux CLI copied into PicoClaw Docker images |
+
+`csgclaw-cli` is built with `CGO_ENABLED=0` so it runs inside musl-based PicoClaw and BoxLite sandbox images. Release CI uses the same setting (`scripts/release-build-all.sh`).
+
+Override statically if needed:
+
+```bash
+make build-csgclaw-cli CGO_ENABLED=0
+```
+
+## Embed dist
+
+Builtin PicoClaw templates ship source under `internal/templates/embed/<name>/`. Runtime files for `go:embed` live in each template's `dist/` directory and are generated locally or in CI.
+
+| Target | Description |
+|--------|-------------|
+| `make prepare-docker-embed-dist` | Copy template source into `embed/*/dist/` (no Docker) |
+| `make patch-docker-embed-image-refs` | Patch `dist/agent.toml` image refs (default tag `:dev`) |
+| `make stage-docker-embed-dist` | `prepare` + `patch` |
+| `make ensure-docker-embed-dist` | Stage dist when missing (used by `build-all`) |
+
+Templates with a `Dockerfile` are discovered by `scripts/list-docker-embed-templates.sh` (currently `picoclaw-manager` and `picoclaw-worker`).
+
+If `make build-server-bin` fails with `pattern embed/.../dist: no matching files found`, run:
+
+```bash
+make stage-docker-embed-dist
+```
+
+## Docker embed images (optional)
+
+Local Docker image builds are **optional** and can be slow. Use them when you need custom `picoclaw-manager` / `picoclaw-worker` images on your machine.
+
+### When images are built
+
+| Command | Builds Docker images? |
+|---------|------------------------|
+| `make` / `make build-all` | No (unless dist was just created for the first time; see below) |
+| `make build-all-with-docker-embed` | Yes |
+| `BUILD_DOCKER_EMBED_IMAGES=1 make` | Yes |
+| `make build-docker-embed-runtime-embed` | Yes (full pipeline) |
+
+On a fresh clone, `ensure-docker-embed-dist` may stage missing `dist/` trees and then trigger a one-time image build so refs resolve to local `:dev` tags. To always skip Docker during default builds, stage dist first:
+
+```bash
+make stage-docker-embed-dist
+make build-all
+```
+
+### Image build targets
+
+| Target | Description |
+|--------|-------------|
+| `make build-docker-embed-images` | Build all embed templates that have a `Dockerfile` |
+| `make build-picoclaw-manager-image` | Build manager image only |
+| `make build-picoclaw-worker-image` | Build worker image only |
+| `make build-docker-embed-runtime-embed` | Build linux CLI, docker-build all templates, patch refs |
+
+Alias targets `build-picoclaw-runtime-embed`, `stage-picoclaw-embed-dist`, and similar names remain for compatibility.
+
+### Useful variables
+
+```bash
+# Registry and tags (defaults shown)
+ACR_REGISTRY=opencsg-registry.cn-beijing.cr.aliyuncs.com
+DOCKER_EMBED_IMAGE_TAG=dev
+PICOCLAW_BASE_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27
+
+# Example: build worker image with a custom tag
+make build-picoclaw-worker-image DOCKER_EMBED_IMAGE_TAG=local
+```
+
+Resulting images follow:
+
+```text
+${ACR_REGISTRY}/opencsghq/picoclaw-manager:${DOCKER_EMBED_IMAGE_TAG}
+${ACR_REGISTRY}/opencsghq/picoclaw-worker:${DOCKER_EMBED_IMAGE_TAG}
+```
+
+Build context is the repository root; Dockerfiles expect `bin/csgclaw-cli` (linux) to be present—`stage-docker-embed-cli` creates it.
+
+### BoxLite vs local Docker images
+
+Images built with `make build-docker-embed-images` are stored in the **Docker** image store. **BoxLite does not use Docker images directly**; pull images into BoxLite with `boxlite pull …` or use a registry BoxLite can reach. See [docs/config.md](config.md) for sandbox provider settings.
+
+## Test, format, and clean
+
+| Target | Description |
+|--------|-------------|
+| `make test` | `stage-docker-embed-dist`, then `go test ./...` |
+| `make fmt` | Format Go sources under `cli/`, `cmd/`, `internal/`, `web/` |
+| `make clean` | Remove `bin/`, `dist/`, `.gocache/`, and generated embed `dist/` contents |
+
+For targeted Go tests:
+
+```bash
+go test ./internal/agent/ -run TestName
+go test ./...
+```
+
+## Packaging and release
+
+Maintainer targets:
+
+| Target | Description |
+|--------|-------------|
+| `make package` | Build Web UI and package current platform binary |
+| `make package-all` | Full build plus `csgclaw` and `csgclaw-cli` packages |
+| `make release` | Cross-platform release bundles (darwin/linux, arm64/amd64) |
+
+CI release flows use `.github/workflows/release.yml` and GitLab jobs for embed dist and image builds.
+
+## Related docs
+
+- [docs/config.md](config.md) — sandbox providers (BoxLite, Docker, CSGHub)
+- [docs/web/development.md](web/development.md) — Web UI development
+- [docs/architecture.md](architecture.md) — system layout
+- `Makefile` — source of truth for targets and defaults

--- a/docs/build.zh.md
+++ b/docs/build.zh.md
@@ -1,0 +1,184 @@
+# 构建指南
+
+[English](build.md) | 中文
+
+本文说明仓库 `Makefile` 中的本地开发、测试、打包，以及可选的 PicoClaw embed 镜像构建命令。
+
+请在仓库根目录执行以下命令。随时可运行：
+
+```bash
+make help
+```
+
+## 前置条件
+
+- Go 工具链（版本见 `go.mod`）
+- Web UI 需要 `pnpm`（`scripts/web-pnpm.sh` 会检查安装）
+- 本地构建 embed 模板镜像时需要 Docker
+- 使用 BoxLite sandbox 运行或测试时需要 `boxlite` CLI（见 [docs/config.zh.md](config.zh.md)）
+
+## 默认构建
+
+默认目标是 `build-all`：
+
+```bash
+make
+# 等价于：
+make build
+make build-all
+```
+
+会依次构建：
+
+1. Web UI 产物到 `web/static-dist/`
+2. 缺失时的 embed 模板 `dist/` 目录（见 [Embed dist](#embed-dist)）
+3. `bin/csgclaw`（服务端 CLI）
+4. 当前平台的 `bin/csgclaw-cli`
+
+**默认不会构建 Docker 镜像**，日常开发更快。
+
+构建完成后可运行：
+
+```bash
+./bin/csgclaw serve
+# 或
+make run
+```
+
+## Web UI
+
+| 目标 | 说明 |
+|------|------|
+| `make web-install` | 安装 Web UI 依赖（`pnpm install --frozen-lockfile`） |
+| `make web-dev` | 启动 Vite 开发服务器 |
+| `make build-web` | 构建 Web UI 到 `web/static-dist/` |
+
+缺少 `node_modules` 时，`make build-web` 会自动执行 `web-install`。
+
+前端结构与验证说明见 [docs/web/development.zh.md](web/development.zh.md)。
+
+## Go 二进制
+
+| 目标 | 输出 | 说明 |
+|------|------|------|
+| `make build-server-bin` | `bin/csgclaw` | 仅服务端；需已准备好 `embed/*/dist` |
+| `make build-csgclaw-cli` | `bin/csgclaw-cli` | 当前平台；`CGO_ENABLED=0`（静态链接） |
+| `make build-csgclaw-cli-for-picoclaw` | `bin/csgclaw-cli_linux_amd64`、`bin/csgclaw-cli_linux_arm64` | Docker embed 镜像构建前使用 |
+| `make stage-docker-embed-cli` | `bin/csgclaw-cli`（linux，宿主机架构） | 打入 PicoClaw Docker 镜像的 Linux CLI |
+
+`csgclaw-cli` 使用 `CGO_ENABLED=0` 构建，以便在 musl 环境的 PicoClaw / BoxLite 沙箱中运行。Release CI 同样使用该设置（`scripts/release-build-all.sh`）。
+
+如需显式指定：
+
+```bash
+make build-csgclaw-cli CGO_ENABLED=0
+```
+
+## Embed dist
+
+内置 PicoClaw 模板源码位于 `internal/templates/embed/<name>/`。供 `go:embed` 使用的运行时文件在各模板的 `dist/` 目录，由本地或 CI 生成。
+
+| 目标 | 说明 |
+|------|------|
+| `make prepare-docker-embed-dist` | 将模板源码复制到 `embed/*/dist/`（不打 Docker） |
+| `make patch-docker-embed-image-refs` | 修补 `dist/agent.toml` 中的镜像 ref（默认 tag `:dev`） |
+| `make stage-docker-embed-dist` | `prepare` + `patch` |
+| `make ensure-docker-embed-dist` | 缺失时自动 stage dist（`build-all` 使用） |
+
+带 `Dockerfile` 的模板由 `scripts/list-docker-embed-templates.sh` 发现（当前为 `picoclaw-manager` 和 `picoclaw-worker`）。
+
+若 `make build-server-bin` 报错 `pattern embed/.../dist: no matching files found`，请执行：
+
+```bash
+make stage-docker-embed-dist
+```
+
+## Docker embed 镜像（可选）
+
+本地 Docker 镜像构建为**可选项**，可能较慢。仅在需要本机自定义 `picoclaw-manager` / `picoclaw-worker` 镜像时使用。
+
+### 何时会构建镜像
+
+| 命令 | 是否构建 Docker 镜像 |
+|------|----------------------|
+| `make` / `make build-all` | 否（除非首次补全 dist 时触发一次，见下） |
+| `make build-all-with-docker-embed` | 是 |
+| `BUILD_DOCKER_EMBED_IMAGES=1 make` | 是 |
+| `make build-docker-embed-runtime-embed` | 是（完整流程） |
+
+全新 clone 时，`ensure-docker-embed-dist` 可能先补全 `dist/`，再触发一次性镜像构建，使 ref 指向本地 `:dev` tag。若希望默认构建始终跳过 Docker，可先 stage dist：
+
+```bash
+make stage-docker-embed-dist
+make build-all
+```
+
+### 镜像构建目标
+
+| 目标 | 说明 |
+|------|------|
+| `make build-docker-embed-images` | 构建所有带 `Dockerfile` 的 embed 模板 |
+| `make build-picoclaw-manager-image` | 仅构建 manager 镜像 |
+| `make build-picoclaw-worker-image` | 仅构建 worker 镜像 |
+| `make build-docker-embed-runtime-embed` | 构建 linux CLI、docker build 全部模板、patch refs |
+
+兼容别名包括 `build-picoclaw-runtime-embed`、`stage-picoclaw-embed-dist` 等。
+
+### 常用变量
+
+```bash
+#  registry 与 tag（默认值）
+ACR_REGISTRY=opencsg-registry.cn-beijing.cr.aliyuncs.com
+DOCKER_EMBED_IMAGE_TAG=dev
+PICOCLAW_BASE_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27
+
+# 示例：自定义 tag 构建 worker 镜像
+make build-picoclaw-worker-image DOCKER_EMBED_IMAGE_TAG=local
+```
+
+产物镜像命名：
+
+```text
+${ACR_REGISTRY}/opencsghq/picoclaw-manager:${DOCKER_EMBED_IMAGE_TAG}
+${ACR_REGISTRY}/opencsghq/picoclaw-worker:${DOCKER_EMBED_IMAGE_TAG}
+```
+
+构建上下文为仓库根目录；Dockerfile 需要 `bin/csgclaw-cli`（linux），由 `stage-docker-embed-cli` 生成。
+
+### BoxLite 与本地 Docker 镜像
+
+`make build-docker-embed-images` 构建的镜像保存在 **Docker** 镜像存储中。**BoxLite 不会直接使用 Docker 镜像**；需通过 `boxlite pull …` 拉取，或使用 BoxLite 可访问的 registry。Sandbox 配置见 [docs/config.zh.md](config.zh.md)。
+
+## 测试、格式化与清理
+
+| 目标 | 说明 |
+|------|------|
+| `make test` | 先 `stage-docker-embed-dist`，再 `go test ./...` |
+| `make fmt` | 格式化 `cli/`、`cmd/`、`internal/`、`web/` 下的 Go 源码 |
+| `make clean` | 删除 `bin/`、`dist/`、`.gocache/` 及 embed 生成的 `dist/` 内容 |
+
+针对性测试：
+
+```bash
+go test ./internal/agent/ -run TestName
+go test ./...
+```
+
+## 打包与发布
+
+维护者常用目标：
+
+| 目标 | 说明 |
+|------|------|
+| `make package` | 构建 Web UI 并打包当前平台二进制 |
+| `make package-all` | 完整构建并打包 `csgclaw` 与 `csgclaw-cli` |
+| `make release` | 跨平台 release bundle（darwin/linux，arm64/amd64） |
+
+CI 发布流程见 `.github/workflows/release.yml` 及 GitLab 中的 embed dist / 镜像 job。
+
+## 相关文档
+
+- [docs/config.zh.md](config.zh.md) — sandbox 提供者（BoxLite、Docker、CSGHub）
+- [docs/web/development.zh.md](web/development.zh.md) — Web UI 开发
+- [docs/architecture.md](architecture.md) — 系统结构
+- `Makefile` — target 与默认值的权威来源

--- a/docs/build.zh.md
+++ b/docs/build.zh.md
@@ -19,13 +19,12 @@ make help
 
 ## 默认构建
 
-默认目标是 `build-all`：
+默认目标是 `build`：
 
 ```bash
 make
 # 等价于：
 make build
-make build-all
 ```
 
 会依次构建：
@@ -35,7 +34,7 @@ make build-all
 3. `bin/csgclaw`（服务端 CLI）
 4. 当前平台的 `bin/csgclaw-cli`
 
-**默认不会构建 Docker 镜像**，日常开发更快。
+**不会构建 Docker 镜像。** 需要完整本地环境（含 embed 镜像）时使用 `make build-all`。
 
 构建完成后可运行：
 
@@ -44,6 +43,16 @@ make build-all
 # 或
 make run
 ```
+
+## 完整构建
+
+`build-all` 先执行 `build`，再 docker build 所有带 `Dockerfile` 的 embed 模板并 patch 镜像 ref：
+
+```bash
+make build-all
+```
+
+需要本地 `picoclaw-manager` / `picoclaw-worker` 镜像时使用，可能较慢。
 
 ## Web UI
 
@@ -95,23 +104,15 @@ make stage-docker-embed-dist
 
 ## Docker embed 镜像（可选）
 
-本地 Docker 镜像构建为**可选项**，可能较慢。仅在需要本机自定义 `picoclaw-manager` / `picoclaw-worker` 镜像时使用。
+本地 Docker 镜像构建为**可选项**，可能较慢。常用入口是 `make build-all`；只需单个镜像时使用下方独立 target。
 
 ### 何时会构建镜像
 
 | 命令 | 是否构建 Docker 镜像 |
 |------|----------------------|
-| `make` / `make build-all` | 否（除非首次补全 dist 时触发一次，见下） |
-| `make build-all-with-docker-embed` | 是 |
-| `BUILD_DOCKER_EMBED_IMAGES=1 make` | 是 |
-| `make build-docker-embed-runtime-embed` | 是（完整流程） |
-
-全新 clone 时，`ensure-docker-embed-dist` 可能先补全 `dist/`，再触发一次性镜像构建，使 ref 指向本地 `:dev` tag。若希望默认构建始终跳过 Docker，可先 stage dist：
-
-```bash
-make stage-docker-embed-dist
-make build-all
-```
+| `make` / `make build` | 否 |
+| `make build-all` | 是 |
+| `make build-docker-embed-runtime-embed` | 是（仅镜像 + patch refs，不重建二进制） |
 
 ### 镜像构建目标
 

--- a/docs/build.zh.md
+++ b/docs/build.zh.md
@@ -70,18 +70,10 @@ make build-all
 
 | 目标 | 输出 | 说明 |
 |------|------|------|
-| `make build-server-bin` | `bin/csgclaw` | 仅服务端；需已准备好 `embed/*/dist` |
-| `make build-csgclaw-cli` | `bin/csgclaw-cli` | 当前平台；`CGO_ENABLED=0`（静态链接） |
-| `make build-csgclaw-cli-for-picoclaw` | `bin/csgclaw-cli_linux_amd64`、`bin/csgclaw-cli_linux_arm64` | Docker embed 镜像构建前使用 |
+| `make build-server-bin` | `bin/csgclaw`、`bin/csgclaw-cli` | 当前平台两个二进制；CLI 使用 `CGO_ENABLED=0` |
 | `make stage-docker-embed-cli` | `bin/csgclaw-cli`（linux，宿主机架构） | 打入 PicoClaw Docker 镜像的 Linux CLI |
 
 `csgclaw-cli` 使用 `CGO_ENABLED=0` 构建，以便在 musl 环境的 PicoClaw / BoxLite 沙箱中运行。Release CI 同样使用该设置（`scripts/release-build-all.sh`）。
-
-如需显式指定：
-
-```bash
-make build-csgclaw-cli CGO_ENABLED=0
-```
 
 ## Embed dist
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -24,6 +24,7 @@ import (
 	"csgclaw/internal/runtime/sandboxgateway"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/sandbox/boxlitecli"
+	"csgclaw/internal/sandbox/hostuser"
 	"csgclaw/internal/sandbox/sandboxtest"
 	"csgclaw/internal/templates"
 )
@@ -5626,6 +5627,13 @@ func TestGatewayCreateSpecBuildsSandboxSpec(t *testing.T) {
 	}
 	if got, want := spec.Env["PICOCLAW_CHANNELS_FEISHU_APP_ID"], "cli_worker"; got != want {
 		t.Fatalf("PICOCLAW_CHANNELS_FEISHU_APP_ID = %q, want %q", got, want)
+	}
+	runUser, err := hostuser.RunUser()
+	if err != nil {
+		t.Skip("host uid/gid unavailable")
+	}
+	if spec.RunUser != runUser {
+		t.Fatalf("gatewayCreateSpec() RunUser = %q, want %q", spec.RunUser, runUser)
 	}
 
 	wantAgentHome := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, "alice")

--- a/internal/bot/service_test.go
+++ b/internal/bot/service_test.go
@@ -44,6 +44,10 @@ func (f fakeBotAgentRuntime) Kind() string {
 	return f.kind
 }
 
+func (f fakeBotAgentRuntime) WorkspaceRoot(agentHome string) string {
+	return filepath.Join(agentHome, "workspace")
+}
+
 func (f fakeBotAgentRuntime) New(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
 	return agentruntime.Handle{
 		RuntimeID: spec.RuntimeID,

--- a/internal/runtime/picoclawsandbox/provision_test.go
+++ b/internal/runtime/picoclawsandbox/provision_test.go
@@ -10,6 +10,7 @@ import (
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/config"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/sandbox/hostuser"
 	"csgclaw/internal/templates"
 )
 
@@ -109,5 +110,12 @@ func TestGatewayCreateSpecMountsPicoClawRuntimeRoot(t *testing.T) {
 	cmd := strings.Join(spec.Cmd, " ")
 	if strings.Contains(cmd, "/csgclaw-projects") || strings.Contains(cmd, "ln -sfn") {
 		t.Fatalf("GatewayCreateSpec() cmd = %q, want direct projects mount without symlink setup", spec.Cmd)
+	}
+	runUser, err := hostuser.RunUser()
+	if err != nil {
+		t.Skip("host uid/gid unavailable")
+	}
+	if spec.RunUser != runUser {
+		t.Fatalf("GatewayCreateSpec() RunUser = %q, want %q", spec.RunUser, runUser)
 	}
 }

--- a/internal/runtime/sandboxgateway/runtime.go
+++ b/internal/runtime/sandboxgateway/runtime.go
@@ -15,6 +15,7 @@ import (
 	"csgclaw/internal/config"
 	agentruntime "csgclaw/internal/runtime"
 	"csgclaw/internal/sandbox"
+	"csgclaw/internal/sandbox/hostuser"
 )
 
 type AgentRef struct {
@@ -378,6 +379,9 @@ func (r *Runtime) GatewayCreateSpec(image, name, botID string, profile agentrunt
 		AutoRemove: false,
 		Env:        envVars,
 		Cmd:        []string{"/bin/sh", "-c", gatewayCommand},
+	}
+	if runUser, err := hostuser.RunUser(); err == nil {
+		spec.RunUser = runUser
 	}
 	spec.Mounts = append(spec.Mounts,
 		sandbox.Mount{HostPath: workspaceLayout.MountHostPath, GuestPath: workspaceLayout.MountGuestPath},

--- a/internal/sandbox/boxlitecli/options.go
+++ b/internal/sandbox/boxlitecli/options.go
@@ -69,6 +69,10 @@ func runArgs(spec sandbox.CreateSpec) ([]string, error) {
 		args = append(args, "-e", key+"="+spec.Env[key])
 	}
 
+	if runUser := strings.TrimSpace(spec.RunUser); runUser != "" {
+		args = append(args, "-u", runUser)
+	}
+
 	for _, mount := range spec.Mounts {
 		if strings.TrimSpace(mount.HostPath) == "" {
 			return nil, fmt.Errorf("invalid sandbox mount: host path is required")

--- a/internal/sandbox/boxlitecli/provider_test.go
+++ b/internal/sandbox/boxlitecli/provider_test.go
@@ -39,6 +39,7 @@ func TestCreateBuildsRunCLIArgs(t *testing.T) {
 		Name:       "agent",
 		Detach:     true,
 		AutoRemove: true,
+		RunUser:    "501:20",
 		Env:        map[string]string{"B": "two", "A": "one"},
 		Cmd:        []string{"sh", "-lc", "echo ok"},
 		Mounts: []sandbox.Mount{
@@ -63,6 +64,7 @@ func TestCreateBuildsRunCLIArgs(t *testing.T) {
 		"--rm",
 		"-e", "A=one",
 		"-e", "B=two",
+		"-u", "501:20",
 		"-v", "/host/rw:/guest/rw",
 		"-v", "/host/ro:/guest/ro:ro",
 		"alpine",

--- a/internal/sandbox/dockercli/provider_test.go
+++ b/internal/sandbox/dockercli/provider_test.go
@@ -38,6 +38,7 @@ func TestCreateBuildsRunCLIArgs(t *testing.T) {
 		Name:       "agent",
 		Detach:     true,
 		AutoRemove: true,
+		RunUser:    "501:20",
 		Env:        map[string]string{"B": "two", "A": "one"},
 		Cmd:        []string{"sh", "-lc", "echo ok"},
 		Mounts: []sandbox.Mount{
@@ -59,6 +60,7 @@ func TestCreateBuildsRunCLIArgs(t *testing.T) {
 		"--rm",
 		"-e", "A=one",
 		"-e", "B=two",
+		"-u", "501:20",
 		"-v", "/host/rw:/guest/rw",
 		"-v", "/host/ro:/guest/ro:ro",
 		"alpine",

--- a/internal/sandbox/dockercli/run_args.go
+++ b/internal/sandbox/dockercli/run_args.go
@@ -39,6 +39,10 @@ func runArgs(spec sandbox.CreateSpec) ([]string, error) {
 		args = append(args, "-e", key+"="+spec.Env[key])
 	}
 
+	if runUser := strings.TrimSpace(spec.RunUser); runUser != "" {
+		args = append(args, "-u", runUser)
+	}
+
 	for _, mount := range spec.Mounts {
 		if strings.TrimSpace(mount.HostPath) == "" {
 			return nil, fmt.Errorf("invalid sandbox mount: host path is required")

--- a/internal/sandbox/hostuser/runuser.go
+++ b/internal/sandbox/hostuser/runuser.go
@@ -1,0 +1,17 @@
+package hostuser
+
+import (
+	"fmt"
+	"os"
+)
+
+// RunUser returns the current process uid:gid for sandbox run --user alignment
+// with bind-mounted host directories.
+func RunUser() (string, error) {
+	uid := os.Getuid()
+	gid := os.Getgid()
+	if uid < 0 || gid < 0 {
+		return "", fmt.Errorf("host uid/gid is unavailable on this platform")
+	}
+	return fmt.Sprintf("%d:%d", uid, gid), nil
+}

--- a/internal/sandbox/hostuser/runuser_test.go
+++ b/internal/sandbox/hostuser/runuser_test.go
@@ -1,0 +1,36 @@
+package hostuser
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRunUserMatchesProcessIDs(t *testing.T) {
+	got, err := RunUser()
+	if err != nil {
+		if os.Getuid() < 0 || os.Getgid() < 0 {
+			t.Skip("host uid/gid unavailable")
+		}
+		t.Fatalf("RunUser() error = %v", err)
+	}
+	uidStr, gidStr, ok := strings.Cut(got, ":")
+	if !ok {
+		t.Fatalf("RunUser() = %q, want uid:gid", got)
+	}
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		t.Fatalf("parse uid %q: %v", uidStr, err)
+	}
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		t.Fatalf("parse gid %q: %v", gidStr, err)
+	}
+	if uid != os.Getuid() {
+		t.Fatalf("uid = %d, want %d", uid, os.Getuid())
+	}
+	if gid != os.Getgid() {
+		t.Fatalf("gid = %d, want %d", gid, os.Getgid())
+	}
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -68,6 +68,9 @@ type CreateSpec struct {
 	Name       string
 	Detach     bool
 	AutoRemove bool
+	// RunUser sets the process user inside the sandbox (docker/boxlite --user).
+	// Format: uid or uid:gid.
+	RunUser    string
 	Env        map[string]string
 	Mounts     []Mount
 	Entrypoint []string

--- a/internal/templates/embed/picoclaw-manager/Dockerfile
+++ b/internal/templates/embed/picoclaw-manager/Dockerfile
@@ -19,3 +19,5 @@ USER root
 
 COPY bin/csgclaw-cli /usr/local/bin/csgclaw-cli
 RUN chmod 755 /usr/local/bin/csgclaw-cli
+
+USER picoclaw

--- a/internal/templates/embed/picoclaw-manager/Dockerfile
+++ b/internal/templates/embed/picoclaw-manager/Dockerfile
@@ -6,7 +6,7 @@
 #   make build-picoclaw-manager-image
 #
 # Manual build:
-#   make build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=bin/csgclaw-cli
+#   make stage-docker-embed-cli
 #   docker build -f internal/templates/embed/picoclaw-manager/Dockerfile \
 #     --build-arg PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27 \
 #     -t picoclaw-manager:local .

--- a/internal/templates/embed/picoclaw-worker/Dockerfile
+++ b/internal/templates/embed/picoclaw-worker/Dockerfile
@@ -19,3 +19,5 @@ USER root
 
 COPY bin/csgclaw-cli /usr/local/bin/csgclaw-cli
 RUN chmod 755 /usr/local/bin/csgclaw-cli
+
+USER picoclaw

--- a/internal/templates/embed/picoclaw-worker/Dockerfile
+++ b/internal/templates/embed/picoclaw-worker/Dockerfile
@@ -6,7 +6,7 @@
 #   make build-picoclaw-worker-image
 #
 # Manual build:
-#   make build-csgclaw-cli TARGET_OS=linux TARGET_ARCH=amd64 CLI_BIN=bin/csgclaw-cli
+#   make stage-docker-embed-cli
 #   docker build -f internal/templates/embed/picoclaw-worker/Dockerfile \
 #     --build-arg PICOCLAW_IMAGE=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/picoclaw:2026.5.27 \
 #     -t picoclaw-worker:local .


### PR DESCRIPTION
- Build csgclaw-cli with CGO_ENABLED=0 for musl PicoClaw images, make docker embed image builds optional, and pass host uid:gid to docker/boxlite runs so bind-mounted workspace directories keep correct ownership.