### PR TITLE
fix(feishu): keep bridge reactions best-effort

### DIFF
--- a/internal/channel/feishu/service.go
+++ b/internal/channel/feishu/service.go
@@ -86,22 +86,58 @@ type SendMessageResponse struct {
 
 type SendMessageFunc func(context.Context, AppConfig, SendMessageRequest) (SendMessageResponse, error)
 
+type UpdateMessageRequest struct {
+	RoomID    string
+	SenderID  string
+	MessageID string
+	Content   string
+}
+
+type UpdateMessageResponse struct {
+	MessageID string
+}
+
+type UpdateMessageFunc func(context.Context, AppConfig, UpdateMessageRequest) (UpdateMessageResponse, error)
+
+type CreateMessageReactionRequest struct {
+	SenderID  string
+	MessageID string
+	EmojiType string
+}
+
+type CreateMessageReactionResponse struct {
+	ReactionID string
+}
+
+type CreateMessageReactionFunc func(context.Context, AppConfig, CreateMessageReactionRequest) (CreateMessageReactionResponse, error)
+
+type DeleteMessageReactionRequest struct {
+	SenderID   string
+	MessageID  string
+	ReactionID string
+}
+
+type DeleteMessageReactionFunc func(context.Context, AppConfig, DeleteMessageReactionRequest) error
+
 type Service struct {
-	mu               sync.RWMutex
-	users            map[string]im.User
-	byHandle         map[string]string
-	rooms            map[string]*im.Room
-	apps             map[string]AppConfig
-	resolveBotInfo   func(context.Context, AppConfig) (BotInfo, error)
-	createChat       CreateChatFunc
-	addChatMembers   AddChatMembersFunc
-	listChatMembers  ListChatMembersFunc
-	listChats        ListChatsFunc
-	listRoomMessages ListRoomMessagesFunc
-	deleteChat       DeleteChatFunc
-	sendMessage      SendMessageFunc
-	messageBus       *MessageBus
-	configProvider   Provider
+	mu                    sync.RWMutex
+	users                 map[string]im.User
+	byHandle              map[string]string
+	rooms                 map[string]*im.Room
+	apps                  map[string]AppConfig
+	resolveBotInfo        func(context.Context, AppConfig) (BotInfo, error)
+	createChat            CreateChatFunc
+	addChatMembers        AddChatMembersFunc
+	listChatMembers       ListChatMembersFunc
+	listChats             ListChatsFunc
+	listRoomMessages      ListRoomMessagesFunc
+	deleteChat            DeleteChatFunc
+	sendMessage           SendMessageFunc
+	updateMessage         UpdateMessageFunc
+	createMessageReaction CreateMessageReactionFunc
+	deleteMessageReaction DeleteMessageReactionFunc
+	messageBus            *MessageBus
+	configProvider        Provider
 }
 
 func NewService(apps ...map[string]AppConfig) *Service {
@@ -112,19 +148,22 @@ func NewService(apps ...map[string]AppConfig) *Service {
 		}
 	}
 	return &Service{
-		users:            make(map[string]im.User),
-		byHandle:         make(map[string]string),
-		rooms:            make(map[string]*im.Room),
-		apps:             configuredApps,
-		resolveBotInfo:   fetchBotInfo,
-		createChat:       defaultCreateChat,
-		addChatMembers:   defaultAddChatMembers,
-		listChatMembers:  defaultListChatMembers,
-		listChats:        defaultListChats,
-		listRoomMessages: defaultListRoomMessages,
-		deleteChat:       defaultDeleteChat,
-		sendMessage:      defaultSendMessage,
-		messageBus:       NewMessageBus(),
+		users:                 make(map[string]im.User),
+		byHandle:              make(map[string]string),
+		rooms:                 make(map[string]*im.Room),
+		apps:                  configuredApps,
+		resolveBotInfo:        fetchBotInfo,
+		createChat:            defaultCreateChat,
+		addChatMembers:        defaultAddChatMembers,
+		listChatMembers:       defaultListChatMembers,
+		listChats:             defaultListChats,
+		listRoomMessages:      defaultListRoomMessages,
+		deleteChat:            defaultDeleteChat,
+		sendMessage:           defaultSendMessage,
+		updateMessage:         defaultUpdateMessage,
+		createMessageReaction: defaultCreateMessageReaction,
+		deleteMessageReaction: defaultDeleteMessageReaction,
+		messageBus:            NewMessageBus(),
 	}
 }
 
@@ -196,6 +235,25 @@ func NewServiceWithSendMessage(apps map[string]AppConfig, sendMessage SendMessag
 	svc := NewService(apps)
 	if sendMessage != nil {
 		svc.sendMessage = sendMessage
+	}
+	return svc
+}
+
+func NewServiceWithUpdateMessage(apps map[string]AppConfig, updateMessage UpdateMessageFunc) *Service {
+	svc := NewService(apps)
+	if updateMessage != nil {
+		svc.updateMessage = updateMessage
+	}
+	return svc
+}
+
+func NewServiceWithMessageReaction(apps map[string]AppConfig, createMessageReaction CreateMessageReactionFunc, deleteMessageReaction DeleteMessageReactionFunc) *Service {
+	svc := NewService(apps)
+	if createMessageReaction != nil {
+		svc.createMessageReaction = createMessageReaction
+	}
+	if deleteMessageReaction != nil {
+		svc.deleteMessageReaction = deleteMessageReaction
 	}
 	return svc
 }
@@ -923,7 +981,6 @@ func feishuMessageMentions(mentions []*larkim.Mention) []im.Mention {
 }
 
 func defaultSendMessage(ctx context.Context, app AppConfig, req SendMessageRequest) (SendMessageResponse, error) {
-	text := slashcommand.RenderFeishuFallback(req.Content)
 	senderInfo, err := fetchBotInfo(ctx, app)
 	if err != nil {
 		return SendMessageResponse{}, err
@@ -944,10 +1001,9 @@ func defaultSendMessage(ctx context.Context, app AppConfig, req SendMessageReque
 			}
 			mentionOpenID = botInfo.OpenID
 		}
-		text = fmt.Sprintf("<at user_id=\"%s\">%s</at> %s", mentionOpenID, mentionID, slashcommand.RenderFeishuFallback(req.Content))
 	}
 
-	content, err := json.Marshal(map[string]string{"text": text})
+	content, err := feishuTextMessageContent(req.Content, mentionID, mentionOpenID)
 	if err != nil {
 		return SendMessageResponse{}, fmt.Errorf("encode feishu message content: %w", err)
 	}
