### PR TITLE
feat: OpenClaw runtime Codex provider and image input support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -140,6 +140,8 @@ csgclaw agent create --name alice --runtime openclaw_sandbox
 
 The recommended image shape is a slim OpenClaw base image with CSGClaw-managed plugins baked under `/home/node/openclaw-plugins` (for example, `csgclaw-extension` and external channel plugins). Runtime state still comes from `~/.csgclaw/agents/<agent>/.openclaw/openclaw.json`; do not mount an empty host directory over `/home/node/openclaw-plugins`, because that hides baked plugins.
 
+Generated OpenClaw bridge models default to `input: ["text", "image"]` and declare `low`, `medium`, `high`, and `xhigh` reasoning levels, so OpenClaw treats them as image-capable and adjustable-reasoning models by default. The generated config also writes a `reasoningEffortMap` that maps `minimal` to `low` and passes the other levels through by name. The actual default thinking value is written to `agents.defaults.thinkingDefault`; it defaults to `medium` and follows the CSGClaw profile `reasoning_effort` when one is configured. Plain OpenAI-compatible profiles still use `openai-completions`; if the upstream model does not actually support images or a reasoning level, the upstream only errors when that content or parameter is sent. With a Codex profile, CSGClaw also declares the bridge model as `openai-codex-responses` and writes streaming usage compatibility metadata.
+
 ## Sandbox Providers
 
 CSGClaw runs Workers through the configured sandbox provider. Supported built-in providers are:

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -140,6 +140,8 @@ csgclaw agent create --name alice --runtime openclaw_sandbox
 
 推荐镜像形态是基于 OpenClaw slim 二次封装，并把 CSGClaw 管理的插件烘焙到 `/home/node/openclaw-plugins`（例如 `csgclaw-extension` 和外部 channel 插件）。运行时状态仍由 `~/.csgclaw/agents/<agent>/.openclaw/openclaw.json` 提供；不要把空的宿主机目录挂载到 `/home/node/openclaw-plugins`，否则会遮住镜像内已经烘焙好的插件。
 
+CSGClaw 生成的 OpenClaw bridge 模型默认声明 `input: ["text", "image"]`，并声明 `low`、`medium`、`high`、`xhigh` reasoning 档位，让 OpenClaw 优先按支持图片输入和可调思考深度的模型处理消息。生成配置还会写入 `reasoningEffortMap`，其中 `minimal` 映射到 `low`，其他档位按同名值透传。实际默认思考深度通过 `agents.defaults.thinkingDefault` 写入；默认是 `medium`，如果 CSGClaw profile 配了 `reasoning_effort` 则使用该值。普通 OpenAI-compatible profile 仍使用 `openai-completions`；如果上游实际不支持图片或某个 reasoning 档位，只有在发送对应内容或参数时会由上游返回错误。使用 Codex profile 时，CSGClaw 还会把桥接模型声明为 `openai-codex-responses`，并写入 streaming usage 兼容元数据。
+
 ## Sandbox Provider
 
 CSGClaw 通过配置的 sandbox provider 隔离 Worker 执行环境。当前内置支持的 provider 包括：

--- a/internal/runtime/openclawsandbox/config.go
+++ b/internal/runtime/openclawsandbox/config.go
@@ -26,7 +26,8 @@ const (
 	BoxProjectsDir    = BoxDir + "/workspace/projects"
 	BoxGatewayLogPath = BoxDir + "/gateway.log"
 
-	openClawBridgeProviderID = "csgclaw-llm"
+	openClawBridgeProviderID  = "csgclaw-llm"
+	openClawCodexResponsesAPI = "openai-codex-responses"
 )
 
 type BaseURLResolver func(config.ServerConfig) string
@@ -190,10 +191,40 @@ func updateOpenClawModelProvider(cfg map[string]any, botID string, server config
 	}
 	entry["id"] = modelID
 	entry["name"] = modelID
-	return updateOpenClawPrimaryModel(cfg, openClawBridgeProviderID, modelID)
+	applyOpenClawCodexModelProfile(llm, entry, modelCfg)
+	return updateOpenClawAgentDefaults(cfg, openClawBridgeProviderID, modelCfg)
 }
 
