### PR TITLE
feat(feishu): support interactive Codex permission approvals

### DIFF
--- a/cli/participant/bind.go
+++ b/cli/participant/bind.go
@@ -338,10 +338,7 @@ func upsertBotParticipantRemote(ctx context.Context, client bindAPIClient, parti
 			warnings = append(warnings, fmt.Sprintf("found noncanonical feishu participant %q for agent %q; keeping it and writing canonical participant %q", item.ID, target.ID, participantID))
 		}
 	}
-	cfg := map[string]any{
-		"app_id":     appID,
-		"app_secret": appSecret,
-	}
+	cfg := feishuBotAppConfig(appID, appSecret)
 	kind := participantpkg.ChannelUserKindAppID
 	displayName := strings.TrimSpace(target.Name)
 	if displayName == "" {
@@ -381,6 +378,13 @@ func upsertBotParticipantRemote(ctx context.Context, client bindAPIClient, parti
 		},
 	})
 	return created, warnings, err
+}
+
+func feishuBotAppConfig(appID, appSecret string) map[string]any {
+	return map[string]any{
+		"app_id": strings.TrimSpace(appID),
+		participantpkg.ChannelAppConfigAppSecretKey: strings.TrimSpace(appSecret),
+	}
 }
 
 func findParticipantByIDRemote(ctx context.Context, client bindAPIClient, channel, id string) (apitypes.Participant, bool, error) {

--- a/cli/participant/bind_test.go
+++ b/cli/participant/bind_test.go
@@ -1,0 +1,20 @@
+package participant
+
+import (
+	"testing"
+
+	participantpkg "csgclaw/internal/participant"
+)
+
+func TestFeishuBotAppConfigStoresOnlyLongConnectionCredentials(t *testing.T) {
+	got := feishuBotAppConfig(" cli_new ", " new-secret ")
+	if got["app_id"] != "cli_new" {
+		t.Fatalf("app_id = %#v, want %q", got["app_id"], "cli_new")
+	}
+	if got[participantpkg.ChannelAppConfigAppSecretKey] != "new-secret" {
+		t.Fatalf("app_secret = %#v, want %q", got[participantpkg.ChannelAppConfigAppSecretKey], "new-secret")
+	}
+	if len(got) != 2 {
+		t.Fatalf("config = %#v, want only app_id and app_secret", got)
+	}
+}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -954,13 +954,22 @@ func newCodexBridgeManager(cfg config.Config, svc *agent.Service, feishuSvc *fei
 			MentionOnly: true,
 		},
 	}
+	var feishuClient *channelbridge.FeishuClient
 	if feishuSvc != nil {
 		if provider := feishuSvc.ConfigProvider(); provider != nil {
-			opts.FeishuClient = channelbridge.NewFeishuClient(feishuSvc)
+			feishuClient = channelbridge.NewFeishuClient(feishuSvc)
+			opts.FeishuClient = feishuClient
 			opts.FeishuProvider = provider
 		}
 	}