@@ -1005,6 +1061,114 @@ func defaultSendMessage(ctx context.Context, app AppConfig, req SendMessageReque
 		SenderOpenID:  senderOpenID,
 		MentionOpenID: mentionOpenID,
 	}, nil
+}
+
+func defaultUpdateMessage(ctx context.Context, app AppConfig, req UpdateMessageRequest) (UpdateMessageResponse, error) {
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return UpdateMessageResponse{}, fmt.Errorf("message_id is required")
+	}
+	content, err := feishuTextMessageContent(req.Content, "", "")
+	if err != nil {
+		return UpdateMessageResponse{}, fmt.Errorf("encode feishu message content: %w", err)
+	}
+
+	client := lark.NewClient(app.AppID, app.AppSecret)
+	updateReq := larkim.NewUpdateMessageReqBuilder().
+		MessageId(messageID).
+		Body(larkim.NewUpdateMessageReqBodyBuilder().
+			MsgType("text").
+			Content(content).
+			Build()).
+		Build()
+	resp, err := client.Im.V1.Message.Update(ctx, updateReq)
+	if err != nil {
+		return UpdateMessageResponse{}, fmt.Errorf("update feishu message: %w", err)
+	}
+	if !resp.Success() {
+		return UpdateMessageResponse{}, fmt.Errorf("update feishu message: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+	}
+	if resp.Data == nil {
+		return UpdateMessageResponse{}, fmt.Errorf("update feishu message: empty response data")
+	}
+	updatedMessageID := strings.TrimSpace(larkcore.StringValue(resp.Data.MessageId))
+	if updatedMessageID == "" {
+		updatedMessageID = messageID
+	}
+	return UpdateMessageResponse{MessageID: updatedMessageID}, nil
+}
+
+func defaultCreateMessageReaction(ctx context.Context, app AppConfig, req CreateMessageReactionRequest) (CreateMessageReactionResponse, error) {
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("message_id is required")
+	}
+	emojiType := strings.TrimSpace(req.EmojiType)
+	if emojiType == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("emoji_type is required")
+	}
+
+	client := lark.NewClient(app.AppID, app.AppSecret)
+	createReq := larkim.NewCreateMessageReactionReqBuilder().
+		MessageId(messageID).
+		Body(larkim.NewCreateMessageReactionReqBodyBuilder().
+			ReactionType(larkim.NewEmojiBuilder().EmojiType(emojiType).Build()).
+			Build()).
+		Build()
+	resp, err := client.Im.V1.MessageReaction.Create(ctx, createReq)
+	if err != nil {
+		return CreateMessageReactionResponse{}, fmt.Errorf("create feishu message reaction: %w", err)
+	}
+	if !resp.Success() {
+		return CreateMessageReactionResponse{}, fmt.Errorf("create feishu message reaction: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+	}
+	if resp.Data == nil {
+		return CreateMessageReactionResponse{}, fmt.Errorf("create feishu message reaction: empty response data")
+	}
+	reactionID := strings.TrimSpace(larkcore.StringValue(resp.Data.ReactionId))
+	if reactionID == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("create feishu message reaction: empty reaction id")
+	}
+	return CreateMessageReactionResponse{ReactionID: reactionID}, nil
+}
+
+func defaultDeleteMessageReaction(ctx context.Context, app AppConfig, req DeleteMessageReactionRequest) error {
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return fmt.Errorf("message_id is required")
+	}
+	reactionID := strings.TrimSpace(req.ReactionID)
+	if reactionID == "" {
+		return fmt.Errorf("reaction_id is required")
+	}
+
+	client := lark.NewClient(app.AppID, app.AppSecret)
+	deleteReq := larkim.NewDeleteMessageReactionReqBuilder().
+		MessageId(messageID).
+		ReactionId(reactionID).
+		Build()
+	resp, err := client.Im.V1.MessageReaction.Delete(ctx, deleteReq)
+	if err != nil {
+		return fmt.Errorf("delete feishu message reaction: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("delete feishu message reaction: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+	}
+	return nil
+}
+
+func feishuTextMessageContent(content, mentionID, mentionOpenID string) (string, error) {
+	text := slashcommand.RenderFeishuFallback(content)
+	mentionID = strings.TrimSpace(mentionID)
+	mentionOpenID = strings.TrimSpace(mentionOpenID)
+	if mentionID != "" && mentionOpenID != "" {
+		text = fmt.Sprintf("<at user_id=\"%s\">%s</at> %s", mentionOpenID, mentionID, text)
+	}
+	data, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 // fetchBotInfo calls the Feishu bot info API to retrieve bot identity fields.
@@ -1147,6 +1311,145 @@ func (s *Service) SendMessage(req im.CreateMessageRequest) (im.Message, error) {
 		})
 	}
 	return message, nil
