### PR TITLE
feat(upgrade): add Windows upgrade support with launcher layout handling

### DIFF
--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -19,10 +19,20 @@ type cmd struct{}
 var newUpgradeClient = func(run *command.Context) upgrade.Client {
 	return upgrade.Client{
 		HTTPClient: run.HTTPClient,
-		GOOS:       runtime.GOOS,
+		GOOS:       currentGOOS,
 		GOARCH:     runtime.GOARCH,
 	}
 }
+
+var (
+	currentGOOS     = runtime.GOOS
+	installPrepared = func(client upgrade.Client, prepared upgrade.PreparedBundle) (upgrade.InstalledBundle, error) {
+		return client.InstallPrepared(prepared)
+	}
+	stopDaemonFromExecutable  = upgrade.StopDaemonFromExecutable
+	startDaemonFromExecutable = upgrade.StartDaemonFromExecutable
+	startInstalledDaemon      = upgrade.StartInstalledDaemon
+)
 
 func NewCmd() command.Command {
 	return cmd{}
@@ -81,8 +91,21 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 	}
 	defer os.RemoveAll(prepared.WorkDir)
 
-	installed, err := client.InstallPrepared(prepared)
+	var stopped upgrade.RestartResult
+	if currentGOOS == "windows" && !*noRestart {
+		stopped, err = stopDaemonFromExecutable(ctx)
+		if err != nil {
+			return fail(err)
+		}
+	}
+
+	installed, err := installPrepared(client, prepared)
 	if err != nil {
+		if currentGOOS == "windows" && stopped.DaemonWasRunning {
+			if restartErr := startDaemonFromExecutable(ctx, upgrade.RestartOptions{ConfigPath: globals.Config}); restartErr != nil {
+				return fail(fmt.Errorf("%w\nAlso failed to restart daemon that was running before upgrade: %v", err, restartErr))
+			}
+		}
 		return fail(err)
 	}
 	if *noRestart {
@@ -90,11 +113,24 @@ func (c cmd) Run(ctx context.Context, run *command.Context, args []string, globa
 		return renderInstallResult(globals.Output, run.Stdout, result, installed, upgrade.RestartResult{}, run.Program, true)
 	}
 
-	restarted, err := client.RestartIfRunning(ctx, installed, upgrade.RestartOptions{
-		ConfigPath: globals.Config,
-	})
-	if err != nil {
-		return fail(err)
+	restarted := upgrade.RestartResult{}
+	if currentGOOS == "windows" {
+		restarted = stopped
+		if stopped.DaemonWasRunning {
+			restarted, err = startInstalledDaemon(ctx, installed, upgrade.RestartOptions{
+				ConfigPath: globals.Config,
+			})
+			if err != nil {
+				return fail(err)
+			}
+		}
+	} else {
+		restarted, err = client.RestartIfRunning(ctx, installed, upgrade.RestartOptions{
+			ConfigPath: globals.Config,
+		})
+		if err != nil {
+			return fail(err)
+		}
 	}
 	if !*noRestart && !restarted.DaemonWasRunning {
 		if recordErr := applyArtifacts.RecordManualRestartRequired("manual restart required"); recordErr != nil {

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"io"
 	"net/http"
@@ -85,6 +86,84 @@ func TestRunNoRestartInstallsBundle(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want substring %q", stdout.String(), want)
 		}
+	}
+	assertFileContent(t, filepath.Join(installRoot, "README.md"), "new")
+}
+
+func TestRunWindowsNoRestartDoesNotStopDaemon(t *testing.T) {
+	originalVersion := appversion.Version
+	appversion.Version = "v0.2.5"
+	t.Cleanup(func() { appversion.Version = originalVersion })
+
+	originalGOOS := currentGOOS
+	originalStop := stopDaemonFromExecutable
+	originalStart := startDaemonFromExecutable
+	currentGOOS = "windows"
+	stopDaemonFromExecutable = func(context.Context) (internalupgrade.RestartResult, error) {
+		t.Fatal("stopDaemonFromExecutable should not be called with --no-restart")
+		return internalupgrade.RestartResult{}, nil
+	}
+	startDaemonFromExecutable = func(context.Context, internalupgrade.RestartOptions) error {
+		t.Fatal("startDaemonFromExecutable should not be called with --no-restart")
+		return nil
+	}
+	t.Cleanup(func() {
+		currentGOOS = originalGOOS
+		stopDaemonFromExecutable = originalStop
+		startDaemonFromExecutable = originalStart
+	})
+
+	installRoot := writeInstalledBundle(t, t.TempDir(), "old")
+	archive := releaseTarball(t, map[string]string{
+		"csgclaw/bin/csgclaw": "#!/bin/sh\n# new\n",
+		"csgclaw/bin/boxlite": "#!/bin/sh\n# new boxlite\n",
+		"csgclaw/README.md":   "new",
+	})
+	sum := sha256.Sum256(archive)
+
+	originalClientFactory := newUpgradeClient
+	newUpgradeClient = func(run *command.Context) internalupgrade.Client {
+		return internalupgrade.Client{
+			HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case "https://example.test/releases/latest":
+					return jsonResponse(http.StatusOK, `{
+						"name":"v0.2.7",
+						"assets":[{"name":"csgclaw_v0.2.7_darwin_arm64.tar.gz","browser_download_url":"https://downloads.example.test/csgclaw.tar.gz","size":`+strconv.Itoa(len(archive))+`,"sha256":"`+hex.EncodeToString(sum[:])+`"}]
+					}`), nil
+				case "https://downloads.example.test/csgclaw.tar.gz":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Header:     make(http.Header),
+						Body:       io.NopCloser(bytes.NewReader(archive)),
+					}, nil
+				default:
+					t.Fatalf("unexpected URL %q", req.URL.String())
+					return nil, nil
+				}
+			}),
+			LatestURL: "https://example.test/releases/latest",
+			GOOS:      "darwin",
+			GOARCH:    "arm64",
+			ExecutablePath: func() (string, error) {
+				return filepath.Join(installRoot, "bin", "csgclaw"), nil
+			},
+		}
+	}
+	t.Cleanup(func() { newUpgradeClient = originalClientFactory })
+
+	var stdout bytes.Buffer
+	err := NewCmd().Run(context.Background(), &command.Context{
+		Program: "csgclaw",
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}, []string{"--no-restart"}, command.GlobalOptions{Output: "table"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Restart skipped") {
+		t.Fatalf("stdout = %q, want restart skipped", stdout.String())
 	}
 	assertFileContent(t, filepath.Join(installRoot, "README.md"), "new")
 }
