### PR TITLE
feat(team): expose agent display names in task APIs and UI

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -1149,6 +1149,18 @@ func (s *Service) Agent(id string) (Agent, bool) {
 	return s.withRuntimeImageMigrationStatus(ctx, s.hydrateAgentStatus(ctx, a)), true
 }
 
+func (s *Service) AgentDisplayName(id string) (string, bool) {
+	a, ok := s.agentSnapshot(id)
+	if !ok {
+		return "", false
+	}
+	name := strings.TrimSpace(a.Name)
+	if name == "" {
+		name = strings.TrimSpace(a.ID)
+	}
+	return name, name != ""
+}
+
 func (s *Service) agentSnapshot(id string) (Agent, bool) {
 	if s == nil {
 		return Agent{}, false

--- a/internal/api/team.go
+++ b/internal/api/team.go
@@ -122,7 +122,7 @@ func (h *Handler) handleListTeamTasks(w http.ResponseWriter, r *http.Request) {
 	if !h.ensureTeamExists(w, svc, pathValue(r, "team_id")) {
 		return
 	}
-	writeJSON(w, http.StatusOK, apiTasks(svc.ListTasks(pathValue(r, "team_id"))))
+	writeJSON(w, http.StatusOK, apiTasks(svc.ListTasks(pathValue(r, "team_id")), h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleListGlobalTasks(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func (h *Handler) handleListGlobalTasks(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, apiGlobalTasks(svc.ListGlobalTaskViews(h.teamDirectory())))
+	writeJSON(w, http.StatusOK, apiGlobalTasks(svc.ListGlobalTaskViews(h.teamDirectory()), h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleCreateTeamTasksBatch(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +149,7 @@ func (h *Handler) handleCreateTeamTasksBatch(w http.ResponseWriter, r *http.Requ
 		writeTeamError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusCreated, apiCreateTasksBatchResponse(result))
+	writeJSON(w, http.StatusCreated, apiCreateTasksBatchResponse(result, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleClaimNextTask(w http.ResponseWriter, r *http.Request) {
@@ -171,7 +171,7 @@ func (h *Handler) handleClaimNextTask(w http.ResponseWriter, r *http.Request) {
 		writeTeamError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, apiTask(item))
+	writeJSON(w, http.StatusOK, apiTask(item, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleClaimTeamTask(w http.ResponseWriter, r *http.Request) {
@@ -193,7 +193,7 @@ func (h *Handler) handleClaimTeamTask(w http.ResponseWriter, r *http.Request) {
 		writeTeamError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, apiTask(item))
+	writeJSON(w, http.StatusOK, apiTask(item, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleUpdateTeamTask(w http.ResponseWriter, r *http.Request) {
@@ -222,7 +222,7 @@ func (h *Handler) handleUpdateTeamTask(w http.ResponseWriter, r *http.Request) {
 		writeTeamError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, apiTask(item))
+	writeJSON(w, http.StatusOK, apiTask(item, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handlePlanTeamTask(w http.ResponseWriter, r *http.Request) {
@@ -256,7 +256,7 @@ func (h *Handler) handlePlanTeamTask(w http.ResponseWriter, r *http.Request) {
 		writeTeamPlanError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, apiPlanTaskWorkflowResponse(result))
+	writeJSON(w, http.StatusOK, apiPlanTaskWorkflowResponse(result, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleStartTeamTask(w http.ResponseWriter, r *http.Request) {
@@ -281,7 +281,7 @@ func (h *Handler) handleStartTeamTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, apitypes.StartTeamTaskResponse{
-		Task:           apiTask(item.Parent),
+		Task:           apiTask(item.Parent, h.newTeamIdentityPresenter()),
 		ScheduledTasks: item.ScheduledCount,
 	})
 }
@@ -309,7 +309,7 @@ func (h *Handler) handleAssignTeamTask(w http.ResponseWriter, r *http.Request) {
 		writeTeamError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, apiTask(item))
+	writeJSON(w, http.StatusOK, apiTask(item, h.newTeamIdentityPresenter()))
 }
 
 func (h *Handler) handleListTeamApprovals(w http.ResponseWriter, r *http.Request) {
@@ -381,5 +381,5 @@ func (h *Handler) handleListTeamEvents(w http.ResponseWriter, r *http.Request) {
 	if !h.ensureTeamExists(w, svc, pathValue(r, "team_id")) {
 		return
 	}
-	writeJSON(w, http.StatusOK, apiEvents(svc.ListEvents(pathValue(r, "team_id"))))
+	writeJSON(w, http.StatusOK, apiEvents(svc.ListEvents(pathValue(r, "team_id")), h.newTeamIdentityPresenter()))
 }

--- a/internal/api/team_support.go
+++ b/internal/api/team_support.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"csgclaw/internal/agent"
 	"csgclaw/internal/apitypes"
 	"csgclaw/internal/llm"
+	"csgclaw/internal/participant"
 	"csgclaw/internal/team"
 )
 
@@ -112,60 +114,132 @@ func apiTeams(items []team.TeamMeta) []apitypes.Team {
 	return resp
 }
 
-func apiTask(item team.TeamTask) apitypes.TeamTask {
-	return apitypes.TeamTask{
-		ID:           item.ID,
-		TeamID:       item.TeamID,
-		RoomID:       item.RoomID,
-		ParentID:     item.ParentID,
-		Title:        item.Title,
-		Body:         item.Body,
-		Status:       item.Status,
-		CreatedBy:    item.CreatedBy,
-		AssignedTo:   item.AssignedTo,
-		ClaimedBy:    item.ClaimedBy,
-		DependsOn:    append([]string(nil), item.DependsOn...),
-		Priority:     item.Priority,
-		PlanSummary:  item.PlanSummary,
-		DispatchedAt: item.DispatchedAt,
-		DeadlineAt:   item.DeadlineAt,
-		TimeoutAt:    item.TimeoutAt,
-		Result:       item.Result,
-		Error:        item.Error,
-		CreatedAt:    item.CreatedAt,
-		UpdatedAt:    item.UpdatedAt,
-		CompletedAt:  item.CompletedAt,
+type teamIdentityPresenter struct {
+	agents    *agent.Service
+	namesByID map[string]string
+}
+
+func (h *Handler) newTeamIdentityPresenter() teamIdentityPresenter {
+	p := teamIdentityPresenter{namesByID: make(map[string]string)}
+	if h != nil {
+		p.agents = h.svc
+	}
+	if h == nil || h.participant == nil {
+		return p
+	}
+	for _, item := range h.participant.List(participant.ListOptions{Channel: participant.ChannelCSGClaw}) {
+		name := p.agentDisplayName(item.AgentID)
+		if name == "" {
+			name = strings.TrimSpace(item.Name)
+		}
+		if name == "" {
+			name = strings.TrimSpace(item.ChannelUserRef)
+		}
+		if name == "" {
+			continue
+		}
+		p.addName(item.ID, name)
+		p.addName(item.ChannelUserRef, name)
+		p.addName(item.AgentID, name)
+	}
+	return p
+}
+
+func (p teamIdentityPresenter) displayAgentName(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || p.namesByID == nil {
+		return ""
+	}
+	if name := p.namesByID[id]; name != "" {
+		return name
+	}
+	return p.agentDisplayName(id)
+}
+
+func (p teamIdentityPresenter) addName(id string, name string) {
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if id == "" || name == "" {
+		return
+	}
+	p.namesByID[id] = name
+	if strings.HasPrefix(id, "u-") && len(id) > len("u-") {
+		p.namesByID[strings.TrimPrefix(id, "u-")] = name
 	}
 }
 
-func apiTasks(items []team.TeamTask) []apitypes.TeamTask {
+func (p teamIdentityPresenter) agentDisplayName(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || p.agents == nil {
+		return ""
+	}
+	if name, ok := p.agents.AgentDisplayName(id); ok {
+		return name
+	}
+	if strings.HasPrefix(id, "u-") || id == "" {
+		return ""
+	}
+	name, _ := p.agents.AgentDisplayName("u-" + id)
+	return name
+}
+
+func apiTask(item team.TeamTask, presenter teamIdentityPresenter) apitypes.TeamTask {
+	return apitypes.TeamTask{
+		ID:                  item.ID,
+		TeamID:              item.TeamID,
+		RoomID:              item.RoomID,
+		ParentID:            item.ParentID,
+		Title:               item.Title,
+		Body:                item.Body,
+		Status:              item.Status,
+		CreatedBy:           item.CreatedBy,
+		CreatedByAgentName:  presenter.displayAgentName(item.CreatedBy),
+		AssignedTo:          item.AssignedTo,
+		AssignedToAgentName: presenter.displayAgentName(item.AssignedTo),
+		ClaimedBy:           item.ClaimedBy,
+		ClaimedByAgentName:  presenter.displayAgentName(item.ClaimedBy),
+		DependsOn:           append([]string(nil), item.DependsOn...),
+		Priority:            item.Priority,
+		PlanSummary:         item.PlanSummary,
+		DispatchedAt:        item.DispatchedAt,
+		DeadlineAt:          item.DeadlineAt,
+		TimeoutAt:           item.TimeoutAt,
+		Result:              item.Result,
+		Error:               item.Error,
+		CreatedAt:           item.CreatedAt,
+		UpdatedAt:           item.UpdatedAt,
+		CompletedAt:         item.CompletedAt,
+	}
+}
+
+func apiTasks(items []team.TeamTask, presenter teamIdentityPresenter) []apitypes.TeamTask {
 	resp := make([]apitypes.TeamTask, 0, len(items))
 	for _, item := range items {
-		resp = append(resp, apiTask(item))
+		resp = append(resp, apiTask(item, presenter))
 	}
 	return resp
 }
 
-func apiGlobalTask(item team.GlobalTaskView) apitypes.GlobalTask {
+func apiGlobalTask(item team.GlobalTaskView, presenter teamIdentityPresenter) apitypes.GlobalTask {
 	return apitypes.GlobalTask{
-		TeamTask:  apiTask(item.Task),
+		TeamTask:  apiTask(item.Task, presenter),
 		TeamTitle: item.TeamTitle,
 		RoomTitle: item.RoomTitle,
 	}
 }
 
-func apiGlobalTasks(items []team.GlobalTaskView) []apitypes.GlobalTask {
+func apiGlobalTasks(items []team.GlobalTaskView, presenter teamIdentityPresenter) []apitypes.GlobalTask {
 	resp := make([]apitypes.GlobalTask, 0, len(items))
 	for _, item := range items {
-		resp = append(resp, apiGlobalTask(item))
+		resp = append(resp, apiGlobalTask(item, presenter))
 	}
 	return resp
 }
 
-func apiPlanTaskWorkflowResponse(result team.PlanTaskWorkflowResult) apitypes.PlanTeamTaskResponse {
+func apiPlanTaskWorkflowResponse(result team.PlanTaskWorkflowResult, presenter teamIdentityPresenter) apitypes.PlanTeamTaskResponse {
 	return apitypes.PlanTeamTaskResponse{
-		Task:           apiTask(result.Parent),
-		CreatedTasks:   apiTasks(result.Tasks),
+		Task:           apiTask(result.Parent, presenter),
+		CreatedTasks:   apiTasks(result.Tasks, presenter),
 		AlreadyPlanned: result.AlreadyPlanned,
 		Started:        result.Started,
 		ScheduledTasks: result.ScheduledCount,
@@ -195,13 +269,13 @@ func teamCreateTaskBatchInput(teamID string, req apitypes.CreateTeamTasksBatchRe
 	return input
 }
 
-func apiCreateTasksBatchResponse(result team.CreateTasksResult) apitypes.CreateTeamTasksBatchResponse {
+func apiCreateTasksBatchResponse(result team.CreateTasksResult, presenter teamIdentityPresenter) apitypes.CreateTeamTasksBatchResponse {
 	resp := apitypes.CreateTeamTasksBatchResponse{
 		Tasks:  make([]apitypes.TeamTask, 0, len(result.Tasks)),
 		IDRefs: make([]apitypes.TeamTaskIDRef, 0, len(result.IDRefs)),
 	}
 	for _, item := range result.Tasks {
-		resp.Tasks = append(resp.Tasks, apiTask(item))
+		resp.Tasks = append(resp.Tasks, apiTask(item, presenter))
 	}
 	for _, ref := range result.IDRefs {
 		resp.IDRefs = append(resp.IDRefs, apitypes.TeamTaskIDRef{IDRef: ref.IDRef, TaskID: ref.TaskID})
@@ -235,24 +309,26 @@ func apiApprovals(items []team.TeamApproval) []apitypes.TeamApproval {
 	return resp
 }
 
-func apiEvent(item team.TeamEvent) apitypes.TeamEvent {
+func apiEvent(item team.TeamEvent, presenter teamIdentityPresenter) apitypes.TeamEvent {
 	return apitypes.TeamEvent{
-		Seq:       item.Seq,
-		TeamID:    item.TeamID,
-		RoomID:    item.RoomID,
-		Type:      item.Type,
-		ActorID:   item.ActorID,
-		TaskID:    item.TaskID,
-		TargetID:  item.TargetID,
-		Summary:   item.Summary,
-		CreatedAt: item.CreatedAt,
+		Seq:             item.Seq,
+		TeamID:          item.TeamID,
+		RoomID:          item.RoomID,
+		Type:            item.Type,
+		ActorID:         item.ActorID,
+		ActorAgentName:  presenter.displayAgentName(item.ActorID),
+		TaskID:          item.TaskID,
+		TargetID:        item.TargetID,
+		TargetAgentName: presenter.displayAgentName(item.TargetID),
+		Summary:         item.Summary,
+		CreatedAt:       item.CreatedAt,
 	}
 }
 
-func apiEvents(items []team.TeamEvent) []apitypes.TeamEvent {
+func apiEvents(items []team.TeamEvent, presenter teamIdentityPresenter) []apitypes.TeamEvent {
 	resp := make([]apitypes.TeamEvent, 0, len(items))
 	for _, item := range items {
-		resp = append(resp, apiEvent(item))
+		resp = append(resp, apiEvent(item, presenter))
 	}
 	return resp
 }

--- a/internal/api/team_test.go
+++ b/internal/api/team_test.go
@@ -87,6 +87,121 @@ func TestTeamRoutesCreateAndTaskFlow(t *testing.T) {
 	}
 }
 
+func TestTeamTaskResponsesIncludeParticipantDisplayNames(t *testing.T) {
+	agentSvc := mustNewSeededService(t, []agent.Agent{
+		{
+			ID:        agent.ManagerUserID,
+			Name:      "manager",
+			Role:      agent.RoleManager,
+			CreatedAt: time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:        "u-agent-ymkx7q",
+			Name:      "data-2-worker",
+			Role:      agent.RoleWorker,
+			CreatedAt: time.Date(2026, 6, 10, 8, 1, 0, 0, time.UTC),
+		},
+	})
+	participantSvc := participant.NewService(participant.NewMemoryStore([]apitypes.Participant{
+		{
+			ID:              agent.ManagerParticipantID,
+			Channel:         participant.ChannelCSGClaw,
+			Type:            participant.TypeAgent,
+			Name:            "manager",
+			ChannelUserRef:  agent.ManagerParticipantID,
+			AgentID:         agent.ManagerUserID,
+			LifecycleStatus: participant.LifecycleStatusActive,
+			Mentionable:     true,
+		},
+		{
+			ID:              "agent-ymkx7q",
+			Channel:         participant.ChannelCSGClaw,
+			Type:            participant.TypeAgent,
+			Name:            "stale participant name",
+			ChannelUserRef:  "u-agent-ymkx7q",
+			AgentID:         "u-agent-ymkx7q",
+			LifecycleStatus: participant.LifecycleStatusActive,
+			Mentionable:     true,
+		},
+	}))
+	imSvc := im.NewService()
+	adapter := team.NewCSGClawAdapter(imSvc, participantSvc)
+	teamSvc := team.NewService()
+	h := &Handler{
+		svc:         agentSvc,
+		participant: participantSvc,
+		im:          imSvc,
+		teamSvc:     teamSvc,
+		teamAdapter: adapter,
+	}
+
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/teams", strings.NewReader(`{"channel":"csgclaw","title":"data","lead_participant_id":"manager","member_participant_ids":["agent-ymkx7q"]}`))
+	createRec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create team status = %d, want %d: %s", createRec.Code, http.StatusCreated, createRec.Body.String())
+	}
+	var created apitypes.Team
+	if err := json.NewDecoder(createRec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create team response: %v", err)
+	}
+
+	batchReq := httptest.NewRequest(http.MethodPost, "/api/v1/teams/"+created.ID+"/tasks/batch", strings.NewReader(`{"created_by":"manager","tasks":[{"title":"Fetch weather","assign_to":"agent-ymkx7q"}]}`))
+	batchRec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(batchRec, batchReq)
+	if batchRec.Code != http.StatusCreated {
+		t.Fatalf("create batch status = %d, want %d: %s", batchRec.Code, http.StatusCreated, batchRec.Body.String())
+	}
+	var batchResp apitypes.CreateTeamTasksBatchResponse
+	if err := json.NewDecoder(batchRec.Body).Decode(&batchResp); err != nil {
+		t.Fatalf("decode batch response: %v", err)
+	}
+	if len(batchResp.Tasks) != 1 {
+		t.Fatalf("batch tasks len = %d, want 1", len(batchResp.Tasks))
+	}
+	if batchResp.Tasks[0].AssignedTo != "agent-ymkx7q" || batchResp.Tasks[0].AssignedToAgentName != "data-2-worker" {
+		t.Fatalf("batch assigned = %q/%q, want agent-ymkx7q/data-2-worker", batchResp.Tasks[0].AssignedTo, batchResp.Tasks[0].AssignedToAgentName)
+	}
+	if batchResp.Tasks[0].CreatedBy != "manager" || batchResp.Tasks[0].CreatedByAgentName != "manager" {
+		t.Fatalf("batch creator = %q/%q, want manager/manager", batchResp.Tasks[0].CreatedBy, batchResp.Tasks[0].CreatedByAgentName)
+	}
+
+	globalReq := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+	globalRec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(globalRec, globalReq)
+	if globalRec.Code != http.StatusOK {
+		t.Fatalf("global tasks status = %d, want %d: %s", globalRec.Code, http.StatusOK, globalRec.Body.String())
+	}
+	var globalTasks []apitypes.GlobalTask
+	if err := json.NewDecoder(globalRec.Body).Decode(&globalTasks); err != nil {
+		t.Fatalf("decode global tasks response: %v", err)
+	}
+	if len(globalTasks) != 1 || globalTasks[0].AssignedToAgentName != "data-2-worker" {
+		t.Fatalf("global tasks = %+v, want assigned_to_agent_name data-2-worker", globalTasks)
+	}
+
+	eventsReq := httptest.NewRequest(http.MethodGet, "/api/v1/teams/"+created.ID+"/events", nil)
+	eventsRec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(eventsRec, eventsReq)
+	if eventsRec.Code != http.StatusOK {
+		t.Fatalf("events status = %d, want %d: %s", eventsRec.Code, http.StatusOK, eventsRec.Body.String())
+	}
+	var events []apitypes.TeamEvent
+	if err := json.NewDecoder(eventsRec.Body).Decode(&events); err != nil {
+		t.Fatalf("decode events response: %v", err)
+	}
+	var taskEvent apitypes.TeamEvent
+	for _, event := range events {
+		if event.TargetID == "agent-ymkx7q" {
+			taskEvent = event
+			break
+		}
+	}
+	if taskEvent.ActorAgentName != "manager" || taskEvent.TargetAgentName != "data-2-worker" {
+		t.Fatalf("events = %+v, want actor_agent_name manager and target_agent_name data-2-worker", events)
+	}
+}
+
 func TestTeamRoutesCreateResolvesAgentIDs(t *testing.T) {
 	imSvc := im.NewService()
 	participantSvc := participant.NewService(participant.NewMemoryStore([]apitypes.Participant{

--- a/internal/apitypes/team.go
+++ b/internal/apitypes/team.go
@@ -14,27 +14,30 @@ type Team struct {
 }
 
 type TeamTask struct {
-	ID           string     `json:"id"`
-	TeamID       string     `json:"team_id"`
-	RoomID       string     `json:"room_id"`
-	ParentID     string     `json:"parent_id,omitempty"`
-	Title        string     `json:"title"`
-	Body         string     `json:"body"`
-	Status       string     `json:"status"`
-	CreatedBy    string     `json:"created_by"`
-	AssignedTo   string     `json:"assigned_to,omitempty"`
-	ClaimedBy    string     `json:"claimed_by,omitempty"`
-	DependsOn    []string   `json:"depends_on,omitempty"`
-	Priority     int        `json:"priority,omitempty"`
-	PlanSummary  string     `json:"plan_summary,omitempty"`
-	DispatchedAt *time.Time `json:"dispatched_at,omitempty"`
-	DeadlineAt   *time.Time `json:"deadline_at,omitempty"`
-	TimeoutAt    *time.Time `json:"timeout_at,omitempty"`
-	Result       string     `json:"result,omitempty"`
-	Error        string     `json:"error,omitempty"`
-	CreatedAt    time.Time  `json:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at"`
-	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	ID                  string     `json:"id"`
+	TeamID              string     `json:"team_id"`
+	RoomID              string     `json:"room_id"`
+	ParentID            string     `json:"parent_id,omitempty"`
+	Title               string     `json:"title"`
+	Body                string     `json:"body"`
+	Status              string     `json:"status"`
+	CreatedBy           string     `json:"created_by"`
+	CreatedByAgentName  string     `json:"created_by_agent_name,omitempty"`
+	AssignedTo          string     `json:"assigned_to,omitempty"`
+	AssignedToAgentName string     `json:"assigned_to_agent_name,omitempty"`
+	ClaimedBy           string     `json:"claimed_by,omitempty"`
+	ClaimedByAgentName  string     `json:"claimed_by_agent_name,omitempty"`
+	DependsOn           []string   `json:"depends_on,omitempty"`
+	Priority            int        `json:"priority,omitempty"`
+	PlanSummary         string     `json:"plan_summary,omitempty"`
+	DispatchedAt        *time.Time `json:"dispatched_at,omitempty"`
+	DeadlineAt          *time.Time `json:"deadline_at,omitempty"`
+	TimeoutAt           *time.Time `json:"timeout_at,omitempty"`
+	Result              string     `json:"result,omitempty"`
+	Error               string     `json:"error,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	CompletedAt         *time.Time `json:"completed_at,omitempty"`
 }
 
 type GlobalTask struct {
@@ -73,15 +76,17 @@ type TeamPresence struct {
 }
 
 type TeamEvent struct {
-	Seq       int64     `json:"seq"`
-	TeamID    string    `json:"team_id"`
-	RoomID    string    `json:"room_id"`
-	Type      string    `json:"type"`
-	ActorID   string    `json:"actor_id,omitempty"`
-	TaskID    string    `json:"task_id,omitempty"`
-	TargetID  string    `json:"target_id,omitempty"`
-	Summary   string    `json:"summary,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	Seq             int64     `json:"seq"`
+	TeamID          string    `json:"team_id"`
+	RoomID          string    `json:"room_id"`
+	Type            string    `json:"type"`
+	ActorID         string    `json:"actor_id,omitempty"`
+	ActorAgentName  string    `json:"actor_agent_name,omitempty"`
+	TaskID          string    `json:"task_id,omitempty"`
+	TargetID        string    `json:"target_id,omitempty"`
+	TargetAgentName string    `json:"target_agent_name,omitempty"`
+	Summary         string    `json:"summary,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
 }
 
 type CreateTeamRequest struct {

--- a/web/app/src/hooks/workspace/useTaskController.ts
+++ b/web/app/src/hooks/workspace/useTaskController.ts
@@ -359,8 +359,12 @@ function workspaceTasksEqual(left: WorkspaceTask, right: WorkspaceTask): boolean
     left.title === right.title &&
     left.body === right.body &&
     left.status === right.status &&
+    left.created_by === right.created_by &&
+    left.created_by_agent_name === right.created_by_agent_name &&
     left.assigned_to === right.assigned_to &&
+    left.assigned_to_agent_name === right.assigned_to_agent_name &&
     left.claimed_by === right.claimed_by &&
+    left.claimed_by_agent_name === right.claimed_by_agent_name &&
     left.priority === right.priority &&
     stringArraysEqual(left.depends_on, right.depends_on) &&
     left.plan_summary === right.plan_summary &&

--- a/web/app/src/models/tasks.ts
+++ b/web/app/src/models/tasks.ts
@@ -8,8 +8,12 @@ export type WorkspaceTask = {
   title: string;
   body: string;
   status: string;
+  created_by: string;
+  created_by_agent_name: string;
   assigned_to: string;
+  assigned_to_agent_name: string;
   claimed_by: string;
+  claimed_by_agent_name: string;
   priority: number;
   depends_on: string[];
   plan_summary: string;
@@ -26,8 +30,10 @@ export type WorkspaceTeamEvent = {
   room_id: string;
   type: string;
   actor_id: string;
+  actor_agent_name: string;
   task_id: string;
   target_id: string;
+  target_agent_name: string;
   summary: string;
   created_at: string;
 };
@@ -123,8 +129,10 @@ export function normalizeTeamEvent(input: unknown): WorkspaceTeamEvent | null {
     room_id: text(item.room_id),
     type,
     actor_id: text(item.actor_id),
+    actor_agent_name: text(item.actor_agent_name),
     task_id: text(item.task_id),
     target_id: text(item.target_id),
+    target_agent_name: text(item.target_agent_name),
     summary: text(item.summary),
     created_at: text(item.created_at),
   };
@@ -151,8 +159,12 @@ export function normalizeTask(input: unknown): WorkspaceTask | null {
     title: text(item.title) || id,
     body: text(item.body),
     status: text(item.status) || "pending",
+    created_by: text(item.created_by),
+    created_by_agent_name: text(item.created_by_agent_name),
     assigned_to: text(item.assigned_to),
+    assigned_to_agent_name: text(item.assigned_to_agent_name),
     claimed_by: text(item.claimed_by),
+    claimed_by_agent_name: text(item.claimed_by_agent_name),
     priority: numberValue(item.priority),
     depends_on: stringArray(item.depends_on),
     plan_summary: text(item.plan_summary),

--- a/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
+++ b/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
@@ -653,12 +653,12 @@ function taskMetaTags(
     {
       key: "assignee",
       label: t("taskAssigneeLabel"),
-      value: task.assigned_to || "-",
+      value: task.assigned_to_agent_name || task.assigned_to || "-",
     },
     {
       key: "claimed_by",
       label: t("taskClaimedByLabel"),
-      value: task.claimed_by || "-",
+      value: task.claimed_by_agent_name || task.claimed_by || "-",
     },
     {
       key: "parent",
@@ -779,12 +779,13 @@ function syntheticTimelineEntries(
     });
   }
   if (task.dispatched_at && !existingEventTypes.has("task.dispatched")) {
+    const assignee = task.assigned_to_agent_name || task.assigned_to;
     entries.push({
       id: `synthetic-dispatched-${task.id}`,
       title: t("taskTimelineDispatched"),
       subject: task.id,
       meta: formatTaskUpdatedAt(task.dispatched_at, locale),
-      body: task.assigned_to ? `${t("taskActivityTargetLabel")}: ${task.assigned_to}` : "",
+      body: assignee ? `${t("taskActivityTargetLabel")}: ${assignee}` : "",
       order: syntheticOrder(),
     });
   }
@@ -849,7 +850,9 @@ function taskEventTitle(type: string, t: TranslateFn): string {
 }
 
 function taskEventMeta(event: WorkspaceTeamEvent, locale: string): string {
-  return [formatTaskUpdatedAt(event.created_at, locale), event.actor_id].filter(Boolean).join(" · ");
+  return [formatTaskUpdatedAt(event.created_at, locale), event.actor_agent_name || event.actor_id]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function taskEventBody(event: WorkspaceTeamEvent, t: TranslateFn): string {
@@ -857,8 +860,9 @@ function taskEventBody(event: WorkspaceTeamEvent, t: TranslateFn): string {
   if (event.summary) {
     lines.push(event.summary);
   }
-  if (event.target_id) {
-    lines.push(`${t("taskActivityTargetLabel")}: ${event.target_id}`);
+  const target = event.target_agent_name || event.target_id;
+  if (target) {
+    lines.push(`${t("taskActivityTargetLabel")}: ${target}`);
   }
   return lines.join("\n");
 }

--- a/web/app/tests/models/tasks.test.ts
+++ b/web/app/tests/models/tasks.test.ts
@@ -22,6 +22,49 @@ describe("tasks model", () => {
     expect(formatTaskUpdatedAt("invalid", "en")).toBe("-");
   });
 
+  it("normalizes participant display names returned by task APIs", () => {
+    const tasks = normalizeTaskList([
+      {
+        id: "task-1",
+        team_id: "team-1",
+        room_id: "room-1",
+        title: "Fetch weather",
+        created_by: "manager",
+        created_by_agent_name: "manager",
+        assigned_to: "agent-ymkx7q",
+        assigned_to_agent_name: "data-2-worker",
+        claimed_by: "agent-ymkx7q",
+        claimed_by_agent_name: "data-2-worker",
+      },
+    ]);
+    expect(tasks[0]).toMatchObject({
+      created_by: "manager",
+      created_by_agent_name: "manager",
+      assigned_to: "agent-ymkx7q",
+      assigned_to_agent_name: "data-2-worker",
+      claimed_by: "agent-ymkx7q",
+      claimed_by_agent_name: "data-2-worker",
+    });
+
+    const events = normalizeTeamEventList([
+      {
+        seq: 1,
+        team_id: "team-1",
+        type: "task.dispatched",
+        actor_id: "manager",
+        actor_agent_name: "manager",
+        target_id: "agent-ymkx7q",
+        target_agent_name: "data-2-worker",
+      },
+    ]);
+    expect(events[0]).toMatchObject({
+      actor_id: "manager",
+      actor_agent_name: "manager",
+      target_id: "agent-ymkx7q",
+      target_agent_name: "data-2-worker",
+    });
+  });
+
   it("normalizes team lead agent ids", () => {
     const teams = normalizeTeamList([
       {


### PR DESCRIPTION
- Show friendly agent display names instead of raw IDs in team task APIs and the Tasks page, e.g. assigned to data-2-worker rather than agent-ymkx7q.