-	return codexmanager.New(opts)
+	manager, err := codexmanager.New(opts)
+	if err != nil {
+		return nil, err
+	}
+	if feishuClient != nil {
+		feishuClient.ActivityDecider = channelActivityDecider(manager)
+	}
+	return manager, nil
 }
 
 func sandboxServiceOptions(cfg config.SandboxConfig) ([]agent.ServiceOption, error) {

--- a/docs/channel/feishu.md
+++ b/docs/channel/feishu.md
@@ -33,6 +33,10 @@ printf '%s' "$APP_SECRET" | csgclaw-cli participant bind \
   --restart
 ```
 
+Interactive Feishu card button clicks are handled over the existing long
+connection and do not require a public HTTP callback URL.
+
+
 Bind the manager app:
 
 ```bash

--- a/docs/channel/feishu.zh.md
+++ b/docs/channel/feishu.zh.md
@@ -32,6 +32,9 @@ printf '%s' "$APP_SECRET" | csgclaw-cli participant bind \
   --restart
 ```
 
+可交互飞书消息卡片按钮会通过已有长连接处理，不需要公网 HTTP callback URL。
+
+
 绑定 manager 应用：
 
 ```bash

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -18,7 +18,7 @@ type ActionStatus string
 const (
 	ActionKindPermission = "permission"
 
-	ActionOptionScopeAgent = "agent"
+	ActionOptionScopeSession = "session"
 
 	ActionStatusPending  ActionStatus = "pending"
 	ActionStatusAllowed  ActionStatus = "allowed"

--- a/internal/channel/feishu/participantprovider/provider.go
+++ b/internal/channel/feishu/participantprovider/provider.go
@@ -165,7 +165,10 @@ func appConfigFromParticipant(item apitypes.Participant) (feishu.AppConfig, bool
 	if appID == "" || appSecret == "" {
 		return feishu.AppConfig{}, false
 	}
-	return feishu.AppConfig{AppID: appID, AppSecret: appSecret}, true
+	return feishu.AppConfig{
+		AppID:     appID,
+		AppSecret: appSecret,
+	}, true
 }
 
 func channelAppConfigString(values map[string]any, key string) string {

--- a/internal/channel/feishu/service.go
+++ b/internal/channel/feishu/service.go
@@ -87,11 +87,22 @@ type SendMessageResponse struct {
 
 type SendMessageFunc func(context.Context, AppConfig, SendMessageRequest) (SendMessageResponse, error)
 
+type SendInteractiveMessageRequest struct {
+	SenderID     string
+	ChatID       string
+	Content      string
+	UUID         string
+	ThreadRootID string
+}
+
+type SendInteractiveMessageFunc func(context.Context, AppConfig, SendInteractiveMessageRequest) (SendMessageResponse, error)
+
 type UpdateMessageRequest struct {
-	RoomID    string
-	SenderID  string
-	MessageID string
-	Content   string
+	RoomID      string
+	SenderID    string
+	MessageID   string
+	Content     string
+	MessageType string
 }
 
 type UpdateMessageResponse struct {
@@ -121,24 +132,25 @@ type DeleteMessageReactionRequest struct {
 type DeleteMessageReactionFunc func(context.Context, AppConfig, DeleteMessageReactionRequest) error
 
 type Service struct {
-	mu                    sync.RWMutex
-	users                 map[string]im.User
-	byHandle              map[string]string
-	rooms                 map[string]*im.Room
-	apps                  map[string]AppConfig
-	resolveBotInfo        func(context.Context, AppConfig) (BotInfo, error)
-	createChat            CreateChatFunc
-	addChatMembers        AddChatMembersFunc
-	listChatMembers       ListChatMembersFunc
-	listChats             ListChatsFunc
-	listRoomMessages      ListRoomMessagesFunc
-	deleteChat            DeleteChatFunc
-	sendMessage           SendMessageFunc
-	updateMessage         UpdateMessageFunc
-	createMessageReaction CreateMessageReactionFunc
-	deleteMessageReaction DeleteMessageReactionFunc
-	messageBus            *MessageBus
-	configProvider        Provider
+	mu                     sync.RWMutex
+	users                  map[string]im.User
+	byHandle               map[string]string
+	rooms                  map[string]*im.Room
+	apps                   map[string]AppConfig
+	resolveBotInfo         func(context.Context, AppConfig) (BotInfo, error)
+	createChat             CreateChatFunc
+	addChatMembers         AddChatMembersFunc
+	listChatMembers        ListChatMembersFunc
+	listChats              ListChatsFunc
+	listRoomMessages       ListRoomMessagesFunc
+	deleteChat             DeleteChatFunc
+	sendMessage            SendMessageFunc
+	sendInteractiveMessage SendInteractiveMessageFunc
+	updateMessage          UpdateMessageFunc
+	createMessageReaction  CreateMessageReactionFunc
+	deleteMessageReaction  DeleteMessageReactionFunc
+	messageBus             *MessageBus
+	configProvider         Provider
 }
 
 func NewService(apps ...map[string]AppConfig) *Service {
@@ -149,22 +161,23 @@ func NewService(apps ...map[string]AppConfig) *Service {
 		}
 	}
 	return &Service{
-		users:                 make(map[string]im.User),
-		byHandle:              make(map[string]string),
-		rooms:                 make(map[string]*im.Room),
-		apps:                  configuredApps,
-		resolveBotInfo:        fetchBotInfo,
-		createChat:            defaultCreateChat,
-		addChatMembers:        defaultAddChatMembers,
-		listChatMembers:       defaultListChatMembers,
-		listChats:             defaultListChats,
-		listRoomMessages:      defaultListRoomMessages,
-		deleteChat:            defaultDeleteChat,
-		sendMessage:           defaultSendMessage,
-		updateMessage:         defaultUpdateMessage,
-		createMessageReaction: defaultCreateMessageReaction,
-		deleteMessageReaction: defaultDeleteMessageReaction,
-		messageBus:            NewMessageBus(),
+		users:                  make(map[string]im.User),
+		byHandle:               make(map[string]string),
+		rooms:                  make(map[string]*im.Room),
+		apps:                   configuredApps,
+		resolveBotInfo:         fetchBotInfo,
+		createChat:             defaultCreateChat,
+		addChatMembers:         defaultAddChatMembers,
+		listChatMembers:        defaultListChatMembers,
+		listChats:              defaultListChats,
+		listRoomMessages:       defaultListRoomMessages,
+		deleteChat:             defaultDeleteChat,
+		sendMessage:            defaultSendMessage,
+		sendInteractiveMessage: defaultSendInteractiveMessage,
+		updateMessage:          defaultUpdateMessage,
+		createMessageReaction:  defaultCreateMessageReaction,
+		deleteMessageReaction:  defaultDeleteMessageReaction,
+		messageBus:             NewMessageBus(),
 	}
 }
 
@@ -236,6 +249,14 @@ func NewServiceWithSendMessage(apps map[string]AppConfig, sendMessage SendMessag
 	svc := NewService(apps)
 	if sendMessage != nil {
 		svc.sendMessage = sendMessage
+	}
+	return svc
+}
+
+func NewServiceWithInteractiveMessage(apps map[string]AppConfig, sendInteractiveMessage SendInteractiveMessageFunc) *Service {
+	svc := NewService(apps)
+	if sendInteractiveMessage != nil {
+		svc.sendInteractiveMessage = sendInteractiveMessage
 	}
 	return svc
 }
@@ -1117,21 +1138,100 @@ func defaultSendMessage(ctx context.Context, app AppConfig, req SendMessageReque
 	}, nil
 }
 
+func defaultSendInteractiveMessage(ctx context.Context, app AppConfig, req SendInteractiveMessageRequest) (SendMessageResponse, error) {
+	senderInfo, err := fetchBotInfo(ctx, app)
+	if err != nil {
+		return SendMessageResponse{}, err
+	}
+	senderOpenID := senderInfo.OpenID
+	content := strings.TrimSpace(req.Content)
+	if content == "" {
+		return SendMessageResponse{}, fmt.Errorf("interactive content is required")
+	}
+
+	client := lark.NewClient(app.AppID, app.AppSecret)
+	if threadRootID := strings.TrimSpace(req.ThreadRootID); threadRootID != "" {
+		replyReq := larkim.NewReplyMessageReqBuilder().
+			MessageId(threadRootID).
+			Body(larkim.NewReplyMessageReqBodyBuilder().
+				MsgType("interactive").
+				Content(content).
+				ReplyInThread(true).
+				Uuid(req.UUID).
+				Build()).
+			Build()
+		resp, err := client.Im.V1.Message.Reply(ctx, replyReq)
+		if err != nil {
+			return SendMessageResponse{}, fmt.Errorf("reply feishu interactive message: %w", err)
+		}
+		if !resp.Success() {
+			return SendMessageResponse{}, fmt.Errorf("reply feishu interactive message: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+		}
+		if resp.Data == nil {
+			return SendMessageResponse{}, fmt.Errorf("reply feishu interactive message: empty response data")
+		}
+		return SendMessageResponse{
+			MessageID:    larkcore.StringValue(resp.Data.MessageId),
+			SenderOpenID: senderOpenID,
+		}, nil
+	}
+
+	sendReq := larkim.NewCreateMessageReqBuilder().
+		ReceiveIdType("chat_id").
+		Body(larkim.NewCreateMessageReqBodyBuilder().
+			ReceiveId(req.ChatID).
+			MsgType("interactive").
+			Content(content).
+			Uuid(req.UUID).
+			Build()).
+		Build()
+
+	resp, err := client.Im.V1.Message.Create(ctx, sendReq)
+	if err != nil {
+		return SendMessageResponse{}, fmt.Errorf("send feishu interactive message: %w", err)
+	}
+	if !resp.Success() {
+		return SendMessageResponse{}, fmt.Errorf("send feishu interactive message: code=%d msg=%s request_id=%s", resp.Code, resp.Msg, resp.RequestId())
+	}
+	if resp.Data == nil {
+		return SendMessageResponse{}, fmt.Errorf("send feishu interactive message: empty response data")
+	}
+	return SendMessageResponse{
+		MessageID:    larkcore.StringValue(resp.Data.MessageId),
+		SenderOpenID: senderOpenID,
+	}, nil
+}
+
 func defaultUpdateMessage(ctx context.Context, app AppConfig, req UpdateMessageRequest) (UpdateMessageResponse, error) {
 	messageID := strings.TrimSpace(req.MessageID)
 	if messageID == "" {
 		return UpdateMessageResponse{}, fmt.Errorf("message_id is required")
 	}
-	content, err := feishuTextMessageContent(req.Content, "", "")
-	if err != nil {
-		return UpdateMessageResponse{}, fmt.Errorf("encode feishu message content: %w", err)
+	messageType := strings.TrimSpace(req.MessageType)
+	if messageType == "" {
+		messageType = larkim.MsgTypeText
+	}
+	content := strings.TrimSpace(req.Content)
+	switch messageType {
+	case larkim.MsgTypeText:
+		encoded, err := feishuTextMessageContent(content, "", "")
+		if err != nil {
+			return UpdateMessageResponse{}, fmt.Errorf("encode feishu message content: %w", err)
+		}
+		content = encoded
+	case "interactive":
+		if content == "" {
+			return UpdateMessageResponse{}, fmt.Errorf("interactive content is required")
+		}
+	default:
+		return UpdateMessageResponse{}, fmt.Errorf("unsupported feishu message type %q", messageType)
 	}
 
 	client := lark.NewClient(app.AppID, app.AppSecret)
 	updateReq := larkim.NewUpdateMessageReqBuilder().
 		MessageId(messageID).
 		Body(larkim.NewUpdateMessageReqBodyBuilder().
-			MsgType("text").
+			MsgType(messageType).
 			Content(content).
 			Build()).
 		Build()
@@ -1367,6 +1467,76 @@ func (s *Service) SendMessage(req im.CreateMessageRequest) (im.Message, error) {
 	return message, nil
 }
 
+func (s *Service) SendInteractiveMessage(ctx context.Context, req SendInteractiveMessageRequest) (im.Message, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	roomID := strings.TrimSpace(req.ChatID)
+	content := strings.TrimSpace(req.Content)
+	if roomID == "" {
+		return im.Message{}, fmt.Errorf("chat_id is required")
+	}
+	if content == "" {
+		return im.Message{}, fmt.Errorf("content is required")
+	}
+
+	senderID := strings.TrimSpace(req.SenderID)
+	if senderID == "" {
+		return im.Message{}, fmt.Errorf("sender_id is required")
+	}
+	s.mu.RLock()
+	app, err := s.appConfigForSenderLocked(senderID)
+	s.mu.RUnlock()
+	if err != nil {
+		return im.Message{}, err
+	}
+
+	var relatesTo *im.MessageRelation
+	threadRootID := strings.TrimSpace(req.ThreadRootID)
+	if threadRootID != "" {
+		relatesTo = &im.MessageRelation{RelType: im.RelationTypeThread, EventID: threadRootID}
+	}
+
+	fallbackID := strings.TrimSpace(req.UUID)
+	if fallbackID == "" {
+		fallbackID = fmt.Sprintf("msg-%d", time.Now().UTC().UnixNano())
+	}
+	sent, err := s.sendInteractiveMessage(ctx, app, SendInteractiveMessageRequest{
+		SenderID:     senderID,
+		ChatID:       roomID,
+		Content:      content,
+		UUID:         fallbackID,
+		ThreadRootID: threadRootID,
+	})
+	if err != nil {
+		return im.Message{}, err
+	}
+	senderOpenID := strings.TrimSpace(sent.SenderOpenID)
+	if senderOpenID == "" {
+		return im.Message{}, fmt.Errorf("resolve feishu sender open_id: empty open_id for %q", senderID)
+	}
+
+	sentMessageID := strings.TrimSpace(sent.MessageID)
+	if sentMessageID == "" {
+		sentMessageID = fallbackID
+	}
+	message := im.Message{
+		ID:        sentMessageID,
+		SenderID:  senderOpenID,
+		Kind:      im.MessageKindMessage,
+		Content:   content,
+		CreatedAt: time.Now().UTC(),
+		RelatesTo: relatesTo,
+	}
+
+	s.mu.Lock()
+	if room, ok := s.rooms[roomID]; ok {
+		room.Messages = append(room.Messages, message)
+	}
+	s.mu.Unlock()
+	return message, nil
+}
+
 func (s *Service) UpdateMessage(req UpdateMessageRequest) (im.Message, error) {
 	return s.UpdateMessageWithContext(context.Background(), req)
 }
@@ -1379,6 +1549,7 @@ func (s *Service) UpdateMessageWithContext(ctx context.Context, req UpdateMessag
 	senderID := strings.TrimSpace(req.SenderID)
 	messageID := strings.TrimSpace(req.MessageID)
 	content := strings.TrimSpace(req.Content)
+	messageType := strings.TrimSpace(req.MessageType)
 	if roomID == "" {
 		return im.Message{}, fmt.Errorf("room_id is required")
 	}
@@ -1400,10 +1571,11 @@ func (s *Service) UpdateMessageWithContext(ctx context.Context, req UpdateMessag
 	}
 
 	updated, err := s.updateMessage(ctx, app, UpdateMessageRequest{
-		RoomID:    roomID,
-		SenderID:  senderID,
-		MessageID: messageID,
-		Content:   content,
+		RoomID:      roomID,
+		SenderID:    senderID,
+		MessageID:   messageID,
+		Content:     content,
+		MessageType: messageType,
 	})
 	if err != nil {
 		return im.Message{}, err

--- a/internal/channelbridge/codexbridge/bridge.go
+++ b/internal/channelbridge/codexbridge/bridge.go
@@ -111,14 +111,16 @@ func (s *Service) StartBot(ctx context.Context, binding Binding) error {
 	}
 	workerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	w := &worker{
-		service:     s,
-		binding:     binding,
-		queue:       make(chan BotEvent, s.queueSize),
-		queued:      make(map[string]struct{}),
-		contextSent: make(map[string]struct{}),
-		seen:        newRecentSet(s.seenWindow),
-		cancel:      cancel,
-		done:        make(chan struct{}),
+		service:          s,
+		binding:          binding,
+		queue:            make(chan BotEvent, s.queueSize),
+		queued:           make(map[string]struct{}),
+		contextSent:      make(map[string]struct{}),
+		activityMessages: make(map[string]string),
+		activityLimit:    s.seenWindow,
+		seen:             newRecentSet(s.seenWindow),
+		cancel:           cancel,
+		done:             make(chan struct{}),
 	}
 	s.workers[binding.BotID] = w
 	slog.Debug("codex bridge bot started",
@@ -185,6 +187,10 @@ type worker struct {
 	processing  string
 	lastEvent   string
 	contextSent map[string]struct{}
+
+	activityMessages map[string]string
+	activityOrder    []string
+	activityLimit    int
 }
 
 func (w *worker) run(ctx context.Context) {
@@ -363,11 +369,18 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 				continue
 			}
 			if renderedActivity, ok := renderer.RenderActivity(event, localChannel, evt.RoomID, w.binding.BotID); ok {
-				threadRootID, err := ensureActivityThreadRoot()
-				if err != nil {
-					return err
+				threadRootID := turnRootID
+				if threadRootID == "" && !sendActivityAtTopLevel(event) {
+					var err error
+					threadRootID, err = ensureActivityThreadRoot()
+					if err != nil {
+						return err
+					}
 				}
-				if err := w.sendActivity(ctx, evt.RoomID, threadRootID, renderedActivity); err != nil {
+				if shouldSkipUntrackedActivityUpdate(event) && w.activityMessageID(renderedActivity.MessageID) == "" {
+					continue
+				}
+				if err := w.sendActivity(ctx, evt.RoomID, threadRootID, event, renderedActivity); err != nil {
 					return err
 				}
 			}
@@ -622,13 +635,98 @@ func (w *worker) sendMessage(ctx context.Context, roomID, threadRootID, text str
 	})
 }
 
-func (w *worker) sendActivity(ctx context.Context, roomID, threadRootID string, activity runtimebridge.RenderedActivity) error {
-	_, err := w.sendMessageRequest(ctx, SendMessageRequest{
+func (w *worker) sendActivity(ctx context.Context, roomID, threadRootID string, event runtimecodex.SessionEvent, activity runtimebridge.RenderedActivity) error {
+	activityID := strings.TrimSpace(activity.MessageID)
+	if messageID := w.activityMessageID(activityID); messageID != "" {
+		if err := w.updateMessage(ctx, roomID, messageID, activity.Text); err != nil {
+			slog.Warn("codex bridge activity update failed",
+				"bot_id", w.binding.BotID,
+				"room_id", strings.TrimSpace(roomID),
+				"message_id", messageID,
+				"activity_id", activityID,
+				"error", err,
+			)
+			if shouldSuppressActivityFallbackOnUpdateFailure(event) {
+				w.deleteActivityMessageID(activityID)
+				return nil
+			}
+		} else {
+			if activityEventIsTerminal(event) {
+				w.deleteActivityMessageID(activityID)
+			}
+			return nil
+		}
+	}
+
+	messageID, err := w.sendMessageRequest(ctx, SendMessageRequest{
 		RoomID:       roomID,
 		Text:         activity.Text,
 		ThreadRootID: strings.TrimSpace(threadRootID),
 	})
+	if err == nil && shouldTrackActivityMessage(event) && activityID != "" && strings.TrimSpace(messageID) != "" {
+		w.setActivityMessageID(activityID, messageID)
+	}
 	return err
+}
+
+func (w *worker) activityMessageID(activityID string) string {
+	activityID = strings.TrimSpace(activityID)
+	if activityID == "" {
+		return ""
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.TrimSpace(w.activityMessages[activityID])
+}
+
+func (w *worker) setActivityMessageID(activityID string, messageID string) {
+	activityID = strings.TrimSpace(activityID)
+	messageID = strings.TrimSpace(messageID)
+	if activityID == "" || messageID == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.activityMessages == nil {
+		w.activityMessages = make(map[string]string)
+	}
+	if _, ok := w.activityMessages[activityID]; !ok {
+		w.activityOrder = append(w.activityOrder, activityID)
+	}
+	w.activityMessages[activityID] = messageID
+	w.pruneActivityMessagesLocked()
+}
+
+func (w *worker) deleteActivityMessageID(activityID string) {
+	activityID = strings.TrimSpace(activityID)
+	if activityID == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.activityMessages, activityID)
+	w.deleteActivityOrderLocked(activityID)
+}
+
+func (w *worker) pruneActivityMessagesLocked() {
+	limit := w.activityLimit
+	if limit <= 0 {
+		limit = defaultSeenWindow
+	}
+	for len(w.activityOrder) > limit {
+		oldest := w.activityOrder[0]
+		w.activityOrder = w.activityOrder[1:]
+		delete(w.activityMessages, oldest)
+	}
+}
+
+func (w *worker) deleteActivityOrderLocked(activityID string) {
+	for i, item := range w.activityOrder {
+		if item == activityID {
+			w.activityOrder = append(w.activityOrder[:i], w.activityOrder[i+1:]...)
+			return
+		}
+	}
 }
 
 func (w *worker) updateMessage(ctx context.Context, roomID, messageID, text string) error {
@@ -813,6 +911,47 @@ func matchesSession(event runtimecodex.SessionEvent, runtimeID, sessionID string
 		return false
 	}
 	return strings.TrimSpace(event.SessionID) == strings.TrimSpace(sessionID)
+}
+
+func sendActivityAtTopLevel(event runtimecodex.SessionEvent) bool {
+	switch event.Kind {
+	case runtimecodex.SessionEventPermissionRequest, runtimecodex.SessionEventPermissionDecision:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldSkipUntrackedActivityUpdate(event runtimecodex.SessionEvent) bool {
+	return event.Kind == runtimecodex.SessionEventPermissionDecision
+}
+
+func shouldSuppressActivityFallbackOnUpdateFailure(event runtimecodex.SessionEvent) bool {
+	return event.Kind == runtimecodex.SessionEventPermissionDecision
+}
+
+func shouldTrackActivityMessage(event runtimecodex.SessionEvent) bool {
+	return !activityEventIsTerminal(event)
+}
+
+func activityEventIsTerminal(event runtimecodex.SessionEvent) bool {
+	switch event.Kind {
+	case runtimecodex.SessionEventPermissionDecision:
+		return true
+	case runtimecodex.SessionEventToolCallUpdate:
+		return toolActivityStatusIsTerminal(event.ToolStatus)
+	default:
+		return false
+	}
+}
+
+func toolActivityStatusIsTerminal(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "failed", "canceled", "cancelled", "error", "errored":
+		return true
+	default:
+		return false
+	}
 }
 
 func sessionIDForEvent(binding Binding, evt BotEvent) string {

--- a/internal/channelbridge/codexbridge/bridge_test.go
+++ b/internal/channelbridge/codexbridge/bridge_test.go
@@ -556,21 +556,121 @@ func assertServiceThreadsTopLevelToolCallsBesideFinalResponse(t *testing.T, chat
 
 	waitFor(t, func() bool {
 		records := client.sentRecords()
-		return len(records) == 4 &&
+		updates := client.updates()
+		return len(records) == 3 &&
+			len(updates) == 1 &&
 			records[0].RoomID == "room-1" &&
 			records[0].ThreadRootID == "" &&
 			records[0].Text == turnPlaceholderText &&
 			records[1].RoomID == "room-1" &&
 			records[1].ThreadRootID == "sent-1" &&
 			strings.Contains(records[1].Text, runtimebridge.AgentToolMsgType) &&
+			updates[0].req.RoomID == "room-1" &&
+			updates[0].req.MessageID == "sent-2" &&
+			strings.Contains(updates[0].req.Text, runtimebridge.AgentToolMsgType) &&
+			strings.Contains(updates[0].req.Text, "command output") &&
 			records[2].RoomID == "room-1" &&
-			records[2].ThreadRootID == "sent-1" &&
-			strings.Contains(records[2].Text, runtimebridge.AgentToolMsgType) &&
-			strings.Contains(records[2].Text, "command output") &&
-			records[3].RoomID == "room-1" &&
-			records[3].ThreadRootID == "" &&
-			records[3].Text == "done"
+			records[2].ThreadRootID == "" &&
+			records[2].Text == "done"
 	})
+}
+
+func TestServiceSendsToolActivityFallbackWhenUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{MessageID: "m-1", RoomID: "room-1", ChatType: "group", Text: "run it"}
+
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"u-codex": {{events: stream, errs: errs}},
+		},
+		updateErr: errors.New("update failed"),
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:  handle.RuntimeID,
+				SessionID:  req.SessionID,
+				Kind:       runtimecodex.SessionEventToolCallStart,
+				ToolCallID: "tool-1",
+				ToolTitle:  "Run shell command",
+				ToolStatus: "pending",
+				Payload:    map[string]any{"tool_call_id": "tool-1", "title": "Run shell command", "status": "pending"},
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:         handle.RuntimeID,
+				SessionID:         req.SessionID,
+				Kind:              runtimecodex.SessionEventToolCallUpdate,
+				ToolCallID:        "tool-1",
+				ToolStatus:        "completed",
+				ToolOutputSummary: "command output",
+				Payload:           map[string]any{"tool_call_id": "tool-1", "status": "completed", "raw_output": "command output"},
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventTextDelta,
+				Text:      "done",
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID: handle.RuntimeID,
+				SessionID: req.SessionID,
+				Kind:      runtimecodex.SessionEventPromptCompleted,
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "u-codex", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return len(client.sentRecords()) == 4 && len(client.updates()) == 1
+	})
+	records := client.sentRecords()
+	if records[2].ThreadRootID != "sent-1" ||
+		!strings.Contains(records[2].Text, runtimebridge.AgentToolMsgType) ||
+		!strings.Contains(records[2].Text, "command output") {
+		t.Fatalf("fallback tool record = %+v, want completed tool activity inside generated root", records[2])
+	}
+	if records[3].Text != "done" {
+		t.Fatalf("final record = %+v, want final response preserved", records[3])
+	}
+}
+
+func TestWorkerBoundsActivityMessageIDs(t *testing.T) {
+	t.Parallel()
+
+	w := &worker{
+		activityMessages: make(map[string]string),
+		activityLimit:    2,
+	}
+	w.setActivityMessageID("act-1", "msg-1")
+	w.setActivityMessageID("act-2", "msg-2")
+	w.setActivityMessageID("act-3", "msg-3")
+
+	if got := w.activityMessageID("act-1"); got != "" {
+		t.Fatalf("act-1 message id = %q, want pruned", got)
+	}
+	if got := w.activityMessageID("act-2"); got != "msg-2" {
+		t.Fatalf("act-2 message id = %q, want msg-2", got)
+	}
+	if got := w.activityMessageID("act-3"); got != "msg-3" {
+		t.Fatalf("act-3 message id = %q, want msg-3", got)
+	}
+	w.deleteActivityMessageID("act-2")
+	if got := w.activityMessageID("act-2"); got != "" {
+		t.Fatalf("act-2 message id after delete = %q, want empty", got)
+	}
 }
 
 func TestServiceAddsAndRemovesFeishuProcessingPinAroundFinalReply(t *testing.T) {
@@ -1458,14 +1558,11 @@ func TestServiceProjectsPermissionEventsAsAgentActivity(t *testing.T) {
 	defer svc.Close()
 
 	waitFor(t, func() bool {
-		return len(client.sentRecords()) == 2
+		return len(client.sentRecords()) == 1
 	})
 	records := client.sentRecords()
-	if records[0].Text != turnPlaceholderText || records[0].ThreadRootID != "" {
-		t.Fatalf("placeholder record = %+v, want top-level blank root", records[0])
-	}
-	if records[1].ThreadRootID != "sent-1" {
-		t.Fatalf("permission activity ThreadRootID = %q, want sent-1", records[1].ThreadRootID)
+	if records[0].ThreadRootID != "" {
+		t.Fatalf("permission activity ThreadRootID = %q, want top-level message", records[0].ThreadRootID)
 	}
 	var payload struct {
 		Type    string `json:"type"`
@@ -1482,7 +1579,7 @@ func TestServiceProjectsPermissionEventsAsAgentActivity(t *testing.T) {
 			} `json:"action"`
 		} `json:"content"`
 	}
-	if err := json.Unmarshal([]byte(records[1].Text), &payload); err != nil {
+	if err := json.Unmarshal([]byte(records[0].Text), &payload); err != nil {
 		t.Fatalf("permission activity json decode: %v", err)
 	}
 	if payload.Type != runtimebridge.AgentActivityType || payload.Content.MsgType != runtimebridge.AgentActionMsgType {
@@ -1573,17 +1670,103 @@ func TestServiceUsesStableMessageIDForPermissionDecisionActivity(t *testing.T) {
 	defer svc.Close()
 
 	waitFor(t, func() bool {
-		return len(client.sentRecords()) == 3
+		return len(client.sentRecords()) == 1 && len(client.updates()) == 1
 	})
 	sent := client.sentRecords()
-	if sent[0].Text != turnPlaceholderText || sent[0].ThreadRootID != "" {
-		t.Fatalf("placeholder record = %+v, want top-level blank root", sent[0])
+	if sent[0].ThreadRootID != "" {
+		t.Fatalf("permission thread root = %q, want top-level message", sent[0].ThreadRootID)
 	}
-	if sent[1].ThreadRootID != "sent-1" || sent[2].ThreadRootID != "sent-1" {
-		t.Fatalf("permission thread roots = %q / %q, want sent-1", sent[1].ThreadRootID, sent[2].ThreadRootID)
+	updates := client.updates()
+	if updates[0].req.MessageID != "sent-1" || !strings.Contains(updates[0].req.Text, `"status":"allowed"`) {
+		t.Fatalf("decision update = %+v, want sent-1 allowed status", updates[0])
 	}
-	if !strings.Contains(sent[2].Text, `"status":"allowed"`) {
-		t.Fatalf("decision activity = %s, want allowed status", sent[2].Text)
+}
+
+func TestServiceDoesNotSendDuplicatePermissionDecisionWhenUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	stream := make(chan BotEvent, 1)
+	errs := make(chan error)
+	close(errs)
+	stream <- BotEvent{MessageID: "m-1", RoomID: "room-1", Text: "hello"}
+
+	now := time.Now().UTC()
+	sink := runtimecodex.NewEventSink()
+	client := &fakeBotClient{
+		streams: map[string][]streamResult{
+			"u-codex": {{events: stream, errs: errs}},
+		},
+		updateErr: errors.New("update failed"),
+	}
+	prompter := &fakePrompter{
+		prompt: func(_ context.Context, handle runtimecodex.SessionHandle, req runtimecodex.PromptRequest) error {
+			pending := runtimecodex.PermissionSnapshot{
+				ID:          "perm-1",
+				Title:       "Run shell command",
+				Status:      runtimecodex.PermissionStatusPending,
+				RequestedAt: now,
+				ExpiresAt:   now.Add(time.Minute),
+				Options: []runtimecodex.PermissionOptionSnapshot{
+					{ID: "once", Kind: "allow_once", Label: "Allow once"},
+				},
+			}
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:    handle.RuntimeID,
+				SessionID:    req.SessionID,
+				Kind:         runtimecodex.SessionEventPermissionRequest,
+				ReceivedAt:   now,
+				ToolCallID:   "tool-1",
+				ToolTitle:    "Run shell command",
+				ActionID:     "perm-1",
+				ActionStatus: string(runtimecodex.PermissionStatusPending),
+				Payload:      pending,
+			})
+			decided := pending
+			decided.Status = runtimecodex.PermissionStatusAllowed
+			decided.Decision = &runtimecodex.PermissionDecisionSnapshot{
+				OptionID:  "once",
+				Kind:      "allow_once",
+				DecidedAt: now.Add(time.Second),
+			}
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:        handle.RuntimeID,
+				SessionID:        req.SessionID,
+				Kind:             runtimecodex.SessionEventPermissionDecision,
+				ReceivedAt:       now.Add(time.Second),
+				ToolCallID:       "tool-1",
+				ToolTitle:        "Run shell command",
+				ActionID:         "perm-1",
+				ActionStatus:     string(runtimecodex.PermissionStatusAllowed),
+				ActionOptionID:   "once",
+				ActionOptionKind: "allow_once",
+				Payload:          decided,
+			})
+			sink.Publish(runtimecodex.SessionEvent{
+				RuntimeID:  handle.RuntimeID,
+				SessionID:  req.SessionID,
+				Kind:       runtimecodex.SessionEventPromptCompleted,
+				ReceivedAt: time.Now().UTC(),
+			})
+			return nil
+		},
+	}
+
+	svc := NewService(client, prompter, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.StartBot(ctx, Binding{BotID: "u-codex", RuntimeID: "rt-1", SessionID: "sess-1"}); err != nil {
+		t.Fatalf("StartBot() error = %v", err)
+	}
+	defer svc.Close()
+
+	waitFor(t, func() bool {
+		return len(client.sentRecords()) == 1 && len(client.updates()) == 1
+	})
+	if sent := client.sentRecords(); len(sent) != 1 {
+		t.Fatalf("sent records = %d, want only original permission request", len(sent))
+	}
+	if updates := client.updates(); updates[0].req.MessageID != "sent-1" || !strings.Contains(updates[0].req.Text, `"status":"allowed"`) {
+		t.Fatalf("decision update = %+v, want attempted update to sent-1", updates[0])
 	}
 }
 

--- a/internal/channelbridge/feishu_activity_format.go
+++ b/internal/channelbridge/feishu_activity_format.go
@@ -10,13 +10,16 @@ import (
 
 type feishuActivityMessage struct {
 	Type    string                `json:"type"`
+	Channel string                `json:"channel"`
+	EventID string                `json:"event_id"`
 	Content feishuActivityContent `json:"content"`
 }
 
 type feishuActivityContent struct {
-	MsgType string             `json:"msgtype"`
-	Body    string             `json:"body"`
-	Tool    feishuActivityTool `json:"tool"`
+	MsgType string               `json:"msgtype"`
+	Body    string               `json:"body"`
+	Tool    feishuActivityTool   `json:"tool"`
+	Action  feishuActivityAction `json:"action"`
 }
 
 type feishuActivityTool struct {
@@ -27,26 +30,64 @@ type feishuActivityTool struct {
 	OutputSummary string `json:"output_summary"`
 }
 
-func formatFeishuBridgeMessageText(text string) string {
+type feishuActivityAction struct {
+	ID          string                  `json:"id"`
+	Kind        string                  `json:"kind"`
+	Title       string                  `json:"title"`
+	Status      string                  `json:"status"`
+	RequestedAt string                  `json:"requested_at"`
+	ExpiresAt   string                  `json:"expires_at"`
+	Options     []feishuActivityOption  `json:"options"`
+	Decision    *feishuActivityDecision `json:"decision"`
+}
+
+type feishuActivityOption struct {
+	ID    string `json:"id"`
+	Kind  string `json:"kind"`
+	Label string `json:"label"`
+	Scope string `json:"scope"`
+}
+
+type feishuActivityDecision struct {
+	OptionID string `json:"option_id"`
+	Kind     string `json:"kind"`
+}
+
+type feishuBridgeFormattedMessage struct {
+	Text string
+	Card string
+}
+
+func formatFeishuBridgeMessage(text string) feishuBridgeFormattedMessage {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
-		return text
+		return feishuBridgeFormattedMessage{Text: text}
 	}
 
 	var msg feishuActivityMessage
 	if err := json.Unmarshal([]byte(trimmed), &msg); err != nil {
-		return text
+		return feishuBridgeFormattedMessage{Text: text}
 	}
 	if msg.Type != runtimebridge.AgentActivityType {
-		return text
+		return feishuBridgeFormattedMessage{Text: text}
 	}
-	if msg.Content.MsgType != runtimebridge.AgentToolMsgType {
-		return firstNonEmpty(msg.Content.Body, text)
+	switch msg.Content.MsgType {
+	case runtimebridge.AgentToolMsgType:
+		if msg.Content.Tool.empty() {
+			return feishuBridgeFormattedMessage{Text: firstNonEmpty(msg.Content.Body, text)}
+		}
+		return feishuBridgeFormattedMessage{Text: renderFeishuToolActivity(msg.Content.Tool, msg.Content.Body)}
+	case runtimebridge.AgentActionMsgType:
+		if card := renderFeishuPermissionActivityCard(msg); card != "" {
+			return feishuBridgeFormattedMessage{
+				Text: firstNonEmpty(msg.Content.Body, text),
+				Card: card,
+			}
+		}
+		return feishuBridgeFormattedMessage{Text: renderFeishuActionActivity(msg.Content.Action, msg.Content.Body)}
+	default:
+		return feishuBridgeFormattedMessage{Text: firstNonEmpty(msg.Content.Body, text)}
 	}
-	if msg.Content.Tool.empty() {
-		return firstNonEmpty(msg.Content.Body, text)
-	}
-	return renderFeishuToolActivity(msg.Content.Tool, msg.Content.Body)
 }
 
 func renderFeishuToolActivity(tool feishuActivityTool, body string) string {
@@ -74,6 +115,196 @@ func renderFeishuToolActivity(tool feishuActivityTool, body string) string {
 		}
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func renderFeishuActionActivity(action feishuActivityAction, body string) string {
+	title := firstNonEmpty(action.Title, action.Kind, "Permission request")
+	switch strings.ToLower(strings.TrimSpace(action.Status)) {
+	case "pending":
+		return strings.TrimSpace("🔐 Permission required · " + title)
+	case "allowed":
+		return strings.TrimSpace("✅ Permission allowed · " + title)
+	case "rejected":
+		return strings.TrimSpace("❌ Permission rejected · " + title)
+	case "expired":
+		return strings.TrimSpace("⌛ Permission expired · " + title)
+	case "canceled", "cancelled":
+		return strings.TrimSpace("⏹️ Permission canceled · " + title)
+	default:
+		return firstNonEmpty(strings.TrimSpace(body), title)
+	}
+}
+
+func renderFeishuPermissionActivityCard(msg feishuActivityMessage) string {
+	card := renderFeishuPermissionActivityCardData(msg)
+	if card == nil {
+		return ""
+	}
+	data, err := json.Marshal(card)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func renderFeishuPermissionActivityCardData(msg feishuActivityMessage) map[string]any {
+	action := msg.Content.Action
+	if strings.ToLower(strings.TrimSpace(action.Kind)) != "permission" {
+		return nil
+	}
+	status := strings.ToLower(strings.TrimSpace(action.Status))
+	if status == "" {
+		return nil
+	}
+
+	actions := renderFeishuPermissionCardActions(msg, action)
+	if status == "pending" && len(actions) == 0 {
+		return nil
+	}
+
+	elements := []any{
+		map[string]any{
+			"tag":     "markdown",
+			"content": renderFeishuPermissionCardMarkdown(action),
+		},
+	}
+	if status == "pending" {
+		elements = append(elements, map[string]any{
+			"tag":     "action",
+			"layout":  feishuActionLayout(len(actions)),
+			"actions": actions,
+		})
+	}
+
+	return map[string]any{
+		"config": map[string]any{
+			"wide_screen_mode": true,
+		},
+		"header": map[string]any{
+			"template": feishuPermissionCardTemplate(status),
+			"title": map[string]any{
+				"tag":     "plain_text",
+				"content": feishuPermissionCardTitle(status),
+			},
+		},
+		"elements": elements,
+	}
+}
+
+func renderFeishuPermissionCardActions(msg feishuActivityMessage, action feishuActivityAction) []map[string]any {
+	activityID := strings.TrimSpace(action.ID)
+	if activityID == "" || len(action.Options) == 0 {
+		return nil
+	}
+
+	actions := make([]map[string]any, 0, len(action.Options))
+	for _, option := range action.Options {
+		optionID := strings.TrimSpace(option.ID)
+		if optionID == "" {
+			continue
+		}
+		buttonType := "default"
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(option.Kind)), "allow") {
+			buttonType = "primary"
+		}
+		if strings.EqualFold(strings.TrimSpace(option.Kind), "reject") || strings.EqualFold(optionID, "reject") {
+			buttonType = "danger"
+		}
+		actions = append(actions, map[string]any{
+			"tag": "button",
+			"text": map[string]any{
+				"tag":     "plain_text",
+				"content": firstNonEmpty(option.Label, optionID),
+			},
+			"type": buttonType,
+			"value": map[string]any{
+				"type":        "csgclaw.permission_decision",
+				"channel":     firstNonEmpty(msg.Channel, "csgclaw"),
+				"activity_id": activityID,
+				"option_id":   optionID,
+			},
+		})
+	}
+	return actions
+}
+
+func feishuPermissionCardTemplate(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "allowed":
+		return "green"
+	case "rejected":
+		return "red"
+	case "expired", "canceled", "cancelled":
+		return "grey"
+	default:
+		return "orange"
+	}
+}
+
+func feishuPermissionCardTitle(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "allowed":
+		return "Permission allowed"
+	case "rejected":
+		return "Permission rejected"
+	case "expired":
+		return "Permission expired"
+	case "canceled", "cancelled":
+		return "Permission canceled"
+	default:
+		return "Permission request"
+	}
+}
+
+func renderFeishuPermissionCardMarkdown(action feishuActivityAction) string {
+	var b strings.Builder
+	b.WriteString("**")
+	b.WriteString(escapeFeishuMarkdown(compactFeishuPermissionTitle(firstNonEmpty(action.Title, "Run tool"))))
+	b.WriteString("**")
+	if decision := action.Decision; decision != nil {
+		b.WriteString("\nDecision: ")
+		b.WriteString(escapeFeishuMarkdown(firstNonEmpty(decision.Kind, decision.OptionID)))
+	}
+	if expiresAt := strings.TrimSpace(action.ExpiresAt); expiresAt != "" {
+		b.WriteString("\nExpires at: ")
+		b.WriteString(escapeFeishuMarkdown(expiresAt))
+	}
+	return b.String()
+}
+
+func feishuActionLayout(count int) string {
+	switch count {
+	case 1:
+		return "flow"
+	case 2:
+		return "bisected"
+	default:
+		return "trisection"
+	}
+}
+
+func escapeFeishuMarkdown(value string) string {
+	return strings.ReplaceAll(value, "`", "'")
+}
+
+func compactFeishuPermissionTitle(value string) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if value == "" {
+		return "Run tool"
+	}
+	return truncateFeishuText(value, 160)
+}
+
+func truncateFeishuText(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 {
+		return value
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return strings.TrimSpace(string(runes[:limit])) + "..."
 }
 
 func feishuToolStatusLabel(status string) string {

--- a/internal/channelbridge/feishu_client.go
+++ b/internal/channelbridge/feishu_client.go
@@ -3,6 +3,7 @@ package channelbridge
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -10,11 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"csgclaw/internal/activity"
 	"csgclaw/internal/channel/feishu"
+	"csgclaw/internal/channelbridge/runtimebridge"
 	"csgclaw/internal/im"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkdispatcher "github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkcallback "github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
 )
@@ -24,12 +28,14 @@ var atMentionRegexp = regexp.MustCompile(`(?i)<at\s+user_id="([^"]+)"`)
 
 const defaultBridgeReconnectWait = 500 * time.Millisecond
 const bridgeThreadRelationType = "m.thread"
+const feishuPermissionDecisionActionType = "csgclaw.permission_decision"
 
 // FeishuClient adapts Feishu events into BotEvent and sends responses to Feishu.
 type FeishuClient struct {
-	Svc           *feishu.Service
-	MentionOnly   bool
-	ReconnectWait time.Duration
+	Svc             *feishu.Service
+	MentionOnly     bool
+	ReconnectWait   time.Duration
+	ActivityDecider activity.ActivityDecider
 }
 
 func NewFeishuClient(svc *feishu.Service) *FeishuClient {
@@ -109,6 +115,9 @@ func (c *FeishuClient) StreamEvents(ctx context.Context, botID, lastEventID stri
 				}).
 				OnP2MessageReactionDeletedV1(func(context.Context, *larkim.P2MessageReactionDeletedV1) error {
 					return nil
+				}).
+				OnP2CardActionTrigger(func(ctx context.Context, event *larkcallback.CardActionTriggerEvent) (*larkcallback.CardActionTriggerResponse, error) {
+					return c.handleCardActionTrigger(ctx, event)
 				})
 			wsClient := larkws.NewClient(
 				app.AppID,
@@ -159,8 +168,10 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 		return SendMessageResponse{}, fmt.Errorf("feishu bridge send: room id is required")
 	}
 
-	text := strings.TrimSpace(formatFeishuBridgeMessageText(req.Text))
-	if text == "" {
+	formatted := formatFeishuBridgeMessage(req.Text)
+	text := strings.TrimSpace(formatted.Text)
+	card := strings.TrimSpace(formatted.Card)
+	if text == "" && card == "" {
 		return SendMessageResponse{}, nil
 	}
 
@@ -177,12 +188,23 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 		mode = "reply"
 	}
 	sendStartedAt := time.Now()
-	message, err := c.Svc.SendMessage(im.CreateMessageRequest{
-		RoomID:    roomID,
-		SenderID:  senderID,
-		Content:   text,
-		RelatesTo: relatesTo,
-	})
+	var message im.Message
+	var err error
+	if card != "" {
+		message, err = c.Svc.SendInteractiveMessage(ctx, feishu.SendInteractiveMessageRequest{
+			SenderID:     senderID,
+			ChatID:       roomID,
+			Content:      card,
+			ThreadRootID: strings.TrimSpace(req.ThreadRootID),
+		})
+	} else {
+		message, err = c.Svc.SendMessage(im.CreateMessageRequest{
+			RoomID:    roomID,
+			SenderID:  senderID,
+			Content:   text,
+			RelatesTo: relatesTo,
+		})
+	}
 	if err != nil {
 		slog.Warn("feishu bridge send failed",
 			"participant_id", senderID,
@@ -190,6 +212,7 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 			"thread_root_id", strings.TrimSpace(req.ThreadRootID),
 			"mode", mode,
 			"text_bytes", len(text),
+			"card_bytes", len(card),
 			"duration", time.Since(sendStartedAt),
 			"error", err,
 		)
@@ -202,6 +225,7 @@ func (c *FeishuClient) SendMessage(ctx context.Context, botID string, req SendMe
 		"thread_root_id", strings.TrimSpace(req.ThreadRootID),
 		"mode", mode,
 		"text_bytes", len(text),
+		"card_bytes", len(card),
 		"duration", time.Since(sendStartedAt),
 	)
 	return SendMessageResponse{MessageID: strings.TrimSpace(message.ID)}, nil
@@ -227,17 +251,26 @@ func (c *FeishuClient) UpdateMessage(ctx context.Context, botID string, req Upda
 	if messageID == "" {
 		return UpdateMessageResponse{}, fmt.Errorf("feishu bridge update: message id is required")
 	}
-	text := strings.TrimSpace(formatFeishuBridgeMessageText(req.Text))
-	if text == "" {
+	formatted := formatFeishuBridgeMessage(req.Text)
+	text := strings.TrimSpace(formatted.Text)
+	card := strings.TrimSpace(formatted.Card)
+	if text == "" && card == "" {
 		return UpdateMessageResponse{}, nil
+	}
+	content := text
+	messageType := ""
+	if card != "" {
+		content = card
+		messageType = "interactive"
 	}
 
 	updateStartedAt := time.Now()
 	message, err := c.Svc.UpdateMessageWithContext(ctx, feishu.UpdateMessageRequest{
-		RoomID:    roomID,
-		SenderID:  senderID,
-		MessageID: messageID,
-		Content:   text,
+		RoomID:      roomID,
+		SenderID:    senderID,
+		MessageID:   messageID,
+		Content:     content,
+		MessageType: messageType,
 	})
 	if err != nil {
 		slog.Warn("feishu bridge update failed",
@@ -245,6 +278,7 @@ func (c *FeishuClient) UpdateMessage(ctx context.Context, botID string, req Upda
 			"room_id", roomID,
 			"message_id", messageID,
 			"text_bytes", len(text),
+			"card_bytes", len(card),
 			"duration", time.Since(updateStartedAt),
 			"error", err,
 		)
@@ -256,6 +290,7 @@ func (c *FeishuClient) UpdateMessage(ctx context.Context, botID string, req Upda
 		"message_id", messageID,
 		"updated_message_id", strings.TrimSpace(message.ID),
 		"text_bytes", len(text),
+		"card_bytes", len(card),
 		"duration", time.Since(updateStartedAt),
 	)
 	return UpdateMessageResponse{MessageID: strings.TrimSpace(message.ID)}, nil
@@ -352,6 +387,127 @@ func (c *FeishuClient) DeleteMessageReaction(ctx context.Context, botID string, 
 		"duration", time.Since(reactionStartedAt),
 	)
 	return nil
+}
+
+func (c *FeishuClient) handleCardActionTrigger(ctx context.Context, event *larkcallback.CardActionTriggerEvent) (*larkcallback.CardActionTriggerResponse, error) {
+	if c == nil || c.ActivityDecider == nil {
+		return feishuCardActionToast("error", "Activity decisions are not configured"), nil
+	}
+	if event == nil || event.Event == nil || event.Event.Action == nil {
+		return feishuCardActionToast("error", "Missing card action"), nil
+	}
+
+	value := event.Event.Action.Value
+	if !strings.EqualFold(feishuCardActionString(value, "type"), feishuPermissionDecisionActionType) {
+		return feishuCardActionToast("error", "Unsupported card action"), nil
+	}
+	channel := feishuCardActionString(value, "channel")
+	activityID := feishuCardActionString(value, "activity_id")
+	optionID := feishuCardActionString(value, "option_id")
+	if channel == "" || activityID == "" || optionID == "" {
+		return feishuCardActionToast("error", "Invalid permission action"), nil
+	}
+
+	snapshot, err := c.ActivityDecider.Decide(ctx, activity.ActivityDecisionRequest{
+		Channel:    channel,
+		ActivityID: activityID,
+		OptionID:   optionID,
+	})
+	switch {
+	case err == nil:
+		resp := feishuCardActionToast("success", "Decision submitted")
+		resp.Card = feishuPermissionSnapshotCallbackCard(channel, snapshot)
+		return resp, nil
+	case errors.Is(err, activity.ErrActionAlreadyDecided):
+		resp := feishuCardActionToast("warning", "This request was already decided")
+		resp.Card = feishuPermissionSnapshotCallbackCard(channel, snapshot)
+		return resp, nil
+	case errors.Is(err, activity.ErrActionGone):
+		resp := feishuCardActionToast("warning", "This request is no longer pending")
+		resp.Card = feishuPermissionSnapshotCallbackCard(channel, snapshot)
+		return resp, nil
+	case errors.Is(err, activity.ErrActionInvalidOption), errors.Is(err, activity.ErrActionNotFound):
+		return feishuCardActionToast("error", err.Error()), nil
+	default:
+		return nil, err
+	}
+}
+
+func feishuCardActionString(values map[string]interface{}, key string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func feishuPermissionSnapshotCallbackCard(channel string, snapshot activity.ActivitySnapshot) *larkcallback.Card {
+	card := renderFeishuPermissionActivityCardData(feishuActivityMessage{
+		Channel: strings.TrimSpace(channel),
+		Content: feishuActivityContent{
+			MsgType: runtimebridge.AgentActionMsgType,
+			Action:  feishuActivityActionFromSnapshot(snapshot),
+		},
+	})
+	if card == nil {
+		return nil
+	}
+	return &larkcallback.Card{
+		Type: "raw",
+		Data: card,
+	}
+}
+
+func feishuActivityActionFromSnapshot(snapshot activity.ActivitySnapshot) feishuActivityAction {
+	options := make([]feishuActivityOption, 0, len(snapshot.Options))
+	for _, option := range snapshot.Options {
+		options = append(options, feishuActivityOption{
+			ID:    strings.TrimSpace(option.ID),
+			Kind:  strings.TrimSpace(option.Kind),
+			Label: strings.TrimSpace(option.Label),
+			Scope: strings.TrimSpace(option.Scope),
+		})
+	}
+	var decision *feishuActivityDecision
+	if snapshot.Decision != nil {
+		decision = &feishuActivityDecision{
+			OptionID: strings.TrimSpace(snapshot.Decision.OptionID),
+			Kind:     strings.TrimSpace(snapshot.Decision.Kind),
+		}
+	}
+	return feishuActivityAction{
+		ID:          strings.TrimSpace(snapshot.ID),
+		Kind:        strings.TrimSpace(snapshot.Kind),
+		Title:       strings.TrimSpace(snapshot.Title),
+		Status:      string(snapshot.Status),
+		RequestedAt: formatFeishuActivityTime(snapshot.RequestedAt),
+		ExpiresAt:   formatFeishuActivityTime(snapshot.ExpiresAt),
+		Options:     options,
+		Decision:    decision,
+	}
+}
+
+func formatFeishuActivityTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func feishuCardActionToast(kind, content string) *larkcallback.CardActionTriggerResponse {
+	return &larkcallback.CardActionTriggerResponse{
+		Toast: &larkcallback.Toast{
+			Type:    strings.TrimSpace(kind),
+			Content: strings.TrimSpace(content),
+		},
+	}
 }
 
 func (c *FeishuClient) emitBotEvent(

--- a/internal/channelbridge/feishu_client_test.go
+++ b/internal/channelbridge/feishu_client_test.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"csgclaw/internal/activity"
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/channelbridge/runtimebridge"
+
+	larkcallback "github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 )
 
 func TestFeishuClientFormatsToolActivityMessages(t *testing.T) {
@@ -89,4 +92,270 @@ func TestFeishuClientFormatsToolActivityMessages(t *testing.T) {
 			t.Fatalf("formatted content leaked %q:\n%s", unwanted, content)
 		}
 	}
+}
+
+func TestFeishuClientSendsPermissionActivityAsInteractiveCard(t *testing.T) {
+	t.Parallel()
+
+	var gotReq feishu.SendInteractiveMessageRequest
+	svc := feishu.NewServiceWithInteractiveMessage(
+		map[string]feishu.AppConfig{
+			"u-codex": {AppID: "cli_codex", AppSecret: "codex-secret"},
+		},
+		func(_ context.Context, _ feishu.AppConfig, req feishu.SendInteractiveMessageRequest) (feishu.SendMessageResponse, error) {
+			gotReq = req
+			return feishu.SendMessageResponse{MessageID: "om_permission", SenderOpenID: "ou_codex"}, nil
+		},
+	)
+	client := NewFeishuClient(svc)
+
+	activityData, err := json.Marshal(map[string]any{
+		"type":             runtimebridge.AgentActivityType,
+		"version":          1,
+		"channel":          "csgclaw",
+		"event_id":         "act-perm-1",
+		"room_id":          "oc_room",
+		"sender":           "agent-1",
+		"origin_server_ts": int64(1781792759561),
+		"content": map[string]any{
+			"msgtype": runtimebridge.AgentActionMsgType,
+			"body":    "Permission required: Run shell command: go test ./...",
+			"action": map[string]any{
+				"id":     "perm-1",
+				"kind":   "permission",
+				"title":  "Run shell command: go test ./...",
+				"status": "pending",
+				"options": []map[string]any{
+					{"id": "allow_once", "kind": "allow_once", "label": "Allow once"},
+					{"id": "reject", "kind": "reject", "label": "Reject"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal activity: %v", err)
+	}
+
+	resp, err := client.SendMessage(context.Background(), "u-codex", SendMessageRequest{
+		RoomID:       "oc_room",
+		Text:         string(activityData),
+		ThreadRootID: "om_root",
+	})
+	if err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+	if resp.MessageID != "om_permission" {
+		t.Fatalf("MessageID = %q, want om_permission", resp.MessageID)
+	}
+	if gotReq.SenderID != "u-codex" || gotReq.ChatID != "oc_room" || gotReq.ThreadRootID != "om_root" {
+		t.Fatalf("interactive request = %+v, want sender/chat/thread", gotReq)
+	}
+
+	var card map[string]any
+	if err := json.Unmarshal([]byte(gotReq.Content), &card); err != nil {
+		t.Fatalf("card content is not JSON: %v\n%s", err, gotReq.Content)
+	}
+	cardData, _ := json.Marshal(card)
+	cardText := string(cardData)
+	for _, want := range []string{
+		"Permission request",
+		"Run shell command: go test ./...",
+		"allow_once",
+		"reject",
+		"csgclaw.permission_decision",
+		"perm-1",
+	} {
+		if !strings.Contains(cardText, want) {
+			t.Fatalf("card missing %q:\n%s", want, cardText)
+		}
+	}
+	if strings.Contains(cardText, "Permission required: Run shell command") {
+		t.Fatalf("pending card leaked duplicated body:\n%s", cardText)
+	}
+}
+
+func TestFeishuClientUpdatesPermissionActivityAsTerminalCard(t *testing.T) {
+	t.Parallel()
+
+	var gotReq feishu.UpdateMessageRequest
+	svc := feishu.NewServiceWithUpdateMessage(
+		map[string]feishu.AppConfig{
+			"u-codex": {AppID: "cli_codex", AppSecret: "codex-secret"},
+		},
+		func(_ context.Context, _ feishu.AppConfig, req feishu.UpdateMessageRequest) (feishu.UpdateMessageResponse, error) {
+			gotReq = req
+			return feishu.UpdateMessageResponse{MessageID: req.MessageID}, nil
+		},
+	)
+	client := NewFeishuClient(svc)
+
+	activityData, err := json.Marshal(map[string]any{
+		"type":             runtimebridge.AgentActivityType,
+		"version":          1,
+		"channel":          "csgclaw",
+		"event_id":         "act-perm-1",
+		"room_id":          "oc_room",
+		"sender":           "agent-1",
+		"origin_server_ts": int64(1781792759561),
+		"content": map[string]any{
+			"msgtype": runtimebridge.AgentActionMsgType,
+			"body":    "Permission allowed: Run shell command: go test ./...",
+			"action": map[string]any{
+				"id":     "perm-1",
+				"kind":   "permission",
+				"title":  "Run shell command: go test ./...",
+				"status": "allowed",
+				"decision": map[string]any{
+					"option_id": "allow_once",
+					"kind":      "allow_once",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal activity: %v", err)
+	}
+
+	resp, err := client.UpdateMessage(context.Background(), "u-codex", UpdateMessageRequest{
+		RoomID:    "oc_room",
+		MessageID: "om_permission",
+		Text:      string(activityData),
+	})
+	if err != nil {
+		t.Fatalf("UpdateMessage() error = %v", err)
+	}
+	if resp.MessageID != "om_permission" {
+		t.Fatalf("MessageID = %q, want om_permission", resp.MessageID)
+	}
+	if gotReq.SenderID != "u-codex" || gotReq.RoomID != "oc_room" || gotReq.MessageID != "om_permission" || gotReq.MessageType != "interactive" {
+		t.Fatalf("update request = %+v, want interactive update", gotReq)
+	}
+
+	var card map[string]any
+	if err := json.Unmarshal([]byte(gotReq.Content), &card); err != nil {
+		t.Fatalf("card content is not JSON: %v\n%s", err, gotReq.Content)
+	}
+	cardData, _ := json.Marshal(card)
+	cardText := string(cardData)
+	for _, want := range []string{
+		"Permission allowed",
+		"Run shell command: go test ./...",
+		"allow_once",
+	} {
+		if !strings.Contains(cardText, want) {
+			t.Fatalf("card missing %q:\n%s", want, cardText)
+		}
+	}
+	if strings.Contains(cardText, "csgclaw.permission_decision") {
+		t.Fatalf("terminal card still contains decision action:\n%s", cardText)
+	}
+	if strings.Contains(cardText, "Permission allowed: Run shell command") {
+		t.Fatalf("terminal card leaked duplicated body:\n%s", cardText)
+	}
+}
+
+func TestFeishuClientCardActionTriggerDecidesPermissionOverLongConnection(t *testing.T) {
+	t.Parallel()
+
+	decider := &recordingActivityDecider{
+		snapshot: activity.ActivitySnapshot{
+			ID:     "perm-1",
+			Kind:   activity.ActionKindPermission,
+			Title:  "Run shell command: go test ./...",
+			Status: activity.ActionStatusAllowed,
+			Options: []activity.ActionOptionSnapshot{
+				{ID: "allow_once", Kind: "allow_once", Label: "Allow once"},
+				{ID: "reject", Kind: "reject", Label: "Reject"},
+			},
+			Decision: &activity.ActionDecisionSnapshot{
+				OptionID: "allow_once",
+				Kind:     "allow_once",
+			},
+		},
+	}
+	client := &FeishuClient{ActivityDecider: decider}
+
+	resp, err := client.handleCardActionTrigger(context.Background(), &larkcallback.CardActionTriggerEvent{
+		Event: &larkcallback.CardActionTriggerRequest{
+			Action: &larkcallback.CallBackAction{
+				Value: map[string]interface{}{
+					"type":        "csgclaw.permission_decision",
+					"channel":     "csgclaw",
+					"activity_id": "perm-1",
+					"option_id":   "allow_once",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleCardActionTrigger() error = %v", err)
+	}
+	if decider.req.Channel != "csgclaw" || decider.req.ActivityID != "perm-1" || decider.req.OptionID != "allow_once" {
+		t.Fatalf("decision request = %+v, want card value fields", decider.req)
+	}
+	if resp == nil || resp.Toast == nil {
+		t.Fatalf("response = %#v, want toast", resp)
+	}
+	if resp.Toast.Type != "success" || resp.Toast.Content != "Decision submitted" {
+		t.Fatalf("toast = %+v, want success decision toast", resp.Toast)
+	}
+	if resp.Card == nil || resp.Card.Type != "raw" {
+		t.Fatalf("response card = %#v, want raw terminal card", resp.Card)
+	}
+	cardData, _ := json.Marshal(resp.Card.Data)
+	cardText := string(cardData)
+	for _, want := range []string{
+		"Permission allowed",
+		"Run shell command: go test ./...",
+		"allow_once",
+	} {
+		if !strings.Contains(cardText, want) {
+			t.Fatalf("callback card missing %q:\n%s", want, cardText)
+		}
+	}
+	if strings.Contains(cardText, "csgclaw.permission_decision") {
+		t.Fatalf("callback terminal card still contains decision action:\n%s", cardText)
+	}
+}
+
+func TestFeishuClientCardActionTriggerMapsGonePermissionToWarningToast(t *testing.T) {
+	t.Parallel()
+
+	client := &FeishuClient{ActivityDecider: &recordingActivityDecider{err: activity.ErrActionGone}}
+
+	resp, err := client.handleCardActionTrigger(context.Background(), &larkcallback.CardActionTriggerEvent{
+		Event: &larkcallback.CardActionTriggerRequest{
+			Action: &larkcallback.CallBackAction{
+				Value: map[string]interface{}{
+					"type":        "csgclaw.permission_decision",
+					"channel":     "csgclaw",
+					"activity_id": "perm-1",
+					"option_id":   "allow_once",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleCardActionTrigger() error = %v", err)
+	}
+	if resp == nil || resp.Toast == nil {
+		t.Fatalf("response = %#v, want toast", resp)
+	}
+	if resp.Toast.Type != "warning" || resp.Toast.Content != "This request is no longer pending" {
+		t.Fatalf("toast = %+v, want warning gone toast", resp.Toast)
+	}
+}
+
+type recordingActivityDecider struct {
+	req      activity.ActivityDecisionRequest
+	snapshot activity.ActivitySnapshot
+	err      error
+}
+
+func (d *recordingActivityDecider) Decide(_ context.Context, req activity.ActivityDecisionRequest) (activity.ActivitySnapshot, error) {
+	d.req = req
+	if d.snapshot.ID == "" {
+		d.snapshot.ID = req.ActivityID
+	}
+	return d.snapshot, d.err
 }

--- a/internal/participant/feishubind/bind.go
+++ b/internal/participant/feishubind/bind.go
@@ -194,10 +194,7 @@ func upsertBotParticipant(ctx context.Context, participantSvc *participant.Servi
 			warnings = append(warnings, fmt.Sprintf("found noncanonical feishu participant %q for agent %q; keeping it and writing canonical participant %q", item.ID, target.ID, participantID))
 		}
 	}
-	cfg := map[string]any{
-		"app_id":     appID,
-		"app_secret": appSecret,
-	}
+	cfg := feishuBotAppConfig(appID, appSecret)
 	kind := participant.ChannelUserKindAppID
 	displayName := strings.TrimSpace(target.Name)
 	if displayName == "" {
@@ -243,6 +240,13 @@ func upsertBotParticipant(ctx context.Context, participantSvc *participant.Servi
 		},
 	})
 	return created, warnings, err
+}
+
+func feishuBotAppConfig(appID, appSecret string) map[string]any {
+	return map[string]any{
+		"app_id":                                 strings.TrimSpace(appID),
+		participant.ChannelAppConfigAppSecretKey: strings.TrimSpace(appSecret),
+	}
 }
 
 func findParticipantByID(participantSvc *participant.Service, channel, id string) (participant.Participant, bool, error) {

--- a/internal/participant/feishubind/bind_test.go
+++ b/internal/participant/feishubind/bind_test.go
@@ -1,0 +1,20 @@
+package feishubind
+
+import (
+	"testing"
+
+	"csgclaw/internal/participant"
+)
+
+func TestFeishuBotAppConfigStoresOnlyLongConnectionCredentials(t *testing.T) {
+	got := feishuBotAppConfig(" cli_new ", " new-secret ")
+	if got["app_id"] != "cli_new" {
+		t.Fatalf("app_id = %#v, want %q", got["app_id"], "cli_new")
+	}
+	if got[participant.ChannelAppConfigAppSecretKey] != "new-secret" {
+		t.Fatalf("app_secret = %#v, want %q", got[participant.ChannelAppConfigAppSecretKey], "new-secret")
+	}
+	if len(got) != 2 {
+		t.Fatalf("config = %#v, want only app_id and app_secret", got)
+	}
+}

--- a/internal/participant/redaction.go
+++ b/internal/participant/redaction.go
@@ -6,10 +6,8 @@ import (
 )
 
 const (
-	ChannelAppConfigAppSecretKey         = "app_secret"
-	ChannelAppConfigVerificationTokenKey = "verification_token"
-	ChannelAppConfigEncryptKeyKey        = "encrypt_key"
-	RedactedSecretValue                  = "present"
+	ChannelAppConfigAppSecretKey = "app_secret"
+	RedactedSecretValue          = "present"
 )
 
 func RedactChannelAppConfig(values map[string]any) map[string]any {
@@ -18,7 +16,7 @@ func RedactChannelAppConfig(values map[string]any) map[string]any {
 	}
 	out := make(map[string]any, len(values))
 	for key, value := range values {
-		if isSecretChannelAppConfigKey(key) &&
+		if strings.EqualFold(strings.TrimSpace(key), ChannelAppConfigAppSecretKey) &&
 			strings.TrimSpace(fmt.Sprint(value)) != "" {
 			out[key] = RedactedSecretValue
 			continue
@@ -26,13 +24,4 @@ func RedactChannelAppConfig(values map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
-}
-
-func isSecretChannelAppConfigKey(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(key)) {
-	case ChannelAppConfigAppSecretKey, ChannelAppConfigVerificationTokenKey, ChannelAppConfigEncryptKeyKey:
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/participant/redaction.go
+++ b/internal/participant/redaction.go
@@ -6,8 +6,10 @@ import (
 )
 
 const (
-	ChannelAppConfigAppSecretKey = "app_secret"
-	RedactedSecretValue          = "present"
+	ChannelAppConfigAppSecretKey         = "app_secret"
+	ChannelAppConfigVerificationTokenKey = "verification_token"
+	ChannelAppConfigEncryptKeyKey        = "encrypt_key"
+	RedactedSecretValue                  = "present"
 )
 
 func RedactChannelAppConfig(values map[string]any) map[string]any {
@@ -16,7 +18,7 @@ func RedactChannelAppConfig(values map[string]any) map[string]any {
 	}
 	out := make(map[string]any, len(values))
 	for key, value := range values {
-		if strings.EqualFold(strings.TrimSpace(key), ChannelAppConfigAppSecretKey) &&
+		if isSecretChannelAppConfigKey(key) &&
 			strings.TrimSpace(fmt.Sprint(value)) != "" {
 			out[key] = RedactedSecretValue
 			continue
@@ -24,4 +26,13 @@ func RedactChannelAppConfig(values map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
+}
+
+func isSecretChannelAppConfigKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case ChannelAppConfigAppSecretKey, ChannelAppConfigVerificationTokenKey, ChannelAppConfigEncryptKeyKey:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/participant/redaction_test.go
+++ b/internal/participant/redaction_test.go
@@ -4,8 +4,10 @@ import "testing"
 
 func TestRedactChannelAppConfigMasksSecretWithoutMutatingInput(t *testing.T) {
 	values := map[string]any{
-		"app_id":                     "cli_dev",
-		ChannelAppConfigAppSecretKey: "dev-secret",
+		"app_id":                             "cli_dev",
+		ChannelAppConfigAppSecretKey:         "dev-secret",
+		ChannelAppConfigVerificationTokenKey: "verify-token",
+		ChannelAppConfigEncryptKeyKey:        "encrypt-key",
 	}
 
 	got := RedactChannelAppConfig(values)
@@ -15,6 +17,12 @@ func TestRedactChannelAppConfigMasksSecretWithoutMutatingInput(t *testing.T) {
 	}
 	if got[ChannelAppConfigAppSecretKey] != RedactedSecretValue {
 		t.Fatalf("app_secret = %#v, want %q", got[ChannelAppConfigAppSecretKey], RedactedSecretValue)
+	}
+	if got[ChannelAppConfigVerificationTokenKey] != RedactedSecretValue {
+		t.Fatalf("verification_token = %#v, want %q", got[ChannelAppConfigVerificationTokenKey], RedactedSecretValue)
+	}
+	if got[ChannelAppConfigEncryptKeyKey] != RedactedSecretValue {
+		t.Fatalf("encrypt_key = %#v, want %q", got[ChannelAppConfigEncryptKeyKey], RedactedSecretValue)
 	}
 	if values[ChannelAppConfigAppSecretKey] != "dev-secret" {
 		t.Fatalf("input app_secret = %#v, want original secret preserved", values[ChannelAppConfigAppSecretKey])

--- a/internal/participant/redaction_test.go
+++ b/internal/participant/redaction_test.go
@@ -4,10 +4,8 @@ import "testing"
 
 func TestRedactChannelAppConfigMasksSecretWithoutMutatingInput(t *testing.T) {
 	values := map[string]any{
-		"app_id":                             "cli_dev",
-		ChannelAppConfigAppSecretKey:         "dev-secret",
-		ChannelAppConfigVerificationTokenKey: "verify-token",
-		ChannelAppConfigEncryptKeyKey:        "encrypt-key",
+		"app_id":                     "cli_dev",
+		ChannelAppConfigAppSecretKey: "dev-secret",
 	}
 
 	got := RedactChannelAppConfig(values)
@@ -17,12 +15,6 @@ func TestRedactChannelAppConfigMasksSecretWithoutMutatingInput(t *testing.T) {
 	}
 	if got[ChannelAppConfigAppSecretKey] != RedactedSecretValue {
 		t.Fatalf("app_secret = %#v, want %q", got[ChannelAppConfigAppSecretKey], RedactedSecretValue)
-	}
-	if got[ChannelAppConfigVerificationTokenKey] != RedactedSecretValue {
-		t.Fatalf("verification_token = %#v, want %q", got[ChannelAppConfigVerificationTokenKey], RedactedSecretValue)
-	}
-	if got[ChannelAppConfigEncryptKeyKey] != RedactedSecretValue {
-		t.Fatalf("encrypt_key = %#v, want %q", got[ChannelAppConfigEncryptKeyKey], RedactedSecretValue)
 	}
 	if values[ChannelAppConfigAppSecretKey] != "dev-secret" {
 		t.Fatalf("input app_secret = %#v, want original secret preserved", values[ChannelAppConfigAppSecretKey])

--- a/internal/runtime/codex/appserver_events.go
+++ b/internal/runtime/codex/appserver_events.go
@@ -95,16 +95,6 @@ func (m *appServerManager) handleRawTurnCompleted(runtimeID string, live *liveSe
 	switch status {
 	case "", "completed", "success", "succeeded":
 		if !live.notifyAppServerTurn(threadID, appServerTurnResult{success: true, stopReason: StopReasonEndTurn, turnID: turnID, activity: "turn:completed"}) {
-			if live.consumeFallbackCompleted(threadID) {
-				if live.appClient != nil {
-					live.appClient.logDebug("codex app-server ignored duplicate turn completion after agent message",
-						"runtime_id", runtimeID,
-						"thread_id", threadID,
-						"turn_id", turnID,
-					)
-				}
-				return
-			}
 			m.publishAppServerEvent(promptCompletedEvent(runtimeID, threadID, PromptResponse{StopReason: StopReasonEndTurn}))
 		}
 	case "cancelled", "canceled", "aborted", "interrupted":
@@ -240,16 +230,6 @@ func (m *appServerManager) handleRawItemNotification(runtimeID string, live *liv
 				Text:      text,
 				Payload:   item,
 			})
-		}
-		if live.notifyAppServerTurn(threadID, appServerTurnResult{success: true, stopReason: StopReasonEndTurn, activity: "item:agentMessage:completed", progress: true}) {
-			live.markFallbackCompleted(threadID)
-			if live.appClient != nil {
-				live.appClient.logDebug("codex app-server completed turn from agent message",
-					"runtime_id", runtimeID,
-					"thread_id", threadID,
-					"item_id", itemID,
-				)
-			}
 		}
 	}
 }

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -537,7 +537,7 @@ func (m *appServerManager) handleAppServerToolApproval(runtimeID string, live *l
 		ToolTitle: appServerApprovalTitle(title, req),
 		Options: NormalizePermissionOptions([]ExternalPermissionOption{
 			{ID: "allow_once", Kind: PermissionOptionKindAllowOnce, Label: "Allow once"},
-			{ID: "allow_always", Kind: PermissionOptionKindAllowAlways, Label: "Allow always"},
+			{ID: "allow_always", Kind: PermissionOptionKindAllowAlways, Label: "Allow for session"},
 			{ID: "reject", Kind: "reject", Label: "Reject"},
 		}),
 	})

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -516,7 +516,7 @@ func (m *appServerManager) handleAppServerServerRequest(runtimeID string, live *
 func (m *appServerManager) handleAppServerToolApproval(runtimeID string, live *liveSession, req appServerServerRequest, title string, toolKind string) (any, error) {
 	sessionID := m.appServerApprovalSessionID(live, req)
 	if m.deps.Permission == nil || strings.TrimSpace(runtimeID) == "" || sessionID == "" {
-		return appServerApprovalResponse(true), nil
+		return appServerApprovalResponse(req.Method, true), nil
 	}
 	approvalCtx := live.appServerTurnContext(sessionID)
 	if approvalCtx == nil {
@@ -544,24 +544,73 @@ func (m *appServerManager) handleAppServerToolApproval(runtimeID string, live *l
 	if err != nil {
 		return nil, err
 	}
-	return appServerApprovalDecisionResponse(decision.Snapshot.Status), nil
+	return appServerApprovalDecisionResponse(req.Method, decision.Snapshot), nil
 }
 
-func appServerApprovalResponse(allowed bool) map[string]any {
+func appServerApprovalResponse(method string, allowed bool) map[string]any {
 	if allowed {
-		return map[string]any{"decision": "accept"}
+		return map[string]any{"decision": appServerApprovalAcceptDecision(method, false)}
 	}
-	return map[string]any{"decision": "decline"}
+	return map[string]any{"decision": appServerApprovalRejectDecision(method)}
 }
 
-func appServerApprovalDecisionResponse(status PermissionStatus) map[string]any {
-	switch status {
+func appServerApprovalDecisionResponse(method string, snapshot PermissionSnapshot) map[string]any {
+	switch snapshot.Status {
 	case PermissionStatusAllowed:
-		return map[string]any{"decision": "accept"}
-	case PermissionStatusCanceled, PermissionStatusExpired:
-		return map[string]any{"decision": "cancel"}
+		return map[string]any{"decision": appServerApprovalAcceptDecision(method, permissionDecisionAllowsForSession(snapshot))}
+	case PermissionStatusCanceled:
+		return map[string]any{"decision": appServerApprovalCancelDecision(method)}
+	case PermissionStatusExpired:
+		return map[string]any{"decision": appServerApprovalExpiredDecision(method)}
 	default:
-		return map[string]any{"decision": "decline"}
+		return map[string]any{"decision": appServerApprovalRejectDecision(method)}
+	}
+}
+
+func permissionDecisionAllowsForSession(snapshot PermissionSnapshot) bool {
+	return snapshot.Decision != nil && strings.TrimSpace(snapshot.Decision.Kind) == PermissionOptionKindAllowAlways
+}
+
+func appServerApprovalAcceptDecision(method string, forSession bool) string {
+	if appServerApprovalUsesLegacyDecisionNames(method) {
+		if forSession {
+			return "approved_for_session"
+		}
+		return "approved"
+	}
+	if forSession {
+		return "acceptForSession"
+	}
+	return "accept"
+}
+
+func appServerApprovalRejectDecision(method string) string {
+	if appServerApprovalUsesLegacyDecisionNames(method) {
+		return "denied"
+	}
+	return "decline"
+}
+
+func appServerApprovalCancelDecision(method string) string {
+	if appServerApprovalUsesLegacyDecisionNames(method) {
+		return "abort"
+	}
+	return "cancel"
+}
+
+func appServerApprovalExpiredDecision(method string) string {
+	if appServerApprovalUsesLegacyDecisionNames(method) {
+		return "timed_out"
+	}
+	return "cancel"
+}
+
+func appServerApprovalUsesLegacyDecisionNames(method string) bool {
+	switch strings.TrimSpace(method) {
+	case "execCommandApproval", "applyPatchApproval":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -14,7 +14,9 @@ import (
 	"sync"
 	"time"
 
+	"csgclaw/internal/activity"
 	"csgclaw/internal/codexcli"
+	agentruntime "csgclaw/internal/runtime"
 )
 
 const appServerStopTimeout = 3 * time.Second
@@ -93,7 +95,6 @@ func (m *appServerManager) Start(ctx context.Context, spec SessionSpec) (*Sessio
 		appClient:            appClient,
 		conversationSessions: make(map[string]string),
 		turnWaiters:          make(map[string]*appServerTurnWaiter),
-		fallbackCompleted:    make(map[string]struct{}),
 	}
 	appClient.onNotification = func(note appServerNotification) {
 		m.handleAppServerNotification(spec.RuntimeID, live, note)
@@ -191,6 +192,9 @@ func (m *appServerManager) Session(handle SessionHandle) (*Session, error) {
 }
 
 func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req PromptRequest) (PromptResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	runtimeID := strings.TrimSpace(handle.RuntimeID)
 	live, err := m.ensureLiveSession(ctx, handle)
 	if err != nil {
@@ -210,14 +214,19 @@ func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req
 		return PromptResponse{}, err
 	}
 
-	waiter, err := live.registerAppServerTurnWaiter(sessionID)
+	turnCtx, cancelTurn := context.WithCancel(ctx)
+	waiter, err := live.registerAppServerTurnWaiter(turnCtx, sessionID)
 	if err != nil {
+		cancelTurn()
 		if m.deps.EventSink != nil {
 			m.deps.EventSink.Publish(promptFailedEvent(runtimeID, sessionID, err))
 		}
 		return PromptResponse{}, err
 	}
-	defer live.removeAppServerTurnWaiter(sessionID, waiter)
+	defer func() {
+		cancelTurn()
+		live.removeAppServerTurnWaiter(sessionID, waiter)
+	}()
 
 	params := appServerTurnStartParams(live.spec, sessionID, promptText)
 	turnStartAt := time.Now()
@@ -487,12 +496,12 @@ func appServerTurnStartParams(spec SessionSpec, threadID string, prompt string) 
 	return params
 }
 
-func (m *appServerManager) handleAppServerServerRequest(_ string, _ *liveSession, req appServerServerRequest) (any, error) {
+func (m *appServerManager) handleAppServerServerRequest(runtimeID string, live *liveSession, req appServerServerRequest) (any, error) {
 	switch strings.TrimSpace(req.Method) {
 	case "item/commandExecution/requestApproval", "execCommandApproval":
-		return map[string]any{"decision": "accept"}, nil
+		return m.handleAppServerToolApproval(runtimeID, live, req, "Run shell command", "exec_command")
 	case "item/fileChange/requestApproval", "applyPatchApproval":
-		return map[string]any{"decision": "accept"}, nil
+		return m.handleAppServerToolApproval(runtimeID, live, req, "Apply patch", "patch_apply")
 	case "mcpServer/elicitation/request":
 		return map[string]any{
 			"action":  "accept",
@@ -502,6 +511,118 @@ func (m *appServerManager) handleAppServerServerRequest(_ string, _ *liveSession
 	default:
 		return nil, fmt.Errorf("unhandled server request: %s", strings.TrimSpace(req.Method))
 	}
+}
+
+func (m *appServerManager) handleAppServerToolApproval(runtimeID string, live *liveSession, req appServerServerRequest, title string, toolKind string) (any, error) {
+	sessionID := m.appServerApprovalSessionID(live, req)
+	if m.deps.Permission == nil || strings.TrimSpace(runtimeID) == "" || sessionID == "" {
+		return appServerApprovalResponse(true), nil
+	}
+	approvalCtx := live.appServerTurnContext(sessionID)
+	if approvalCtx == nil {
+		approvalCtx = context.Background()
+	}
+
+	live.notifyAppServerPermissionWait(sessionID, true)
+	defer live.notifyAppServerPermissionWait(sessionID, false)
+
+	decision, err := m.deps.Permission.Request(approvalCtx, PendingPermissionRequest{
+		ExecutionRef: activity.ExecutionRef{
+			RuntimeKind: agentruntime.KindCodex,
+			RuntimeID:   strings.TrimSpace(runtimeID),
+			SessionID:   sessionID,
+			ToolCallID:  appServerApprovalToolCallID(req),
+			ToolKind:    strings.TrimSpace(toolKind),
+		},
+		ToolTitle: appServerApprovalTitle(title, req),
+		Options: NormalizePermissionOptions([]ExternalPermissionOption{
+			{ID: "allow_once", Kind: PermissionOptionKindAllowOnce, Label: "Allow once"},
+			{ID: "allow_always", Kind: PermissionOptionKindAllowAlways, Label: "Allow always"},
+			{ID: "reject", Kind: "reject", Label: "Reject"},
+		}),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return appServerApprovalDecisionResponse(decision.Snapshot.Status), nil
+}
+
+func appServerApprovalResponse(allowed bool) map[string]any {
+	if allowed {
+		return map[string]any{"decision": "accept"}
+	}
+	return map[string]any{"decision": "decline"}
+}
+
+func appServerApprovalDecisionResponse(status PermissionStatus) map[string]any {
+	switch status {
+	case PermissionStatusAllowed:
+		return map[string]any{"decision": "accept"}
+	case PermissionStatusCanceled, PermissionStatusExpired:
+		return map[string]any{"decision": "cancel"}
+	default:
+		return map[string]any{"decision": "decline"}
+	}
+}
+
+func (m *appServerManager) appServerApprovalSessionID(live *liveSession, req appServerServerRequest) string {
+	if live == nil {
+		return ""
+	}
+	params := appServerServerRequestParams(req)
+	if threadID := appServerNotificationThreadID(params); threadID != "" && live != nil && live.appServerTracksThread(threadID) {
+		return threadID
+	}
+	if threadID := live.activeAppServerTurnThreadID(); threadID != "" {
+		return threadID
+	}
+	return m.appServerPrimaryThreadID(live)
+}
+
+func appServerApprovalToolCallID(req appServerServerRequest) string {
+	params := appServerServerRequestParams(req)
+	for _, key := range []string{"itemId", "item_id", "callId", "call_id", "id"} {
+		if value := appServerString(params, key); value != "" {
+			return value
+		}
+	}
+	if itemID := appServerNestedString(params, "item", "id"); itemID != "" {
+		return itemID
+	}
+	return ""
+}
+
+func appServerApprovalTitle(base string, req appServerServerRequest) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "Run tool"
+	}
+	params := appServerServerRequestParams(req)
+	summary := firstPermissionText(
+		appServerString(params, "command"),
+		appServerString(params, "cmd"),
+		appServerNestedString(params, "item", "command"),
+		appServerString(params, "path"),
+		appServerString(params, "file"),
+		appServerString(params, "filename"),
+		appServerNestedString(params, "item", "path"),
+		appServerNestedString(params, "item", "file"),
+	)
+	if summary == "" {
+		return base
+	}
+	return base + ": " + truncateSummary(summary, 160)
+}
+
+func appServerServerRequestParams(req appServerServerRequest) map[string]any {
+	var params map[string]any
+	if len(req.Params) > 0 && string(req.Params) != "null" {
+		_ = json.Unmarshal(req.Params, &params)
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	return params
 }
 
 func appServerReasoningConfig(effort string) map[string]any {
@@ -596,6 +717,7 @@ func (m *appServerManager) persistedThreadID(spec SessionSpec) string {
 }
 
 type appServerTurnWaiter struct {
+	ctx           context.Context
 	threadID      string
 	turnID        string
 	ch            chan appServerTurnResult
@@ -606,19 +728,24 @@ type appServerTurnWaiter struct {
 }
 
 type appServerTurnResult struct {
-	success    bool
-	stopReason string
-	err        error
-	turnID     string
-	activity   string
-	started    bool
-	progress   bool
+	success           bool
+	stopReason        string
+	err               error
+	turnID            string
+	activity          string
+	started           bool
+	progress          bool
+	permissionPending bool
+	permissionDone    bool
 }
 
-func (s *liveSession) registerAppServerTurnWaiter(threadID string) (*appServerTurnWaiter, error) {
+func (s *liveSession) registerAppServerTurnWaiter(ctx context.Context, threadID string) (*appServerTurnWaiter, error) {
 	threadID = strings.TrimSpace(threadID)
 	if threadID == "" {
 		return nil, fmt.Errorf("thread id is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -629,6 +756,7 @@ func (s *liveSession) registerAppServerTurnWaiter(threadID string) (*appServerTu
 		return nil, fmt.Errorf("codex turn already in progress for thread %s", threadID)
 	}
 	waiter := &appServerTurnWaiter{
+		ctx:           ctx,
 		threadID:      threadID,
 		ch:            make(chan appServerTurnResult, 8),
 		lastActivity:  "turn/start",
@@ -636,6 +764,35 @@ func (s *liveSession) registerAppServerTurnWaiter(threadID string) (*appServerTu
 	}
 	s.turnWaiters[threadID] = waiter
 	return waiter, nil
+}
+
+func (s *liveSession) appServerTurnContext(threadID string) context.Context {
+	if s == nil {
+		return nil
+	}
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	waiter := s.turnWaiters[threadID]
+	if waiter == nil {
+		return nil
+	}
+	return waiter.ctx
+}
+
+func (s *liveSession) notifyAppServerPermissionWait(threadID string, pending bool) {
+	result := appServerTurnResult{
+		activity:          "permission:pending",
+		permissionPending: pending,
+		permissionDone:    !pending,
+	}
+	if !pending {
+		result.activity = "permission:resolved"
+	}
+	s.notifyAppServerTurn(threadID, result)
 }
 
 func (s *liveSession) removeAppServerTurnWaiter(threadID string, waiter *appServerTurnWaiter) {
@@ -679,31 +836,19 @@ func (s *liveSession) notifyAppServerTurn(threadID string, result appServerTurnR
 	return true
 }
 
-func (s *liveSession) markFallbackCompleted(threadID string) {
-	threadID = strings.TrimSpace(threadID)
-	if threadID == "" {
-		return
+func (s *liveSession) activeAppServerTurnThreadID() string {
+	if s == nil {
+		return ""
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.fallbackCompleted == nil {
-		s.fallbackCompleted = make(map[string]struct{})
+	if len(s.turnWaiters) != 1 {
+		return ""
 	}
-	s.fallbackCompleted[threadID] = struct{}{}
-}
-
-func (s *liveSession) consumeFallbackCompleted(threadID string) bool {
-	threadID = strings.TrimSpace(threadID)
-	if threadID == "" {
-		return false
+	for threadID := range s.turnWaiters {
+		return strings.TrimSpace(threadID)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.fallbackCompleted[threadID]; !ok {
-		return false
-	}
-	delete(s.fallbackCompleted, threadID)
-	return true
+	return ""
 }
 
 func (w *appServerTurnWaiter) setTurnID(turnID string) {
@@ -725,11 +870,24 @@ func (m *appServerManager) waitAppServerTurn(ctx context.Context, live *liveSess
 	}
 	semanticTimer := time.NewTimer(semanticTimeout)
 	defer semanticTimer.Stop()
+	semanticC := semanticTimer.C
 
 	var noProgressTimer *time.Timer
 	var noProgressC <-chan time.Time
+	permissionPending := false
 	waitStartedAt := time.Now()
 	lastActivityAt := waitStartedAt
+	startNoProgress := func() {
+		if noProgressTimeout <= 0 || noProgressC != nil || permissionPending {
+			return
+		}
+		if noProgressTimer == nil {
+			noProgressTimer = time.NewTimer(noProgressTimeout)
+		} else {
+			noProgressTimer.Reset(noProgressTimeout)
+		}
+		noProgressC = noProgressTimer.C
+	}
 	stopNoProgress := func() {
 		if noProgressTimer == nil {
 			return
@@ -744,14 +902,22 @@ func (m *appServerManager) waitAppServerTurn(ctx context.Context, live *liveSess
 	}
 	defer stopNoProgress()
 
-	resetSemantic := func() {
+	stopSemantic := func() {
 		if !semanticTimer.Stop() {
 			select {
 			case <-semanticTimer.C:
 			default:
 			}
 		}
+		semanticC = nil
+	}
+	resetSemantic := func() {
+		if permissionPending {
+			return
+		}
+		stopSemantic()
 		semanticTimer.Reset(semanticTimeout)
+		semanticC = semanticTimer.C
 	}
 
 	for {
@@ -775,9 +941,20 @@ func (m *appServerManager) waitAppServerTurn(ctx context.Context, live *liveSess
 				lastActivityAt = now
 				resetSemantic()
 			}
-			if result.started && noProgressTimeout > 0 && noProgressTimer == nil {
-				noProgressTimer = time.NewTimer(noProgressTimeout)
-				noProgressC = noProgressTimer.C
+			if result.permissionPending {
+				permissionPending = true
+				stopNoProgress()
+				stopSemantic()
+			}
+			if result.permissionDone {
+				permissionPending = false
+				resetSemantic()
+				if waiter.started && !waiter.progress {
+					startNoProgress()
+				}
+			}
+			if result.started {
+				startNoProgress()
 			}
 			if result.progress {
 				stopNoProgress()
@@ -803,7 +980,7 @@ func (m *appServerManager) waitAppServerTurn(ctx context.Context, live *liveSess
 				)
 			}
 			return PromptResponse{}, m.appServerTurnTimeoutError(live, waiter, "codex app-server no progress timeout", noProgressTimeout)
-		case <-semanticTimer.C:
+		case <-semanticC:
 			if live.appClient != nil {
 				live.appClient.logDebug("codex app-server turn semantic inactivity timeout",
 					"runtime_id", strings.TrimSpace(live.spec.RuntimeID),

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -191,8 +191,8 @@ func TestAppServerManagerPromptCompletesTurn(t *testing.T) {
 	}
 }
 
-func TestAppServerManagerPromptCompletesOnAgentMessageWithoutTurnCompleted(t *testing.T) {
-	withAppServerHelperCommand(t, "prompt-agent-message-complete")
+func TestAppServerManagerPromptCompletesOnIdleStatusWithoutTurnCompleted(t *testing.T) {
+	withAppServerHelperCommand(t, "prompt-idle-status-complete")
 	dir := t.TempDir()
 	spec := testAppServerSessionSpec(dir)
 	sink := &recordingSink{}
@@ -373,36 +373,206 @@ func TestAppServerManagerAutoAcceptsMCPElicitation(t *testing.T) {
 	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
 }
 
-func TestAppServerManagerPromptAutoAcceptDoesNotBlockLifecycle(t *testing.T) {
+func TestAppServerManagerPromptApprovalUsesPermissionBroker(t *testing.T) {
 	withAppServerHelperCommand(t, "prompt-approval-complete")
 	dir := t.TempDir()
 	spec := testAppServerSessionSpec(dir)
 	sink := &recordingSink{}
-	manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
+	deps := testAppServerManagerDepsWithSink(sink)
+	broker := NewPermissionBroker(sink)
+	deps.Permission = broker
+	manager := newAppServerManager(deps)
 	session, err := manager.Start(context.Background(), spec)
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
 	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
 
-	resp, err := manager.Prompt(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
+	decisionErr := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			for _, event := range sink.snapshot() {
+				if event.Kind == SessionEventPermissionRequest && event.ActionID != "" {
+					_, err := broker.Decide(context.Background(), event.ActionID, "allow_once")
+					decisionErr <- err
+					return
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+		decisionErr <- fmt.Errorf("permission request was not published")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := manager.Prompt(ctx, SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
 		SessionID: session.SessionID,
 		Prompt:    []PromptContentBlock{TextBlock("hello with approval")},
 	})
 	if err != nil {
 		t.Fatalf("Prompt() error = %v", err)
 	}
+	if err := <-decisionErr; err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
 	if resp.StopReason != StopReasonEndTurn {
 		t.Fatalf("StopReason = %q, want %q", resp.StopReason, StopReasonEndTurn)
 	}
 
-	waitForRuntime(t, func() bool { return len(sink.snapshot()) >= 2 })
+	waitForRuntime(t, func() bool { return len(sink.snapshot()) >= 4 })
 	events := sink.snapshot()
-	if len(events) != 2 ||
+	if len(events) < 4 ||
 		events[0].Kind != SessionEventTextDelta ||
-		events[1].Kind != SessionEventPromptCompleted {
-		t.Fatalf("events = %#v, want text delta then prompt completed", events)
+		events[0].Text != "preparing approval" ||
+		events[1].Kind != SessionEventPermissionRequest ||
+		events[1].ActionStatus != string(PermissionStatusPending) ||
+		events[1].SessionID != session.SessionID ||
+		!strings.Contains(events[1].ToolTitle, "go test ./...") ||
+		events[2].Kind != SessionEventPermissionDecision ||
+		events[2].ActionStatus != string(PermissionStatusAllowed) ||
+		events[3].Kind != SessionEventPromptCompleted {
+		t.Fatalf("events = %#v, want text delta then permission request/decision and prompt completed", events)
 	}
+	if snapshot, ok := events[1].Payload.(PermissionSnapshot); !ok || !hasPermissionOptions(snapshot.Options, "allow_once", "allow_always", "reject") {
+		t.Fatalf("permission payload = %#v, want allow once, allow always, and reject", events[1].Payload)
+	}
+}
+
+func TestAppServerManagerPromptApprovalPausesTurnTimeouts(t *testing.T) {
+	withAppServerHelperCommand(t, "prompt-approval-wait-without-progress")
+	originalSemantic := appServerSemanticInactivityTimeout
+	originalNoProgress := appServerFirstTurnNoProgressTimeout
+	appServerSemanticInactivityTimeout = 40 * time.Millisecond
+	appServerFirstTurnNoProgressTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		appServerSemanticInactivityTimeout = originalSemantic
+		appServerFirstTurnNoProgressTimeout = originalNoProgress
+	})
+
+	dir := t.TempDir()
+	spec := testAppServerSessionSpec(dir)
+	sink := &recordingSink{}
+	deps := testAppServerManagerDepsWithSink(sink)
+	broker := NewPermissionBroker(sink)
+	deps.Permission = broker
+	manager := newAppServerManager(deps)
+	session, err := manager.Start(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
+
+	decisionErr := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			for _, event := range sink.snapshot() {
+				if event.Kind == SessionEventPermissionRequest && event.ActionID != "" {
+					time.Sleep(80 * time.Millisecond)
+					_, err := broker.Decide(context.Background(), event.ActionID, "allow_once")
+					decisionErr <- err
+					return
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+		decisionErr <- fmt.Errorf("permission request was not published")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := manager.Prompt(ctx, SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
+		SessionID: session.SessionID,
+		Prompt:    []PromptContentBlock{TextBlock("hello slow approval")},
+	})
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+	if err := <-decisionErr; err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	if resp.StopReason != StopReasonEndTurn {
+		t.Fatalf("StopReason = %q, want %q", resp.StopReason, StopReasonEndTurn)
+	}
+	for _, event := range sink.snapshot() {
+		if event.Kind == SessionEventPromptFailed {
+			t.Fatalf("events = %#v, want approval wait without prompt timeout", sink.snapshot())
+		}
+	}
+}
+
+func TestAppServerManagerPromptApprovalCancelsWithTurnContext(t *testing.T) {
+	withAppServerHelperCommand(t, "prompt-approval-cancel")
+	dir := t.TempDir()
+	spec := testAppServerSessionSpec(dir)
+	sink := &recordingSink{}
+	deps := testAppServerManagerDepsWithSink(sink)
+	broker := NewPermissionBroker(sink)
+	deps.Permission = broker
+	manager := newAppServerManager(deps)
+	session, err := manager.Start(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	_, err = manager.Prompt(ctx, SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
+		SessionID: session.SessionID,
+		Prompt:    []PromptContentBlock{TextBlock("hello cancel approval")},
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Prompt() error = %v, want context deadline exceeded", err)
+	}
+
+	waitForRuntime(t, func() bool {
+		for _, event := range sink.snapshot() {
+			if event.Kind == SessionEventPermissionDecision && event.ActionStatus == string(PermissionStatusCanceled) {
+				return true
+			}
+		}
+		return false
+	})
+	for _, event := range sink.snapshot() {
+		if event.Kind == SessionEventPermissionRequest {
+			if snapshot, ok := event.Payload.(PermissionSnapshot); !ok || !hasPermissionOptions(snapshot.Options, "allow_once", "allow_always", "reject") {
+				t.Fatalf("permission payload = %#v, want allow once, allow always, and reject", event.Payload)
+			}
+		}
+	}
+}
+
+func TestAppServerApprovalResponseUsesCurrentCodexDecisionNames(t *testing.T) {
+	if got := appServerApprovalResponse(false)["decision"]; got != "decline" {
+		t.Fatalf("rejected approval decision = %#v, want decline", got)
+	}
+	if got := appServerApprovalDecisionResponse(PermissionStatusRejected)["decision"]; got != "decline" {
+		t.Fatalf("rejected permission status decision = %#v, want decline", got)
+	}
+	if got := appServerApprovalDecisionResponse(PermissionStatusCanceled)["decision"]; got != "cancel" {
+		t.Fatalf("canceled permission status decision = %#v, want cancel", got)
+	}
+	if got := appServerApprovalDecisionResponse(PermissionStatusExpired)["decision"]; got != "cancel" {
+		t.Fatalf("expired permission status decision = %#v, want cancel", got)
+	}
+}
+
+func hasPermissionOptions(options []PermissionOptionSnapshot, want ...string) bool {
+	if len(options) != len(want) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(options))
+	for _, option := range options {
+		seen[strings.TrimSpace(option.ID)] = struct{}{}
+	}
+	for _, id := range want {
+		if _, ok := seen[id]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func TestAppServerEventAdapterRawTextAndToolEvents(t *testing.T) {
@@ -785,7 +955,7 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				return nil, false
 			}
 		})
-	case "prompt-agent-message-complete":
+	case "prompt-idle-status-complete":
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
 			switch msg["method"] {
 			case "thread/start":
@@ -794,6 +964,7 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				assertTurnStartParams(t, msg, "main-thread", "medium", "hello codex")
 				writeRPCNotification(t, "turn/started", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-1"}})
 				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "item-1", "type": "agentMessage", "text": "done"}})
+				writeRPCNotification(t, "thread/status/changed", map[string]any{"threadId": "main-thread", "status": map[string]any{"type": "idle"}})
 				return rpcResult(msg["id"], map[string]any{"turnId": "turn-1"}), true
 			default:
 				return nil, false
@@ -928,8 +1099,6 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 					}
 				})
 				awaitingApproval = false
-				writeRPCNotification(t, "turn/started", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-approval"}})
-				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "item-approval", "type": "agentMessage", "text": "approved"}})
 				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-approval", "status": "completed"}})
 				return nil, false
 			}
@@ -938,9 +1107,61 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
 			case "turn/start":
 				assertTurnStartParams(t, msg, "main-thread", "medium", "hello with approval")
+				writeRPCNotification(t, "turn/started", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-approval"}})
+				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "item-preapproval", "type": "agentMessage", "text": "preparing approval"}})
 				awaitingApproval = true
-				writeRPCServerRequest(t, 9001, "item/commandExecution/requestApproval", map[string]any{})
+				writeRPCServerRequest(t, 9001, "item/commandExecution/requestApproval", map[string]any{"command": "go test ./..."})
 				return rpcResult(msg["id"], map[string]any{"turnId": "turn-approval"}), true
+			default:
+				return nil, false
+			}
+		})
+	case "prompt-approval-wait-without-progress":
+		awaitingApproval := false
+		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
+			if awaitingApproval {
+				assertServerRequestResponse(t, msg, 9001, func(result map[string]any) {
+					if got := result["decision"]; got != "accept" {
+						t.Fatalf("slow approval decision = %#v, want accept", got)
+					}
+				})
+				awaitingApproval = false
+				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-slow-approval", "status": "completed"}})
+				return nil, false
+			}
+			switch msg["method"] {
+			case "thread/start":
+				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+			case "turn/start":
+				assertTurnStartParams(t, msg, "main-thread", "medium", "hello slow approval")
+				writeRPCNotification(t, "turn/started", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-slow-approval"}})
+				awaitingApproval = true
+				writeRPCServerRequest(t, 9001, "item/commandExecution/requestApproval", map[string]any{"command": "go test ./..."})
+				return rpcResult(msg["id"], map[string]any{"turnId": "turn-slow-approval"}), true
+			default:
+				return nil, false
+			}
+		})
+	case "prompt-approval-cancel":
+		awaitingApproval := false
+		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
+			if awaitingApproval {
+				assertServerRequestResponse(t, msg, 9001, func(result map[string]any) {
+					if got := result["decision"]; got != "cancel" {
+						t.Fatalf("canceled approval decision = %#v, want cancel", got)
+					}
+				})
+				awaitingApproval = false
+				return nil, false
+			}
+			switch msg["method"] {
+			case "thread/start":
+				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+			case "turn/start":
+				assertTurnStartParams(t, msg, "main-thread", "medium", "hello cancel approval")
+				awaitingApproval = true
+				writeRPCServerRequest(t, 9001, "item/commandExecution/requestApproval", map[string]any{"command": "go test ./..."})
+				return rpcResult(msg["id"], map[string]any{"turnId": "turn-approval-cancel"}), true
 			default:
 				return nil, false
 			}

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -394,7 +394,7 @@ func TestAppServerManagerPromptApprovalUsesPermissionBroker(t *testing.T) {
 		for time.Now().Before(deadline) {
 			for _, event := range sink.snapshot() {
 				if event.Kind == SessionEventPermissionRequest && event.ActionID != "" {
-					_, err := broker.Decide(context.Background(), event.ActionID, "allow_once")
+					_, err := broker.Decide(context.Background(), event.ActionID, "allow_always")
 					decisionErr <- err
 					return
 				}
@@ -545,17 +545,47 @@ func TestAppServerManagerPromptApprovalCancelsWithTurnContext(t *testing.T) {
 }
 
 func TestAppServerApprovalResponseUsesCurrentCodexDecisionNames(t *testing.T) {
-	if got := appServerApprovalResponse(false)["decision"]; got != "decline" {
+	if got := appServerApprovalResponse("item/commandExecution/requestApproval", false)["decision"]; got != "decline" {
 		t.Fatalf("rejected approval decision = %#v, want decline", got)
 	}
-	if got := appServerApprovalDecisionResponse(PermissionStatusRejected)["decision"]; got != "decline" {
+	if got := appServerApprovalDecisionResponse("item/commandExecution/requestApproval", PermissionSnapshot{Status: PermissionStatusRejected})["decision"]; got != "decline" {
 		t.Fatalf("rejected permission status decision = %#v, want decline", got)
 	}
-	if got := appServerApprovalDecisionResponse(PermissionStatusCanceled)["decision"]; got != "cancel" {
+	if got := appServerApprovalDecisionResponse("item/commandExecution/requestApproval", PermissionSnapshot{Status: PermissionStatusCanceled})["decision"]; got != "cancel" {
 		t.Fatalf("canceled permission status decision = %#v, want cancel", got)
 	}
-	if got := appServerApprovalDecisionResponse(PermissionStatusExpired)["decision"]; got != "cancel" {
+	if got := appServerApprovalDecisionResponse("item/commandExecution/requestApproval", PermissionSnapshot{Status: PermissionStatusExpired})["decision"]; got != "cancel" {
 		t.Fatalf("expired permission status decision = %#v, want cancel", got)
+	}
+	if got := appServerApprovalDecisionResponse("item/commandExecution/requestApproval", PermissionSnapshot{
+		Status:   PermissionStatusAllowed,
+		Decision: &PermissionDecisionSnapshot{Kind: PermissionOptionKindAllowOnce},
+	})["decision"]; got != "accept" {
+		t.Fatalf("allow once permission decision = %#v, want accept", got)
+	}
+	if got := appServerApprovalDecisionResponse("item/commandExecution/requestApproval", PermissionSnapshot{
+		Status:   PermissionStatusAllowed,
+		Decision: &PermissionDecisionSnapshot{Kind: PermissionOptionKindAllowAlways},
+	})["decision"]; got != "acceptForSession" {
+		t.Fatalf("allow always permission decision = %#v, want acceptForSession", got)
+	}
+	if got := appServerApprovalResponse("applyPatchApproval", true)["decision"]; got != "approved" {
+		t.Fatalf("legacy auto approval decision = %#v, want approved", got)
+	}
+	if got := appServerApprovalDecisionResponse("execCommandApproval", PermissionSnapshot{Status: PermissionStatusRejected})["decision"]; got != "denied" {
+		t.Fatalf("legacy rejected permission decision = %#v, want denied", got)
+	}
+	if got := appServerApprovalDecisionResponse("execCommandApproval", PermissionSnapshot{Status: PermissionStatusCanceled})["decision"]; got != "abort" {
+		t.Fatalf("legacy canceled permission decision = %#v, want abort", got)
+	}
+	if got := appServerApprovalDecisionResponse("execCommandApproval", PermissionSnapshot{Status: PermissionStatusExpired})["decision"]; got != "timed_out" {
+		t.Fatalf("legacy expired permission decision = %#v, want timed_out", got)
+	}
+	if got := appServerApprovalDecisionResponse("execCommandApproval", PermissionSnapshot{
+		Status:   PermissionStatusAllowed,
+		Decision: &PermissionDecisionSnapshot{Kind: PermissionOptionKindAllowAlways},
+	})["decision"]; got != "approved_for_session" {
+		t.Fatalf("legacy allow always permission decision = %#v, want approved_for_session", got)
 	}
 }
 
@@ -1046,8 +1076,8 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
 			if awaitingApproval {
 				assertServerRequestResponse(t, msg, 9001, func(result map[string]any) {
-					if got := result["decision"]; got != "accept" {
-						t.Fatalf("file approval decision = %#v, want accept", got)
+					if got := result["decision"]; got != "approved" {
+						t.Fatalf("file approval decision = %#v, want approved", got)
 					}
 				})
 				awaitingApproval = false
@@ -1094,8 +1124,8 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
 			if awaitingApproval {
 				assertServerRequestResponse(t, msg, 9001, func(result map[string]any) {
-					if got := result["decision"]; got != "accept" {
-						t.Fatalf("turn approval decision = %#v, want accept", got)
+					if got := result["decision"]; got != "acceptForSession" {
+						t.Fatalf("turn approval decision = %#v, want acceptForSession", got)
 					}
 				})
 				awaitingApproval = false

--- a/internal/runtime/codex/permission_broker.go
+++ b/internal/runtime/codex/permission_broker.go
@@ -378,7 +378,7 @@ func permissionOptionAllows(kind string) bool {
 
 func permissionOptionScope(kind string) string {
 	if strings.TrimSpace(kind) == PermissionOptionKindAllowAlways {
-		return activity.ActionOptionScopeAgent
+		return activity.ActionOptionScopeSession
 	}
 	return ""
 }

--- a/internal/runtime/codex/permission_broker.go
+++ b/internal/runtime/codex/permission_broker.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultPermissionTimeout  = time.Minute
+	defaultPermissionTimeout  = 5 * time.Minute
 	defaultPermissionCacheTTL = 10 * time.Minute
 )
 

--- a/internal/runtime/codex/permission_broker_test.go
+++ b/internal/runtime/codex/permission_broker_test.go
@@ -23,6 +23,37 @@ func TestPermissionBrokerRequestIDUsesProcessPrefix(t *testing.T) {
 	}
 }
 
+func TestPermissionBrokerDefaultTimeoutIsLongEnoughForRemoteApproval(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	broker := NewPermissionBroker(sink)
+	requestedAt := time.Date(2026, 6, 22, 10, 30, 0, 0, time.UTC)
+	resultCh := make(chan PermissionDecision, 1)
+	go func() {
+		decision, _ := broker.Request(context.Background(), PendingPermissionRequest{
+			ExecutionRef: activity.ExecutionRef{RuntimeID: "rt-1", SessionID: "sess-1"},
+			RequestedAt:  requestedAt,
+			Options:      []PermissionOptionSnapshot{{ID: "reject", Kind: "reject", Label: "Reject"}},
+		})
+		resultCh <- decision
+	}()
+
+	waitForRuntime(t, func() bool { return len(sink.snapshot()) == 1 })
+	event := sink.snapshot()[0]
+	snapshot, ok := event.Payload.(PermissionSnapshot)
+	if !ok {
+		t.Fatalf("permission payload = %T, want PermissionSnapshot", event.Payload)
+	}
+	if got := snapshot.ExpiresAt.Sub(requestedAt); got != 5*time.Minute {
+		t.Fatalf("default permission timeout = %s, want 5m", got)
+	}
+	if _, err := broker.Decide(context.Background(), event.ActionID, "reject"); err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+	<-resultCh
+}
+
 func TestPermissionBrokerDecideSelectsOption(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/codex/permission_broker_test.go
+++ b/internal/runtime/codex/permission_broker_test.go
@@ -99,14 +99,14 @@ func TestPermissionBrokerDecideSelectsOption(t *testing.T) {
 	}
 }
 
-func TestNormalizePermissionOptionsMarksRememberedDecisionsAsAgentScoped(t *testing.T) {
+func TestNormalizePermissionOptionsMarksSessionDecisionsAsSessionScoped(t *testing.T) {
 	t.Parallel()
 
 	options := NormalizePermissionOptions([]ExternalPermissionOption{
 		{
 			ID:    "always",
 			Kind:  PermissionOptionKindAllowAlways,
-			Label: "Allow always",
+			Label: "Allow for session",
 		},
 		{
 			ID:    "once",
@@ -115,8 +115,11 @@ func TestNormalizePermissionOptionsMarksRememberedDecisionsAsAgentScoped(t *test
 		},
 	})
 
-	if options[0].Scope != activity.ActionOptionScopeAgent {
-		t.Fatalf("allow_always scope = %q, want %q", options[0].Scope, activity.ActionOptionScopeAgent)
+	if options[0].Label != "Allow for session" {
+		t.Fatalf("allow_always label = %q, want %q", options[0].Label, "Allow for session")
+	}
+	if options[0].Scope != activity.ActionOptionScopeSession {
+		t.Fatalf("allow_always scope = %q, want %q", options[0].Scope, activity.ActionOptionScopeSession)
 	}
 	if options[1].Scope != "" {
 		t.Fatalf("allow_once scope = %q, want empty", options[1].Scope)

--- a/internal/runtime/codex/session_manager.go
+++ b/internal/runtime/codex/session_manager.go
@@ -19,7 +19,6 @@ type liveSession struct {
 	spec                 SessionSpec
 	conversationSessions map[string]string
 	turnWaiters          map[string]*appServerTurnWaiter
-	fallbackCompleted    map[string]struct{}
 	appProtocol          string
 }
 

--- a/web/app/src/models/agentActivity.ts
+++ b/web/app/src/models/agentActivity.ts
@@ -94,7 +94,11 @@ export function isToolActivityMessage(message: IMMessage | null | undefined): bo
 
 export function actionOptionLabel(option: AgentActivityActionOption): string {
   const label = stringValue(option.label, option.kind, option.id);
-  if (optionScope(option) === "agent" && !/\bagent\b/i.test(label)) {
+  const scope = optionScope(option);
+  if (scope === "session" && !/\bsession\b/i.test(label)) {
+    return `${label} (this session)`;
+  }
+  if (scope === "agent" && !/\bagent\b/i.test(label)) {
     return `${label} (this agent)`;
   }
   return label;
@@ -200,7 +204,7 @@ function optionScope(option: AgentActivityActionOption): string {
 }
 
 function defaultOptionScope(kind: string): string {
-  return kind === "allow_always" ? "agent" : "";
+  return kind === "allow_always" ? "session" : "";
 }
 
 function isRecord(value: unknown): value is UnknownRecord {

--- a/web/app/tests/components/MessageContent.test.tsx
+++ b/web/app/tests/components/MessageContent.test.tsx
@@ -226,7 +226,7 @@ describe("MessageContent", () => {
     );
 
     expect(screen.getByText("Permission request")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Allow always \(this agent\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Allow always \(this session\)/ })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Allow once/ }));
 


### PR DESCRIPTION
## Summary
- add Feishu interactive card delivery and updates for Codex permission requests
- route Feishu card button decisions through the Codex permission broker
- preserve Codex allow-always decisions as session-scoped app-server approvals
- extend participant secret redaction and bind tests for Feishu app config

## Validation
- codex-cli 0.130.0 app-server schemas checked for current and legacy approval decision names
- go test ./internal/runtime/codex
- go test ./...
- git diff --check

## Impact
- Feishu users can approve, always approve for the Codex session, or reject Codex tool permission requests from message cards over the existing long connection
- Codex app-server approvals now wait on broker decisions when an activity decision path is configured