-func updateOpenClawPrimaryModel(cfg map[string]any, providerID, modelID string) error {
+func applyOpenClawCodexModelProfile(providerCfg, entry map[string]any, modelCfg config.ModelConfig) {
+	if !isCodexProfileProvider(modelCfg.Provider) {
+		return
+	}
+	providerCfg["api"] = openClawCodexResponsesAPI
+	entry["api"] = openClawCodexResponsesAPI
+	entry["reasoning"] = true
+	entry["input"] = []any{"text", "image"}
+	compat, _ := entry["compat"].(map[string]any)
+	if compat == nil {
+		compat = map[string]any{}
+	}
+	compat["supportsReasoningEffort"] = true
+	compat["supportedReasoningEfforts"] = []any{"low", "medium", "high", "xhigh"}
+	compat["reasoningEffortMap"] = map[string]any{
+		"minimal": "low",
+		"low":     "low",
+		"medium":  "medium",
+		"high":    "high",
+		"xhigh":   "xhigh",
+	}
+	compat["supportsUsageInStreaming"] = true
+	entry["compat"] = compat
+}
+
+func isCodexProfileProvider(provider string) bool {
+	return strings.EqualFold(strings.TrimSpace(provider), "codex")
+}
+
+func updateOpenClawAgentDefaults(cfg map[string]any, providerID string, modelCfg config.ModelConfig) error {
 	agents, ok := cfg["agents"].(map[string]any)
 	if !ok {
 		return fmt.Errorf("embedded openclaw config is missing agents")
@@ -206,7 +237,10 @@ func updateOpenClawPrimaryModel(cfg map[string]any, providerID, modelID string) 
 	if !ok {
 		return fmt.Errorf("embedded openclaw config is missing agents.defaults.model")
 	}
-	modelBlock["primary"] = providerID + "/" + modelID
+	modelBlock["primary"] = providerID + "/" + strings.TrimSpace(modelCfg.ModelID)
+	if thinkingDefault := strings.TrimSpace(modelCfg.ReasoningEffort); thinkingDefault != "" {
+		defaults["thinkingDefault"] = thinkingDefault
+	}
 	return nil
 }
 

--- a/internal/runtime/openclawsandbox/config_test.go
+++ b/internal/runtime/openclawsandbox/config_test.go
@@ -2,6 +2,7 @@ package openclawsandbox
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -44,14 +45,46 @@ func TestRenderAgentOpenClawConfigUsesOpenAICompatForMinimaxBaseURL(t *testing.T
 	if got, want := llm["authHeader"], true; got != want {
 		t.Fatalf("csgclaw-llm authHeader = %v, want %v", got, want)
 	}
+	modelList := llm["models"].([]any)
+	entry := modelList[0].(map[string]any)
+	if got, want := entry["reasoning"], true; got != want {
+		t.Fatalf("model reasoning = %v, want %v", got, want)
+	}
+	if got, want := entry["input"], []any{"text", "image"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("model input = %#v, want %#v", got, want)
+	}
+	compat := entry["compat"].(map[string]any)
+	if got, want := compat["supportsReasoningEffort"], true; got != want {
+		t.Fatalf("model compat.supportsReasoningEffort = %v, want %v", got, want)
+	}
+	if got, want := compat["supportedReasoningEfforts"], []any{"low", "medium", "high", "xhigh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("model compat.supportedReasoningEfforts = %#v, want %#v", got, want)
+	}
+	wantReasoningMap := map[string]any{
+		"minimal": "low",
+		"low":     "low",
+		"medium":  "medium",
+		"high":    "high",
+		"xhigh":   "xhigh",
+	}
+	if got := compat["reasoningEffortMap"]; !reflect.DeepEqual(got, wantReasoningMap) {
+		t.Fatalf("model compat.reasoningEffortMap = %#v, want %#v", got, wantReasoningMap)
+	}
 	agents := cfg["agents"].(map[string]any)
 	defaults := agents["defaults"].(map[string]any)
 	model := defaults["model"].(map[string]any)
 	if got, want := model["primary"], "csgclaw-llm/MiniMax-M2.7"; got != want {
 		t.Fatalf("primary model = %v, want %v", got, want)
 	}
+	if got, want := defaults["thinkingDefault"], "medium"; got != want {
+		t.Fatalf("thinkingDefault = %v, want %v", got, want)
+	}
 	if got, want := defaults["verboseDefault"], "on"; got != want {
 		t.Fatalf("verboseDefault = %v, want %v", got, want)
+	}
+	tools := cfg["tools"].(map[string]any)
+	if got, want := tools["deny"], []any{"image"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tools.deny = %#v, want %#v", got, want)
 	}
 }
 
@@ -129,6 +162,67 @@ func TestRenderAgentOpenClawConfigUsesBridgeWhenBaseURLEmpty(t *testing.T) {
 		if strings.Contains(text, placeholder) {
 			t.Fatalf("rendered OpenClaw config leaked template placeholder %q:\n%s", placeholder, text)
 		}
+	}
+}
+
+func TestRenderAgentOpenClawConfigUsesCodexResponsesModelMetadata(t *testing.T) {
+	data, err := renderConfig("u-manager", "u-manager", config.ServerConfig{
+		ListenAddr:       "127.0.0.1:18080",
+		AdvertiseBaseURL: "http://127.0.0.1:18080",
+		AccessToken:      "shared-token",
+	}, config.ModelConfig{
+		Provider:        "codex",
+		ModelID:         "gpt-5.5",
+		ReasoningEffort: "high",
+	}, testBaseURLResolver, nil)
+	if err != nil {
+		t.Fatalf("renderAgentOpenClawConfig() error = %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	models := cfg["models"].(map[string]any)
+	providers := models["providers"].(map[string]any)
+	llm := providers["csgclaw-llm"].(map[string]any)
+	if got, want := llm["api"], "openai-codex-responses"; got != want {
+		t.Fatalf("csgclaw-llm api = %v, want %v", got, want)
+	}
+	modelList := llm["models"].([]any)
+	entry := modelList[0].(map[string]any)
+	if got, want := entry["api"], "openai-codex-responses"; got != want {
+		t.Fatalf("model api = %v, want %v", got, want)
+	}
+	if got, want := entry["reasoning"], true; got != want {
+		t.Fatalf("model reasoning = %v, want %v", got, want)
+	}
+	if got, want := entry["input"], []any{"text", "image"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("model input = %#v, want %#v", got, want)
+	}
+	compat := entry["compat"].(map[string]any)
+	if got, want := compat["supportsReasoningEffort"], true; got != want {
+		t.Fatalf("model compat.supportsReasoningEffort = %v, want %v", got, want)
+	}
+	if got, want := compat["supportedReasoningEfforts"], []any{"low", "medium", "high", "xhigh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("model compat.supportedReasoningEfforts = %#v, want %#v", got, want)
+	}
+	wantReasoningMap := map[string]any{
+		"minimal": "low",
+		"low":     "low",
+		"medium":  "medium",
+		"high":    "high",
+		"xhigh":   "xhigh",
+	}
+	if got := compat["reasoningEffortMap"]; !reflect.DeepEqual(got, wantReasoningMap) {
+		t.Fatalf("model compat.reasoningEffortMap = %#v, want %#v", got, wantReasoningMap)
+	}
+	if got, want := compat["supportsUsageInStreaming"], true; got != want {
+		t.Fatalf("model compat.supportsUsageInStreaming = %v, want %v", got, want)
+	}
+	agents := cfg["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if got, want := defaults["thinkingDefault"], "high"; got != want {
+		t.Fatalf("thinkingDefault = %v, want %v", got, want)
 	}
 }
 

--- a/internal/runtime/openclawsandbox/defaults/openclaw-gateway.json
+++ b/internal/runtime/openclawsandbox/defaults/openclaw-gateway.json
@@ -12,8 +12,19 @@
           {
             "id": "REPLACE_WITH_MODEL_ID",
             "name": "REPLACE_WITH_MODEL_ID",
-            "reasoning": false,
-            "input": ["text"],
+            "reasoning": true,
+            "input": ["text", "image"],
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "medium", "high", "xhigh"],
+              "reasoningEffortMap": {
+                "minimal": "low",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh"
+              }
+            },
             "cost": {
               "input": 0,
               "output": 0,
@@ -39,6 +50,7 @@
       "compaction": {
         "mode": "safeguard"
       },
+      "thinkingDefault": "medium",
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
@@ -48,6 +60,7 @@
   },
   "tools": {
     "profile": "full",
+    "deny": ["image"],
     "exec": {
       "host": "gateway",
       "security": "full",


### PR DESCRIPTION
- OpenClaw runtime Codex provider: when using a Codex profile, CSGClaw declares the bridge model as `openai-codex-responses` with streaming usage compatibility metadata and reasoning support.
- OpenClaw runtime image input: bridge models default to `input: ["text", "image"]` with configurable reasoning levels (low/medium/high/xhigh) and effort mapping, enabling Feishu channel image input via OpenClaw.