@@ -169,6 +248,95 @@ func TestRunRestartsRunningDaemonAfterInstall(t *testing.T) {
 	}
 	if got := string(logData); got != "stop\nserve --daemon\n" {
 		t.Fatalf("restart log = %q, want stop then serve", got)
+	}
+}
+
+func TestRunWindowsRestartsStoppedDaemonWhenInstallFails(t *testing.T) {
+	originalVersion := appversion.Version
+	appversion.Version = "v0.2.5"
+	t.Cleanup(func() { appversion.Version = originalVersion })
+
+	originalGOOS := currentGOOS
+	originalStop := stopDaemonFromExecutable
+	originalStart := startDaemonFromExecutable
+	originalInstall := installPrepared
+	currentGOOS = "windows"
+	stopCalls := 0
+	startCalls := 0
+	stopDaemonFromExecutable = func(context.Context) (internalupgrade.RestartResult, error) {
+		stopCalls++
+		return internalupgrade.RestartResult{DaemonWasRunning: true}, nil
+	}
+	startDaemonFromExecutable = func(_ context.Context, opts internalupgrade.RestartOptions) error {
+		startCalls++
+		if opts.ConfigPath != "/tmp/csgclaw-test-config.toml" {
+			t.Fatalf("ConfigPath = %q, want test config path", opts.ConfigPath)
+		}
+		return nil
+	}
+	installPrepared = func(internalupgrade.Client, internalupgrade.PreparedBundle) (internalupgrade.InstalledBundle, error) {
+		return internalupgrade.InstalledBundle{}, errors.New("install exploded")
+	}
+	t.Cleanup(func() {
+		currentGOOS = originalGOOS
+		stopDaemonFromExecutable = originalStop
+		startDaemonFromExecutable = originalStart
+		installPrepared = originalInstall
+	})
+
+	installRoot := writeInstalledBundle(t, t.TempDir(), "old")
+	archive := releaseTarball(t, map[string]string{
+		"csgclaw/bin/csgclaw": "#!/bin/sh\n# new\n",
+		"csgclaw/bin/boxlite": "#!/bin/sh\n# new boxlite\n",
+		"csgclaw/README.md":   "new",
+	})
+	sum := sha256.Sum256(archive)
+
+	originalClientFactory := newUpgradeClient
+	newUpgradeClient = func(run *command.Context) internalupgrade.Client {
+		return internalupgrade.Client{
+			HTTPClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.String() {
+				case "https://example.test/releases/latest":
+					return jsonResponse(http.StatusOK, `{
+						"name":"v0.2.7",
+						"assets":[{"name":"csgclaw_v0.2.7_darwin_arm64.tar.gz","browser_download_url":"https://downloads.example.test/csgclaw.tar.gz","size":`+strconv.Itoa(len(archive))+`,"sha256":"`+hex.EncodeToString(sum[:])+`"}]
+					}`), nil
+				case "https://downloads.example.test/csgclaw.tar.gz":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     http.StatusText(http.StatusOK),
+						Header:     make(http.Header),
+						Body:       io.NopCloser(bytes.NewReader(archive)),
+					}, nil
+				default:
+					t.Fatalf("unexpected URL %q", req.URL.String())
+					return nil, nil
+				}
+			}),
+			LatestURL: "https://example.test/releases/latest",
+			GOOS:      "darwin",
+			GOARCH:    "arm64",
+			ExecutablePath: func() (string, error) {
+				return filepath.Join(installRoot, "bin", "csgclaw"), nil
+			},
+		}
+	}
+	t.Cleanup(func() { newUpgradeClient = originalClientFactory })
+
+	err := NewCmd().Run(context.Background(), &command.Context{
+		Program: "csgclaw",
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}, nil, command.GlobalOptions{Output: "table", Config: "/tmp/csgclaw-test-config.toml"})
+	if err == nil || !strings.Contains(err.Error(), "install exploded") {
+		t.Fatalf("Run() error = %v, want install failure", err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+	if startCalls != 1 {
+		t.Fatalf("start calls = %d, want 1", startCalls)
 	}
 }
 

--- a/internal/upgrade/helper.go
+++ b/internal/upgrade/helper.go
@@ -2,9 +2,14 @@ package upgrade
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 )
+
+const upgradeHelperTempPattern = "csgclaw-upgrade-helper-*"
 
 var (
 	startHelperExecutable = os.Executable
@@ -16,9 +21,9 @@ type ApplyHelperOptions struct {
 }
 
 func StartApplyHelper(opts ApplyHelperOptions) error {
-	exe, err := startHelperExecutable()
+	exe, originalExe, err := helperLaunchExecutable()
 	if err != nil {
-		return fmt.Errorf("resolve executable: %w", err)
+		return err
 	}
 
 	artifacts, err := PrepareApplyArtifacts(opts.ConfigPath)
@@ -42,6 +47,9 @@ func StartApplyHelper(opts ApplyHelperOptions) error {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.Env = append(os.Environ(), artifacts.Env()...)
+	if originalExe != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", originalExecutableEnvVar, originalExe))
+	}
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
@@ -56,4 +64,64 @@ func StartApplyHelper(opts ApplyHelperOptions) error {
 	}()
 
 	return nil
+}
+
+func helperLaunchExecutable() (string, string, error) {
+	exe, err := startHelperExecutable()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve executable: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		return exe, exe, nil
+	}
+	cleanupUpgradeHelperTempDirs("")
+	launchExe, err := copyHelperExecutableToTemp(exe)
+	if err != nil {
+		return "", "", err
+	}
+	return launchExe, exe, nil
+}
+
+func copyHelperExecutableToTemp(exe string) (string, error) {
+	src, err := os.Open(exe)
+	if err != nil {
+		return "", fmt.Errorf("open helper executable %s: %w", exe, err)
+	}
+	defer src.Close()
+
+	helperDir, err := os.MkdirTemp("", upgradeHelperTempPattern)
+	if err != nil {
+		return "", fmt.Errorf("create helper temp dir: %w", err)
+	}
+
+	target := filepath.Join(helperDir, filepath.Base(exe))
+	dst, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o700)
+	if err != nil {
+		return "", fmt.Errorf("create helper executable %s: %w", target, err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return "", fmt.Errorf("copy helper executable to %s: %w", target, err)
+	}
+	if err := dst.Close(); err != nil {
+		return "", fmt.Errorf("close helper executable %s: %w", target, err)
+	}
+	return target, nil
+}
+
+func cleanupUpgradeHelperTempDirs(tempRoot string) {
+	if tempRoot == "" {
+		tempRoot = os.TempDir()
+	}
+	matches, err := filepath.Glob(filepath.Join(tempRoot, upgradeHelperTempPattern))
+	if err != nil {
+		return
+	}
+	for _, path := range matches {
+		info, err := os.Lstat(path)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		_ = os.RemoveAll(path)
+	}
 }

