### PR TITLE
Fix(UI): profile defaults for CSGHub Lite

### DIFF
--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -305,8 +305,8 @@ func modelConfigFromProfile(profile AgentProfile) config.ModelConfig {
 	profile = normalizeProfile(profile, profile.Name, profile.Description)
 	return config.ModelConfig{
 		Provider:        profile.Provider,
-		BaseURL:         profile.BaseURL,
-		APIKey:          profile.APIKey,
+		BaseURL:         profileBaseURL(profile),
+		APIKey:          profileAPIKey(profile),
 		ModelID:         profile.ModelID,
 		ReasoningEffort: profile.ReasoningEffort,
 	}.Resolved()

--- a/internal/agent/runtime_state.go
+++ b/internal/agent/runtime_state.go
@@ -127,8 +127,8 @@ func (s *Service) runtimeProfileForAgent(a Agent) agentruntime.Profile {
 
 func (s *Service) runtimeProfileForKind(runtimeKind, agentID, fallbackName, fallbackDescription string, profile AgentProfile) agentruntime.Profile {
 	profile = normalizeProfile(profile, fallbackName, fallbackDescription)
-	baseURL := profile.BaseURL
-	apiKey := profile.APIKey
+	baseURL := profileBaseURL(profile)
+	apiKey := profileAPIKey(profile)
 	env := normalizeStringMap(profile.Env)
 
 	if runtimeKind == RuntimeKindCodex {

--- a/internal/agent/runtime_state_test.go
+++ b/internal/agent/runtime_state_test.go
@@ -208,6 +208,33 @@ func TestPicoClawRuntimeHostResolveRuntimeProfilePreservesAPIProfile(t *testing.
 	}
 }
 
+func TestRuntimeProfileForKindUsesEffectiveCSGHubLiteTarget(t *testing.T) {
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{},
+		"manager-image:test",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	profile := svc.runtimeProfileForKind(RuntimeKindPicoClawSandbox, "u-alice", "alice", "", AgentProfile{
+		Name:     "alice",
+		Provider: ProviderCSGHubLite,
+		ModelID:  "Qwen3-0.6B-GGUF",
+		BaseURL:  "https://api.deepseek.com",
+		APIKey:   "stale-key",
+	})
+
+	if got, want := profile.BaseURL, defaultCSGHubLiteBaseURL; got != want {
+		t.Fatalf("runtimeProfileForKind().BaseURL = %q, want CSGHub Lite default %q", got, want)
+	}
+	if got, want := profile.APIKey, defaultCSGHubLiteAPIKey; got != want {
+		t.Fatalf("runtimeProfileForKind().APIKey = %q, want CSGHub Lite default key", got)
+	}
+}
+
 func TestRuntimeRecordForAgentPreservesEmptyRuntimeKind(t *testing.T) {
 	rt := runtimeRecordForAgent(Agent{
 		ID:        "u-alice",

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -419,11 +419,12 @@ func runtimeConfigChangeForAgent(previousProfile, currentProfile AgentProfile, p
 }
 
 func runtimeConfigSnapshotForAgent(profile AgentProfile, options map[string]any) agentruntime.RuntimeConfigSnapshot {
+	profile = normalizeProfile(profile, profile.Name, profile.Description)
 	return agentruntime.RuntimeConfigSnapshot{
 		Profile: agentruntime.RuntimeProfileConfig{
 			Provider:        strings.TrimSpace(profile.Provider),
-			BaseURL:         strings.TrimRight(strings.TrimSpace(profile.BaseURL), "/"),
-			APIKey:          strings.TrimSpace(profile.APIKey),
+			BaseURL:         profileBaseURL(profile),
+			APIKey:          profileAPIKey(profile),
 			ModelID:         strings.TrimSpace(profile.ModelID),
 			ReasoningEffort: strings.TrimSpace(profile.ReasoningEffort),
 			Headers:         normalizeStringMap(profile.Headers),

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -981,6 +981,62 @@ func TestCreateWorkerCodexRuntimeContinuesWhenResponsesUnsupported(t *testing.T)
 	}
 }
 
+func TestCreateWorkerCodexRuntimeCSGHubLiteProbeUsesDefaultEndpoint(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{
+			ListenAddr:       "0.0.0.0:18080",
+			AdvertiseBaseURL: "http://127.0.0.1:18080",
+			AccessToken:      "shared-token",
+		},
+		"manager-image:test",
+		"",
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			validate: func(_ context.Context, current agentruntime.RuntimeConfigSnapshot) error {
+				if current.Profile.Provider != ProviderCSGHubLite {
+					t.Fatalf("responses probe provider = %q, want %q", current.Profile.Provider, ProviderCSGHubLite)
+				}
+				if current.Profile.BaseURL != defaultCSGHubLiteBaseURL {
+					t.Fatalf("responses probe baseURL = %q, want CSGHub Lite default %q", current.Profile.BaseURL, defaultCSGHubLiteBaseURL)
+				}
+				if current.Profile.APIKey != defaultCSGHubLiteAPIKey {
+					t.Fatalf("responses probe apiKey = %q, want CSGHub Lite default key", current.Profile.APIKey)
+				}
+				return nil
+			},
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-alice"}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderCSGHubLite,
+			BaseURL:         "https://api.deepseek.com",
+			APIKey:          "stale-key",
+			ModelID:         "Qwen3-0.6B-GGUF",
+			ProfileComplete: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateWorker() error = %v", err)
+	}
+	if got.BoxID != "codex-session-alice" {
+		t.Fatalf("CreateWorker().BoxID = %q, want codex-session-alice", got.BoxID)
+	}
+}
+
 func TestUpdateCodexAgentProfilePatchRestartsActiveBridge(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"csgclaw/internal/llm"
 	"csgclaw/internal/participant"
 	agentruntime "csgclaw/internal/runtime"
+	codexruntime "csgclaw/internal/runtime/codex"
 	"csgclaw/internal/runtime/openclawsandbox"
 	"csgclaw/internal/runtime/picoclawsandbox"
 	"csgclaw/internal/sandbox"
@@ -47,7 +48,7 @@ func init() {
 		}
 		return runtimewiring.WithOpenClawSandboxRuntime(nil)(s)
 	})
-	_ = agent.TestOnlySetResponsesAPIProbe(func(context.Context, string, string, string, map[string]string) error {
+	_ = codexruntime.TestOnlySetResponsesAPIProbe(func(context.Context, string, string, string, map[string]string) error {
 		return nil
 	})
 }
@@ -1227,7 +1228,7 @@ func TestHandleAgentsListRedactsProfileAPIKey(t *testing.T) {
 }
 
 func TestHandleAgentsPatchUpdatesMetadataAndProfile(t *testing.T) {
-	svc := mustNewSeededService(t, []agent.Agent{
+	svc := mustNewSeededServiceWithOptions(t, []agent.Agent{
 		{
 			ID:          "u-alice",
 			Name:        "alice",
@@ -1243,7 +1244,7 @@ func TestHandleAgentsPatchUpdatesMetadataAndProfile(t *testing.T) {
 			ProfileComplete: true,
 			CreatedAt:       time.Date(2026, 3, 28, 10, 0, 0, 0, time.UTC),
 		},
-	})
+	}, agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindCodex}))
 
 	srv := &Handler{svc: svc}
 	body := `{"description":"new role","agent_profile":{"name":"alice","provider":"csghub_lite","model_id":"new-model","env":{"A":"B"}}}`
@@ -5070,7 +5071,20 @@ func mustNewSeededService(t *testing.T, agents []agent.Agent) *agent.Service {
 	return svc
 }
 
+func mustNewSeededServiceWithOptions(t *testing.T, agents []agent.Agent, opts ...agent.ServiceOption) *agent.Service {
+	t.Helper()
+
+	svc, _ := mustNewSeededServiceWithPathAndOptions(t, agents, opts...)
+	return svc
+}
+
 func mustNewSeededServiceWithPath(t *testing.T, agents []agent.Agent) (*agent.Service, string) {
+	t.Helper()
+
+	return mustNewSeededServiceWithPathAndOptions(t, agents)
+}
+
+func mustNewSeededServiceWithPathAndOptions(t *testing.T, agents []agent.Agent, opts ...agent.ServiceOption) (*agent.Service, string) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	t.Cleanup(agent.TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
@@ -5090,18 +5104,21 @@ func mustNewSeededServiceWithPath(t *testing.T, agents []agent.Agent) (*agent.Se
 		t.Fatalf("hub.NewService() error = %v", err)
 	}
 
-	svc, err := agent.NewService(config.ModelConfig{
-		Provider: config.ProviderLLMAPI,
-		BaseURL:  "http://127.0.0.1:4000",
-		APIKey:   "sk-test",
-		ModelID:  "model-1",
-	}, config.ServerConfig{}, "manager-image:test", statePath,
+	serviceOpts := []agent.ServiceOption{
 		agent.WithHubService(hubSvc),
 		agent.WithBootstrapDefaultTemplates(config.BootstrapConfig{
 			DefaultManagerTemplate: config.DefaultBootstrapManagerTemplate,
 			DefaultWorkerTemplate:  config.DefaultBootstrapWorkerTemplate,
 		}),
-	)
+	}
+	serviceOpts = append(serviceOpts, opts...)
+
+	svc, err := agent.NewService(config.ModelConfig{
+		Provider: config.ProviderLLMAPI,
+		BaseURL:  "http://127.0.0.1:4000",
+		APIKey:   "sk-test",
+		ModelID:  "model-1",
+	}, config.ServerConfig{}, "manager-image:test", statePath, serviceOpts...)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -986,16 +986,17 @@ export function applyTemplateToDraft(
 
 export function draftToProfile(draft: AgentDraft, options: DraftProfileOptions = {}): JSONRecord {
   const requestOptions = parseJSONMap(draft.requestOptionsText);
+  const usesAPIProvider = draft.provider === "api";
   return {
     name: options.name || draft.name || MANAGER_AGENT_NAME,
     description: options.description || draft.description || DEFAULT_MANAGER_DESCRIPTION,
     provider: draft.provider,
-    base_url: draft.base_url,
-    api_key: draft.api_key,
+    base_url: usesAPIProvider ? draft.base_url : "",
+    api_key: usesAPIProvider ? draft.api_key : "",
     model_id: draft.model_id,
     reasoning_effort: draft.reasoning_effort || DEFAULT_REASONING_EFFORT,
     enable_fast_mode: Boolean(draft.enable_fast_mode),
-    headers: parseJSONMap(draft.headersText),
+    headers: usesAPIProvider ? parseJSONMap(draft.headersText) : {},
     request_options: requestOptions,
     env: envRowsToMap(draft.envRows),
   };

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -217,7 +217,7 @@ describe("agent model helpers", () => {
         envRows: [{ key: "MODEL_HOME", value: "/models" }],
         headersText: '{"Authorization":"Bearer test"}',
         model_id: "Qwen/Qwen3-0.6B-GGUF",
-        provider: "csghub_lite",
+        provider: "api",
         reasoning_effort: "",
         requestOptionsText: '{"top_p":0.9}',
         runtime_kind: "picoclaw_sandbox",
@@ -230,6 +230,31 @@ describe("agent model helpers", () => {
       name: "manager",
       reasoning_effort: "medium",
       request_options: { top_p: 0.9 },
+    });
+  });
+
+  it("does not serialize hidden OpenAPI fields for CSGHub Lite profiles", () => {
+    expect(
+      draftToProfile({
+        api_key: "stale-key",
+        api_key_preview: "",
+        api_key_set: false,
+        base_url: "https://api.deepseek.com",
+        enable_fast_mode: false,
+        envRows: [],
+        headersText: '{"X-Stale":"1"}',
+        model_id: "Qwen3-0.6B-GGUF",
+        provider: "csghub_lite",
+        reasoning_effort: "medium",
+        requestOptionsText: "{}",
+        runtime_kind: "codex",
+      }),
+    ).toMatchObject({
+      provider: "csghub_lite",
+      base_url: "",
+      api_key: "",
+      headers: {},
+      model_id: "Qwen3-0.6B-GGUF",
     });
   });
 


### PR DESCRIPTION
It fixes CSGHub Lite profile handling so stale OpenAPI fields do not leak into CSGHub Lite/Codex runtime configuration. Backend profile snapshots and runtime profiles now use the effective CSGHub Lite base URL/API key, and the frontend stops serializing hidden OpenAPI base_url, api_key, and headers for non-API providers.