### PR TITLE
fix(agent): apply gateway profile on save and fix glm token limits

### DIFF
--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -301,6 +301,17 @@ func profileFromConfigModel(name, description string, model config.ModelConfig) 
 	}, name, description)
 }
 
+func modelConfigFromProfile(profile AgentProfile) config.ModelConfig {
+	profile = normalizeProfile(profile, profile.Name, profile.Description)
+	return config.ModelConfig{
+		Provider:        profile.Provider,
+		BaseURL:         profile.BaseURL,
+		APIKey:          profile.APIKey,
+		ModelID:         profile.ModelID,
+		ReasoningEffort: profile.ReasoningEffort,
+	}.Resolved()
+}
+
 func profileBaseURL(profile AgentProfile) string {
 	switch normalizeProfileProvider(profile.Provider) {
 	case ProviderAPI:

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -399,8 +399,17 @@ func (svc *Service) EnsureBootstrapManager(ctx context.Context, forceRecreate bo
 	if err != nil {
 		return err
 	}
+	modelCfg := defaultModel
+	svc.mu.RLock()
+	if manager, ok := svc.agents[ManagerUserID]; ok {
+		profile := normalizeProfileForAgentRuntime(manager.AgentProfile, manager.RuntimeOptions, manager.Name, manager.Description, manager.RuntimeKind, nil)
+		if profile.ProfileComplete {
+			modelCfg = modelConfigFromProfile(profile)
+		}
+	}
+	svc.mu.RUnlock()
 	recreateForParticipantBridgeConfig := !forceRecreate && agentPicoClawConfigNeedsParticipantRecreate(ManagerName, ManagerParticipantID)
-	if _, err := ensureAgentPicoClawConfigForParticipant(ManagerName, ManagerParticipantID, ManagerUserID, svc.server, defaultModel); err != nil {
+	if _, err := ensureAgentPicoClawConfigForParticipant(ManagerName, ManagerParticipantID, ManagerUserID, svc.server, modelCfg); err != nil {
 		return err
 	}
 	if recreateForParticipantBridgeConfig {
@@ -2062,9 +2071,14 @@ func (s *Service) hydrateAgentStatus(ctx context.Context, a Agent) Agent {
 }
 
 func statusAfterHydrateFailure(a Agent, stage string, err error) Agent {
-	if strings.TrimSpace(a.Status) != "" && !sandbox.IsNotFound(err) {
-		logHydrateStaleStatus(a, stage, err)
-		return a
+	if status := strings.TrimSpace(a.Status); status != "" {
+		if !sandbox.IsNotFound(err) {
+			logHydrateStaleStatus(a, stage, err)
+			return a
+		}
+		if strings.EqualFold(status, "profile_incomplete") {
+			return a
+		}
 	}
 	logHydrateUnknownStatus(a, stage, err)
 	a.Status = string(sandbox.StateUnknown)

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -51,8 +51,9 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	if strings.TrimSpace(profile.APIKey) == "" {
 		profile.APIKey = current.AgentProfile.APIKey
 	}
+	previous := current
 	normalized := normalizeProfileForAgentRuntime(profile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, nil)
-	restartRequired := !profilesEqualEnv(current.AgentProfile, normalized) || codexProfileRuntimeRestartRequired(current, normalized)
+	restartRequired := profileRestartRequired(previous, normalized)
 	runtimeKind := strings.TrimSpace(current.RuntimeKind)
 	runningCodex := runtimeKind == RuntimeKindCodex && isRuntimeRunning(current)
 	s.mu.Unlock()
@@ -74,6 +75,9 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	current.ProfileComplete = normalized.ProfileComplete
 	current.Profile = profileSelector(normalized)
 	current.DetectionResults = nil
+	if current.ProfileComplete && strings.EqualFold(strings.TrimSpace(current.Status), "profile_incomplete") {
+		current.Status = string(sandbox.StateStopped)
+	}
 	s.agents[id] = current
 	if normalized.ProfileComplete {
 		s.profileDefaults = cloneProfile(normalized)
@@ -87,7 +91,20 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	if restartRequired && runningCodex {
 		s.stopLifecycleAgent(id)
 	}
-	return profileViewWithAgentRuntimeOptions(normalized, current.RuntimeOptions, current.RuntimeKind, current.DetectionResults), nil
+	if err := s.syncGatewayAfterProfileChange(context.Background(), id, previous, normalized, restartRequired); err != nil {
+		return AgentProfileView{}, err
+	}
+	got, ok := s.Agent(id)
+	if !ok {
+		return AgentProfileView{}, fmt.Errorf("agent %q not found", id)
+	}
+	return profileViewWithAgentRuntimeOptions(got.AgentProfile, got.RuntimeOptions, got.RuntimeKind, got.DetectionResults), nil
+}
+
+func profileRestartRequired(current Agent, next AgentProfile) bool {
+	return !profilesEqualEnv(current.AgentProfile, next) ||
+		codexProfileRuntimeRestartRequired(current, next) ||
+		gatewayProfileRuntimeRestartRequired(current, next)
 }
 
 func codexProfileRuntimeRestartRequired(current Agent, next AgentProfile) bool {
@@ -109,6 +126,35 @@ func codexProfileRuntimeInputsEqual(a, b AgentProfile) bool {
 		strings.TrimSpace(a.ReasoningEffort) == strings.TrimSpace(b.ReasoningEffort) &&
 		reflect.DeepEqual(a.Headers, b.Headers) &&
 		reflect.DeepEqual(a.RequestOptions, b.RequestOptions)
+}
+
+func gatewayProfileRuntimeRestartRequired(current Agent, next AgentProfile) bool {
+	if !isGatewayRuntimeKind(strings.TrimSpace(current.RuntimeKind)) {
+		return false
+	}
+	previous := normalizeProfileForAgentRuntime(current.AgentProfile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, nil)
+	return !codexProfileRuntimeInputsEqual(previous, next)
+}
+
+func (s *Service) syncGatewayAfterProfileChange(ctx context.Context, id string, previous Agent, normalized AgentProfile, restartRequired bool) error {
+	if s == nil || !normalized.ProfileComplete {
+		return nil
+	}
+	got, ok := s.Agent(id)
+	if !ok || !isGatewayRuntimeKind(strings.TrimSpace(got.RuntimeKind)) {
+		return nil
+	}
+	profileJustCompleted := !isAgentProfileComplete(previous) && normalized.ProfileComplete
+	boxMissing := strings.TrimSpace(got.BoxID) == ""
+	if isManagerAgent(got) && (profileJustCompleted || boxMissing) {
+		_, err := s.EnsureManager(ctx, false)
+		return err
+	}
+	if restartRequired {
+		_, err := s.Recreate(ctx, id)
+		return err
+	}
+	return nil
 }
 
 func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Agent, error) {
@@ -176,12 +222,15 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 		mergedFlat := runtimeOptionsAfterPatch(current.RuntimeKind, current.RuntimeOptions, patch)
 		current.RuntimeOptions = nextAgentRuntimeOptions(current.RuntimeKind, current.RuntimeOptions, mergedFlat)
 		normalized := normalizeProfileForAgentRuntime(profile, current.RuntimeOptions, current.Name, current.Description, current.RuntimeKind, mergedFlat)
-		restartRequired = !profilesEqualEnv(previous.AgentProfile, normalized) || codexProfileRuntimeRestartRequired(previous, normalized)
+		restartRequired = profileRestartRequired(previous, normalized)
 		normalized.EnvRestartRequired = restartRequired
 		current.AgentProfile = normalized
 		current.ProfileComplete = normalized.ProfileComplete
 		current.Profile = profileSelector(normalized)
 		current.DetectionResults = nil
+		if current.ProfileComplete && strings.EqualFold(strings.TrimSpace(current.Status), "profile_incomplete") {
+			current.Status = string(sandbox.StateStopped)
+		}
 		if normalized.ProfileComplete && runtimeKind == RuntimeKindCodex {
 			ensureProfile = normalized
 			shouldEnsureProfile = true
@@ -217,6 +266,16 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 	updated, ok := s.Agent(id)
 	if !ok {
 		return Agent{}, fmt.Errorf("agent %q not found", id)
+	}
+	if profileUpdated {
+		normalized := normalizeProfileForAgentRuntime(updated.AgentProfile, updated.RuntimeOptions, updated.Name, updated.Description, updated.RuntimeKind, nil)
+		if err := s.syncGatewayAfterProfileChange(ctx, id, previous, normalized, restartRequired); err != nil {
+			return Agent{}, err
+		}
+		updated, ok = s.Agent(id)
+		if !ok {
+			return Agent{}, fmt.Errorf("agent %q not found", id)
+		}
 	}
 	return updated, nil
 }

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"csgclaw/internal/channel/feishu"
 	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/openclawsandbox"
 	"csgclaw/internal/sandbox"
 	"csgclaw/internal/utils"
 )
@@ -103,8 +105,7 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 
 func profileRestartRequired(current Agent, next AgentProfile) bool {
 	return !profilesEqualEnv(current.AgentProfile, next) ||
-		codexProfileRuntimeRestartRequired(current, next) ||
-		gatewayProfileRuntimeRestartRequired(current, next)
+		codexProfileRuntimeRestartRequired(current, next)
 }
 
 func codexProfileRuntimeRestartRequired(current Agent, next AgentProfile) bool {
@@ -150,11 +151,56 @@ func (s *Service) syncGatewayAfterProfileChange(ctx context.Context, id string, 
 		_, err := s.EnsureManager(ctx, false)
 		return err
 	}
+	if gatewayProfileRuntimeRestartRequired(previous, normalized) {
+		return s.syncGatewayHostConfig(got, normalized)
+	}
 	if restartRequired {
 		_, err := s.Recreate(ctx, id)
 		return err
 	}
 	return nil
+}
+
+func (s *Service) syncGatewayHostConfig(got Agent, profile AgentProfile) error {
+	if s == nil {
+		return nil
+	}
+	modelCfg := modelConfigFromProfile(profile)
+	participantID := participantIDForAgent(got.Name, got.ID)
+	switch strings.TrimSpace(got.RuntimeKind) {
+	case RuntimeKindPicoClawSandbox:
+		if _, err := ensureAgentPicoClawConfigForParticipant(got.Name, participantID, got.ID, s.server, modelCfg); err != nil {
+			return fmt.Errorf("sync gateway picoclaw config: %w", err)
+		}
+	case RuntimeKindOpenClawSandbox:
+		agentHome, err := agentHomeDir(got.Name)
+		if err != nil {
+			return err
+		}
+		var feishuProvider feishu.BotCredentialProvider
+		if rt, err := s.runtimeForKind(RuntimeKindOpenClawSandbox); err == nil {
+			if fp, ok := rt.(interface {
+				CurrentFeishuProvider() feishu.BotCredentialProvider
+			}); ok {
+				feishuProvider = fp.CurrentFeishuProvider()
+			}
+		}
+		if _, err := openclawsandbox.EnsureConfig(agentHome, participantID, got.ID, s.server, modelCfg, resolveManagerBaseURL, feishuProvider); err != nil {
+			return fmt.Errorf("sync gateway openclaw config: %w", err)
+		}
+	default:
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.agents[got.ID]
+	if !ok {
+		return nil
+	}
+	current.AgentProfile.EnvRestartRequired = false
+	s.agents[got.ID] = current
+	return s.saveLocked()
 }
 
 func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Agent, error) {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -6568,8 +6568,8 @@ func TestGatewayProfileRuntimeRestartRequiredOnModelChange(t *testing.T) {
 	if !gatewayProfileRuntimeRestartRequired(current, next) {
 		t.Fatal("gatewayProfileRuntimeRestartRequired() = false, want true when gateway model changes")
 	}
-	if !profileRestartRequired(current, next) {
-		t.Fatal("profileRestartRequired() = false, want true when gateway model changes")
+	if profileRestartRequired(current, next) {
+		t.Fatal("profileRestartRequired() = true, want false when only gateway model settings change")
 	}
 }
 
@@ -6592,5 +6592,85 @@ func TestGatewayProfileRuntimeRestartNotRequiredForCodex(t *testing.T) {
 	}, "alice", "")
 	if gatewayProfileRuntimeRestartRequired(current, next) {
 		t.Fatal("gatewayProfileRuntimeRestartRequired() = true, want false for codex runtime")
+	}
+}
+
+func TestUpdateAgentProfileSyncsGatewayHostConfigWithoutRecreate(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	recreateCalled := false
+	SetTestHooks(
+		nil,
+		func(_ *Service, _ context.Context, _ sandbox.Runtime, _, _, _ string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+			recreateCalled = true
+			return nil, sandbox.Info{}, fmt.Errorf("unexpected recreate")
+		},
+	)
+	defer ResetTestHooks()
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{
+		ListenAddr:  ":18080",
+		AccessToken: "token",
+	}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents[ManagerUserID] = Agent{
+		ID:          ManagerUserID,
+		Name:        ManagerName,
+		Role:        RoleManager,
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		BoxID:       "box-manager",
+		Status:      string(sandbox.StateRunning),
+		AgentProfile: AgentProfile{
+			Name:            ManagerName,
+			Provider:        ProviderAPI,
+			BaseURL:         "https://api.example/v1",
+			APIKey:          "api-key",
+			ModelID:         "qwen3.7-max",
+			ProfileComplete: true,
+		},
+		ProfileComplete: true,
+	}
+
+	if _, err := ensureAgentPicoClawConfigForParticipant(ManagerName, ManagerParticipantID, ManagerUserID, svc.server, config.ModelConfig{
+		Provider: config.ProviderLLMAPI,
+		BaseURL:  "https://api.example/v1",
+		APIKey:   "api-key",
+		ModelID:  "qwen3.7-max",
+	}); err != nil {
+		t.Fatalf("ensureAgentPicoClawConfigForParticipant() error = %v", err)
+	}
+
+	_, err = svc.UpdateAgentProfile(ManagerUserID, AgentProfile{
+		Name:            ManagerName,
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.example/v1",
+		APIKey:          "api-key",
+		ModelID:         "glm-5.1",
+		ProfileComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgentProfile() error = %v", err)
+	}
+	if recreateCalled {
+		t.Fatal("UpdateAgentProfile() recreated gateway box, want host config sync only")
+	}
+
+	configPath := filepath.Join(homeDir, config.AppDirName, managerAgentsDirName, ManagerName, picoclawsandbox.HostDir, picoclawsandbox.HostConfig)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(manager config) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"model_name": "glm-5.1"`) {
+		t.Fatalf("manager config missing updated model:\n%s", data)
+	}
+	got, ok := svc.Agent(ManagerUserID)
+	if !ok {
+		t.Fatal("Agent() ok = false, want true")
+	}
+	if got.AgentProfile.EnvRestartRequired {
+		t.Fatal("Agent().AgentProfile.EnvRestartRequired = true, want false after config sync")
 	}
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -6543,3 +6543,54 @@ func TestResolveManagerBaseURLPrefersAdvertiseBaseURL(t *testing.T) {
 		t.Fatalf("resolveManagerBaseURL() = %q, want %q", got, want)
 	}
 }
+
+func TestGatewayProfileRuntimeRestartRequiredOnModelChange(t *testing.T) {
+	current := Agent{
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		Name:        ManagerName,
+		AgentProfile: AgentProfile{
+			Name:            ManagerName,
+			Provider:        ProviderAPI,
+			BaseURL:         "https://api.example/v1",
+			APIKey:          "api-key",
+			ModelID:         "qwen3.7-max",
+			ProfileComplete: true,
+		},
+	}
+	next := normalizeProfile(AgentProfile{
+		Name:            ManagerName,
+		Provider:        ProviderAPI,
+		BaseURL:         "https://api.example/v1",
+		APIKey:          "api-key",
+		ModelID:         "glm-5.1",
+		ProfileComplete: true,
+	}, ManagerName, "")
+	if !gatewayProfileRuntimeRestartRequired(current, next) {
+		t.Fatal("gatewayProfileRuntimeRestartRequired() = false, want true when gateway model changes")
+	}
+	if !profileRestartRequired(current, next) {
+		t.Fatal("profileRestartRequired() = false, want true when gateway model changes")
+	}
+}
+
+func TestGatewayProfileRuntimeRestartNotRequiredForCodex(t *testing.T) {
+	current := Agent{
+		RuntimeKind: RuntimeKindCodex,
+		Name:        "alice",
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderCodex,
+			ModelID:         "gpt-5.4",
+			ProfileComplete: true,
+		},
+	}
+	next := normalizeProfile(AgentProfile{
+		Name:            "alice",
+		Provider:        ProviderCodex,
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	}, "alice", "")
+	if gatewayProfileRuntimeRestartRequired(current, next) {
+		t.Fatal("gatewayProfileRuntimeRestartRequired() = true, want false for codex runtime")
+	}
+}

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -182,6 +182,7 @@ func (s *Service) forwardRemoteChat(ctx context.Context, profile agent.AgentProf
 		return nil, 0, "", &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("decode request: %v", err)}
 	}
 	mergeProfilePayload(payload, profile)
+	normalizeCompletionTokenLimits(payload)
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return nil, 0, "", &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("encode request: %v", err)}
@@ -286,6 +287,7 @@ func (s *Service) forwardResponsesViaChat(ctx context.Context, profile agent.Age
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: err.Error()}
 	}
 	mergeProfilePayload(chatPayload, profile)
+	normalizeCompletionTokenLimits(chatPayload)
 	encoded, err := json.Marshal(chatPayload)
 	if err != nil {
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("encode chat fallback request: %v", err)}
@@ -1044,6 +1046,95 @@ func applyProviderPayloadConstraints(payload map[string]any, profile agent.Agent
 	case agent.ProviderCodex:
 		payload["store"] = false
 	}
+}
+
+const (
+	gatewayReasoningThinkingBudget = 32768
+	reasoningCompletionHeadroom    = 1024
+)
+
+func normalizeCompletionTokenLimits(payload map[string]any) {
+	if payload == nil {
+		return
+	}
+	thinkingBudget := payloadInt(payload, "thinking_budget")
+	maxCompletion := payloadInt(payload, "max_completion_tokens")
+	maxTokens := payloadInt(payload, "max_tokens")
+	effectiveMax := maxCompletion
+	if effectiveMax <= 0 {
+		effectiveMax = maxTokens
+	}
+	if effectiveMax <= 0 {
+		return
+	}
+
+	thinkingFloor := thinkingBudget
+	if thinkingFloor <= 0 {
+		thinkingFloor = reasoningModelThinkingBudgetFloor(stringValue(payload["model"]))
+	}
+	if thinkingFloor <= 0 && (effectiveMax == gatewayReasoningThinkingBudget || effectiveMax == 16384) {
+		// Picoclaw defaults can collide with gateway-side thinking budgets even when the
+		// client omits thinking_budget from the forwarded payload.
+		thinkingFloor = gatewayReasoningThinkingBudget
+	}
+	if thinkingFloor <= 0 || effectiveMax > thinkingFloor {
+		return
+	}
+	newMax := thinkingFloor + reasoningCompletionHeadroom
+	setPayloadInt(payload, "max_completion_tokens", newMax)
+	setPayloadInt(payload, "max_tokens", newMax)
+}
+
+func reasoningModelThinkingBudgetFloor(model string) int {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return 0
+	}
+	switch {
+	case strings.Contains(model, "glm-5"),
+		strings.Contains(model, "glm-4.5"),
+		strings.Contains(model, "glm-4.6"),
+		strings.Contains(model, "glm-4.7"):
+		return gatewayReasoningThinkingBudget
+	case strings.Contains(model, "qwen3"),
+		strings.Contains(model, "qwen-max"),
+		strings.Contains(model, "qwen-plus"):
+		return gatewayReasoningThinkingBudget
+	default:
+		return 0
+	}
+}
+
+func payloadInt(payload map[string]any, key string) int {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch v := value.(type) {
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0
+		}
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func setPayloadInt(payload map[string]any, key string, value int) {
+	if value <= 0 {
+		return
+	}
+	payload[key] = value
 }
 
 func (s *Service) agentProfileWebsocketTarget(ctx context.Context, profile agent.AgentProfile) (string, string, error) {

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -986,3 +986,49 @@ func mustSeededAgentService(t *testing.T, llmCfg config.LLMConfig, agents []agen
 	}
 	return svc
 }
+
+func TestNormalizeCompletionTokenLimitsRaisesSymmetric32768Budget(t *testing.T) {
+	payload := map[string]any{
+		"max_tokens": float64(32768),
+	}
+	normalizeCompletionTokenLimits(payload)
+	if got, want := payloadInt(payload, "max_tokens"), 33792; got != want {
+		t.Fatalf("max_tokens = %d, want %d", got, want)
+	}
+	if got, want := payloadInt(payload, "max_completion_tokens"), 33792; got != want {
+		t.Fatalf("max_completion_tokens = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCompletionTokenLimitsRaises16384ForReasoningModel(t *testing.T) {
+	payload := map[string]any{
+		"model":      "glm-5.1",
+		"max_tokens": float64(16384),
+	}
+	normalizeCompletionTokenLimits(payload)
+	if got, want := payloadInt(payload, "max_tokens"), 33792; got != want {
+		t.Fatalf("max_tokens = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCompletionTokenLimitsEnsuresMaxAboveThinkingBudget(t *testing.T) {
+	payload := map[string]any{
+		"max_completion_tokens": float64(32768),
+		"thinking_budget":       float64(32768),
+	}
+	normalizeCompletionTokenLimits(payload)
+	if got, want := payloadInt(payload, "max_completion_tokens"), 33792; got != want {
+		t.Fatalf("max_completion_tokens = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCompletionTokenLimitsLeavesSmallNonReasoningLimits(t *testing.T) {
+	payload := map[string]any{
+		"model":      "gpt-4.1-mini",
+		"max_tokens": float64(4096),
+	}
+	normalizeCompletionTokenLimits(payload)
+	if got, want := payloadInt(payload, "max_tokens"), 4096; got != want {
+		t.Fatalf("max_tokens = %d, want %d", got, want)
+	}
+}

--- a/internal/runtime/picoclawsandbox/defaults/picoclaw-config.json
+++ b/internal/runtime/picoclawsandbox/defaults/picoclaw-config.json
@@ -14,7 +14,7 @@
       "allow_read_outside_workspace": true,
       "provider": "",
       "model_name": "minimax-m2.7",
-      "max_tokens": 32768,
+      "max_tokens": 33792,
       "max_tool_iterations": 50,
       "summarize_message_threshold": 20,
       "summarize_token_percent": 75,

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -95,6 +95,9 @@ type AgentWithProfile = {
   profile?: AgentProfileLike | null;
 };
 
+const AGENT_RUNTIME_SYNC_INTERVAL_MS = 2_000;
+const AGENT_RUNTIME_SYNC_TIMEOUT_MS = 120_000;
+
 export function useAgentController({
   activeConversationId,
   activePane,
@@ -446,6 +449,7 @@ export function useAgentController({
       image,
     });
     await refreshAgentsWithUpdatedAgent(rebuiltAgent);
+    await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
     await refreshManagerProfile();
     await refreshWorkspaceBootstrapConfig();
   }
@@ -516,6 +520,8 @@ export function useAgentController({
       setManagerProfileData(saved);
       setProfileDraft({ ...profileToDraft(saved), agent_id: MANAGER_AGENT_ID });
       await refreshManagerProfile();
+      await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
+      await refreshWorkspaceBootstrap();
     } catch (err) {
       setProfileError(errorMessage(err, t("sendFailed")));
     } finally {
@@ -547,19 +553,57 @@ export function useAgentController({
     }
   }
 
+  function applyAgentListUpdate(agent: AgentLike | null | undefined) {
+    const agentID = String(agent?.id ?? "").trim();
+    if (!agentID || !agent) {
+      return;
+    }
+    setAgentsData((current) => mergeAgentIntoList(current, agent));
+    if (activePane.type === WorkspacePaneTypes.agent && activePane.id === agentID) {
+      setAgentPageDraft((current) =>
+        agentDraftWithRuntimeFieldsFromAgent(current ?? agentToDraft(agent), agent),
+      );
+      setAgentPageSavedDraft((current) =>
+        agentDraftWithRuntimeFieldsFromAgent(current ?? agentToDraft(agent), agent),
+      );
+    }
+  }
+
+  async function syncAgentStateUntilRunning(
+    agentID: string,
+    options: { timeoutMs?: number; intervalMs?: number } = {},
+  ): Promise<AgentLike | null> {
+    const timeoutMs = options.timeoutMs ?? AGENT_RUNTIME_SYNC_TIMEOUT_MS;
+    const intervalMs = options.intervalMs ?? AGENT_RUNTIME_SYNC_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+    let latest: AgentLike | null = null;
+    while (Date.now() < deadline) {
+      try {
+        latest = await fetchAgent(agentID);
+        applyAgentListUpdate(latest);
+        if (isAgentRunning(latest)) {
+          return latest;
+        }
+      } catch {
+        // Manager sandbox provisioning can lag behind profile save.
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, intervalMs));
+    }
+    try {
+      await refreshWorkspaceAgents({ silent: true });
+      latest = (await fetchAgent(agentID)) ?? latest;
+      applyAgentListUpdate(latest);
+    } catch {
+      // Best-effort final refresh.
+    }
+    return latest;
+  }
+
   async function refreshAgentsWithUpdatedAgent(updatedAgent: AgentLike | null | undefined): Promise<void> {
     const latestAgent = await fetchLatestActionAgent(updatedAgent);
     await refreshAgents();
     if (latestAgent?.id) {
-      setAgentsData((current) => mergeAgentIntoList(current, latestAgent));
-      if (activePane.type === WorkspacePaneTypes.agent && activePane.id === latestAgent.id) {
-        setAgentPageDraft((current) =>
-          agentDraftWithRuntimeFieldsFromAgent(current ?? agentToDraft(latestAgent), latestAgent),
-        );
-        setAgentPageSavedDraft((current) =>
-          agentDraftWithRuntimeFieldsFromAgent(current ?? agentToDraft(latestAgent), latestAgent),
-        );
-      }
+      applyAgentListUpdate(latestAgent);
     }
   }
 
@@ -815,7 +859,10 @@ export function useAgentController({
       }
       debugAgentPageSavePayload("full", payload);
       const saved = await updateAgentRequest(selectedAgentForPage.id, payload);
-      await refreshAgents();
+      await refreshAgentsWithUpdatedAgent(saved);
+      if (saved.id === MANAGER_AGENT_ID && profileChanged) {
+        await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
+      }
       await refreshWorkspaceBootstrap();
       if (saved.id === MANAGER_AGENT_ID) {
         await refreshManagerProfile();
@@ -978,6 +1025,9 @@ export function useAgentController({
       await refreshAgentsWithUpdatedAgent(updatedAgent);
       if (item.id === MANAGER_AGENT_ID) {
         await refreshManagerProfile();
+        if (action === "recreate" || action === "start") {
+          await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
+        }
       }
     } catch (err) {
       setAgentsError(errorMessage(err, t("agentActionFailed")));

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -37,6 +37,7 @@ import {
   applyTemplateToDraft,
   advanceAgentProgress,
   agentDraftWithRuntimeFieldsFromAgent,
+  agentRuntimePollSettled,
   agentToDraft,
   availableManagerRebuildImageOptions,
   availableManagerRebuildRuntimeOptions,
@@ -63,6 +64,7 @@ import {
   resolvedNotifierWebhookOrigin,
   resolveAgentChannelUserID,
   runtimeImageForKind,
+  shouldWaitForManagerRuntimeAfterProfileSave,
   startAgentCreateProgress,
 } from "@/models/agents";
 import type {
@@ -520,7 +522,7 @@ export function useAgentController({
       setManagerProfileData(saved);
       setProfileDraft({ ...profileToDraft(saved), agent_id: MANAGER_AGENT_ID });
       await refreshManagerProfile();
-      await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
+      await syncManagerRuntimeAfterProfileSave(managerAgent, Boolean(managerProfileIncomplete));
       await refreshWorkspaceBootstrap();
     } catch (err) {
       setProfileError(errorMessage(err, t("sendFailed")));
@@ -569,12 +571,30 @@ export function useAgentController({
     }
   }
 
+  async function refreshAgentState(agentID: string): Promise<AgentLike | null> {
+    try {
+      const latest = await fetchAgent(agentID, { cacheBust: true });
+      applyAgentListUpdate(latest);
+      return latest;
+    } catch {
+      try {
+        await refreshWorkspaceAgents({ silent: true });
+        const latest = await fetchAgent(agentID);
+        applyAgentListUpdate(latest);
+        return latest;
+      } catch {
+        return null;
+      }
+    }
+  }
+
   async function syncAgentStateUntilRunning(
     agentID: string,
-    options: { timeoutMs?: number; intervalMs?: number } = {},
+    options: { timeoutMs?: number; intervalMs?: number; acceptStopped?: boolean } = {},
   ): Promise<AgentLike | null> {
     const timeoutMs = options.timeoutMs ?? AGENT_RUNTIME_SYNC_TIMEOUT_MS;
     const intervalMs = options.intervalMs ?? AGENT_RUNTIME_SYNC_INTERVAL_MS;
+    const acceptStopped = options.acceptStopped ?? false;
     const deadline = Date.now() + timeoutMs;
     let latest: AgentLike | null = null;
     while (Date.now() < deadline) {
@@ -582,6 +602,9 @@ export function useAgentController({
         latest = await fetchAgent(agentID);
         applyAgentListUpdate(latest);
         if (isAgentRunning(latest)) {
+          return latest;
+        }
+        if (acceptStopped && agentRuntimePollSettled(latest)) {
           return latest;
         }
       } catch {
@@ -597,6 +620,21 @@ export function useAgentController({
       // Best-effort final refresh.
     }
     return latest;
+  }
+
+  async function syncManagerRuntimeAfterProfileSave(
+    agentBeforeSave: AgentLike | null | undefined,
+    profileIncompleteBeforeSave = false,
+  ): Promise<void> {
+    if (
+      shouldWaitForManagerRuntimeAfterProfileSave(agentBeforeSave, {
+        profileIncompleteBeforeSave,
+      })
+    ) {
+      await syncAgentStateUntilRunning(MANAGER_AGENT_ID, { acceptStopped: true });
+      return;
+    }
+    await refreshAgentState(MANAGER_AGENT_ID);
   }
 
   async function refreshAgentsWithUpdatedAgent(updatedAgent: AgentLike | null | undefined): Promise<void> {
@@ -858,10 +896,11 @@ export function useAgentController({
         return;
       }
       debugAgentPageSavePayload("full", payload);
+      const managerBeforeSave = selectedAgentForPage;
       const saved = await updateAgentRequest(selectedAgentForPage.id, payload);
       await refreshAgentsWithUpdatedAgent(saved);
       if (saved.id === MANAGER_AGENT_ID && profileChanged) {
-        await syncAgentStateUntilRunning(MANAGER_AGENT_ID);
+        await syncManagerRuntimeAfterProfileSave(managerBeforeSave);
       }
       await refreshWorkspaceBootstrap();
       if (saved.id === MANAGER_AGENT_ID) {

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -64,6 +64,7 @@ export type AgentProfileLike = {
 export type AgentLike = AgentProfileLike & {
   agent_profile?: AgentProfileLike | null;
   bot_type?: BotType | null;
+  box_id?: string | null;
   default_image?: string | null;
   from_template?: string | null;
   handle?: string | null;
@@ -1080,6 +1081,36 @@ export function isAgentIncomplete(
 
 export function isAgentRestartNeeded(item: AgentLike | null | undefined): boolean {
   return Boolean(item?.env_restart_required || item?.agent_profile?.env_restart_required);
+}
+
+export function shouldWaitForManagerRuntimeAfterProfileSave(
+  agent: AgentLike | null | undefined,
+  options: { profileIncompleteBeforeSave?: boolean } = {},
+): boolean {
+  if (options.profileIncompleteBeforeSave) {
+    return true;
+  }
+  if (!isAgentProfileMarkedComplete(agent)) {
+    return true;
+  }
+  if (!String(agent?.box_id ?? "").trim()) {
+    return true;
+  }
+  if (String(agent?.status ?? "").toLowerCase() === "profile_incomplete") {
+    return true;
+  }
+  return false;
+}
+
+export function agentRuntimePollSettled(item: AgentLike | null | undefined): boolean {
+  if (isAgentRunning(item)) {
+    return true;
+  }
+  if (!String(item?.box_id ?? "").trim()) {
+    return false;
+  }
+  const status = String(item?.status ?? "").toLowerCase();
+  return status === "stopped" || status === "offline" || status === "failed" || status === "error";
 }
 
 export function isAgentUpgradeNeeded(item: AgentLike | null | undefined): boolean {

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -379,6 +379,9 @@ export function agentStatusLabel(status: unknown, t: TranslateFn): string {
   if (normalized === "offline" || normalized === "stopped") {
     return t("offline");
   }
+  if (normalized === "profile_incomplete") {
+    return t("offline");
+  }
   if (normalized === "failed" || normalized === "error") {
     return t("agentStatusFailed");
   }
@@ -1045,6 +1048,16 @@ export function isAgentProfileMarkedComplete(item: AgentLike | null | undefined)
   return item?.profile_complete === true || item?.agent_profile?.profile_complete === true;
 }
 
+export function isAgentProfileDraftComplete(draft: Partial<AgentDraft> | null | undefined): boolean {
+  if (!String(draft?.model_id ?? "").trim()) {
+    return false;
+  }
+  if (draft?.provider === "api" && !String(draft.base_url ?? "").trim()) {
+    return false;
+  }
+  return true;
+}
+
 export function isAgentIncomplete(
   item: AgentLike | null | undefined,
   draftOverride?: AgentDraft | null | undefined,
@@ -1058,6 +1071,9 @@ export function isAgentIncomplete(
   const draft = draftOverride ?? agentToDraft(item);
   if (isNotifierRuntimeDraftOnAgentPage(draft, item)) {
     return !notifierFormIsComplete(draft, item);
+  }
+  if (isAgentProfileDraftComplete(draft)) {
+    return false;
   }
   return item?.profile_complete === false || item?.agent_profile?.profile_complete === false;
 }

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
@@ -133,6 +133,20 @@
 .agent-detail-pane .entity-title-row {
   flex-wrap: wrap;
   row-gap: 6px;
+  align-items: center;
+}
+
+.agent-detail-pane .agent-status-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: oklch(0.48 0.02 248);
+}
+
+.agent-detail-pane .agent-status-dot.online {
+  background: var(--portal-success-700);
+  box-shadow: 0 0 0 3px rgba(6, 118, 71, 0.12);
 }
 
 .agent-detail-pane .status-pill {

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -152,6 +152,7 @@ export function AgentDetailPane({
         <div className="entity-heading">
           <div className="entity-title-row">
             <h1>{item.name}</h1>
+            <span className={`agent-status-dot ${running ? "online" : ""}`} aria-hidden="true"></span>
             <span className={`status-pill ${running ? "online" : ""}`}>{agentStatusLabel(item.status, t)}</span>
             <span className={`status-pill profile-state-pill ${incomplete ? "warn" : "ready"}`}>
               {incomplete ? t("profileIncompleteBadge") : t("profileCompleteBadge")}

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -9,6 +9,7 @@ import {
   collectManagerTemplateVariants,
   defaultManagerRebuildImageForRuntime,
   agentDraftWithRuntimeFieldsFromAgent,
+  agentStatusLabel,
   draftNotifierRuntimeOptionsForSave,
   draftToProfile,
   ensureNotifierPullSubscriptionDraft,
@@ -468,6 +469,29 @@ describe("agent model helpers", () => {
     expect(notifierFormIsComplete(draft)).toBe(true);
     expect(isAgentIncomplete({ type: "notification", runtime_options: {} })).toBe(true);
     expect(isAgentIncomplete({ type: "notification", available: true, runtime_options: {} })).toBe(false);
+  });
+
+  it("treats a saved profile draft as configured even when profile_complete is false", () => {
+    const draft = agentToDraft({
+      id: "u-manager",
+      profile_complete: false,
+      agent_profile: {
+        profile_complete: false,
+        provider: "api",
+        base_url: "https://api.example/v1",
+        model_id: "glm-5.1",
+      },
+    });
+
+    expect(isAgentIncomplete({ id: "u-manager", profile_complete: false, agent_profile: { profile_complete: false } }, draft)).toBe(
+      false,
+    );
+  });
+
+  it("maps profile_incomplete status to offline label", () => {
+    const t = (key: string) => key;
+    expect(agentStatusLabel("profile_incomplete", t)).toBe("offline");
+    expect(agentStatusLabel("running", t)).toBe("online");
   });
 
   it("locks runtime and image on create when a template is selected", () => {

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -9,6 +9,7 @@ import {
   collectManagerTemplateVariants,
   defaultManagerRebuildImageForRuntime,
   agentDraftWithRuntimeFieldsFromAgent,
+  agentRuntimePollSettled,
   agentStatusLabel,
   draftNotifierRuntimeOptionsForSave,
   draftToProfile,
@@ -33,6 +34,7 @@ import {
   resolveAgentChannelUserID,
   resolveAgentAvatarSource,
   runtimeImageForKind,
+  shouldWaitForManagerRuntimeAfterProfileSave,
 } from "@/models/agents";
 
 describe("agent model helpers", () => {
@@ -492,6 +494,47 @@ describe("agent model helpers", () => {
     const t = (key: string) => key;
     expect(agentStatusLabel("profile_incomplete", t)).toBe("offline");
     expect(agentStatusLabel("running", t)).toBe("online");
+  });
+
+  it("waits for manager runtime only when profile save may bootstrap sandbox", () => {
+    const runningManager = {
+      id: "u-manager",
+      box_id: "box-manager",
+      profile_complete: true,
+      status: "running",
+    };
+    const stoppedManager = { ...runningManager, status: "stopped" };
+
+    expect(shouldWaitForManagerRuntimeAfterProfileSave(runningManager)).toBe(false);
+    expect(shouldWaitForManagerRuntimeAfterProfileSave(stoppedManager)).toBe(false);
+    expect(
+      shouldWaitForManagerRuntimeAfterProfileSave(runningManager, { profileIncompleteBeforeSave: true }),
+    ).toBe(true);
+    expect(shouldWaitForManagerRuntimeAfterProfileSave({ ...runningManager, box_id: "" })).toBe(true);
+    expect(
+      shouldWaitForManagerRuntimeAfterProfileSave({
+        id: "u-manager",
+        profile_complete: false,
+        status: "profile_incomplete",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats stopped manager with a box as settled for runtime polling", () => {
+    expect(
+      agentRuntimePollSettled({
+        id: "u-manager",
+        box_id: "box-manager",
+        status: "stopped",
+      }),
+    ).toBe(true);
+    expect(
+      agentRuntimePollSettled({
+        id: "u-manager",
+        box_id: "",
+        status: "stopped",
+      }),
+    ).toBe(false);
   });
 
   it("locks runtime and image on create when a template is selected", () => {


### PR DESCRIPTION
- Recreate picoclaw sandbox when profile inputs change, bootstrap manager after first complete profile, and normalize completion tokens above the 32768 thinking budget. 
- Refresh agent UI state after save and show online indicator when the manager runtime is running.