+}
+
+func (s *Service) UpdateMessage(req UpdateMessageRequest) (im.Message, error) {
+	return s.UpdateMessageWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateMessageWithContext(ctx context.Context, req UpdateMessageRequest) (im.Message, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	roomID := strings.TrimSpace(req.RoomID)
+	senderID := strings.TrimSpace(req.SenderID)
+	messageID := strings.TrimSpace(req.MessageID)
+	content := strings.TrimSpace(req.Content)
+	if roomID == "" {
+		return im.Message{}, fmt.Errorf("room_id is required")
+	}
+	if senderID == "" {
+		return im.Message{}, fmt.Errorf("sender_id is required")
+	}
+	if messageID == "" {
+		return im.Message{}, fmt.Errorf("message_id is required")
+	}
+	if content == "" {
+		return im.Message{}, fmt.Errorf("content is required")
+	}
+
+	s.mu.RLock()
+	app, err := s.appConfigForSenderLocked(senderID)
+	s.mu.RUnlock()
+	if err != nil {
+		return im.Message{}, err
+	}
+
+	updated, err := s.updateMessage(ctx, app, UpdateMessageRequest{
+		RoomID:    roomID,
+		SenderID:  senderID,
+		MessageID: messageID,
+		Content:   content,
+	})
+	if err != nil {
+		return im.Message{}, err
+	}
+	updatedMessageID := strings.TrimSpace(updated.MessageID)
+	if updatedMessageID == "" {
+		updatedMessageID = messageID
+	}
+
+	message := im.Message{
+		ID:        updatedMessageID,
+		Kind:      im.MessageKindMessage,
+		Content:   content,
+		CreatedAt: time.Now().UTC(),
+	}
+	s.mu.Lock()
+	if room, ok := s.rooms[roomID]; ok {
+		for idx := range room.Messages {
+			if strings.TrimSpace(room.Messages[idx].ID) != messageID {
+				continue
+			}
+			message = room.Messages[idx]
+			message.ID = updatedMessageID
+			message.Content = content
+			room.Messages[idx] = message
+			break
+		}
+	}
+	s.mu.Unlock()
+	return message, nil
+}
+
+func (s *Service) CreateMessageReaction(req CreateMessageReactionRequest) (CreateMessageReactionResponse, error) {
+	return s.CreateMessageReactionWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateMessageReactionWithContext(ctx context.Context, req CreateMessageReactionRequest) (CreateMessageReactionResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	senderID := strings.TrimSpace(req.SenderID)
+	messageID := strings.TrimSpace(req.MessageID)
+	emojiType := strings.TrimSpace(req.EmojiType)
+	if senderID == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("sender_id is required")
+	}
+	if messageID == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("message_id is required")
+	}
+	if emojiType == "" {
+		return CreateMessageReactionResponse{}, fmt.Errorf("emoji_type is required")
+	}
+
+	s.mu.RLock()
+	app, err := s.appConfigForSenderLocked(senderID)
+	s.mu.RUnlock()
+	if err != nil {
+		return CreateMessageReactionResponse{}, err
+	}
+
+	return s.createMessageReaction(ctx, app, CreateMessageReactionRequest{
+		SenderID:  senderID,
+		MessageID: messageID,
+		EmojiType: emojiType,
+	})
+}
+
+func (s *Service) DeleteMessageReaction(req DeleteMessageReactionRequest) error {
+	return s.DeleteMessageReactionWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteMessageReactionWithContext(ctx context.Context, req DeleteMessageReactionRequest) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	senderID := strings.TrimSpace(req.SenderID)
+	messageID := strings.TrimSpace(req.MessageID)
+	reactionID := strings.TrimSpace(req.ReactionID)
+	if senderID == "" {
+		return fmt.Errorf("sender_id is required")
+	}
+	if messageID == "" {
+		return fmt.Errorf("message_id is required")
+	}
+	if reactionID == "" {
+		return fmt.Errorf("reaction_id is required")
+	}
+
+	s.mu.RLock()
+	app, err := s.appConfigForSenderLocked(senderID)
+	s.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+
+	return s.deleteMessageReaction(ctx, app, DeleteMessageReactionRequest{
+		SenderID:   senderID,
+		MessageID:  messageID,
+		ReactionID: reactionID,
+	})
 }
 
 func (s *Service) ResolveBotOpenID(ctx context.Context, botID string) (string, string, error) {

--- a/internal/channel/feishu/service_test.go
+++ b/internal/channel/feishu/service_test.go
@@ -370,6 +370,121 @@ func TestFeishuSendMessageUsesSenderAppAndStoresLocalMessage(t *testing.T) {
 	}
 }
 