--- a/internal/upgrade/helper_test.go
+++ b/internal/upgrade/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -18,9 +19,8 @@ func TestStartApplyHelperIncludesConfigPath(t *testing.T) {
 		startHelperCommand = origCommand
 	})
 
-	startHelperExecutable = func() (string, error) {
-		return "/tmp/csgclaw", nil
-	}
+	helperPath := writeTestHelperExecutable(t)
+	startHelperExecutable = func() (string, error) { return helperPath, nil }
 
 	var gotName string
 	var gotArgs []string
@@ -28,7 +28,7 @@ func TestStartApplyHelperIncludesConfigPath(t *testing.T) {
 	startHelperCommand = func(name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string(nil), args...)
-		startedCmd = exec.Command("sh", "-c", "exit 0")
+		startedCmd = testNoopCommand()
 		return startedCmd
 	}
 
@@ -37,8 +37,15 @@ func TestStartApplyHelperIncludesConfigPath(t *testing.T) {
 		t.Fatalf("StartApplyHelper() error = %v", err)
 	}
 
-	if gotName != "/tmp/csgclaw" {
-		t.Fatalf("command name = %q, want %q", gotName, "/tmp/csgclaw")
+	if runtime.GOOS == "windows" {
+		if gotName == helperPath {
+			t.Fatalf("command name = %q, want temp helper copy instead of original executable", gotName)
+		}
+		if filepath.Base(gotName) != filepath.Base(helperPath) {
+			t.Fatalf("command name base = %q, want %q", filepath.Base(gotName), filepath.Base(helperPath))
+		}
+	} else if gotName != helperPath {
+		t.Fatalf("command name = %q, want %q", gotName, helperPath)
 	}
 	wantArgs := []string{"--config", configPath, "upgrade"}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
@@ -63,6 +70,17 @@ func TestStartApplyHelperIncludesConfigPath(t *testing.T) {
 			t.Fatalf("command env missing %q in %#v", want, startedCmd.Env)
 		}
 	}
