### PR TITLE
fix(web): improve chat overlay layering

### DIFF
--- a/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.css
+++ b/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.css
@@ -370,10 +370,13 @@
 
 .composer {
   position: relative;
+  isolation: isolate;
 }
 
 .composer-box {
   display: block;
+  position: relative;
+  z-index: 1;
 }
 
 .composer-input-wrap {
@@ -479,10 +482,11 @@
 
 .mention-picker {
   position: absolute;
-  left: 24px;
-  bottom: 124px;
-  width: 280px;
-  max-height: min(360px, 48vh);
+  z-index: var(--z-portal-popover);
+  left: 20px;
+  bottom: calc(100% + 8px);
+  width: min(360px, calc(100% - 40px));
+  max-height: min(320px, calc(100dvh - 220px));
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
@@ -511,10 +515,11 @@
 
 .mention-option {
   width: 100%;
+  min-height: 56px;
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 12px;
+  padding: 9px 10px;
   border: 0;
   background: transparent;
   border-radius: 14px;
@@ -525,6 +530,15 @@
 .mention-option:hover,
 .mention-option.active {
   background: var(--primary-soft);
+}
+
+.mention-option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.mention-option > div {
+  min-width: 0;
 }
 
 .messages-empty {
@@ -1459,7 +1473,7 @@
 }
 
 .mention-picker {
-  width: min(340px, calc(100% - 48px));
+  width: min(360px, calc(100% - 40px));
   padding: 6px;
   border-radius: 14px;
   box-shadow: var(--shadow-sm);
@@ -1467,7 +1481,8 @@
 
 .mention-option {
   gap: 10px;
-  padding: 8px 10px;
+  min-height: 58px;
+  padding: 9px 10px;
   border-radius: 10px;
 }
 
@@ -1475,6 +1490,7 @@
   width: 38px;
   height: 38px;
   flex-basis: 38px;
+  overflow: hidden;
   border-radius: 50%;
   background: var(--avatar-default-bg);
   color: var(--avatar-default-fg);

--- a/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
+++ b/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
@@ -645,11 +645,13 @@ function MentionPicker({ users = [], activeIndex = 0, className = "", showRole =
   }, [activeIndex, activeUserID, users.length]);
 
   return (
-    <div className={`mention-picker ${className}`.trim()}>
+    <div className={`mention-picker ${className}`.trim()} role="listbox">
       {users.map((user, index) => (
         <button
           key={user.id}
           ref={index === activeIndex ? activeOptionRef : null}
+          role="option"
+          aria-selected={index === activeIndex}
           className={`mention-option ${index === activeIndex ? "active" : ""}`}
           onMouseDown={(event) => {
             event.preventDefault();
@@ -684,13 +686,15 @@ function SkillPicker({ candidates = [], activeIndex = 0, loading = false, classN
   }, [activeIndex, activeSkill, candidates.length]);
 
   return (
-    <div className={`mention-picker skill-picker ${className}`.trim()}>
+    <div className={`mention-picker skill-picker ${className}`.trim()} role="listbox">
       {loading ? <div className="skill-picker-empty">{t("agentWorkspaceLoading")}</div> : null}
       {!loading && candidates.length === 0 ? <div className="skill-picker-empty">{t("skillPickerEmpty")}</div> : null}
       {candidates.map((name, index) => (
         <button
           key={name}
           ref={index === activeIndex ? activeOptionRef : null}
+          role="option"
+          aria-selected={index === activeIndex}
           className={`mention-option skill-option ${index === activeIndex ? "active" : ""}`}
           onMouseDown={(event) => {
             event.preventDefault();

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -622,7 +622,12 @@
 }
 
 .profile-modal {
+  display: flex;
+  flex-direction: column;
   width: min(880px, 100%);
+  max-height: min(860px, calc(100dvh - 40px));
+  padding: 0;
+  overflow: hidden;
 }
 
 .agent-modal {
@@ -630,14 +635,14 @@
 }
 
 .profile-modal .modal-header {
-  position: sticky;
-  top: -24px;
+  position: relative;
+  flex: 0 0 auto;
   z-index: 2;
-  margin: -24px -24px 0;
+  margin: 0;
   padding: 18px 24px 14px;
   background: color-mix(in oklab, var(--panel) 94%, transparent);
   border-bottom: 1px solid var(--line);
-  backdrop-filter: blur(14px);
+  backdrop-filter: none;
 }
 
 .modal-card .modal-header .modal-close {
@@ -682,7 +687,12 @@
 
 .profile-editor-shell {
   display: grid;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   margin-top: 14px;
+  padding: 14px 24px 18px;
+  overscroll-behavior: contain;
 }
 
 .profile-section {
@@ -1055,6 +1065,7 @@
 
 .profile-editor-shell {
   gap: 16px;
+  margin-top: 0;
 }
 
 .profile-section {
@@ -1068,6 +1079,23 @@
 
 .modal-actions {
   background: var(--panel);
+}
+
+.agent-modal > .form-error {
+  flex: 0 0 auto;
+  margin: 12px 24px 0;
+}
+
+.agent-modal > .agent-create-progress {
+  flex: 0 0 auto;
+  margin: 12px 24px 0;
+}
+
+.agent-modal > .modal-actions {
+  flex: 0 0 auto;
+  margin-top: 0;
+  padding: 16px 24px 24px;
+  border-top: 1px solid var(--line);
 }
 
 .modal-card .field input,
@@ -1392,6 +1420,7 @@
   padding: 24px 28px 26px;
   min-width: 0;
   overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .manager-rebuild-modal .profile-section {

--- a/web/app/tests/components/ConversationPane.test.tsx
+++ b/web/app/tests/components/ConversationPane.test.tsx
@@ -111,12 +111,18 @@ function renderThreadPane({
   onPreviewUser = vi.fn(),
   replies = [],
   showToolCalls = false,
+  mentionCandidates = [],
+  mentionIndex = 0,
+  onApplyMention = vi.fn(),
 }: {
   conversationMembers?: IMUser[];
   isDirect?: boolean;
   messages?: IMConversation["messages"];
+  mentionCandidates?: IMUser[];
+  mentionIndex?: number;
   onClearRoomMessages?: (id: string) => void;
   onDeleteRoom?: (id: string) => void;
+  onApplyMention?: (user: IMUser) => void;
   onPreviewUser?: (user: IMUser) => void;
   replies?: ThreadView["replies"];
   showToolCalls?: boolean;
@@ -170,13 +176,13 @@ function renderThreadPane({
         managerProfile={null}
         managerProfileIncomplete={false}
         memberMenuRef={createRef<HTMLDivElement>()}
-        mentionCandidates={[]}
-        mentionIndex={0}
+        mentionCandidates={mentionCandidates}
+        mentionIndex={mentionIndex}
         mentionableUsersByHandle={new Map([["manager", users[1]]])}
         messageActionBusy={false}
         messageActionError=""
         messageListRef={createRef<HTMLElement>()}
-        onApplyMention={() => {}}
+        onApplyMention={onApplyMention}
         onClearRoomMessages={onClearRoomMessages}
         onCloseThread={() => {}}
         onComposerCompositionEnd={() => {}}
@@ -274,6 +280,24 @@ describe("ConversationPane", () => {
     await user.type(threadComposer, "@");
 
     expect(screen.getByText("@manager")).toBeInTheDocument();
+  });
+
+  it("renders main composer mention choices as clickable options", async () => {
+    const user = userEvent.setup();
+    const onApplyMention = vi.fn();
+    renderThreadPane({
+      mentionCandidates: roomUsers,
+      mentionIndex: 1,
+      onApplyMention,
+    });
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(roomUsers.length);
+    expect(options[1]).toHaveClass("mention-option", "active");
+    expect(options[1]).toHaveAttribute("aria-selected", "true");
+
+    await user.click(options[2]);
+    expect(onApplyMention).toHaveBeenCalledWith(roomUsers[2]);
   });
 
   it("keeps keyboard selection while navigating thread mention choices", async () => {

--- a/web/app/tests/legacy-contract.test.ts
+++ b/web/app/tests/legacy-contract.test.ts
@@ -125,8 +125,19 @@ describe("legacy UI contract", () => {
 
   it("keeps the mention picker scrollbar slim", () => {
     expect(styles).toMatch(/\.mention-picker\s*\{[\s\S]*scrollbar-width:\s*thin;/);
+    expect(styles).toMatch(/\.mention-picker\s*\{[\s\S]*z-index:\s*var\(--z-portal-popover\);/);
+    expect(styles).toMatch(/\.mention-picker\s*\{[\s\S]*bottom:\s*calc\(100% \+ 8px\);/);
     expect(styles).toContain(".mention-picker::-webkit-scrollbar");
     expect(styles).toContain(".mention-picker::-webkit-scrollbar-thumb");
+    expect(styles).toMatch(/\.mention-option\s*\{[\s\S]*min-height:\s*56px;/);
+  });
+
+  it("keeps profile dialogs from clipping header or actions", () => {
+    expect(styles).toMatch(/\.profile-modal\s*\{[\s\S]*display:\s*flex;[\s\S]*overflow:\s*hidden;/);
+    expect(styles).toMatch(/\.profile-modal \.modal-header\s*\{[\s\S]*position:\s*relative;/);
+    expect(styles).not.toContain("top: -24px;");
+    expect(styles).toMatch(/\.profile-editor-shell\s*\{[\s\S]*overflow-y:\s*auto;/);
+    expect(styles).toMatch(/\.agent-modal > \.modal-actions\s*\{[\s\S]*flex:\s*0 0 auto;/);
   });
 
   it("shows agent running status dots in direct message rows", () => {


### PR DESCRIPTION
- Keep profile dialogs from clipping headers and actions
- Render mention and skill pickers above the composer input
- Raise picker layering and enlarge clickable option rows
- Add regression coverage for dialog and mention picker layout