+func TestFeishuUpdateMessageUsesSenderAppAndUpdatesLocalMessage(t *testing.T) {
+	var gotApp AppConfig
+	var gotReq UpdateMessageRequest
+	svc := NewServiceWithUpdateMessage(
+		map[string]AppConfig{"manager": {AppID: "cli_manager", AppSecret: "manager-secret"}},
+		func(_ context.Context, app AppConfig, req UpdateMessageRequest) (UpdateMessageResponse, error) {
+			gotApp = app
+			gotReq = req
+			return UpdateMessageResponse{MessageID: req.MessageID}, nil
+		},
+	)
+	svc.rooms["oc_alpha"] = &im.Room{
+		ID:      "oc_alpha",
+		Title:   "alpha",
+		Members: []string{"manager"},
+		Messages: []im.Message{
+			{ID: "om_root", SenderID: "ou_manager", Kind: im.MessageKindMessage, Content: "\u200b"},
+		},
+	}
+
+	message, err := svc.UpdateMessage(UpdateMessageRequest{
+		RoomID:    "oc_alpha",
+		SenderID:  "manager",
+		MessageID: "om_root",
+		Content:   "final answer",
+	})
+	if err != nil {
+		t.Fatalf("UpdateMessage() error = %v", err)
+	}
+
+	if gotApp.AppID != "cli_manager" {
+		t.Fatalf("update app = %+v, want manager app", gotApp)
+	}
+	if gotReq.RoomID != "oc_alpha" || gotReq.SenderID != "manager" || gotReq.MessageID != "om_root" || gotReq.Content != "final answer" {
+		t.Fatalf("update request = %+v, want room/sender/message/content", gotReq)
+	}
+	if message.ID != "om_root" || message.SenderID != "ou_manager" || message.Content != "final answer" {
+		t.Fatalf("message = %+v, want updated local root", message)
+	}
+	if got := svc.rooms["oc_alpha"].Messages[0].Content; got != "final answer" {
+		t.Fatalf("stored root content = %q, want final answer", got)
+	}
+}
+
+func TestFeishuUpdateMessageRequiresRoomID(t *testing.T) {
+	svc := NewServiceWithUpdateMessage(
+		map[string]AppConfig{"manager": {AppID: "cli_manager", AppSecret: "manager-secret"}},
+		func(context.Context, AppConfig, UpdateMessageRequest) (UpdateMessageResponse, error) {
+			t.Fatal("updateMessage should not be called without room_id")
+			return UpdateMessageResponse{}, nil
+		},
+	)
+
+	_, err := svc.UpdateMessage(UpdateMessageRequest{
+		SenderID:  "manager",
+		MessageID: "om_root",
+		Content:   "final answer",
+	})
+	if err == nil || !strings.Contains(err.Error(), "room_id is required") {
+		t.Fatalf("UpdateMessage() error = %v, want room_id validation", err)
+	}
+}
+
+func TestFeishuMessageReactionUsesSenderApp(t *testing.T) {
+	var gotCreateApp AppConfig
+	var gotCreateReq CreateMessageReactionRequest
+	var gotDeleteApp AppConfig
+	var gotDeleteReq DeleteMessageReactionRequest
+	svc := NewServiceWithMessageReaction(
+		map[string]AppConfig{"manager": {AppID: "cli_manager", AppSecret: "manager-secret"}},
+		func(_ context.Context, app AppConfig, req CreateMessageReactionRequest) (CreateMessageReactionResponse, error) {
+			gotCreateApp = app
+			gotCreateReq = req
+			return CreateMessageReactionResponse{ReactionID: "reaction-1"}, nil
+		},
+		func(_ context.Context, app AppConfig, req DeleteMessageReactionRequest) error {
+			gotDeleteApp = app
+			gotDeleteReq = req
+			return nil
+		},
+	)
+
+	created, err := svc.CreateMessageReaction(CreateMessageReactionRequest{
+		SenderID:  "manager",
+		MessageID: "om_user",
+		EmojiType: "Pin",
+	})
+	if err != nil {
+		t.Fatalf("CreateMessageReaction() error = %v", err)
+	}
+	if created.ReactionID != "reaction-1" {
+		t.Fatalf("ReactionID = %q, want reaction-1", created.ReactionID)
+	}
+	if gotCreateApp.AppID != "cli_manager" {
+		t.Fatalf("create app = %+v, want manager app", gotCreateApp)
+	}
+	if gotCreateReq.SenderID != "manager" || gotCreateReq.MessageID != "om_user" || gotCreateReq.EmojiType != "Pin" {
+		t.Fatalf("create request = %+v, want sender/message/emoji", gotCreateReq)
+	}
+
+	if err := svc.DeleteMessageReaction(DeleteMessageReactionRequest{
+		SenderID:   "manager",
+		MessageID:  "om_user",
+		ReactionID: created.ReactionID,
+	}); err != nil {
+		t.Fatalf("DeleteMessageReaction() error = %v", err)
+	}
+	if gotDeleteApp.AppID != "cli_manager" {
+		t.Fatalf("delete app = %+v, want manager app", gotDeleteApp)
+	}
+	if gotDeleteReq.SenderID != "manager" || gotDeleteReq.MessageID != "om_user" || gotDeleteReq.ReactionID != "reaction-1" {
+		t.Fatalf("delete request = %+v, want sender/message/reaction", gotDeleteReq)
+	}
+}
+
 func TestFeishuSendMessagePassesThreadRootIDForReply(t *testing.T) {
 	var gotReq SendMessageRequest
 	svc := NewServiceWithSendMessage(

--- a/internal/channelbridge/codexbridge/bridge.go
+++ b/internal/channelbridge/codexbridge/bridge.go
@@ -15,12 +15,14 @@ import (
 )
 
 const (
-	defaultQueueSize    = 32
-	defaultSeenWindow   = 256
-	defaultPromptSettle = 150 * time.Millisecond
-	localChannel        = csgclawchannel.ChannelID
-	turnPlaceholderText = "\u200b"
-	turnCompleteText    = "Done."
+	defaultQueueSize          = 32
+	defaultSeenWindow         = 256
+	defaultPromptSettle       = 150 * time.Millisecond
+	localChannel              = csgclawchannel.ChannelID
+	turnPlaceholderText       = "\u200b"
+	turnCompleteText          = "Done."
+	processingPinEmoji        = "Pin"
+	processingReactionTimeout = 2 * time.Second
 )
 
 type Binding struct {
@@ -248,11 +250,15 @@ func (w *worker) enqueue(ctx context.Context, evt BotEvent) {
 
 func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-chan runtimecodex.SessionEvent) error {
 	eventStartedAt := time.Now()
+	cleanupProcessingReaction := w.startProcessingReaction(ctx, evt)
+	defer cleanupProcessingReaction(context.Background())
 	if cmd, ok, err := slashcommand.Parse(evt.Text); err == nil && ok && slashcommand.IsNewConversationCommand(cmd) {
+		cleanupProcessingReaction(ctx)
 		return w.handleConversationReset(ctx, evt)
 	} else if err != nil {
 		renderer := runtimebridge.NewTurnRenderer()
 		renderer.SetPromptError(err.Error())
+		cleanupProcessingReaction(ctx)
 		_, err := w.flushTurn(ctx, evt.RoomID, evt.ThreadRootID, renderer)
 		return err
 	}
@@ -260,6 +266,7 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 	if err != nil {
 		renderer := runtimebridge.NewTurnRenderer()
 		renderer.SetPromptError(err.Error())
+		cleanupProcessingReaction(ctx)
 		_, err := w.flushTurn(ctx, evt.RoomID, evt.ThreadRootID, renderer)
 		return err
 	}
@@ -303,8 +310,12 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 		return generatedRootID, nil
 	}
 	flushTurn := func() (string, error) {
+		cleanupProcessingReaction(ctx)
 		if generatedRootID == "" {
 			return w.flushTurn(ctx, evt.RoomID, turnRootID, renderer)
+		}
+		if w.canUpdateGeneratedTurnRoot(evt) {
+			return w.flushTurnByUpdatingRoot(ctx, evt.RoomID, generatedRootID, renderer)
 		}
 		if len(renderer.FinalMessages()) == 0 {
 			return w.flushTurnWithEmptyCompletion(ctx, evt.RoomID, generatedRootID, renderer)
@@ -446,12 +457,42 @@ func (w *worker) flushTurnWithEmptyCompletion(ctx context.Context, roomID, threa
 	return w.flushTurnMessages(ctx, roomID, threadRootID, true, renderer)
 }
 
+func (w *worker) flushTurnByUpdatingRoot(ctx context.Context, roomID, rootMessageID string, renderer *runtimebridge.TurnRenderer) (string, error) {
+	messages := renderer.FinalMessages()
+	if len(messages) == 0 {
+		messages = []string{turnCompleteText}
+	}
+	if len(messages) == 0 {
+		return strings.TrimSpace(rootMessageID), nil
+	}
+	if err := w.updateMessage(ctx, roomID, rootMessageID, messages[0]); err != nil {
+		slog.Warn("codex bridge update generated turn root failed; sending completion inside activity thread",
+			"bot_id", w.binding.BotID,
+			"room_id", strings.TrimSpace(roomID),
+			"message_id", strings.TrimSpace(rootMessageID),
+			"text_bytes", len(strings.TrimSpace(messages[0])),
+			"error", err,
+		)
+		return w.flushMessages(ctx, roomID, rootMessageID, messages)
+	}
+	if len(messages) > 1 {
+		if _, err := w.flushMessages(ctx, roomID, rootMessageID, messages[1:]); err != nil {
+			return "", err
+		}
+	}
+	return strings.TrimSpace(rootMessageID), nil
+}
+
 func (w *worker) flushTurnMessages(ctx context.Context, roomID, threadRootID string, includeEmptyCompletion bool, renderer *runtimebridge.TurnRenderer) (string, error) {
-	var firstSentMessageID string
 	messages := renderer.FinalMessages()
 	if len(messages) == 0 && includeEmptyCompletion {
 		messages = []string{turnCompleteText}
 	}
+	return w.flushMessages(ctx, roomID, threadRootID, messages)
+}
+
+func (w *worker) flushMessages(ctx context.Context, roomID, threadRootID string, messages []string) (string, error) {
+	var firstSentMessageID string
 	for _, text := range messages {
 		req := SendMessageRequest{
 			RoomID:       roomID,
@@ -469,6 +510,110 @@ func (w *worker) flushTurnMessages(ctx context.Context, roomID, threadRootID str
 	return firstSentMessageID, nil
 }
 
+func (w *worker) canUpdateGeneratedTurnRoot(evt BotEvent) bool {
+	if !strings.EqualFold(strings.TrimSpace(evt.Channel), "feishu") {
+		return false
+	}
+	_, ok := w.service.client.(MessageUpdater)
+	return ok
+}
+
+func (w *worker) startProcessingReaction(ctx context.Context, evt BotEvent) func(context.Context) {
+	if !strings.EqualFold(strings.TrimSpace(evt.Channel), "feishu") {
+		return func(context.Context) {}
+	}
+	messageID := strings.TrimSpace(evt.MessageID)
+	if messageID == "" {
+		return func(context.Context) {}
+	}
+	reactor, ok := w.service.client.(MessageReactor)
+	if !ok {
+		return func(context.Context) {}
+	}
+
+	addCtx, cancelAdd := contextWithDefaultTimeout(ctx, processingReactionTimeout)
+	resultCh := make(chan processingReactionResult, 1)
+	go func() {
+		defer cancelAdd()
+		resp, err := reactor.AddMessageReaction(addCtx, w.binding.BotID, AddMessageReactionRequest{
+			MessageID: messageID,
+			EmojiType: processingPinEmoji,
+		})
+		if err != nil {
+			slog.Debug("codex bridge add processing reaction failed",
+				"bot_id", w.binding.BotID,
+				"room_id", strings.TrimSpace(evt.RoomID),
+				"message_id", messageID,
+				"emoji_type", processingPinEmoji,
+				"error", err,
+			)
+			resultCh <- processingReactionResult{}
+			return
+		}
+		resultCh <- processingReactionResult{reactionID: strings.TrimSpace(resp.ReactionID)}
+	}()
+
+	var once sync.Once
+	return func(cleanupCtx context.Context) {
+		once.Do(func() {
+			cancelAdd()
+			go w.deleteProcessingReaction(cleanupCtx, evt, reactor, messageID, resultCh)
+		})
+	}
+}
+
+type processingReactionResult struct {
+	reactionID string
+}
+
+func (w *worker) deleteProcessingReaction(cleanupCtx context.Context, evt BotEvent, reactor MessageReactor, messageID string, resultCh <-chan processingReactionResult) {
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), processingReactionTimeout)
+	defer cancelWait()
+
+	var result processingReactionResult
+	select {
+	case result = <-resultCh:
+	case <-waitCtx.Done():
+		slog.Debug("codex bridge processing reaction cleanup timed out",
+			"bot_id", w.binding.BotID,
+			"room_id", strings.TrimSpace(evt.RoomID),
+			"message_id", messageID,
+			"emoji_type", processingPinEmoji,
+		)
+		return
+	}
+	reactionID := strings.TrimSpace(result.reactionID)
+	if reactionID == "" {
+		return
+	}
+
+	deleteCtx, cancelDelete := contextWithDefaultTimeout(cleanupCtx, processingReactionTimeout)
+	defer cancelDelete()
+	if err := reactor.DeleteMessageReaction(deleteCtx, w.binding.BotID, DeleteMessageReactionRequest{
+		MessageID:  messageID,
+		ReactionID: reactionID,
+	}); err != nil {
+		slog.Debug("codex bridge delete processing reaction failed",
+			"bot_id", w.binding.BotID,
+			"room_id", strings.TrimSpace(evt.RoomID),
+			"message_id", messageID,
+			"reaction_id", reactionID,
+			"emoji_type", processingPinEmoji,
+			"error", err,
+		)
+	}
+}
+
+func contextWithDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 func (w *worker) sendMessage(ctx context.Context, roomID, threadRootID, text string) (string, error) {
 	return w.sendMessageRequest(ctx, SendMessageRequest{
 		RoomID:       roomID,
@@ -484,6 +629,44 @@ func (w *worker) sendActivity(ctx context.Context, roomID, threadRootID string, 
 		ThreadRootID: strings.TrimSpace(threadRootID),
 	})
 	return err
+}
+
+func (w *worker) updateMessage(ctx context.Context, roomID, messageID, text string) error {
+	text = strings.TrimSpace(text)
+	messageID = strings.TrimSpace(messageID)
+	if text == "" || messageID == "" {
+		return nil
+	}
+	updater, ok := w.service.client.(MessageUpdater)
+	if !ok {
+		return fmt.Errorf("message update is not supported")
+	}
+	updateStartedAt := time.Now()
+	resp, err := updater.UpdateMessage(ctx, w.binding.BotID, UpdateMessageRequest{
+		RoomID:    strings.TrimSpace(roomID),
+		MessageID: messageID,
+		Text:      text,
+	})
+	if err != nil {
+		slog.Debug("codex bridge update message failed",
+			"bot_id", w.binding.BotID,
+			"room_id", strings.TrimSpace(roomID),
+			"message_id", messageID,
+			"text_bytes", len(text),
+			"duration", time.Since(updateStartedAt),
+			"error", err,
+		)
+		return err
+	}
+	slog.Debug("codex bridge update message completed",
+		"bot_id", w.binding.BotID,
+		"room_id", strings.TrimSpace(roomID),
+		"message_id", messageID,
+		"updated_message_id", strings.TrimSpace(resp.MessageID),
+		"text_bytes", len(text),
+		"duration", time.Since(updateStartedAt),
+	)
+	return nil
 }
 
 func (w *worker) sendMessageRequest(ctx context.Context, req SendMessageRequest) (string, error) {

--- a/internal/channelbridge/codexbridge/bridge_test.go
+++ b/internal/channelbridge/codexbridge/bridge_test.go
@@ -24,10 +24,34 @@ type streamResult struct {
 }
 
 type fakeBotClient struct {
-	mu          sync.Mutex
-	streams     map[string][]streamResult
-	streamCtxs  []context.Context
-	sendRecords []SendMessageRequest
+	mu                 sync.Mutex
+	streams            map[string][]streamResult
+	streamCtxs         []context.Context
+	sendRecords        []SendMessageRequest
+	updateRecords      []updateRecord
+	addReactions       []reactionAddRecord
+	delReactions       []reactionDeleteRecord
+	ops                []string
+	updateErr          error
+	addReactionErr     error
+	deleteReactionErr  error
+	addReactionStarted chan struct{}
+	addReactionBlock   <-chan struct{}
+}
+
+type updateRecord struct {
+	botID string
+	req   UpdateMessageRequest
+}
+
+type reactionAddRecord struct {
+	botID string
+	req   AddMessageReactionRequest
+}
+
+type reactionDeleteRecord struct {
+	botID string
+	req   DeleteMessageReactionRequest
 }
 
 func (c *fakeBotClient) StreamEvents(ctx context.Context, botID, _ string) (<-chan BotEvent, <-chan error) {
@@ -59,7 +83,58 @@ func (c *fakeBotClient) SendMessage(_ context.Context, _ string, req SendMessage
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.sendRecords = append(c.sendRecords, req)
+	c.ops = append(c.ops, "send:"+req.Text)
 	return SendMessageResponse{MessageID: "sent-" + strconv.Itoa(len(c.sendRecords))}, nil
+}
+
+func (c *fakeBotClient) UpdateMessage(_ context.Context, botID string, req UpdateMessageRequest) (UpdateMessageResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updateRecords = append(c.updateRecords, updateRecord{botID: botID, req: req})
+	c.ops = append(c.ops, "update:"+req.MessageID+":"+req.Text)
+	if c.updateErr != nil {
+		return UpdateMessageResponse{}, c.updateErr
+	}
+	return UpdateMessageResponse{MessageID: req.MessageID}, nil
+}
+
+func (c *fakeBotClient) AddMessageReaction(ctx context.Context, botID string, req AddMessageReactionRequest) (AddMessageReactionResponse, error) {
+	signal(c.addReactionStarted)
+	if c.addReactionBlock != nil {
+		select {
+		case <-ctx.Done():
+			return AddMessageReactionResponse{}, ctx.Err()
+		case <-c.addReactionBlock:
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.addReactions = append(c.addReactions, reactionAddRecord{botID: botID, req: req})
+	reactionID := "reaction-" + strconv.Itoa(len(c.addReactions))
+	c.ops = append(c.ops, "reaction-add:"+req.MessageID+":"+req.EmojiType)
+	if c.addReactionErr != nil {
+		return AddMessageReactionResponse{}, c.addReactionErr
+	}
+	return AddMessageReactionResponse{ReactionID: reactionID}, nil
+}
+
+func (c *fakeBotClient) DeleteMessageReaction(_ context.Context, botID string, req DeleteMessageReactionRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.delReactions = append(c.delReactions, reactionDeleteRecord{botID: botID, req: req})
+	c.ops = append(c.ops, "reaction-delete:"+req.MessageID+":"+req.ReactionID)
+	return c.deleteReactionErr
+}
+
+func signal(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func (c *fakeBotClient) sentTexts() []string {
@@ -77,6 +152,38 @@ func (c *fakeBotClient) sentRecords() []SendMessageRequest {
 	defer c.mu.Unlock()
 	out := make([]SendMessageRequest, len(c.sendRecords))
 	copy(out, c.sendRecords)
+	return out
+}
+
+func (c *fakeBotClient) updates() []updateRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]updateRecord, len(c.updateRecords))
+	copy(out, c.updateRecords)
+	return out
+}
+
+func (c *fakeBotClient) reactionAdds() []reactionAddRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]reactionAddRecord, len(c.addReactions))
+	copy(out, c.addReactions)
+	return out
+}
+
+func (c *fakeBotClient) reactionDeletes() []reactionDeleteRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]reactionDeleteRecord, len(c.delReactions))
+	copy(out, c.delReactions)
+	return out
+}
+
+func (c *fakeBotClient) operationLog() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.ops))
+	copy(out, c.ops)
 	return out
 }
 
@@ -464,6 +571,389 @@ func assertServiceThreadsTopLevelToolCallsBesideFinalResponse(t *testing.T, chat
 			records[3].ThreadRootID == "" &&
 			records[3].Text == "done"
 	})
