### PR TITLE
fix(web): keep agent page after delete

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.test.ts
+++ b/web/app/src/hooks/workspace/useAgentController.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { WorkspacePaneTypes } from "@/models/routing";
+import { shouldReturnToAgentOverviewAfterAgentMissing } from "./useAgentController";
+
+describe("shouldReturnToAgentOverviewAfterAgentMissing", () => {
+  it("keeps the workspace on the agent overview when an agent disappears", () => {
+    expect(
+      shouldReturnToAgentOverviewAfterAgentMissing({
+        type: WorkspacePaneTypes.agent,
+        id: "u-test-agent",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not redirect non-agent panes", () => {
+    expect(
+      shouldReturnToAgentOverviewAfterAgentMissing({
+        type: WorkspacePaneTypes.conversation,
+        id: "room-1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -103,6 +103,10 @@ type AgentWithProfile = {
 const AGENT_RUNTIME_SYNC_INTERVAL_MS = 2_000;
 const AGENT_RUNTIME_SYNC_TIMEOUT_MS = 120_000;
 
+export function shouldReturnToAgentOverviewAfterAgentMissing(activePane: { type?: string; id?: string | undefined } | null | undefined) {
+  return activePane?.type === WorkspacePaneTypes.agent;
+}
+
 export function useAgentController({
   activeConversationId,
   activePane,
@@ -339,14 +343,10 @@ export function useAgentController({
     if (!agentsLoaded) {
       return;
     }
-    if (!agents.some((item) => item.id === activePane.id)) {
-      if (activeConversationId) {
-        selectConversation(activeConversationId, { replace: true });
-      } else {
-        selectComputer({ replace: true });
-      }
+    if (shouldReturnToAgentOverviewAfterAgentMissing(activePane) && !agents.some((item) => item.id === activePane.id)) {
+      selectComputer({ replace: true });
     }
-  }, [agents, agentsLoaded, activePane, activeConversationId, selectComputer, selectConversation]);
+  }, [agents, agentsLoaded, activePane, selectComputer]);
 
   useEffect(() => {
     if (agentPageNavigationBlocker.state !== "blocked") {


### PR DESCRIPTION
## Summary
- keep the workspace on the agent overview after deleting the current agent
- add a regression test for the fallback route decision

## Validation
- PATH=/Users/shenyongfan/.nvm/versions/node/v22.13.0/bin:/Users/shenyongfan/.codex/tmp/arg0/codex-arg00lQ6rj:/Users/shenyongfan/.rvm/gems/ruby-3.2.2/bin:/Users/shenyongfan/.rvm/gems/ruby-3.2.2@global/bin:/Users/shenyongfan/.rvm/rubies/ruby-3.2.2/bin:/Users/shenyongfan/.local/lib/csgclaw/v0.2.5/csgclaw/bin:/Users/shenyongfan/.local/bin:/Users/shenyongfan/.langflow/uv:/Users/shenyongfan/.npm-global/bin:/Users/shenyongfan/.codeium/windsurf/bin:/Users/shenyongfan/.rbenv/shims:/Users/shenyongfan/miniconda3/bin:/Users/shenyongfan/miniconda3/condabin:/Users/shenyongfan/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/go/bin:/Users/shenyongfan/.rvm/bin:/usr/local/bin:/Users/shenyongfan/go/bin:/Applications/Codex.app/Contents/Resources pnpm --dir web/app typecheck
- PATH=/Users/shenyongfan/.nvm/versions/node/v22.13.0/bin:/Users/shenyongfan/.codex/tmp/arg0/codex-arg00lQ6rj:/Users/shenyongfan/.rvm/gems/ruby-3.2.2/bin:/Users/shenyongfan/.rvm/gems/ruby-3.2.2@global/bin:/Users/shenyongfan/.rvm/rubies/ruby-3.2.2/bin:/Users/shenyongfan/.local/lib/csgclaw/v0.2.5/csgclaw/bin:/Users/shenyongfan/.local/bin:/Users/shenyongfan/.langflow/uv:/Users/shenyongfan/.npm-global/bin:/Users/shenyongfan/.codeium/windsurf/bin:/Users/shenyongfan/.rbenv/shims:/Users/shenyongfan/miniconda3/bin:/Users/shenyongfan/miniconda3/condabin:/Users/shenyongfan/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/go/bin:/Users/shenyongfan/.rvm/bin:/usr/local/bin:/Users/shenyongfan/go/bin:/Applications/Codex.app/Contents/Resources pnpm --dir web/app exec vitest run src/hooks/workspace/useAgentController.test.ts