+	wantOriginalExecutable := originalExecutableEnvVar + "=" + helperPath
+	foundOriginalExecutable := false
+	for _, got := range startedCmd.Env {
+		if got == wantOriginalExecutable {
+			foundOriginalExecutable = true
+			break
+		}
+	}
+	if !foundOriginalExecutable {
+		t.Fatalf("command env missing %q in %#v", wantOriginalExecutable, startedCmd.Env)
+	}
 }
 
 func TestStartApplyHelperOmitsEmptyConfigPath(t *testing.T) {
@@ -73,15 +91,15 @@ func TestStartApplyHelperOmitsEmptyConfigPath(t *testing.T) {
 		startHelperCommand = origCommand
 	})
 
-	startHelperExecutable = func() (string, error) {
-		return "/tmp/csgclaw", nil
-	}
+	helperPath := writeTestHelperExecutable(t)
+	startHelperExecutable = func() (string, error) { return helperPath, nil }
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 
 	var gotArgs []string
 	startHelperCommand = func(name string, args ...string) *exec.Cmd {
 		gotArgs = append([]string(nil), args...)
-		cmd := exec.Command("sh", "-c", "exit 0")
+		cmd := testNoopCommand()
 		return cmd
 	}
 
@@ -101,9 +119,8 @@ func TestStartApplyHelperReturnsLogOpenError(t *testing.T) {
 		startHelperExecutable = origExecutable
 	})
 