+}
+
+func TestServiceAddsAndRemovesFeishuProcessingPinAroundFinalReply(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "你好",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "收到",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return len(client.sentRecords()) == 1 && len(client.reactionAdds()) == 1 && len(client.reactionDeletes()) == 1
+	})
+
+	adds := client.reactionAdds()
+	if adds[0].botID != "manager" || adds[0].req.MessageID != "om-user" || adds[0].req.EmojiType != processingPinEmoji {
+		t.Fatalf("add reaction = %+v, want Pin on inbound message", adds[0])
+	}
+	deletes := client.reactionDeletes()
+	if deletes[0].botID != "manager" || deletes[0].req.MessageID != "om-user" || deletes[0].req.ReactionID != "reaction-1" {
+		t.Fatalf("delete reaction = %+v, want same inbound reaction", deletes[0])
+	}
+	if got := client.sentTexts(); !slices.Equal(got, []string{"收到"}) {
+		t.Fatalf("sent texts = %+v, want final reply", got)
+	}
+}
+
+func TestServiceDoesNotBlockPromptOnFeishuProcessingPin(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "你好",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	unblockReaction := make(chan struct{})
+	reactionStarted := make(chan struct{}, 1)
+	promptStarted := make(chan struct{}, 1)
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+		addReactionStarted: reactionStarted,
+		addReactionBlock:   unblockReaction,
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			signal(promptStarted)
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "收到",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	select {
+	case <-reactionStarted:
+	case <-time.After(time.Second):
+		t.Fatal("processing reaction did not start")
+	}
+	select {
+	case <-promptStarted:
+	case <-time.After(time.Second):
+		t.Fatal("prompt did not start while processing reaction was blocked")
+	}
+	close(unblockReaction)
+	waitFor(t, func() bool {
+		return slices.Equal(client.sentTexts(), []string{"收到"})
+	})
+}
+
+func TestServiceIgnoresFeishuProcessingPinAddFailure(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "你好",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+		addReactionErr: errors.New("reaction denied"),
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "收到",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return slices.Equal(client.sentTexts(), []string{"收到"}) && len(client.reactionAdds()) == 1
+	})
+	if got := client.reactionDeletes(); len(got) != 0 {
+		t.Fatalf("reaction deletes = %+v, want none after add failure", got)
+	}
+}
+
+func TestServiceIgnoresFeishuProcessingPinDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "你好",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+		deleteReactionErr: errors.New("delete denied"),
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "收到",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return slices.Equal(client.sentTexts(), []string{"收到"}) && len(client.reactionAdds()) == 1 && len(client.reactionDeletes()) == 1
+	})
+}
+
+func TestServiceUpdatesFeishuGeneratedToolRootWithFinalResponse(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "run it",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:        handle.RuntimeID,
+				SessionID:        req.SessionID,
+				Kind:             runtimecodex.SessionEventToolCallStart,
+				ToolCallID:       "tool-1",
+				ToolTitle:        "Run shell command",
+				ToolStatus:       "pending",
+				ToolInputSummary: `{"cmd":"pwd"}`,
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "done",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return len(client.sentRecords()) == 2 && len(client.updates()) == 1
+	})
+	records := client.sentRecords()
+	if records[0].RoomID != "oc-alpha" || records[0].ThreadRootID != "" || records[0].Text != turnPlaceholderText {
+		t.Fatalf("placeholder record = %+v, want top-level generated root", records[0])
+	}
+	if records[1].RoomID != "oc-alpha" || records[1].ThreadRootID != "sent-1" || !strings.Contains(records[1].Text, runtimebridge.AgentToolMsgType) {
+		t.Fatalf("tool record = %+v, want activity reply under generated root", records[1])
+	}
+	updates := client.updates()
+	if updates[0].botID != "manager" ||
+		updates[0].req.RoomID != "oc-alpha" ||
+		updates[0].req.MessageID != "sent-1" ||
+		updates[0].req.Text != "done" {
+		t.Fatalf("update record = %+v, want final response replacing generated root", updates[0])
+	}
+}
+
+func TestServiceFallsBackWhenFeishuGeneratedRootUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{
+		Channel:       "feishu",
+		ParticipantID: "manager",
+		MessageID:     "om-user",
+		RoomID:        "oc-alpha",
+		ChatType:      "group",
+		Text:          "run it",
+	}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"manager": {{events: stream, errs: errs}},
+		},
+		updateErr: errors.New("update denied"),
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:        handle.RuntimeID,
+				SessionID:        req.SessionID,
+				Kind:             runtimecodex.SessionEventToolCallStart,
+				ToolCallID:       "tool-1",
+				ToolTitle:        "Run shell command",
+				ToolStatus:       "pending",
+				ToolInputSummary: `{"cmd":"pwd"}`,
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "done",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "manager", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return len(client.sentRecords()) == 3 && len(client.updates()) == 1
+	})
+	records := client.sentRecords()
+	if records[0].Text != turnPlaceholderText || records[0].ThreadRootID != "" {
+		t.Fatalf("placeholder record = %+v, want top-level generated root", records[0])
+	}
+	if records[1].ThreadRootID != "sent-1" || !strings.Contains(records[1].Text, runtimebridge.AgentToolMsgType) {
+		t.Fatalf("tool record = %+v, want activity reply under generated root", records[1])
+	}
+	if records[2].ThreadRootID != "sent-1" || records[2].Text != "done" {
+		t.Fatalf("fallback record = %+v, want final response inside generated root", records[2])
+	}
 }
 
 func TestServiceKeepsToolActivityInsideExistingThread(t *testing.T) {
@@ -1318,6 +1808,8 @@ func waitFor(t *testing.T, fn func() bool) {
 }
 
 var _ BotClient = (*fakeBotClient)(nil)
+var _ MessageUpdater = (*fakeBotClient)(nil)
+var _ MessageReactor = (*fakeBotClient)(nil)
 var _ SessionPrompter = (*fakePrompter)(nil)
 
 func TestWorkerReturnsPromptError(t *testing.T) {

--- a/internal/channelbridge/codexbridge/sse_client.go
+++ b/internal/channelbridge/codexbridge/sse_client.go
@@ -21,7 +21,14 @@ type BotThreadContextMessage = channelbridge.BotThreadContextMessage
 type BotThreadContextSummary = channelbridge.BotThreadContextSummary
 type SendMessageRequest = channelbridge.SendMessageRequest
 type SendMessageResponse = channelbridge.SendMessageResponse
+type UpdateMessageRequest = channelbridge.UpdateMessageRequest
+type UpdateMessageResponse = channelbridge.UpdateMessageResponse
+type AddMessageReactionRequest = channelbridge.AddMessageReactionRequest
+type AddMessageReactionResponse = channelbridge.AddMessageReactionResponse
+type DeleteMessageReactionRequest = channelbridge.DeleteMessageReactionRequest
 type BotClient = channelbridge.BotClient
+type MessageUpdater = channelbridge.MessageUpdater
+type MessageReactor = channelbridge.MessageReactor
 
 type HTTPClient struct {
 	BaseURL     string

--- a/internal/channelbridge/feishu_client.go
+++ b/internal/channelbridge/feishu_client.go
@@ -201,6 +201,153 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 	return SendMessageResponse{MessageID: strings.TrimSpace(message.ID)}, nil
 }
 
+func (c *FeishuClient) UpdateMessage(ctx context.Context, botID string, req UpdateMessageRequest) (UpdateMessageResponse, error) {
+	if c == nil || c.Svc == nil {
+		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: service is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	senderID := strings.TrimSpace(botID)
+	if senderID == "" {
+		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: bot id is required")
+	}
+	roomID := strings.TrimSpace(req.RoomID)
+	if roomID == "" {
+		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: room id is required")
+	}
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: message id is required")
+	}
+	text := strings.TrimSpace(req.Text)
+	if text == "" {
+		return UpdateMessageResponse{}, nil
+	}
+
+	updateStartedAt := time.Now()
+	message, err := c.Svc.UpdateMessageWithContext(ctx, feishu.UpdateMessageRequest{
+		RoomID:    roomID,
+		SenderID:  senderID,
+		MessageID: messageID,
+		Content:   text,
+	})
+	if err != nil {
+		slog.Warn("feishu bridge update failed",
+			"participant_id", senderID,
+			"room_id", roomID,
+			"message_id", messageID,
+			"text_bytes", len(text),
+			"duration", time.Since(updateStartedAt),
+			"error", err,
+		)
+		return UpdateMessageResponse{}, err
+	}
+	slog.Debug("feishu bridge update completed",
+		"participant_id", senderID,
+		"room_id", roomID,
+		"message_id", messageID,
+		"updated_message_id", strings.TrimSpace(message.ID),
+		"text_bytes", len(text),
+		"duration", time.Since(updateStartedAt),
+	)
+	return UpdateMessageResponse{MessageID: strings.TrimSpace(message.ID)}, nil
+}
+
+func (c *FeishuClient) AddMessageReaction(ctx context.Context, botID string, req AddMessageReactionRequest) (AddMessageReactionResponse, error) {
+	if c == nil || c.Svc == nil {
+		return AddMessageReactionResponse{}, fmt.Errorf("feishu bridge reaction: service is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	senderID := strings.TrimSpace(botID)
+	if senderID == "" {
+		return AddMessageReactionResponse{}, fmt.Errorf("feishu bridge reaction: bot id is required")
+	}
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return AddMessageReactionResponse{}, fmt.Errorf("feishu bridge reaction: message id is required")
+	}
+	emojiType := strings.TrimSpace(req.EmojiType)
+	if emojiType == "" {
+		return AddMessageReactionResponse{}, fmt.Errorf("feishu bridge reaction: emoji type is required")
+	}
+
+	reactionStartedAt := time.Now()
+	reaction, err := c.Svc.CreateMessageReactionWithContext(ctx, feishu.CreateMessageReactionRequest{
+		SenderID:  senderID,
+		MessageID: messageID,
+		EmojiType: emojiType,
+	})
+	if err != nil {
+		slog.Warn("feishu bridge add reaction failed",
+			"participant_id", senderID,
+			"message_id", messageID,
+			"emoji_type", emojiType,
+			"duration", time.Since(reactionStartedAt),
+			"error", err,
+		)
+		return AddMessageReactionResponse{}, err
+	}
+	slog.Debug("feishu bridge add reaction completed",
+		"participant_id", senderID,
+		"message_id", messageID,
+		"reaction_id", strings.TrimSpace(reaction.ReactionID),
+		"emoji_type", emojiType,
+		"duration", time.Since(reactionStartedAt),
+	)
+	return AddMessageReactionResponse{ReactionID: strings.TrimSpace(reaction.ReactionID)}, nil
+}
+
+func (c *FeishuClient) DeleteMessageReaction(ctx context.Context, botID string, req DeleteMessageReactionRequest) error {
+	if c == nil || c.Svc == nil {
+		return fmt.Errorf("feishu bridge reaction delete: service is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	senderID := strings.TrimSpace(botID)
+	if senderID == "" {
+		return fmt.Errorf("feishu bridge reaction delete: bot id is required")
+	}
+	messageID := strings.TrimSpace(req.MessageID)
+	if messageID == "" {
+		return fmt.Errorf("feishu bridge reaction delete: message id is required")
+	}
+	reactionID := strings.TrimSpace(req.ReactionID)
+	if reactionID == "" {
+		return fmt.Errorf("feishu bridge reaction delete: reaction id is required")
+	}
+
+	reactionStartedAt := time.Now()
+	err := c.Svc.DeleteMessageReactionWithContext(ctx, feishu.DeleteMessageReactionRequest{
+		SenderID:   senderID,
+		MessageID:  messageID,
+		ReactionID: reactionID,
+	})
+	if err != nil {
+		slog.Warn("feishu bridge delete reaction failed",
+			"participant_id", senderID,
+			"message_id", messageID,
+			"reaction_id", reactionID,
+			"duration", time.Since(reactionStartedAt),
+			"error", err,
+		)
+		return err
+	}
+	slog.Debug("feishu bridge delete reaction completed",
+		"participant_id", senderID,
+		"message_id", messageID,
+		"reaction_id", reactionID,
+		"duration", time.Since(reactionStartedAt),
+	)
+	return nil
+}
+
 func (c *FeishuClient) emitBotEvent(
 	ctx context.Context,
 	participantID string,

--- a/internal/channelbridge/types.go
+++ b/internal/channelbridge/types.go
@@ -44,7 +44,40 @@ type SendMessageResponse struct {
 	MessageID string `json:"message_id"`
 }
 
+type UpdateMessageRequest struct {
+	RoomID    string `json:"room_id,omitempty"`
+	MessageID string `json:"message_id"`
+	Text      string `json:"text"`
+}
+
+type UpdateMessageResponse struct {
+	MessageID string `json:"message_id"`
+}
+
+type AddMessageReactionRequest struct {
+	MessageID string `json:"message_id"`
+	EmojiType string `json:"emoji_type,omitempty"`
+}
+
+type AddMessageReactionResponse struct {
+	ReactionID string `json:"reaction_id"`
+}
+
+type DeleteMessageReactionRequest struct {
+	MessageID  string `json:"message_id"`
+	ReactionID string `json:"reaction_id"`
+}
+
 type BotClient interface {
 	StreamEvents(ctx context.Context, botID, lastEventID string) (<-chan BotEvent, <-chan error)
 	SendMessage(ctx context.Context, botID string, req SendMessageRequest) (SendMessageResponse, error)
+}
+
+type MessageUpdater interface {
+	UpdateMessage(ctx context.Context, botID string, req UpdateMessageRequest) (UpdateMessageResponse, error)
+}
+
+type MessageReactor interface {
+	AddMessageReaction(ctx context.Context, botID string, req AddMessageReactionRequest) (AddMessageReactionResponse, error)
+	DeleteMessageReaction(ctx context.Context, botID string, req DeleteMessageReactionRequest) error
 }


### PR DESCRIPTION
## Summary
- Make Feishu processing reactions asynchronous best-effort with bounded cleanup.
- Add context-aware Feishu update/reaction service paths and require room_id for local update consistency.
- Cover update fallback and reaction add/delete failure paths with regression tests.

## Validation
- make fmt
- git diff --check
- go test -count=1 ./internal/channel/feishu ./internal/channelbridge/codexbridge
- go test -count=10 ./internal/channelbridge/codexbridge -run 'FeishuProcessingPin|GeneratedRootUpdate'

## Notes
- Full go test ./... still has existing internal/api failures unrelated to this change: TestDirectoryPickerCanceled and TestHandleAgentsPatchFieldMaskClearsRuntimeOptions.