### PR TITLE
fix(auth): restore same-tab OpenCSG login

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -16,9 +16,8 @@ import (
 const authCallbackPath = "/api/v1/auth/callback"
 
 type authLoginRequest struct {
-	ReturnURL         string `json:"return_url,omitempty"`
-	SuppressReturnURL bool   `json:"suppress_return_url,omitempty"`
-	CallbackURL       string `json:"-"`
+	ReturnURL   string `json:"return_url,omitempty"`
+	CallbackURL string `json:"-"`
 }
 
 var appAuthStatus = func(r *http.Request) (auth.Status, error) {
@@ -91,7 +90,7 @@ func (h *Handler) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
 		return
 	}
-	if req.ReturnURL == "" && !req.SuppressReturnURL {
+	if req.ReturnURL == "" {
 		req.ReturnURL = r.Referer()
 	}
 	if req.CallbackURL == "" {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -72,27 +72,6 @@ func TestHandleAuthLogin(t *testing.T) {
 	}
 }
 
-func TestHandleAuthLoginCanSuppressReturnURL(t *testing.T) {
-	var gotReturnURL string
-	restore := stubAuthLogin(func(_ *http.Request, req authLoginRequest) (auth.LoginResponse, error) {
-		gotReturnURL = req.ReturnURL
-		return auth.LoginResponse{LoginURL: "https://iam.example.test/login"}, nil
-	})
-	defer restore()
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"suppress_return_url":true}`))
-	req.Host = "127.0.0.1:18080"
-	req.Header.Set("Referer", "http://127.0.0.1:18080/#/models/opencsg")
-	(&Handler{}).Routes().ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
-	}
-	if gotReturnURL != "" {
-		t.Fatalf("return_url = %q, want empty when suppressed", gotReturnURL)
-	}
-}
-
 func TestHandleAuthCallback(t *testing.T) {
 	var gotToken string
 	restore := stubAuthCallback(func(r *http.Request) (string, error) {

--- a/web/app/src/api/auth.ts
+++ b/web/app/src/api/auth.ts
@@ -5,15 +5,8 @@ export function fetchAuthStatus(): Promise<unknown> {
   return get(ApiEndpoints.authStatus);
 }
 
-export type AuthLoginOptions = {
-  suppressReturnURL?: boolean;
-};
-
-export function beginAuthLogin(returnURL = "", options: AuthLoginOptions = {}): Promise<unknown> {
-  return post(ApiEndpoints.authLogin, {
-    return_url: returnURL,
-    suppress_return_url: options.suppressReturnURL || undefined,
-  });
+export function beginAuthLogin(returnURL = ""): Promise<unknown> {
+  return post(ApiEndpoints.authLogin, { return_url: returnURL });
 }
 
 export function logoutAuth(): Promise<unknown> {

--- a/web/app/src/hooks/workspace/useAuthController.ts
+++ b/web/app/src/hooks/workspace/useAuthController.ts
@@ -67,19 +67,17 @@ export function useAuthController(t: TranslateFn): AuthController {
     if (busyAction) {
       return;
     }
-    const loginWindow = openLoginWindow();
     setBusyAction("login");
     setAuthError("");
     try {
-      const loginResp = normalizeLoginResponse(await beginAuthLogin("", { suppressReturnURL: true }));
+      const loginResp = normalizeLoginResponse(await beginAuthLogin(window.location.href));
       if (!loginResp.login_url) {
         throw new Error(t("csghubLoginURLMissing"));
       }
       markPendingAuthLogin();
       setLoginPending(true);
-      navigateLoginWindow(loginWindow, loginResp.login_url);
+      window.location.assign(loginResp.login_url);
     } catch (err) {
-      closeLoginWindow(loginWindow);
       clearPendingAuthLogin();
       setLoginPending(false);
       setAuthError(errorMessage(err, t("csghubLoginFailed")));
@@ -187,34 +185,6 @@ export function useAuthController(t: TranslateFn): AuthController {
 
 async function fetchNormalizedAuthStatus(): Promise<AuthStatus> {
   return normalizeAuthStatus(await fetchAuthStatus());
-}
-
-function openLoginWindow(): Window | null {
-  try {
-    const loginWindow = window.open("about:blank", "_blank");
-    if (loginWindow) {
-      loginWindow.opener = null;
-    }
-    return loginWindow;
-  } catch (_) {
-    return null;
-  }
-}
-
-function navigateLoginWindow(loginWindow: Window | null, loginURL: string) {
-  if (loginWindow) {
-    loginWindow.location.href = loginURL;
-    return;
-  }
-  window.open(loginURL, "_blank", "noopener,noreferrer");
-}
-
-function closeLoginWindow(loginWindow: Window | null) {
-  try {
-    loginWindow?.close();
-  } catch (_) {
-    // Some browser contexts do not allow scripts to close the opened tab.
-  }
 }
 
 function markPendingAuthLogin() {

--- a/web/app/tests/hooks/useAuthController.test.tsx
+++ b/web/app/tests/hooks/useAuthController.test.tsx
@@ -63,16 +63,11 @@ describe("useAuthController", () => {
     expect(result.current.notice).toBeNull();
   });
 
-  it("opens OpenCSG login in a new tab without returning that tab to CSGClaw", async () => {
+  it("redirects the current tab to OpenCSG login and back to CSGClaw", async () => {
     vi.mocked(fetchAuthStatus).mockResolvedValue({ authenticated: false });
-    vi.mocked(beginAuthLogin).mockResolvedValue({ login_url: "https://opencsg.com/sso/login?redirect_url=callback" });
-    const openedTab = {
-      close: vi.fn(),
-      location: {
-        href: "",
-      },
-    };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(openedTab as unknown as Window);
+    vi.mocked(beginAuthLogin).mockResolvedValue({ login_url: "#/opencsg-login?redirect_url=callback" });
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const returnURL = window.location.href;
 
     const { result } = renderHook(() => useAuthController(t), { wrapper: createWrapper() });
 
@@ -80,9 +75,9 @@ describe("useAuthController", () => {
       await result.current.login();
     });
 
-    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
-    expect(beginAuthLogin).toHaveBeenCalledWith("", { suppressReturnURL: true });
-    expect(openedTab.location.href).toBe("https://opencsg.com/sso/login?redirect_url=callback");
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(beginAuthLogin).toHaveBeenCalledWith(returnURL);
+    expect(window.location.hash).toBe("#/opencsg-login?redirect_url=callback");
     expect(window.sessionStorage.getItem(loginPendingStorageKey)).toBe("1");
   });
 });


### PR DESCRIPTION
## Summary

- Restore OpenCSG sign-in to redirect in the current CSGClaw tab instead of opening a new tab.
- Send the current CSGClaw URL as the auth return URL and remove the suppress-return-url API path.