-	startHelperExecutable = func() (string, error) {
-		return "/tmp/csgclaw", nil
-	}
+	helperPath := writeTestHelperExecutable(t)
+	startHelperExecutable = func() (string, error) { return helperPath, nil }
 
 	configPath := filepath.Join(t.TempDir(), "blocked", "config.toml")
 	if err := os.WriteFile(filepath.Dir(configPath), []byte("file blocks dir"), 0o600); err != nil {
@@ -114,4 +131,48 @@ func TestStartApplyHelperReturnsLogOpenError(t *testing.T) {
 	if err == nil || (!errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "create upgrade helper state dir")) {
 		t.Fatalf("StartApplyHelper() error = %v, want artifact setup failure", err)
 	}
+}
+
+func TestCleanupUpgradeHelperTempDirsRemovesOnlyHelperDirs(t *testing.T) {
+	tempRoot := t.TempDir()
+	oldHelperDir := filepath.Join(tempRoot, "csgclaw-upgrade-helper-old")
+	keepDir := filepath.Join(tempRoot, "csgclaw-other-temp")
+	if err := os.MkdirAll(oldHelperDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", oldHelperDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(oldHelperDir, "csgclaw.exe"), []byte("old helper"), 0o600); err != nil {
+		t.Fatalf("WriteFile(old helper) error = %v", err)
+	}
+	if err := os.MkdirAll(keepDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", keepDir, err)
+	}
+
+	cleanupUpgradeHelperTempDirs(tempRoot)
+
+	if _, err := os.Stat(oldHelperDir); !os.IsNotExist(err) {
+		t.Fatalf("old helper dir still exists, stat err = %v", err)
+	}
+	if _, err := os.Stat(keepDir); err != nil {
+		t.Fatalf("keep dir stat error = %v", err)
+	}
+}
+
+func writeTestHelperExecutable(t *testing.T) string {
+	t.Helper()
+	name := "csgclaw"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("helper"), 0o700); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func testNoopCommand() *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+	return exec.Command("sh", "-c", "exit 0")
 }

--- a/internal/upgrade/install.go
+++ b/internal/upgrade/install.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -20,6 +21,8 @@ var (
 	openFile     = os.OpenFile
 	nowUTC       = func() time.Time { return time.Now().UTC() }
 )
+
+const originalExecutableEnvVar = "CSGCLAW_ORIGINAL_EXECUTABLE"
 
 var ErrNotOfficialBundle = errors.New("current executable is not installed from an official csgclaw bundle")
 
