### PR TITLE
fix(feishu): format Codex tool activity replies

### DIFF
--- a/internal/channelbridge/feishu_activity_format.go
+++ b/internal/channelbridge/feishu_activity_format.go
@@ -1,0 +1,149 @@
+package channelbridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"csgclaw/internal/channelbridge/runtimebridge"
+)
+
+type feishuActivityMessage struct {
+	Type    string                `json:"type"`
+	Content feishuActivityContent `json:"content"`
+}
+
+type feishuActivityContent struct {
+	MsgType string             `json:"msgtype"`
+	Body    string             `json:"body"`
+	Tool    feishuActivityTool `json:"tool"`
+}
+
+type feishuActivityTool struct {
+	Kind          string `json:"kind"`
+	Title         string `json:"title"`
+	Status        string `json:"status"`
+	InputSummary  string `json:"input_summary"`
+	OutputSummary string `json:"output_summary"`
+}
+
+func formatFeishuBridgeMessageText(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return text
+	}
+
+	var msg feishuActivityMessage
+	if err := json.Unmarshal([]byte(trimmed), &msg); err != nil {
+		return text
+	}
+	if msg.Type != runtimebridge.AgentActivityType {
+		return text
+	}
+	if msg.Content.MsgType != runtimebridge.AgentToolMsgType {
+		return firstNonEmpty(msg.Content.Body, text)
+	}
+	if msg.Content.Tool.empty() {
+		return firstNonEmpty(msg.Content.Body, text)
+	}
+	return renderFeishuToolActivity(msg.Content.Tool, msg.Content.Body)
+}
+
+func renderFeishuToolActivity(tool feishuActivityTool, body string) string {
+	var b strings.Builder
+	b.WriteString(feishuToolStatusLabel(tool.Status))
+	b.WriteString(" · ")
+	b.WriteString(firstNonEmpty(tool.Title, tool.Kind, "Run tool"))
+
+	sections := 0
+	if command := feishuSummaryValue(tool.InputSummary, "command", "cmd"); command != "" {
+		appendFeishuCodeSection(&b, "Command", command)
+		sections++
+	} else if input := feishuSummaryValue(tool.InputSummary, "input", "query", "path", "file", "filename"); input != "" {
+		appendFeishuCodeSection(&b, "Input", input)
+		sections++
+	}
+	if output := feishuSummaryValue(tool.OutputSummary, "output", "result", "stdout", "stderr", "error"); output != "" {
+		appendFeishuCodeSection(&b, "Result", output)
+		sections++
+	}
+	if sections == 0 {
+		if body = strings.TrimSpace(body); body != "" {
+			b.WriteString("\n\n")
+			b.WriteString(body)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func feishuToolStatusLabel(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "success", "succeeded":
+		return "✅ Tool completed"
+	case "failed", "failure", "error":
+		return "❌ Tool failed"
+	case "canceled", "cancelled":
+		return "⏹️ Tool canceled"
+	default:
+		return "🔧 Tool call"
+	}
+}
+
+func feishuSummaryValue(summary string, keys ...string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return ""
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(summary), &decoded); err != nil {
+		return summary
+	}
+	if object, ok := decoded.(map[string]any); ok {
+		for _, key := range keys {
+			if value := feishuSummaryText(object[key]); value != "" {
+				return value
+			}
+		}
+		if len(keys) > 0 {
+			return ""
+		}
+	}
+	return feishuSummaryText(decoded)
+}
+
+func feishuSummaryText(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case float64, bool:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(data))
+	}
+}
+
+func appendFeishuCodeSection(b *strings.Builder, label, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	b.WriteString("\n\n")
+	b.WriteString(label)
+	b.WriteString("\n```\n")
+	b.WriteString(strings.ReplaceAll(value, "```", "` ` `"))
+	if !strings.HasSuffix(value, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("```")
+}
+
+func (t feishuActivityTool) empty() bool {
+	return firstNonEmpty(t.Kind, t.Title, t.Status, t.InputSummary, t.OutputSummary) == ""
+}

--- a/internal/channelbridge/feishu_client.go
+++ b/internal/channelbridge/feishu_client.go
@@ -103,6 +103,12 @@ func (c *FeishuClient) StreamEvents(ctx context.Context, botID, lastEventID stri
 				OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
 					c.emitBotEvent(ctx, botID, botOpenID, requireBotMention, event, events, &lastEventID, &lastEventIDMu)
 					return nil
+				}).
+				OnP2MessageReactionCreatedV1(func(context.Context, *larkim.P2MessageReactionCreatedV1) error {
+					return nil
+				}).
+				OnP2MessageReactionDeletedV1(func(context.Context, *larkim.P2MessageReactionDeletedV1) error {
+					return nil
 				})
 			wsClient := larkws.NewClient(
 				app.AppID,
@@ -153,7 +159,7 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 		return SendMessageResponse{}, fmt.Errorf("feishu bridge send: room id is required")
 	}
 
