### PR TITLE
fix(openclaw): plugin permissions and kanban trackpad scroll

### DIFF
--- a/internal/hub/builtin_store_test.go
+++ b/internal/hub/builtin_store_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260529.2-csgclaw"
+	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"
 )
 
 func TestBuiltinStoreListGetAndFetchWorkspace(t *testing.T) {

--- a/internal/templates/embed/openclaw-manager/agent.toml
+++ b/internal/templates/embed/openclaw-manager/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "openclaw_sandbox"
 updated_at = "2026-05-29T03:10:23Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260529.2-csgclaw"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"

--- a/internal/templates/embed/openclaw-worker/agent.toml
+++ b/internal/templates/embed/openclaw-worker/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "openclaw_sandbox"
 updated_at = "2026-05-29T03:10:23Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260529.2-csgclaw"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"

--- a/web/app/src/pages/TasksPage/components/TasksView/TasksView.css
+++ b/web/app/src/pages/TasksPage/components/TasksView/TasksView.css
@@ -203,6 +203,7 @@
 
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
   min-height: 0;
   height: 100%;
   overflow: hidden;
@@ -230,9 +231,12 @@
   display: grid;
   align-content: start;
   gap: 8px;
+  overflow-x: hidden;
   overflow-y: auto;
+  min-width: 0;
   min-height: 0;
-  overscroll-behavior: contain;
+  overscroll-behavior-y: contain;
+  overscroll-behavior-x: auto;
   padding: 4px;
   border-radius: 8px;
   scrollbar-width: thin;


### PR DESCRIPTION
- Upgrade OpenClaw runtime image so baked csgclaw-extension plugins use root-owned directories and load correctly under host sandbox uid.
- Fix sub-task kanban horizontal trackpad scroll on task cards by allowing overscroll-x to propagate to the board container.