@@ -62,6 +65,12 @@ func (c Client) officialInstallRoot() (string, error) {
 		if !ok {
 			continue
 		}
+		if launcherRoot, ok := installedBundleRootFromLauncher(root); ok {
+			return launcherRoot, nil
+		}
+		if isLauncherInstallRoot(root) {
+			continue
+		}
 		if err := validateBundleDir(root); err == nil {
 			return root, nil
 		}
@@ -75,6 +84,9 @@ func (c Client) officialInstallRoot() (string, error) {
 func (c Client) resolvedExecutablePath() (string, error) {
 	if c.ExecutablePath != nil {
 		return c.ExecutablePath()
+	}
+	if exe := strings.TrimSpace(os.Getenv(originalExecutableEnvVar)); exe != "" {
+		return exe, nil
 	}
 	return os.Executable()
 }
@@ -143,6 +155,55 @@ func isOfficialInstallerManagedPath(root string) bool {
 		return false
 	}
 	return filepath.Base(versionDir) != "." && filepath.Base(versionDir) != string(filepath.Separator)
+}
+
+func installedBundleRootFromLauncher(root string) (string, bool) {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if !isLauncherInstallRoot(root) {
+		return "", false
+	}
+
+	libDir := filepath.Join(root, "lib", "csgclaw")
+	entries, err := readDir(libDir)
+	if err != nil {
+		return "", false
+	}
+
+	type bundleCandidate struct {
+		version string
+		root    string
+	}
+
+	var candidates []bundleCandidate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		bundleRoot := filepath.Join(libDir, entry.Name(), "csgclaw")
+		if err := validateBundleDir(bundleRoot); err != nil && !isLegacyOfficialInstallRoot(bundleRoot) {
+			continue
+		}
+		candidates = append(candidates, bundleCandidate{
+			version: entry.Name(),
+			root:    bundleRoot,
+		})
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+	slices.SortFunc(candidates, func(a, b bundleCandidate) int {
+		return compareSemver(b.version, a.version)
+	})
+	return candidates[0].root, true
+}
+
+func isLauncherInstallRoot(root string) bool {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "" || filepath.Base(root) != "csgclaw" {
+		return false
+	}
+	info, err := os.Lstat(filepath.Join(root, "lib", "csgclaw"))
+	return err == nil && info.IsDir()
 }
 
 func hasSourceCheckoutMarker(root string) bool {

--- a/internal/upgrade/restart_daemon.go
+++ b/internal/upgrade/restart_daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -35,11 +36,11 @@ func RestartDaemon(ctx context.Context, exePath string, opts RestartOptions) (Re
 		return result, nil
 	}
 
-	if err := runUpgradeCommand(ctx, exePath, "stop"); err != nil {
+	if err := stopDaemonWithExecutable(ctx, exePath); err != nil {
 		return RestartResult{}, fmt.Errorf("stop running daemon: %w", err)
 	}
 
-	if err := runUpgradeCommand(ctx, exePath, commandArgsWithConfig(opts.ConfigPath, "serve", "--daemon")...); err != nil {
+	if err := startDaemonWithExecutable(ctx, exePath, opts); err != nil {
 		return RestartResult{}, fmt.Errorf("restart daemon: %w", err)
 	}
 
@@ -49,9 +50,96 @@ func RestartDaemon(ctx context.Context, exePath string, opts RestartOptions) (Re
 
 // RestartDaemonFromExecutable stops and restarts the daemon using the current process binary.
 func RestartDaemonFromExecutable(ctx context.Context, opts RestartOptions) (RestartResult, error) {
-	exePath, err := os.Executable()
+	exePath, err := daemonLifecycleExecutable()
 	if err != nil {
 		return RestartResult{}, fmt.Errorf("resolve executable: %w", err)
 	}
 	return RestartDaemon(ctx, exePath, opts)
+}
+
+func StopDaemonFromExecutable(ctx context.Context) (RestartResult, error) {
+	exePath, err := daemonLifecycleExecutable()
+	if err != nil {
+		return RestartResult{}, fmt.Errorf("resolve executable: %w", err)
+	}
+
+	pidPath, err := defaultUpgradePIDPath()
+	if err != nil {
+		return RestartResult{}, err
+	}
+
+	running, stale, err := daemonRunning(pidPath)
+	if err != nil {
+		return RestartResult{}, err
+	}
+	result := RestartResult{
+		PIDPath:          pidPath,
+		DaemonWasRunning: running,
+	}
+	if stale {
+		_ = removePIDFilePath(pidPath)
+	}
+	if !running {
+		return result, nil
+	}
+	if err := stopDaemonWithExecutable(ctx, exePath); err != nil {
+		return RestartResult{}, fmt.Errorf("stop running daemon: %w", err)
+	}
+	return result, nil
+}
+
+func StartDaemonFromExecutable(ctx context.Context, opts RestartOptions) error {
+	exePath, err := daemonLifecycleExecutable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+	return startDaemonWithExecutable(ctx, exePath, opts)
+}
+
+func StartInstalledDaemon(ctx context.Context, installed InstalledBundle, opts RestartOptions) (RestartResult, error) {
+	layout, err := inspectBundleDir(installed.InstallRoot)
+	if err != nil {
+		return RestartResult{}, err
+	}
+	if err := startDaemonWithExecutable(ctx, layout.CSGClawPath, opts); err != nil {
+		return RestartResult{}, fmt.Errorf("restart daemon: %w", err)
+	}
+
+	pidPath, err := defaultUpgradePIDPath()
+	if err != nil {
+		return RestartResult{}, err
+	}
+	return RestartResult{
+		PIDPath:          pidPath,
+		DaemonWasRunning: true,
+		Restarted:        true,
+	}, nil
+}
+
+func stopDaemonWithExecutable(ctx context.Context, exePath string) error {
+	return runUpgradeCommand(ctx, exePath, "stop")
+}
+
+func daemonLifecycleExecutable() (string, error) {
+	if exe := strings.TrimSpace(os.Getenv(originalExecutableEnvVar)); exe != "" {
+		return exe, nil
+	}
+	return os.Executable()
+}
+
+func startDaemonWithExecutable(ctx context.Context, exePath string, opts RestartOptions) error {
+	exeDir := filepath.Clean(filepath.Dir(strings.TrimSpace(exePath)))
+	cmd := execCommandContext(ctx, exePath, commandArgsWithConfig(opts.ConfigPath, "serve", "--daemon")...)
+	if exeDir != "" {
+		cmd.Dir = exeDir
+	}
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return fmt.Errorf("%s serve --daemon: %w", exePath, err)
+	}
+	return fmt.Errorf("%s serve --daemon: %w: %s", exePath, err, trimmed)
 }

--- a/internal/upgrade/restart_helper_test.go
+++ b/internal/upgrade/restart_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -16,9 +17,8 @@ func TestStartRestartHelperIncludesConfigPath(t *testing.T) {
 		startRestartCommand = origCommand
 	})
 
-	startRestartExecutable = func() (string, error) {
-		return "/tmp/csgclaw", nil
-	}
+	helperPath := writeTestRestartHelperExecutable(t)
+	startRestartExecutable = func() (string, error) { return helperPath, nil }
 
 	var gotName string
 	var gotArgs []string
@@ -26,7 +26,7 @@ func TestStartRestartHelperIncludesConfigPath(t *testing.T) {
 	startRestartCommand = func(name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string(nil), args...)
-		startedCmd = exec.Command("sh", "-c", "exit 0")
+		startedCmd = testRestartNoopCommand()
 		return startedCmd
 	}
 
@@ -38,8 +38,8 @@ func TestStartRestartHelperIncludesConfigPath(t *testing.T) {
 		t.Fatalf("StartRestartHelper() error = %v", err)
 	}
 
-	if gotName != "/tmp/csgclaw" {
-		t.Fatalf("command name = %q, want %q", gotName, "/tmp/csgclaw")
+	if gotName != helperPath {
+		t.Fatalf("command name = %q, want %q", gotName, helperPath)
 	}
 	wantArgs := []string{"--config", configPath, "_restart"}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
@@ -64,6 +64,26 @@ func TestStartRestartHelperIncludesConfigPath(t *testing.T) {
 			t.Fatalf("command env missing %q in %#v", want, startedCmd.Env)
 		}
 	}
+}
+
+func writeTestRestartHelperExecutable(t *testing.T) string {
+	t.Helper()
+	name := "csgclaw"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("helper"), 0o700); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func testRestartNoopCommand() *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+	return exec.Command("sh", "-c", "exit 0")
 }
 
 func TestConsumeRestartStatusManualRestartRequired(t *testing.T) {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -672,6 +672,105 @@ func TestClientInstallPreparedReplacesWindowsBundle(t *testing.T) {
 	assertFileContent(t, filepath.Join(installRoot, "bin", "csgclaw.exe"), "@echo off\r\nREM new\r\n")
 }
 
+func TestClientInstallPreparedUsesOriginalExecutableEnv(t *testing.T) {
+	installParent := t.TempDir()
+	installRoot := writeBundleFiles(t, installParent, map[string]string{
+		filepath.Join("csgclaw", "bin", "csgclaw.exe"): "@echo off\r\nREM old\r\n",
+		filepath.Join("csgclaw", "README.md"):          "old",
+	})
+	preparedRoot := writeBundleFiles(t, t.TempDir(), map[string]string{
+		filepath.Join("csgclaw", "bin", "csgclaw.exe"): "@echo off\r\nREM new\r\n",
+		filepath.Join("csgclaw", "README.md"):          "new",
+	})
+
+	t.Setenv(originalExecutableEnvVar, filepath.Join(installRoot, "bin", "csgclaw.exe"))
+
+	installed, err := Client{}.InstallPrepared(PreparedBundle{BundleDir: preparedRoot})
+	if err != nil {
+		t.Fatalf("InstallPrepared() error = %v", err)
+	}
+	if got, want := installed.InstallRoot, installRoot; got != want {
+		t.Fatalf("InstallRoot = %q, want %q", got, want)
+	}
+	assertFileContent(t, filepath.Join(installRoot, "README.md"), "new")
+}
+
+func TestClientInstallPreparedResolvesWindowsLauncherLayout(t *testing.T) {
+	appHome := filepath.Join(t.TempDir(), "csgclaw")
+	installRoot := writeBundleFilesWithoutMarker(t, filepath.Join(appHome, "lib", "csgclaw", "v0.3.10"), map[string]string{
+		filepath.Join("csgclaw", "bin", "csgclaw.exe"): "@echo off\r\nREM old\r\n",
+		filepath.Join("csgclaw", "README.md"):          "old",
+	})
+	launcherDir := filepath.Join(appHome, "bin")
+	if err := os.MkdirAll(launcherDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", launcherDir, err)
+	}
+	launcherPath := filepath.Join(launcherDir, "csgclaw.exe")
+	if err := os.WriteFile(launcherPath, []byte("launcher"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", launcherPath, err)
+	}
+	if err := os.WriteFile(bundleMarkerPath(appHome), []byte(`{"app":"csgclaw","layout":"official-bundle"}`), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", bundleMarkerPath(appHome), err)
+	}
+	preparedRoot := writeBundleFiles(t, t.TempDir(), map[string]string{
+		filepath.Join("csgclaw", "bin", "csgclaw.exe"): "@echo off\r\nREM new\r\n",
+		filepath.Join("csgclaw", "README.md"):          "new",
+	})
+
+	client := Client{
+		ExecutablePath: func() (string, error) {
+			return launcherPath, nil
+		},
+	}
+
+	installed, err := client.InstallPrepared(PreparedBundle{BundleDir: preparedRoot})
+	if err != nil {
+		t.Fatalf("InstallPrepared() error = %v", err)
+	}
+	if got, want := installed.InstallRoot, installRoot; got != want {
+		t.Fatalf("InstallRoot = %q, want %q", got, want)
+	}
+	assertFileContent(t, filepath.Join(installRoot, "README.md"), "new")
+}
+
+func TestClientInstallPreparedDoesNotReplaceLauncherRootWhenInnerBundleMissing(t *testing.T) {
+	appHome := filepath.Join(t.TempDir(), "csgclaw")
+	launcherDir := filepath.Join(appHome, "bin")
+	libDir := filepath.Join(appHome, "lib", "csgclaw")
+	if err := os.MkdirAll(launcherDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", launcherDir, err)
+	}
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", libDir, err)
+	}
+	launcherPath := filepath.Join(launcherDir, "csgclaw.exe")
+	if err := os.WriteFile(launcherPath, []byte("launcher"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", launcherPath, err)
+	}
+	if err := os.WriteFile(bundleMarkerPath(appHome), []byte(`{"app":"csgclaw","layout":"official-bundle"}`), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", bundleMarkerPath(appHome), err)
+	}
+	keepPath := filepath.Join(appHome, "keep-me")
+	if err := os.WriteFile(keepPath, []byte("user file"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", keepPath, err)
+	}
+
+	client := Client{
+		ExecutablePath: func() (string, error) {
+			return launcherPath, nil
+		},
+	}
+
+	_, err := client.InstallPrepared(PreparedBundle{BundleDir: writeBundleFiles(t, t.TempDir(), map[string]string{
+		filepath.Join("csgclaw", "bin", "csgclaw.exe"): "@echo off\r\nREM new\r\n",
+		filepath.Join("csgclaw", "README.md"):          "new",
+	})})
+	if err == nil || !strings.Contains(err.Error(), "not installed from an official csgclaw bundle") {
+		t.Fatalf("InstallPrepared() error = %v, want non-bundle install error", err)
+	}
+	assertFileContent(t, keepPath, "user file")
+}
+
 func TestClientInstallPreparedRollsBackOnRenameFailure(t *testing.T) {
 	installParent := t.TempDir()
 	installRoot := writeBundleDir(t, installParent, "old")


### PR DESCRIPTION
- Add Windows-specific daemon stop/restart during upgrade process
- Support launcher installation layout path resolution
- Implement helper executable copy to temp directory for Windows
- Pass original executable path via CSGCLAW_ORIGINAL_EXECUTABLE env var
- Add cleanup for upgrade helper temp directories
- Update CLI upgrade flow to handle Windows daemon lifecycle
- Add comprehensive tests for new Windows upgrade scenarios