### PR TITLE
chore: bump openclaw image for participant upgrade

### DIFF
--- a/internal/hub/builtin_store_test.go
+++ b/internal/hub/builtin_store_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"
+	testBuiltinOpenClawImage = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260608.2-csgclaw"
 )
 
 func TestBuiltinStoreListGetAndFetchWorkspace(t *testing.T) {

--- a/internal/templates/embed/openclaw-manager/agent.toml
+++ b/internal/templates/embed/openclaw-manager/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "openclaw_sandbox"
 updated_at = "2026-05-29T03:10:23Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260608.2-csgclaw"

--- a/internal/templates/embed/openclaw-worker/agent.toml
+++ b/internal/templates/embed/openclaw-worker/agent.toml
@@ -5,4 +5,4 @@ runtime_kind = "openclaw_sandbox"
 updated_at = "2026-05-29T03:10:23Z"
 
 [image]
-ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260607.1-csgclaw"
+ref = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/openclaw:20260608.2-csgclaw"


### PR DESCRIPTION
- Bump openclaw manager and worker image from 20260607.1-csgclaw to 20260608.2-csgclaw
- Update builtin_store_test.go test constant to match the new image tag
- Required for compatibility with the openclaw runtime participant upgrade