### PR TITLE
fix(im): preserve at-mention context for bot commands

### DIFF
--- a/internal/api/conversation_command.go
+++ b/internal/api/conversation_command.go
@@ -85,7 +85,7 @@ func messageMentions(message im.Message, userID string) bool {
 			return true
 		}
 	}
-	return false
+	return im.HasMentionTagForUser(message.Content, userID)
 }
 
 func conversationThreadRootID(message im.Message) string {

--- a/internal/api/conversation_command_test.go
+++ b/internal/api/conversation_command_test.go
@@ -66,3 +66,44 @@ func TestNewConversationTargetsGroupRoomRequiresMentionedAgent(t *testing.T) {
 		t.Fatalf("newConversationTargets() = %#v, want %#v", got, want)
 	}
 }
+
+func TestNewConversationTargetsGroupRoomSupportsAtMentionTag(t *testing.T) {
+	room := im.Room{
+		ID:       "room-1",
+		IsDirect: false,
+		Members:  []string{"u-user", "u-agent-a", "u-agent-b"},
+	}
+	message := im.Message{
+		SenderID: "u-user",
+		Content:  `<at user_id="u-agent-b">qa-worker</at>`,
+	}
+	got := newConversationTargets(room, message, func(id string) bool {
+		return id == "u-agent-a" || id == "u-agent-b"
+	})
+	want := []string{"u-agent-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("newConversationTargets() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNewConversationTargetsGroupRoomSupportsAtMentionTagWithExtraMentions(t *testing.T) {
+	room := im.Room{
+		ID:       "room-1",
+		IsDirect: false,
+		Members:  []string{"u-user", "u-agent-a", "u-agent-b", "u-human-c"},
+	}
+	message := im.Message{
+		SenderID: "u-user",
+		Content:  `<at user_id="u-human-c">human-c</at> <at user_id="u-agent-b">qa-worker</at>`,
+		Mentions: []im.Mention{
+			{ID: "u-human-c"},
+		},
+	}
+	got := newConversationTargets(room, message, func(id string) bool {
+		return id == "u-agent-a" || id == "u-agent-b"
+	})
+	want := []string{"u-agent-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("newConversationTargets() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/im/bot_bridge.go
+++ b/internal/im/bot_bridge.go
@@ -187,7 +187,10 @@ func (b *BotBridge) EnqueueMessageEventWithText(room Room, sender User, message 
 		return true
 	}
 	evt := messageEventForBot(room, sender, message, botID)
-	evt.Text = strings.TrimSpace(text)
+	evt.Text = botActionTextForEvent(message, botID, text)
+	if messageMentionsBot(message, botID) {
+		ensureBotMentioned(&evt, botID)
+	}
 	return b.enqueue(botID, evt)
 }
 
@@ -383,7 +386,7 @@ func messageEventForBot(room Room, sender User, message Message, botID string) B
 func textForBotEvent(message Message, botID string) string {
 	content := message.Content
 	botID = strings.TrimSpace(botID)
-	if content == "" || botID == "" || hasMentionTagForUser(content, botID) {
+	if content == "" || botID == "" || HasMentionTagForUser(content, botID) {
 		return content
 	}
 	for _, mention := range message.Mentions {
@@ -394,17 +397,53 @@ func textForBotEvent(message Message, botID string) string {
 	return content
 }
 
-func hasMentionTagForUser(content, userID string) bool {
-	userID = strings.TrimSpace(userID)
-	if userID == "" {
+func botActionTextForEvent(message Message, botID, text string) string {
+	text = strings.TrimSpace(text)
+	botID = strings.TrimSpace(botID)
+	if text == "" || botID == "" || HasMentionTagForUser(text, botID) || !messageMentionsBot(message, botID) {
+		return text
+	}
+	return text + " " + mentionTagForBot(message, botID)
+}
+
+func messageMentionsBot(message Message, botID string) bool {
+	botID = strings.TrimSpace(botID)
+	if botID == "" {
 		return false
 	}
-	for _, match := range mentionTagPattern.FindAllStringSubmatch(content, -1) {
-		if len(match) > 1 && strings.TrimSpace(match[1]) == userID {
+	for _, mention := range message.Mentions {
+		if strings.TrimSpace(mention.ID) == botID {
 			return true
 		}
 	}
-	return false
+	return HasMentionTagForUser(message.Content, botID)
+}
+
+func ensureBotMentioned(evt *BotEvent, botID string) {
+	if evt == nil {
+		return
+	}
+	botID = strings.TrimSpace(botID)
+	if botID == "" {
+		return
+	}
+	for _, mention := range evt.Mentions {
+		if strings.TrimSpace(mention) == botID {
+			evt.Context.Mentioned = true
+			return
+		}
+	}
+	evt.Mentions = append(evt.Mentions, botID)
+	evt.Context.Mentioned = true
+}
+
+func mentionTagForBot(message Message, botID string) string {
+	for _, mention := range message.Mentions {
+		if strings.TrimSpace(mention.ID) == strings.TrimSpace(botID) {
+			return fmt.Sprintf(`<at user_id="%s">%s</at>`, strings.TrimSpace(botID), mentionDisplayName(mention))
+		}
+	}
+	return fmt.Sprintf(`<at user_id="%s">%s</at>`, strings.TrimSpace(botID), strings.TrimSpace(botID))
 }
 
 func replaceMentionHandleWithTag(content string, mention Mention) string {

--- a/internal/im/bot_bridge_test.go
+++ b/internal/im/bot_bridge_test.go
@@ -238,6 +238,42 @@ func TestPublishMessageEventNormalizesPlainThreadMentionForPicoClaw(t *testing.T
 	}
 }
 
+func TestEnqueueMessageEventWithTextKeepsGroupMentionVisible(t *testing.T) {
+	bridge := NewBotBridge("")
+	events, cancel := bridge.Subscribe("u-qa")
+	defer cancel()
+
+	room := Room{
+		ID:       "room-group",
+		IsDirect: false,
+		Members:  []string{"u-admin", "u-qa"},
+	}
+	sender := User{ID: "u-admin", Name: "Admin", Handle: "admin"}
+	message := Message{
+		ID:        "msg-new",
+		SenderID:  "u-admin",
+		Content:   `<slash-command name="new" arg="conversation"></slash-command> <at user_id="u-qa">qa</at>`,
+		CreatedAt: time.Now().UTC(),
+		Mentions:  []Mention{{ID: "u-qa", Name: "qa"}},
+	}
+
+	if !bridge.EnqueueMessageEventWithText(room, sender, message, "u-qa", "/clear") {
+		t.Fatal("EnqueueMessageEventWithText() = false, want true for subscribed bot")
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Text != `/clear <at user_id="u-qa">qa</at>` {
+			t.Fatalf("Text = %q, want action text with mention tag", evt.Text)
+		}
+		if len(evt.Mentions) != 1 || evt.Mentions[0] != "u-qa" || !evt.Context.Mentioned {
+			t.Fatalf("Mentions = %+v context = %+v, want u-qa mentioned", evt.Mentions, evt.Context)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("EnqueueMessageEventWithText() timed out waiting for event")
+	}
+}
+
 func TestPublishMessageEventQueuesUntilBotSubscribes(t *testing.T) {
 	bridge := NewBotBridge("")
 	room := Room{

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -128,6 +128,36 @@ type Service struct {
 var mentionPattern = regexp.MustCompile(`(^|[^\w])@([a-zA-Z0-9._-]+)`)
 var mentionTagPattern = regexp.MustCompile(`<at\s+user_id="([^"]+)">[^<]*</at>`)
 
+func MentionTagUserIDs(content string) []string {
+	if content == "" {
+		return nil
+	}
+	ids := make([]string, 0, 1)
+	for _, match := range mentionTagPattern.FindAllStringSubmatch(content, -1) {
+		if len(match) <= 1 {
+			continue
+		}
+		id := strings.TrimSpace(match[1])
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func HasMentionTagForUser(content, userID string) bool {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return false
+	}
+	for _, id := range MentionTagUserIDs(content) {
+		if id == userID {
+			return true
+		}
+	}
+	return false
+}
+
 const sessionsDirName = "sessions"
 
 type persistedBootstrap struct {

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -910,3 +910,22 @@ func TestRoomIDsForMember(t *testing.T) {
 		t.Fatal("expected empty for unknown user")
 	}
 }
+
+func TestMentionTagUserIDs(t *testing.T) {
+	ids := MentionTagUserIDs(`<at user_id="u-agent-a">agent-a</at> hi <at user_id="u-agent-b">agent-b</at>`)
+	if len(ids) != 2 || ids[0] != "u-agent-a" || ids[1] != "u-agent-b" {
+		t.Fatalf("MentionTagUserIDs() = %#v, want [u-agent-a u-agent-b]", ids)
+	}
+	if len(MentionTagUserIDs("plain hi")) != 0 {
+		t.Fatalf("MentionTagUserIDs(\"plain hi\") = %#v, want empty", MentionTagUserIDs("plain hi"))
+	}
+}
+
+func TestHasMentionTagForUser(t *testing.T) {
+	if !HasMentionTagForUser(`<at user_id="u-agent-a">agent-a</at>`, "u-agent-a") {
+		t.Fatalf("HasMentionTagForUser() = false, want true")
+	}
+	if HasMentionTagForUser(`<at user_id="u-agent-a">agent-a</at>`, "u-agent-b") {
+		t.Fatalf("HasMentionTagForUser(u-agent-b) = true, want false")
+	}
+}

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -200,6 +200,21 @@ export function useConversationController({
     const agent = agents.find((item) => item.id === agentID || agentMatchesUser(item, directUser));
     return agent ?? null;
   }, [agents, data?.current_user_id, selectedConversation, usersById]);
+  const hasActiveConversationAgent = useMemo(() => {
+    if (!selectedConversation) {
+      return false;
+    }
+    if (logAgent?.id) {
+      return true;
+    }
+    return selectedConversation.members.some((memberId) => {
+      if (memberId === data?.current_user_id) {
+        return false;
+      }
+      const member = usersById.get(memberId);
+      return agents.some((agent) => agent.id === memberId || (member && agentMatchesUser(agent, member)));
+    });
+  }, [agents, data?.current_user_id, logAgent?.id, selectedConversation, usersById]);
   const activeConversationMembers = activeConversation
     ? activeConversation.members.map((id) => usersById.get(id)).filter(Boolean)
     : [];
@@ -243,14 +258,15 @@ export function useConversationController({
     [draftsByConversationId, activeConversationId],
   );
   const draftText = useMemo(() => segmentsToPlainText(draftSegments), [draftSegments]);
+  const slashPickerEnabled = Boolean((logAgent?.id || hasActiveConversationAgent) && !slashPickerDismissed);
   const slashPickerState = useMemo(
     () =>
       buildSlashPickerState({
         draftText,
-        enabled: Boolean(logAgent?.id && !slashPickerDismissed),
+        enabled: slashPickerEnabled,
         skillNames,
       }),
-    [draftText, logAgent, slashPickerDismissed, skillNames],
+    [draftText, slashPickerEnabled, skillNames],
   );
   const slashPickerQuery = slashPickerState.query;
   const slashPickerActive = slashPickerState.active;
@@ -263,15 +279,16 @@ export function useConversationController({
     return activeThreadDraftKey ? (threadDraftsByKey[activeThreadDraftKey] ?? []) : [];
   }, [activeThreadDraftKey, threadDraftsByKey]);
   const activeThreadDraft = useMemo(() => segmentsToPlainText(activeThreadDraftSegments), [activeThreadDraftSegments]);
+  const threadSlashPickerEnabled = Boolean((logAgent?.id || hasActiveConversationAgent) && activeThreadDraftKey);
   const threadSlashPickerState = useMemo(
     () =>
       buildSlashPickerState({
         draftText: activeThreadDraft,
-        enabled: Boolean(logAgent?.id && activeThreadDraftKey),
+        enabled: threadSlashPickerEnabled,
         skillNames,
         disabled: threadSlashPickerDismissed,
       }),
-    [activeThreadDraft, logAgent, activeThreadDraftKey, threadSlashPickerDismissed, skillNames],
+    [activeThreadDraft, threadSlashPickerEnabled, threadSlashPickerDismissed, skillNames],
   );
   const threadSlashPickerQuery = threadSlashPickerState.query;
   const threadSlashPickerActive = threadSlashPickerState.active;

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -219,6 +219,15 @@ export function useConversationController({
   const hasActiveConversationAgent = useMemo(() => {
     return activeConversationAgentMembers.length > 0;
   }, [activeConversationAgentMembers]);
+  const activeConversationAgentId = useMemo(() => {
+    if (logAgent?.id) {
+      return logAgent.id;
+    }
+    if (activeConversationAgentMembers.length === 1) {
+      return activeConversationAgentMembers[0];
+    }
+    return "";
+  }, [activeConversationAgentMembers, logAgent?.id]);
   const activeConversationMembers = activeConversation
     ? activeConversation.members.map((id) => usersById.get(id)).filter(Boolean)
     : [];
@@ -262,33 +271,7 @@ export function useConversationController({
     [draftsByConversationId, activeConversationId],
   );
   const draftText = useMemo(() => segmentsToPlainText(draftSegments), [draftSegments]);
-  const activeConversationAgentId = useMemo(() => {
-    if (logAgent?.id) {
-      return logAgent.id;
-    }
-
-    const mentionedAgentIds = new Set<string>();
-    for (const segment of draftSegments) {
-      if (segment.type !== "mention") {
-        continue;
-      }
-      const user = usersById.get(segment.userId);
-      const mentionedAgent = agents.find(
-        (agent) => agent.id === segment.userId || (user && agentMatchesUser(agent, user)),
-      );
-      if (mentionedAgent) {
-        mentionedAgentIds.add(mentionedAgent.id);
-      }
-    }
-    if (mentionedAgentIds.size === 1) {
-      return [...mentionedAgentIds][0];
-    }
-    if (activeConversationAgentMembers.length === 1) {
-      return activeConversationAgentMembers[0];
-    }
-    return "";
-  }, [activeConversationAgentMembers, agents, draftSegments, logAgent?.id, usersById]);
-  const slashPickerEnabled = Boolean((activeConversationAgentId || hasActiveConversationAgent) && !slashPickerDismissed);
+  const slashPickerEnabled = Boolean((hasActiveConversationAgent || logAgent?.id) && !slashPickerDismissed);
   const slashPickerState = useMemo(
     () =>
       buildSlashPickerState({

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -200,21 +200,25 @@ export function useConversationController({
     const agent = agents.find((item) => item.id === agentID || agentMatchesUser(item, directUser));
     return agent ?? null;
   }, [agents, data?.current_user_id, selectedConversation, usersById]);
-  const hasActiveConversationAgent = useMemo(() => {
+  const activeConversationAgentMembers = useMemo(() => {
     if (!selectedConversation) {
-      return false;
+      return [];
     }
-    if (logAgent?.id) {
-      return true;
-    }
-    return selectedConversation.members.some((memberId) => {
-      if (memberId === data?.current_user_id) {
-        return false;
-      }
-      const member = usersById.get(memberId);
-      return agents.some((agent) => agent.id === memberId || (member && agentMatchesUser(agent, member)));
-    });
-  }, [agents, data?.current_user_id, logAgent?.id, selectedConversation, usersById]);
+
+    return selectedConversation.members
+      .filter((memberId) => memberId !== data?.current_user_id)
+      .map((memberId) => ({
+        memberId: memberId,
+        user: usersById.get(memberId),
+      }))
+      .filter((entry) =>
+        agents.some((agent) => agent.id === entry.memberId || (entry.user && agentMatchesUser(agent, entry.user))),
+      )
+      .map((entry) => entry.memberId);
+  }, [agents, data?.current_user_id, selectedConversation, usersById]);
+  const hasActiveConversationAgent = useMemo(() => {
+    return activeConversationAgentMembers.length > 0;
+  }, [activeConversationAgentMembers]);
   const activeConversationMembers = activeConversation
     ? activeConversation.members.map((id) => usersById.get(id)).filter(Boolean)
     : [];
@@ -258,7 +262,33 @@ export function useConversationController({
     [draftsByConversationId, activeConversationId],
   );
   const draftText = useMemo(() => segmentsToPlainText(draftSegments), [draftSegments]);
-  const slashPickerEnabled = Boolean((logAgent?.id || hasActiveConversationAgent) && !slashPickerDismissed);
+  const activeConversationAgentId = useMemo(() => {
+    if (logAgent?.id) {
+      return logAgent.id;
+    }
+
+    const mentionedAgentIds = new Set<string>();
+    for (const segment of draftSegments) {
+      if (segment.type !== "mention") {
+        continue;
+      }
+      const user = usersById.get(segment.userId);
+      const mentionedAgent = agents.find(
+        (agent) => agent.id === segment.userId || (user && agentMatchesUser(agent, user)),
+      );
+      if (mentionedAgent) {
+        mentionedAgentIds.add(mentionedAgent.id);
+      }
+    }
+    if (mentionedAgentIds.size === 1) {
+      return [...mentionedAgentIds][0];
+    }
+    if (activeConversationAgentMembers.length === 1) {
+      return activeConversationAgentMembers[0];
+    }
+    return "";
+  }, [activeConversationAgentMembers, agents, draftSegments, logAgent?.id, usersById]);
+  const slashPickerEnabled = Boolean((activeConversationAgentId || hasActiveConversationAgent) && !slashPickerDismissed);
   const slashPickerState = useMemo(
     () =>
       buildSlashPickerState({
@@ -350,14 +380,14 @@ export function useConversationController({
   }, [threadSlashPickerQuery, skillNames]);
 
   useEffect(() => {
-    if (!isAnySlashPickerNeeded || !logAgent?.id) {
+    if (!isAnySlashPickerNeeded || !activeConversationAgentId) {
       setSkillNames([]);
       setSlashPickerLoading(false);
       return;
     }
     let cancelled = false;
     setSlashPickerLoading(true);
-    fetchAgentWorkspace(logAgent.id, "skills")
+    fetchAgentWorkspace(activeConversationAgentId, "skills")
       .then((workspace) => {
         if (cancelled) {
           return;
@@ -377,7 +407,7 @@ export function useConversationController({
     return () => {
       cancelled = true;
     };
-  }, [isAnySlashPickerNeeded, logAgent?.id]);
+  }, [activeConversationAgentId, isAnySlashPickerNeeded]);
 
   useEffect(() => {
     if (!managerProfileIncomplete) {


### PR DESCRIPTION
- 复用提及标签解析能力，支持群聊中仅有 <at> 标签时 bot 也能识别命令目标
- 增加 bot 侧消息事件构造逻辑：当消息未显式包含 bot 标签但已 mention bot 时自动补充 mention tag 与 Context.Mentioned
- 扩展 /conversation 命令入口与 text 透传逻辑的单测（internal/api, internal/im）
- 修复前端会话内 slash picker 启用条件，支持当前会话成员含 bot 时也可触发