### PR TITLE
fix(feishu): expose bot invite failures and setup guidance

### DIFF
--- a/internal/channel/feishu/service.go
+++ b/internal/channel/feishu/service.go
@@ -1,6 +1,7 @@
 package feishu
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -529,10 +530,9 @@ func (s *Service) CreateRoom(req im.CreateRoomRequest) (im.Room, error) {
 	description := strings.TrimSpace(req.Description)
 
 	created, err := s.createChat(context.Background(), app, CreateChatRequest{
-		Title:        title,
-		Description:  description,
-		CreatorID:    adminOpenID,
-		MemberAppIDs: memberAppIDs,
+		Title:       title,
+		Description: description,
+		CreatorID:   adminOpenID,
 	})
 	if err != nil {
 		return im.Room{}, err
@@ -546,6 +546,15 @@ func (s *Service) CreateRoom(req im.CreateRoomRequest) (im.Room, error) {
 	}
 	if responseDescription := strings.TrimSpace(created.Description); responseDescription != "" {
 		description = responseDescription
+	}
+	if len(memberAppIDs) > 0 {
+		if err := s.addChatMembers(context.Background(), app, AddChatMembersRequest{
+			ChatID:       chatID,
+			MemberBotIDs: memberBotIDs,
+			MemberAppIDs: memberAppIDs,
+		}); err != nil {
+			return im.Room{}, fmt.Errorf("create feishu chat %s succeeded but add members failed: %w", chatID, err)
+		}
 	}
 
 	room := im.Room{
@@ -595,7 +604,17 @@ func defaultCreateChat(ctx context.Context, app AppConfig, req CreateChatRequest
 		return CreateChatResponse{}, fmt.Errorf("create feishu chat: %w", err)
 	}
 	if !resp.Success() {
-		return CreateChatResponse{}, fmt.Errorf("create feishu chat: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+		return CreateChatResponse{}, fmt.Errorf(
+			"create feishu chat: code=%d msg=%s request_id=%s request_app_id=%s owner_open_id=%s bot_app_ids=%s response_data=%s response_body=%s",
+			resp.Code,
+			resp.Msg,
+			resp.RequestId(),
+			strings.TrimSpace(app.AppID),
+			req.CreatorID,
+			strings.Join(normalizeNonEmptyStrings(req.MemberAppIDs), ","),
+			feishuResponseData(resp.Data),
+			feishuResponseBody(resp.RawBody),
+		)
 	}
 	if resp.Data == nil {
 		return CreateChatResponse{}, fmt.Errorf("create feishu chat: empty response data")
@@ -617,7 +636,7 @@ func defaultAddChatMembers(ctx context.Context, app AppConfig, req AddChatMember
 	addReq := larkim.NewCreateChatMembersReqBuilder().
 		ChatId(req.ChatID).
 		MemberIdType("app_id").
-		SucceedType(0).
+		SucceedType(2).
 		Body(larkim.NewCreateChatMembersReqBodyBuilder().
 			IdList(memberAppIDs).
 			Build()).
@@ -628,9 +647,44 @@ func defaultAddChatMembers(ctx context.Context, app AppConfig, req AddChatMember
 		return fmt.Errorf("add feishu chat members: %w", err)
 	}
 	if !resp.Success() {
-		return fmt.Errorf("add feishu chat members: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+		return fmt.Errorf(
+			"add feishu chat members: code=%d msg=%s request_id=%s request_app_id=%s chat_id=%s member_id_type=app_id succeed_type=2 member_app_ids=%s response_data=%s response_body=%s",
+			resp.Code,
+			resp.Msg,
+			resp.RequestId(),
+			strings.TrimSpace(app.AppID),
+			strings.TrimSpace(req.ChatID),
+			strings.Join(memberAppIDs, ","),
+			feishuResponseData(resp.Data),
+			feishuResponseBody(resp.RawBody),
+		)
 	}
 	return nil
+}
+
+func feishuResponseData(data any) string {
+	if data == nil {
+		return "null"
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Sprintf("%T", data)
+	}
+	return string(raw)
+}
+
+func feishuResponseBody(raw []byte) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return "null"
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err == nil {
+		if normalized, err := json.Marshal(value); err == nil {
+			return string(normalized)
+		}
+	}
+	return string(raw)
 }
 
 func defaultDeleteChat(ctx context.Context, app AppConfig, chatID string) error {

--- a/internal/channel/feishu/service_test.go
+++ b/internal/channel/feishu/service_test.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,37 @@ func TestFeishuServiceInitializesMessageBus(t *testing.T) {
 
 	if svc.MessageBus() == nil {
 		t.Fatal("MessageBus() = nil, want initialized bus")
+	}
+}
+
+func TestFeishuResponseDataSerializesFailureDetails(t *testing.T) {
+	got := feishuResponseData(map[string]any{
+		"invalid_id_list":          []string{"cli_bad"},
+		"not_existed_id_list":      []string{"cli_missing"},
+		"pending_approval_id_list": []string{"cli_pending"},
+	})
+
+	for _, want := range []string{"invalid_id_list", "cli_bad", "not_existed_id_list", "cli_missing", "pending_approval_id_list", "cli_pending"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("feishuResponseData() = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFeishuResponseBodySerializesErrorDetails(t *testing.T) {
+	got := feishuResponseBody([]byte(`{
+		"code": 2200,
+		"msg": "Internal Error",
+		"error": {
+			"log_id": "log_123",
+			"troubleshooter": "https://open.feishu.cn/search?log_id=log_123"
+		}
+	}`))
+
+	for _, want := range []string{"Internal Error", "log_123", "troubleshooter"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("feishuResponseBody() = %q, want substring %q", got, want)
+		}
 	}
 }
 
@@ -265,7 +297,8 @@ func TestFeishuBotMembersInChatWithResolversIncludesConfiguredBots(t *testing.T)
 
 func TestFeishuCreateRoomUsesConfiguredAdminOpenID(t *testing.T) {
 	var gotCreatorID string
-	var gotMemberAppIDs []string
+	var gotCreateMemberAppIDs []string
+	var gotAddReq AddChatMembersRequest
 	svc := NewServiceWithCreateChatAndAddMembers(
 		map[string]AppConfig{
 			"manager": {AppID: "cli_manager", AppSecret: "manager-secret", AdminOpenID: "ou_admin"},
@@ -273,10 +306,13 @@ func TestFeishuCreateRoomUsesConfiguredAdminOpenID(t *testing.T) {
 		},
 		func(_ context.Context, _ AppConfig, req CreateChatRequest) (CreateChatResponse, error) {
 			gotCreatorID = req.CreatorID
-			gotMemberAppIDs = append([]string(nil), req.MemberAppIDs...)
+			gotCreateMemberAppIDs = append([]string(nil), req.MemberAppIDs...)
 			return CreateChatResponse{ChatID: "oc_alpha", Name: req.Title, Description: req.Description}, nil
 		},
-		func(context.Context, AppConfig, AddChatMembersRequest) error { return nil },
+		func(_ context.Context, _ AppConfig, req AddChatMembersRequest) error {
+			gotAddReq = req
+			return nil
+		},
 	)
 
 	if _, err := svc.CreateRoom(im.CreateRoomRequest{Title: "alpha", CreatorID: "u-manager", MemberIDs: []string{"u-dev"}}); err != nil {
@@ -286,8 +322,17 @@ func TestFeishuCreateRoomUsesConfiguredAdminOpenID(t *testing.T) {
 	if got, want := gotCreatorID, "ou_admin"; got != want {
 		t.Fatalf("create chat creator_id = %q, want %q", got, want)
 	}
-	if len(gotMemberAppIDs) != 1 || gotMemberAppIDs[0] != "cli_dev" {
-		t.Fatalf("create chat member app_ids = %+v, want [cli_dev]", gotMemberAppIDs)
+	if len(gotCreateMemberAppIDs) != 0 {
+		t.Fatalf("create chat member app_ids = %+v, want none", gotCreateMemberAppIDs)
+	}
+	if got, want := gotAddReq.ChatID, "oc_alpha"; got != want {
+		t.Fatalf("add members chat_id = %q, want %q", got, want)
+	}
+	if len(gotAddReq.MemberBotIDs) != 1 || gotAddReq.MemberBotIDs[0] != "u-dev" {
+		t.Fatalf("add member bot ids = %+v, want [u-dev]", gotAddReq.MemberBotIDs)
+	}
+	if len(gotAddReq.MemberAppIDs) != 1 || gotAddReq.MemberAppIDs[0] != "cli_dev" {
+		t.Fatalf("add members app_ids = %+v, want [cli_dev]", gotAddReq.MemberAppIDs)
 	}
 }
 
@@ -308,6 +353,35 @@ func TestFeishuCreateRoomRequiresConfiguredMemberBots(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), `feishu app is not configured for bot "u-dev"`) {
 		t.Fatalf("CreateRoom() error = %v, want configured bot error", err)
+	}
+}
+
+func TestFeishuCreateRoomReportsCreatedChatIDWhenAddMembersFails(t *testing.T) {
+	svc := NewServiceWithCreateChatAndAddMembers(
+		map[string]AppConfig{
+			"manager": {AppID: "cli_manager", AppSecret: "manager-secret", AdminOpenID: "ou_admin"},
+			"u-dev":   {AppID: "cli_dev", AppSecret: "dev-secret"},
+		},
+		func(_ context.Context, _ AppConfig, req CreateChatRequest) (CreateChatResponse, error) {
+			if len(req.MemberAppIDs) != 0 {
+				t.Fatalf("create chat member app_ids = %+v, want none", req.MemberAppIDs)
+			}
+			return CreateChatResponse{ChatID: "oc_alpha", Name: req.Title, Description: req.Description}, nil
+		},
+		func(context.Context, AppConfig, AddChatMembersRequest) error {
+			return fmt.Errorf("feishu add failed")
+		},
+	)
+
+	_, err := svc.CreateRoom(im.CreateRoomRequest{
+		Title:     "alpha",
+		CreatorID: "u-manager",
+		MemberIDs: []string{"u-dev"},
+	})
+	if err == nil ||
+		!strings.Contains(err.Error(), "create feishu chat oc_alpha succeeded but add members failed") ||
+		!strings.Contains(err.Error(), "feishu add failed") {
+		t.Fatalf("CreateRoom() error = %v, want created chat id and add failure", err)
 	}
 }
 

--- a/internal/templates/embed/openclaw-manager/workspace/skills/basics/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/basics/SKILL.md
@@ -145,7 +145,7 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 - When a **new** worker is needed, use `agent-creator`; do not run bare `participant create --bind create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added participant as a new member. Create a new room with `--member-ids` containing the existing DM participants and the new participant.
-- For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist. Use `member create` only for an existing Feishu group; that path requires manager app scopes such as `im:chat.members:write_only` or `im:chat`.
+- For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist; it creates the chat first, then invites configured worker bot apps. Use `member create` only for an existing Feishu group. Both paths require manager app scopes such as `im:chat.members:write_only` or `im:chat`.
 - Use participant IDs at the CLI boundary. For the local CSGClaw manager use `manager`; use `u-manager` only when calling an agent route or the Feishu credential config API field that still names its key `bot_id`.
 - Never notify a worker with plain-text `@name`; always use `message create --mention-id` and verify `<at user_id="...">` in `message list`.
 - Keep the response focused on the concrete CLI result instead of introducing external planning artifacts.

--- a/internal/templates/embed/openclaw-manager/workspace/skills/feishu/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/feishu/SKILL.md
@@ -170,7 +170,7 @@ By default, `finalize` will:
 
 1. poll Feishu/Lark until credentials are available or timeout
 2. receive `client_id/client_secret`
-3. bind `feishu:admin` human to the registration `open_id` when Feishu returns one
+3. for manager targets only, bind `feishu:admin` human to the registration `open_id` when Feishu returns one
 4. bind the Feishu bot participant through `csgclaw-cli participant bind --feishu-kind bot`
 5. for worker targets, recreate the worker from the bind command so the new Feishu env/files take effect
    - if BoxLite reports `box with name '<name>' already exists` while CSGClaw reports `agent "<id>" not found`, stop and tell the user the host has a stale partial worker box; do not keep trying random API paths or host-only commands from inside manager
@@ -184,6 +184,7 @@ python /home/node/.openclaw/workspace/skills/feishu/scripts/feishu_register.py f
 ```
 
 Use an exec/tool timeout of at least 600 seconds for this command. For workers, finalize should report `config.bot_bind.restart_status`; do not create a second worker or change the target agent ID.
+Worker finalize must not bind or overwrite `feishu:admin`, even when Feishu returns a registration `open_id`; `feishu:admin` belongs to the manager Feishu app scope.
 
 For manager, default finalize binds `feishu:admin` when Feishu returns `open_id`, binds `feishu:manager`, then prints a structured action card. Return the JSON object exactly as the chat message content: no leading sentence, no Markdown table, no bullet list, no ```json fence, and no explanatory wrapper. The CSGClaw Web frontend will render a "重建 Manager" button.
 The click is handled by the browser and calls the manager bootstrap replace surface (`POST /api/v1/agents` with `{"id":"u-manager","replace":true}`), not the hazardous generic recreate route.

--- a/internal/templates/embed/openclaw-manager/workspace/skills/feishu/SKILL.md
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/feishu/SKILL.md
@@ -85,9 +85,9 @@ For new Feishu groups, after the manager and worker Feishu configs exist, prefer
 csgclaw-cli room create --title dev-ui-group --creator-id manager --member-ids manager,dev --channel feishu
 ```
 
-CSGClaw resolves those participant IDs to the configured Feishu app credentials during chat creation and avoids the separate `member create` path for new groups.
+CSGClaw creates the Feishu chat first, then resolves those participant IDs to configured Feishu app credentials and invites the worker bot apps. This keeps the created `chat_id` visible if the invite fails, but it still requires manager app group scopes for chat creation and member invites.
 
-For existing Feishu groups, `csgclaw-cli member list` and `member create` require manager app scopes such as:
+For Feishu group operations, `room create --member-ids`, `csgclaw-cli member list`, and `member create` require manager app scopes such as:
 
 - `im:chat:read`
 - `im:chat.members:read`

--- a/internal/templates/embed/openclaw-manager/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
@@ -100,8 +100,9 @@ def csgclaw_cli_json(args, cli_args: list[str], input_text: Optional[str] = None
 def configure_csgclaw(args, state: dict, result: dict) -> dict:
     agent_id = state["agent_id"]
     response: dict[str, Any] = {}
+    role = resolve_role(args, state)
     candidate_admin_open_id = str(result.get("open_id") or "").strip()
-    if candidate_admin_open_id:
+    if role == "manager" and candidate_admin_open_id:
         admin_bind_args = [
             "participant",
             "bind",
@@ -133,11 +134,10 @@ def configure_csgclaw(args, state: dict, result: dict) -> dict:
         result["app_id"],
         "--app-secret-stdin",
     ]
-    role = resolve_role(args, state)
     if role == "worker" and args.recreate in ("auto", "worker"):
         bot_bind_args.append("--restart")
     response["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=result["app_secret"])
-    if candidate_admin_open_id:
+    if role == "manager" and candidate_admin_open_id:
         response["admin_open_id"] = candidate_admin_open_id
         response["admin_open_id_source"] = "registration"
     else:

--- a/internal/templates/embed/openclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
+++ b/internal/templates/embed/openclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
@@ -69,14 +69,12 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertFalse(any("--restart" in call[0] for call in calls))
         self.assertTrue(any("--app-secret-env" in call[0] for call in calls))
 
-    def test_configure_worker_binds_admin_from_registration_open_id(self):
+    def test_configure_worker_skips_admin_from_registration_open_id(self):
         calls = []
         original_csgclaw_cli_json = csgclaw.csgclaw_cli_json
 
         def fake_csgclaw_cli_json(args, cli_args, input_text=None):
             calls.append((cli_args, input_text))
-            if "--feishu-kind" in cli_args and cli_args[cli_args.index("--feishu-kind") + 1] == "human":
-                return {"participant_id": "admin", "config_saved": True}
             return {
                 "participant_id": "dev",
                 "agent_id": "u-dev",
@@ -93,14 +91,13 @@ class ManagerActionCardTest(unittest.TestCase):
         finally:
             csgclaw.csgclaw_cli_json = original_csgclaw_cli_json
 
-        self.assertEqual(response["admin_bind"]["participant_id"], "admin")
-        self.assertEqual(response["admin_open_id"], "ou_admin")
-        self.assertEqual(response["admin_open_id_source"], "registration")
-        self.assertTrue(any("--feishu-kind" in call[0] and "human" in call[0] for call in calls))
+        self.assertNotIn("admin_bind", response)
+        self.assertNotIn("admin_open_id", response)
+        self.assertFalse(any("--feishu-kind" in call[0] and "human" in call[0] for call in calls))
         self.assertTrue(any("--restart" in call[0] for call in calls))
         self.assertTrue(any(call[1] == "secret-value" for call in calls))
 
-    def test_configure_worker_passes_admin_name_from_registration(self):
+    def test_configure_manager_passes_admin_name_from_registration(self):
         calls = []
         original_csgclaw_cli_json = csgclaw.csgclaw_cli_json
 
@@ -109,16 +106,16 @@ class ManagerActionCardTest(unittest.TestCase):
             if "--feishu-kind" in cli_args and cli_args[cli_args.index("--feishu-kind") + 1] == "human":
                 return {"participant_id": "admin", "config_saved": True}
             return {
-                "participant_id": "dev",
-                "agent_id": "u-dev",
-                "restart_status": "worker_recreated",
+                "participant_id": "manager",
+                "agent_id": "u-manager",
+                "restart_status": "restart_skipped",
             }
 
         csgclaw.csgclaw_cli_json = fake_csgclaw_cli_json
         try:
-            csgclaw.configure_csgclaw(
-                Namespace(role="worker", recreate="auto"),
-                {"agent_id": "u-dev", "role": "worker"},
+            response = csgclaw.configure_csgclaw(
+                Namespace(role="manager", recreate="auto"),
+                {"agent_id": "u-manager", "role": "manager"},
                 {"app_id": "cli_dev", "app_secret": "secret-value", "open_id": "ou_admin", "name": "龙韵"},
             )
         finally:
@@ -127,6 +124,9 @@ class ManagerActionCardTest(unittest.TestCase):
         admin_bind = next(call[0] for call in calls if "--feishu-kind" in call[0] and "human" in call[0])
         self.assertIn("--name", admin_bind)
         self.assertEqual(admin_bind[admin_bind.index("--name") + 1], "龙韵")
+        self.assertEqual(response["admin_bind"]["participant_id"], "admin")
+        self.assertEqual(response["admin_open_id"], "ou_admin")
+        self.assertEqual(response["admin_open_id_source"], "registration")
 
     def test_worker_finalize_uses_bind_restart_status(self):
         originals = {

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
@@ -144,7 +144,7 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 - When a **new** worker is needed, use `agent-creator`; do not run bare `participant create --bind create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added participant as a new member. Create a new room with `--member-ids` containing the existing DM participants and the new participant.
-- For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist. Use `member create` only for an existing Feishu group; that path requires manager app scopes such as `im:chat.members:write_only` or `im:chat`.
+- For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist; it creates the chat first, then invites configured worker bot apps. Use `member create` only for an existing Feishu group. Both paths require manager app scopes such as `im:chat.members:write_only` or `im:chat`.
 - Use participant IDs at the CLI boundary. For the local CSGClaw manager use `manager`; use `u-manager` only when calling an agent route or the Feishu credential config API field that still names its key `bot_id`.
 - Never notify a worker with plain-text `@name`; always use `message create --mention-id` and verify `<at user_id="...">` in `message list`.
 - Keep the response focused on the concrete CLI result instead of introducing external planning artifacts.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/basics/SKILL.md
@@ -144,6 +144,7 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 - When a **new** worker is needed, use `agent-creator`; do not run bare `participant create --bind create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added participant as a new member. Create a new room with `--member-ids` containing the existing DM participants and the new participant.
+- For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist. Use `member create` only for an existing Feishu group; that path requires manager app scopes such as `im:chat.members:write_only` or `im:chat`.
 - Use participant IDs at the CLI boundary. For the local CSGClaw manager use `manager`; use `u-manager` only when calling an agent route or the Feishu credential config API field that still names its key `bot_id`.
 - Never notify a worker with plain-text `@name`; always use `message create --mention-id` and verify `<at user_id="...">` in `message list`.
 - Keep the response focused on the concrete CLI result instead of introducing external planning artifacts.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/SKILL.md
@@ -85,9 +85,9 @@ For new Feishu groups, after the manager and worker Feishu configs exist, prefer
 csgclaw-cli room create --title dev-ui-group --creator-id manager --member-ids manager,dev --channel feishu
 ```
 
-CSGClaw resolves those participant IDs to the configured Feishu app credentials during chat creation and avoids the separate `member create` path for new groups.
+CSGClaw creates the Feishu chat first, then resolves those participant IDs to configured Feishu app credentials and invites the worker bot apps. This keeps the created `chat_id` visible if the invite fails, but it still requires manager app group scopes for chat creation and member invites.
 
-For existing Feishu groups, `csgclaw-cli member list` and `member create` require manager app scopes such as:
+For Feishu group operations, `room create --member-ids`, `csgclaw-cli member list`, and `member create` require manager app scopes such as:
 
 - `im:chat:read`
 - `im:chat.members:read`

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/SKILL.md
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/SKILL.md
@@ -75,6 +75,27 @@ Do not use this skill for generic Feishu webhook integrations or non-CSGClaw Fei
    - `POST /api/v1/channels/feishu/participants`
    - `POST /api/v1/agents/{id}/recreate`
 
+## Manager Group Permissions
+
+CSGClaw cannot silently grant Feishu/Lark app scopes from inside the PicoClaw runtime. Feishu group operations use the manager agent's Feishu bot app credentials, so the tenant admin must approve the required scopes in Feishu/Lark Open Platform.
+
+For new Feishu groups, after the manager and worker Feishu configs exist, prefer creating the group with all participant IDs already included:
+
+```bash
+csgclaw-cli room create --title dev-ui-group --creator-id manager --member-ids manager,dev --channel feishu
+```
+
+CSGClaw resolves those participant IDs to the configured Feishu app credentials during chat creation and avoids the separate `member create` path for new groups.
+
+For existing Feishu groups, `csgclaw-cli member list` and `member create` require manager app scopes such as:
+
+- `im:chat:read`
+- `im:chat.members:read`
+- `im:chat.members:write_only`
+- or the broader `im:chat`
+
+`finalize` prints `manager_group_scopes` and `manager_group_permission_url`. Send that URL to the user/admin when Feishu returns `Access denied` for group member inspection or adding a worker agent's Feishu bot app to an existing group.
+
 ## Safe Credential Rules
 
 1. Never print `app_secret`, `client_secret`, access tokens, verification tokens, encryption keys, or connection strings.
@@ -149,7 +170,7 @@ By default, `finalize` will:
 
 1. poll Feishu/Lark until credentials are available or timeout
 2. receive `client_id/client_secret`
-3. bind `feishu:admin` human to the registration `open_id` when Feishu returns one
+3. for manager targets only, bind `feishu:admin` human to the registration `open_id` when Feishu returns one
 4. bind the Feishu bot participant through `csgclaw-cli participant bind --feishu-kind bot`
 5. for worker targets, recreate the worker from the bind command so the new Feishu env/files take effect
    - if BoxLite reports `box with name '<name>' already exists` while CSGClaw reports `agent "<id>" not found`, stop and tell the user the host has a stale partial worker box; do not keep trying random API paths or host-only commands from inside manager
@@ -163,6 +184,7 @@ python /home/picoclaw/.picoclaw/workspace/skills/feishu/scripts/feishu_register.
 ```
 
 Use an exec/tool timeout of at least 600 seconds for this command. The bind command should report `restart_status`; do not create a second worker or change the target agent ID.
+Worker finalize must not bind or overwrite `feishu:admin`, even when Feishu returns a registration `open_id`; `feishu:admin` belongs to the manager Feishu app scope.
 
 For manager, default finalize binds `feishu:admin` when Feishu returns `open_id`, binds `feishu:manager`, then prints a structured action card. Return the JSON object exactly as the chat message content: no leading sentence, no Markdown table, no bullet list, no ```json fence, and no explanatory wrapper. The CSGClaw Web frontend will render a "重建 Manager" button.
 The click is handled by the browser and calls the manager bootstrap replace surface (`POST /api/v1/agents` with `{"id":"u-manager","replace":true}`), not the hazardous generic recreate route.

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/commands.py
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/commands.py
@@ -8,8 +8,9 @@ import sys
 import time
 import uuid
 from typing import Any, Optional
+from urllib.parse import quote
 
-from .config import API_REQUEST_TIMEOUT, DEFAULT_EXPIRE_SECONDS
+from .config import API_REQUEST_TIMEOUT, DEFAULT_EXPIRE_SECONDS, MANAGER_GROUP_SCOPES, ONBOARD_OPEN_URLS
 from .csgclaw import (
     api_json,
     configure_csgclaw,
@@ -31,6 +32,54 @@ from .state import delete_state, load_state, save_state, state_path
 
 def eprint(*args: Any) -> None:
     print(*args, file=sys.stderr)
+
+
+def manager_group_permission_url(domain: str, app_id: str) -> str:
+    base = ONBOARD_OPEN_URLS.get(domain or "feishu", ONBOARD_OPEN_URLS["feishu"])
+    quoted_app_id = quote(app_id, safe="")
+    quoted_scopes = quote(",".join(MANAGER_GROUP_SCOPES), safe=",:")
+    return f"{base}/app/{quoted_app_id}/auth?q={quoted_scopes}&op_from=openapi&token_type=tenant"
+
+
+def resolve_manager_app_id(args: argparse.Namespace, state: dict, result: dict) -> str:
+    if state.get("agent_id") == "u-manager":
+        return str(result.get("app_id") or "").strip()
+    try:
+        participants = csgclaw_cli_json(args, ["participant", "list", "--channel", "feishu"])
+    except RuntimeError:
+        return ""
+    if not isinstance(participants, list):
+        return ""
+    for participant in participants:
+        if not isinstance(participant, dict):
+            continue
+        is_manager_participant = str(participant.get("id") or "").strip() == "manager"
+        is_manager_agent = str(participant.get("agent_id") or "").strip() == "u-manager"
+        if not (is_manager_participant or is_manager_agent):
+            continue
+        config = participant.get("channel_app_config")
+        if not isinstance(config, dict):
+            continue
+        app_id = str(config.get("app_id") or "").strip()
+        if app_id:
+            return app_id
+    return ""
+
+
+def add_manager_group_permission_info(args: argparse.Namespace, state: dict, result: dict, output: dict) -> None:
+    manager_app_id = resolve_manager_app_id(args, state, result)
+    domain = str(result.get("domain") or state.get("domain") or "feishu")
+    output["manager_group_scopes"] = MANAGER_GROUP_SCOPES
+    output["manager_group_permission_note"] = (
+        "Approve these scopes on the manager Feishu app when the manager needs to "
+        "create Feishu groups, inspect group members, or add worker bots to existing Feishu groups."
+    )
+    if manager_app_id:
+        output["manager_group_permission_app_id"] = manager_app_id
+        output["manager_group_permission_url"] = manager_group_permission_url(domain, manager_app_id)
+    else:
+        output["manager_group_permission_app_id"] = ""
+        output["manager_group_permission_url"] = ""
 
 
 def manager_secret_cli_args(args: argparse.Namespace) -> tuple[list[str], Optional[str]]:
@@ -103,9 +152,8 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         *secret_args,
     ]
     config["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=input_text)
-    setup_status = "configured"
     output = {
-        "status": setup_status,
+        "status": "configured",
         "agent_id": agent_id,
         "bot_id": agent_id,
         "role": "manager",
@@ -116,6 +164,13 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         "config": public_result(config),
         "bot_ensured": True,
     }
+    add_manager_group_permission_info(
+        args,
+        {"agent_id": agent_id, "domain": args.domain},
+        {"app_id": app_id, "domain": args.domain, "open_id": open_id},
+        output,
+    )
+    setup_status = output["status"]
     recreated = manager_recreate_action_card(agent_id)
     output.update(recreated)
     output["setup_status"] = setup_status
@@ -245,6 +300,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         "worker_recreate_policy": worker_recreate_policy,
         "recreate": public_result(recreated or {}),
     }
+    add_manager_group_permission_info(args, state, result, output)
     if isinstance(recreated, dict) and recreated.get("type") == "csgclaw.action_card":
         setup_status = output["status"]
         output.update(recreated)

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/config.py
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/config.py
@@ -4,10 +4,24 @@ ONBOARD_ACCOUNTS_URLS = {
     "feishu": "https://accounts.feishu.cn",
     "lark": "https://accounts.larksuite.com",
 }
+ONBOARD_OPEN_URLS = {
+    "feishu": "https://open.feishu.cn",
+    "lark": "https://open.larksuite.com",
+}
 REGISTRATION_PATH = "/oauth/v1/app/registration"
 REQUEST_TIMEOUT = 15
 API_REQUEST_TIMEOUT = 600
 DEFAULT_EXPIRE_SECONDS = 600
+
+# The manager app performs CSGClaw's Feishu group operations. These scopes cover
+# creating a group, listing members, and adding configured worker bots to an
+# existing group. Feishu tenant admins still need to approve the scopes.
+MANAGER_GROUP_SCOPES = [
+    "im:chat:create",
+    "im:chat:read",
+    "im:chat.members:read",
+    "im:chat.members:write_only",
+]
 
 STATE_DIR_ENV = "CSGCLAW_FEISHU_SETUP_STATE_DIR"
 STATE_DIR_NAME = ".feishu"

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
@@ -100,8 +100,9 @@ def csgclaw_cli_json(args, cli_args: list[str], input_text: Optional[str] = None
 def configure_csgclaw(args, state: dict, result: dict) -> dict:
     agent_id = state["agent_id"]
     response: dict[str, Any] = {}
+    role = resolve_role(args, state)
     candidate_admin_open_id = str(result.get("open_id") or "").strip()
-    if candidate_admin_open_id:
+    if role == "manager" and candidate_admin_open_id:
         admin_bind_args = [
             "participant",
             "bind",
@@ -133,11 +134,10 @@ def configure_csgclaw(args, state: dict, result: dict) -> dict:
         result["app_id"],
         "--app-secret-stdin",
     ]
-    role = resolve_role(args, state)
     if role == "worker" and args.recreate in ("auto", "worker"):
         bot_bind_args.append("--restart")
     response["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=result["app_secret"])
-    if candidate_admin_open_id:
+    if role == "manager" and candidate_admin_open_id:
         response["admin_open_id"] = candidate_admin_open_id
         response["admin_open_id_source"] = "registration"
     else:

--- a/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
+++ b/internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
@@ -66,17 +66,18 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertEqual(payload["bot_id"], "u-manager")
         self.assertEqual(payload["config"]["bot_bind"]["restart_status"], "restart_skipped")
         self.assertEqual(payload["actions"][0]["id"], "rebuild-manager")
+        self.assertEqual(payload["manager_group_permission_app_id"], "cli_example")
+        self.assertIn("/app/cli_example/auth", payload["manager_group_permission_url"])
+        self.assertIn("im:chat.members:write_only", payload["manager_group_permission_url"])
         self.assertFalse(any("--restart" in call[0] for call in calls))
         self.assertTrue(any("--app-secret-env" in call[0] for call in calls))
 
-    def test_configure_worker_binds_admin_from_registration_open_id(self):
+    def test_configure_worker_skips_admin_from_registration_open_id(self):
         calls = []
         original_csgclaw_cli_json = csgclaw.csgclaw_cli_json
 
         def fake_csgclaw_cli_json(args, cli_args, input_text=None):
             calls.append((cli_args, input_text))
-            if "--feishu-kind" in cli_args and cli_args[cli_args.index("--feishu-kind") + 1] == "human":
-                return {"participant_id": "admin", "config_saved": True}
             return {
                 "participant_id": "dev",
                 "agent_id": "u-dev",
@@ -93,14 +94,13 @@ class ManagerActionCardTest(unittest.TestCase):
         finally:
             csgclaw.csgclaw_cli_json = original_csgclaw_cli_json
 
-        self.assertEqual(response["admin_bind"]["participant_id"], "admin")
-        self.assertEqual(response["admin_open_id"], "ou_admin")
-        self.assertEqual(response["admin_open_id_source"], "registration")
-        self.assertTrue(any("--feishu-kind" in call[0] and "human" in call[0] for call in calls))
+        self.assertNotIn("admin_bind", response)
+        self.assertNotIn("admin_open_id", response)
+        self.assertFalse(any("--feishu-kind" in call[0] and "human" in call[0] for call in calls))
         self.assertTrue(any("--restart" in call[0] for call in calls))
         self.assertTrue(any(call[1] == "secret-value" for call in calls))
 
-    def test_configure_worker_passes_admin_name_from_registration(self):
+    def test_configure_manager_passes_admin_name_from_registration(self):
         calls = []
         original_csgclaw_cli_json = csgclaw.csgclaw_cli_json
 
@@ -109,16 +109,16 @@ class ManagerActionCardTest(unittest.TestCase):
             if "--feishu-kind" in cli_args and cli_args[cli_args.index("--feishu-kind") + 1] == "human":
                 return {"participant_id": "admin", "config_saved": True}
             return {
-                "participant_id": "dev",
-                "agent_id": "u-dev",
-                "restart_status": "worker_recreated",
+                "participant_id": "manager",
+                "agent_id": "u-manager",
+                "restart_status": "restart_skipped",
             }
 
         csgclaw.csgclaw_cli_json = fake_csgclaw_cli_json
         try:
-            csgclaw.configure_csgclaw(
-                Namespace(role="worker", recreate="auto"),
-                {"agent_id": "u-dev", "role": "worker"},
+            response = csgclaw.configure_csgclaw(
+                Namespace(role="manager", recreate="auto"),
+                {"agent_id": "u-manager", "role": "manager"},
                 {"app_id": "cli_dev", "app_secret": "secret-value", "open_id": "ou_admin", "name": "龙韵"},
             )
         finally:
@@ -127,6 +127,9 @@ class ManagerActionCardTest(unittest.TestCase):
         admin_bind = next(call[0] for call in calls if "--feishu-kind" in call[0] and "human" in call[0])
         self.assertIn("--name", admin_bind)
         self.assertEqual(admin_bind[admin_bind.index("--name") + 1], "龙韵")
+        self.assertEqual(response["admin_bind"]["participant_id"], "admin")
+        self.assertEqual(response["admin_open_id"], "ou_admin")
+        self.assertEqual(response["admin_open_id_source"], "registration")
 
     def test_manager_finalize_promotes_action_card_to_top_level(self):
         originals = {
@@ -182,6 +185,9 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertEqual(payload["bot_id"], "u-manager")
         self.assertEqual(payload["actions"][0]["id"], "rebuild-manager")
         self.assertEqual(payload["app_secret"], "present")
+        self.assertEqual(payload["manager_group_permission_app_id"], "cli_example")
+        self.assertIn("/app/cli_example/auth", payload["manager_group_permission_url"])
+        self.assertIn("im:chat.members:write_only", payload["manager_group_permission_url"])
         self.assertNotIn("fallback", payload)
         self.assertNotIn("non_web_instruction", payload)
         self.assertNotIn("render_target", payload)


### PR DESCRIPTION
## Summary
- make Feishu room creation add worker bots after chat creation so partial failures include the created chat ID
- expose Feishu response data and raw response body for chat/member failures, including troubleshooting log IDs
- add PicoClaw manager group permission scope guidance and keep worker Feishu setup from overwriting admin binding

## Validation
- go test ./internal/channel/feishu
- python3 -m unittest internal/templates/embed/picoclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
- python3 -m unittest internal/templates/embed/openclaw-manager/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
- git diff --check

## Notes
- Tested locally against Feishu; failures now surface Feishu response_body.error.log_id for support escalation.