-	text := strings.TrimSpace(req.Text)
+	text := strings.TrimSpace(formatFeishuBridgeMessageText(req.Text))
 	if text == "" {
 		return SendMessageResponse{}, nil
 	}
@@ -221,7 +227,7 @@ func (c *FeishuClient) UpdateMessage(ctx context.Context, botID string, req Upda
 	if messageID == "" {
 		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: message id is required")
 	}
-	text := strings.TrimSpace(req.Text)
+	text := strings.TrimSpace(formatFeishuBridgeMessageText(req.Text))
 	if text == "" {
 		return UpdateMessageResponse{}, nil
 	}

--- a/internal/channelbridge/feishu_client_test.go
+++ b/internal/channelbridge/feishu_client_test.go
@@ -1,0 +1,92 @@
+package channelbridge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/channel/feishu"
+	"csgclaw/internal/channelbridge/runtimebridge"
+)
+
+func TestFeishuClientFormatsToolActivityMessages(t *testing.T) {
+	t.Parallel()
+
+	var gotReq feishu.SendMessageRequest
+	svc := feishu.NewServiceWithSendMessage(
+		map[string]feishu.AppConfig{
+			"manager": {AppID: "cli_manager", AppSecret: "manager-secret"},
+		},
+		func(_ context.Context, _ feishu.AppConfig, req feishu.SendMessageRequest) (feishu.SendMessageResponse, error) {
+			gotReq = req
+			return feishu.SendMessageResponse{MessageID: "om_tool", SenderOpenID: "ou_codex"}, nil
+		},
+	)
+	client := NewFeishuClient(svc)
+
+	activityData, err := json.Marshal(map[string]any{
+		"type":             runtimebridge.AgentActivityType,
+		"version":          1,
+		"channel":          "csgclaw",
+		"event_id":         "tool-f8e39e393ff08ef6dd33f95b",
+		"room_id":          "oc_afb50868a26e1732e5ad4ad20a0d9391",
+		"sender":           "agent-2te2nl",
+		"origin_server_ts": int64(1781792759561),
+		"content": map[string]any{
+			"msgtype": runtimebridge.AgentToolMsgType,
+			"body":    "Tool completed: Run shell command",
+			"tool": map[string]any{
+				"id":             "f8e39e393ff08ef6dd33f95b",
+				"kind":           "exec_command",
+				"title":          "Run shell command",
+				"status":         "completed",
+				"input_summary":  `{"command":"/bin/bash -lc 'which csgclaw-cli || find /home/jhw -name csgclaw-cli -type f 2>/dev/null | head'"}`,
+				"output_summary": `{"output":"/home/jhw/opcsg/csgclaw/bin/csgclaw-cli"}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal activity: %v", err)
+	}
+
+	resp, err := client.SendMessage(context.Background(), "u-codex", SendMessageRequest{
+		RoomID:       "oc_afb50868a26e1732e5ad4ad20a0d9391",
+		Text:         string(activityData),
+		ThreadRootID: "om_root",
+	})
+	if err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+	if resp.MessageID != "om_tool" {
+		t.Fatalf("MessageID = %q, want om_tool", resp.MessageID)
+	}
+	if gotReq.ThreadRootID != "om_root" {
+		t.Fatalf("ThreadRootID = %q, want om_root", gotReq.ThreadRootID)
+	}
+
+	content := gotReq.Content
+	for _, want := range []string{
+		"✅ Tool completed · Run shell command",
+		"Command\n```\n/bin/bash -lc 'which csgclaw-cli || find /home/jhw -name csgclaw-cli -type f 2>/dev/null | head'\n```",
+		"Result\n```\n/home/jhw/opcsg/csgclaw/bin/csgclaw-cli\n```",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("formatted content missing %q:\n%s", want, content)
+		}
+	}
+	for _, unwanted := range []string{
+		"event_id",
+		"room_id",
+		"sender",
+		"origin_server_ts",
+		"input_summary",
+		"output_summary",
+		runtimebridge.AgentActivityType,
+		runtimebridge.AgentToolMsgType,
+	} {
+		if strings.Contains(content, unwanted) {
+			t.Fatalf("formatted content leaked %q:\n%s", unwanted, content)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Format Codex tool activity payloads before sending them to Feishu so replies show command/result text instead of raw activity JSON.
- Register no-op Feishu reaction event handlers so processing pin events do not log missing-handler errors.

## Validation
- `go test ./internal/channelbridge/... ./internal/channel/feishu`

## Impact
- Feishu tool threads become easier to read while the internal structured activity payload contract remains unchanged.
