### PR TITLE
feat(hub): lazy load official template workspaces

### DIFF
--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1343,7 +1343,7 @@ enabled = false
 [[hub.registries]]
 name = "official"
 kind = "remote"
-url = "https://csgclaw.opencsg.com"
+url = "https://hub.opencsg.com"
 enabled = true
 
 [[hub.registries]]

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,7 +221,7 @@ Current platform expectations:
 
 CSGClaw can read agent templates from one or more hub registries. Registry configuration is additive: built-in, local, and remote registries can coexist in the same `config.toml`.
 
-When `[hub]` is omitted, CSGClaw enables three registries by default: `builtin` (read-only), `local` (writable publish target at `~/.csgclaw/hub`), and `official` (official remote at `https://csgclaw.opencsg.com`). If your `config.toml` lists only some registries, missing defaults are merged in automatically so removing `builtin` does not break startup.
+When `[hub]` is omitted, CSGClaw enables three registries by default: `builtin` (read-only), `local` (writable publish target at `~/.csgclaw/hub`), and `official` (official remote at `https://hub.opencsg.com`). If your `config.toml` lists only some registries, missing defaults are merged in automatically so removing `builtin` does not break startup.
 
 ```toml
 [hub]
@@ -244,7 +244,7 @@ enabled = true
 [[hub.registries]]
 name = "official"
 kind = "remote"
-url = "https://csgclaw.opencsg.com"
+url = "https://hub.opencsg.com"
 enabled = true
 
 [[hub.registries]]
@@ -254,6 +254,8 @@ url = "https://hub.example.com"
 token = "${CSGCLAW_HUB_TOKEN}"
 enabled = true
 ```
+
+All production template APIs use `https://hub.opencsg.com`. Until those APIs are deployed, set the `official` registry `url` to `https://hub.opencsg-stg.com` in `config.toml`; for the current staging deployment, CSGClaw temporarily uses `https://opencsg-stg.com` for repository details, trees, and file contents.
 
 Field behavior:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -255,8 +255,6 @@ token = "${CSGCLAW_HUB_TOKEN}"
 enabled = true
 ```
 
-All production template APIs use `https://hub.opencsg.com`. Until those APIs are deployed, set the `official` registry `url` to `https://hub.opencsg-stg.com` in `config.toml`; for the current staging deployment, CSGClaw temporarily uses `https://opencsg-stg.com` for repository details, trees, and file contents.
-
 Field behavior:
 
 - `default_registry` selects the default source registry when a command needs one registry context.

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -221,7 +221,7 @@ docker_cli_path = "/usr/local/bin/docker"
 
 CSGClaw 可以从一个或多个 hub registry 读取 agent 模板。registry 配置是可叠加的：内置、本地和远端 registry 可以同时存在于同一个 `config.toml` 中。
 
-即使省略 `[hub]`，CSGClaw 也会默认启用三个 registry：`builtin`（内置只读）、`local`（本地发布）和 `official`（官方远端 `https://csgclaw.opencsg.com`）。你在 `config.toml` 里只写了部分 registry 时，缺失的默认项会自动合并进来，因此删掉 `builtin` 也不会导致启动失败。
+即使省略 `[hub]`，CSGClaw 也会默认启用三个 registry：`builtin`（内置只读）、`local`（本地发布）和 `official`（官方远端 `https://hub.opencsg.com`）。你在 `config.toml` 里只写了部分 registry 时，缺失的默认项会自动合并进来，因此删掉 `builtin` 也不会导致启动失败。
 
 ```toml
 [hub]
@@ -244,7 +244,7 @@ enabled = true
 [[hub.registries]]
 name = "official"
 kind = "remote"
-url = "https://csgclaw.opencsg.com"
+url = "https://hub.opencsg.com"
 enabled = true
 
 [[hub.registries]]
@@ -254,6 +254,8 @@ url = "https://hub.example.com"
 token = "${CSGCLAW_HUB_TOKEN}"
 enabled = true
 ```
+
+正式环境的全部模板 API 均使用 `https://hub.opencsg.com`。在这些 API 尚未部署期间，可以在 `config.toml` 中将 `official` 的 `url` 覆盖为 `https://hub.opencsg-stg.com`；CSGClaw 会针对当前 stg 部署临时使用 `https://opencsg-stg.com` 读取仓库详情、文件树和文件内容。
 
 字段说明：
 

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -255,8 +255,6 @@ token = "${CSGCLAW_HUB_TOKEN}"
 enabled = true
 ```
 
-正式环境的全部模板 API 均使用 `https://hub.opencsg.com`。在这些 API 尚未部署期间，可以在 `config.toml` 中将 `official` 的 `url` 覆盖为 `https://hub.opencsg-stg.com`；CSGClaw 会针对当前 stg 部署临时使用 `https://opencsg-stg.com` 读取仓库详情、文件树和文件内容。
-
 字段说明：
 
 - `default_registry`：当某个命令需要一个默认读取源 registry 时，使用这个值。

--- a/internal/agentworkspace/list.go
+++ b/internal/agentworkspace/list.go
@@ -11,6 +11,10 @@ func List(root, relativePath string) (apitypes.WorkspaceListing, error) {
 	return filebrowse.List(root, relativePath)
 }
 
+func ListDirectory(root, relativePath string) (apitypes.WorkspaceListing, error) {
+	return filebrowse.ListDirectory(root, relativePath)
+}
+
 func ReadFile(root, relativePath string) (apitypes.WorkspaceFile, error) {
 	return filebrowse.ReadFile(root, relativePath)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2038,24 +2038,47 @@ func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
 	if got.Source.Name != "local" || got.Source.Kind != "local" {
 		t.Fatalf("template source = %+v, want local/local", got.Source)
 	}
-	if len(got.Workspace.Entries) == 0 {
-		t.Fatalf("workspace entries = %#v, want non-empty result", got.Workspace.Entries)
+	if len(got.Workspace.Entries) != 0 {
+		t.Fatalf("workspace entries = %#v, want lazy-loaded empty result", got.Workspace.Entries)
 	}
-	paths := make([]string, 0, len(got.Workspace.Entries))
-	for _, entry := range got.Workspace.Entries {
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local.review-bot/workspace", nil)
+	rec = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("workspace status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var listing apitypes.WorkspaceListing
+	if err := json.NewDecoder(rec.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode workspace response: %v", err)
+	}
+	paths := make([]string, 0, len(listing.Entries))
+	for _, entry := range listing.Entries {
 		paths = append(paths, entry.Path)
 	}
-	if !slices.Contains(paths, "USER.md") || !slices.Contains(paths, "skills/custom/SKILL.md") {
-		t.Fatalf("workspace paths = %#v, want USER.md and skills/custom/SKILL.md", paths)
+	if !slices.Contains(paths, "USER.md") || !slices.Contains(paths, "skills") {
+		t.Fatalf("workspace paths = %#v, want USER.md and skills", paths)
 	}
-	if got, want := slices.Index(paths, "skills"), 1; got != want {
-		t.Fatalf("workspace entry index for %q = %d, want %d; paths=%#v", "skills", got, want, paths)
+	if slices.Contains(paths, "skills/custom") || slices.Contains(paths, "skills/custom/SKILL.md") {
+		t.Fatalf("workspace paths = %#v, want top-level entries only", paths)
 	}
-	if got, want := slices.Index(paths, "skills/custom"), 2; got != want {
-		t.Fatalf("workspace entry index for %q = %d, want %d; paths=%#v", "skills/custom", got, want, paths)
+
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/hub/templates/local.review-bot/workspace?path=skills",
+		nil,
+	)
+	rec = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nested workspace status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if got, want := slices.Index(paths, "skills/custom/SKILL.md"), 3; got != want {
-		t.Fatalf("workspace entry index for %q = %d, want %d; paths=%#v", "skills/custom/SKILL.md", got, want, paths)
+	listing = apitypes.WorkspaceListing{}
+	if err := json.NewDecoder(rec.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode nested workspace response: %v", err)
+	}
+	if len(listing.Entries) != 1 || listing.Entries[0].Path != "skills/custom" {
+		t.Fatalf("nested workspace entries = %#v, want skills/custom only", listing.Entries)
 	}
 }
 
@@ -2870,14 +2893,28 @@ func TestHandleHubTemplateWithoutWorkspaceOmitsEntriesAndFilePreview(t *testing.
 		t.Fatalf("workspace entries = %#v, want empty", detail.Workspace.Entries)
 	}
 
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local.review-bot/workspace", nil)
+	rec = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("workspace status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var listing apitypes.WorkspaceListing
+	if err := json.NewDecoder(rec.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode workspace response: %v", err)
+	}
+	if len(listing.Entries) != 0 {
+		t.Fatalf("workspace entries = %#v, want empty", listing.Entries)
+	}
+
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/hub/templates/local.review-bot/workspace/file?path=USER.md", nil)
 	rec = httptest.NewRecorder()
 	srv.Routes().ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("file status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "hub workspace is not available") {
-		t.Fatalf("file response body = %q, want unavailable workspace error", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "workspace") {
+		t.Fatalf("file response body = %q, want workspace error", rec.Body.String())
 	}
 }
 

--- a/internal/api/hub_workspace.go
+++ b/internal/api/hub_workspace.go
@@ -7,30 +7,42 @@ import (
 	"os"
 	"strings"
 
-	"csgclaw/internal/agentworkspace"
 	"csgclaw/internal/apitypes"
 	hub "csgclaw/internal/template"
 )
 
 func (h *Handler) presentHubTemplateDetail(ctx context.Context, item hub.Template) (apitypes.HubTemplate, error) {
-	presented := presentHubTemplate(item)
-	workspaceRoot, cleanup, err := h.hubWorkspaceRoot(ctx, item)
-	if err != nil {
-		return apitypes.HubTemplate{}, err
-	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	if strings.TrimSpace(workspaceRoot) == "" {
-		return presented, nil
-	}
+	return presentHubTemplate(item), nil
+}
 
-	listing, err := agentworkspace.List(workspaceRoot, "")
-	if err != nil {
-		return apitypes.HubTemplate{}, err
+func (h *Handler) handleHubTemplateWorkspaceByID(w http.ResponseWriter, r *http.Request) {
+	h.handleHubTemplateWorkspace(w, r, pathValue(r, "id"))
+}
+
+func (h *Handler) handleHubTemplateWorkspace(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
 	}
-	presented.Workspace.Entries = listing.Entries
-	return presented, nil
+	if h.hub == nil {
+		http.Error(w, "hub service is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	listing, err := h.hub.ListWorkspace(r.Context(), id, strings.TrimSpace(r.URL.Query().Get("path")))
+	if err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(strings.ToLower(err.Error()), "not found") {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	writeJSON(w, http.StatusOK, listing)
 }
 
 func (h *Handler) handleHubTemplateWorkspaceFile(w http.ResponseWriter, r *http.Request, id string) {
@@ -47,35 +59,8 @@ func (h *Handler) handleHubTemplateWorkspaceFile(w http.ResponseWriter, r *http.
 		http.NotFound(w, r)
 		return
 	}
-	item, err := h.hub.Get(r.Context(), id)
-	if err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "not found") {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
-
-	workspaceRoot, cleanup, err := h.hubWorkspaceRoot(r.Context(), item)
-	if err != nil {
-		status := http.StatusInternalServerError
-		if errors.Is(err, os.ErrNotExist) {
-			status = http.StatusNotFound
-		}
-		http.Error(w, err.Error(), status)
-		return
-	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	if strings.TrimSpace(workspaceRoot) == "" {
-		http.Error(w, "hub workspace is not available", http.StatusBadRequest)
-		return
-	}
-
 	path := strings.TrimSpace(r.URL.Query().Get("path"))
-	file, err := agentworkspace.ReadFile(workspaceRoot, path)
+	file, err := h.hub.ReadWorkspaceFile(r.Context(), id, path)
 	if err != nil {
 		status := http.StatusBadRequest
 		if errors.Is(err, os.ErrNotExist) {
@@ -85,17 +70,4 @@ func (h *Handler) handleHubTemplateWorkspaceFile(w http.ResponseWriter, r *http.
 		return
 	}
 	writeJSON(w, http.StatusOK, file)
-}
-
-func (h *Handler) hubWorkspaceRoot(ctx context.Context, item hub.Template) (string, func(), error) {
-	switch item.Source.Kind {
-	case hub.RegistryKindBuiltin, hub.RegistryKindRemote:
-		workspace, err := h.hub.FetchWorkspace(ctx, item.ID)
-		if err != nil {
-			return "", nil, err
-		}
-		return workspace.Path, func() { _ = os.RemoveAll(workspace.Path) }, nil
-	default:
-		return strings.TrimSpace(item.WorkspaceRef.Path), nil, nil
-	}
 }

--- a/internal/api/rest_handlers.go
+++ b/internal/api/rest_handlers.go
@@ -78,6 +78,9 @@ func (h *Handler) deleteHubTemplateByID(w http.ResponseWriter, r *http.Request) 
 func (h *Handler) getHubTemplateWorkspaceFileByID(w http.ResponseWriter, r *http.Request) {
 	h.handleHubTemplateWorkspaceFileByID(w, r)
 }
+func (h *Handler) getHubTemplateWorkspaceByID(w http.ResponseWriter, r *http.Request) {
+	h.handleHubTemplateWorkspaceByID(w, r)
+}
 func (h *Handler) getBootstrapConfig(w http.ResponseWriter, r *http.Request) {
 	h.handleBootstrapConfig(w, r)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -56,6 +56,7 @@ func (h *Handler) registerCoreRoutes(router chi.Router) {
 			r.Post("/", h.createHubTemplate)
 			r.Get("/{id}", h.getHubTemplateByID)
 			r.Delete("/{id}", h.deleteHubTemplateByID)
+			r.Get("/{id}/workspace", h.getHubTemplateWorkspaceByID)
 			r.Get("/{id}/workspace/file", h.getHubTemplateWorkspaceFileByID)
 		})
 		r.Get("/skills", h.listSkills)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -294,7 +294,7 @@ const (
 	DefaultHubRegistry              = "builtin"
 	DefaultHubPublishRegistry       = "local"
 	DefaultOfficialHubRegistryName  = "official"
-	DefaultOfficialHubRegistryURL   = "https://csgclaw.opencsg.com"
+	DefaultOfficialHubRegistryURL   = "https://hub.opencsg.com"
 	DefaultBootstrapManagerTemplate = "builtin.picoclaw-manager"
 	DefaultBootstrapWorkerTemplate  = "builtin.picoclaw-worker"
 	HubRegistryKindBuiltin          = "builtin"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1144,7 +1144,7 @@ enabled = true
 [[hub.registries]]
 name = "official"
 kind = "remote"
-url = "https://csgclaw.opencsg.com"
+url = "https://hub.opencsg.com"
 enabled = true
 `
 	if got := string(data); got != want {

--- a/internal/onboard/onboard_test.go
+++ b/internal/onboard/onboard_test.go
@@ -701,7 +701,7 @@ models = ["gpt-test"]
 		`name = "official"`,
 		`kind = "local"`,
 		`kind = "remote"`,
-		`url = "https://csgclaw.opencsg.com"`,
+		`url = "https://hub.opencsg.com"`,
 		`enabled = true`,
 	} {
 		if !strings.Contains(content, want) {

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -1,95 +1,433 @@
 package template
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"csgclaw/internal/apitypes"
+	toml "github.com/pelletier/go-toml/v2"
 )
 
 const (
-	defaultRemoteHTTPTimeout     = 60 * time.Second
-	defaultRemoteMaxJSONBytes    = 4 * 1024 * 1024
-	defaultRemoteMaxArchiveBytes = 50 * 1024 * 1024
+	defaultRemoteHTTPTimeout  = 60 * time.Second
+	defaultRemoteMaxJSONBytes = 4 * 1024 * 1024
+	defaultRemoteMaxFileBytes = 50 * 1024 * 1024
+	officialTemplateNamespace = "Agentic"
+	remoteManifestFileName    = "agent.toml"
+	remoteWorkspaceDirName    = "workspace"
+	stagingHubBaseURL         = "https://hub.opencsg-stg.com"
+	stagingContentBaseURL     = "https://opencsg-stg.com"
+	remoteFilePreviewMaxBytes = 256 * 1024
 )
 
 type RemoteStore struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
-	maxJSON    int64
-	maxArchive int64
+	hubBaseURL     string
+	contentBaseURL string
+	token          string
+	httpClient     *http.Client
+	maxJSON        int64
+	maxWorkspace   int64
+}
+
+type remoteCodeListResponse struct {
+	Data  []remoteCodeRepository `json:"data"`
+	Total int                    `json:"total"`
+}
+
+type remoteCodeResponse struct {
+	Data remoteCodeRepository `json:"data"`
+}
+
+type remoteCodeRepository struct {
+	Name          string    `json:"name"`
+	Nickname      string    `json:"nickname"`
+	Description   string    `json:"description"`
+	Path          string    `json:"path"`
+	DefaultBranch string    `json:"default_branch"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type remoteTreeResponse struct {
+	Data remoteTreeData `json:"data"`
+}
+
+type remoteTreeData struct {
+	Files  []remoteTreeEntry `json:"Files"`
+	Cursor string            `json:"Cursor"`
+}
+
+type remoteTreeEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+type remoteBlobResponse struct {
+	Data remoteBlob `json:"data"`
+}
+
+type remoteBlob struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
 }
 
 func NewRemoteStore(baseURL, token string) *RemoteStore {
-	baseURL = strings.TrimSpace(strings.TrimRight(baseURL, "/"))
+	hubBaseURL := strings.TrimSpace(strings.TrimRight(baseURL, "/"))
 	return &RemoteStore{
-		baseURL: baseURL,
-		token:   strings.TrimSpace(token),
+		hubBaseURL:     hubBaseURL,
+		contentBaseURL: remoteContentBaseURL(hubBaseURL),
+		token:          strings.TrimSpace(token),
 		httpClient: &http.Client{
 			Timeout: defaultRemoteHTTPTimeout,
 		},
-		maxJSON:    defaultRemoteMaxJSONBytes,
-		maxArchive: defaultRemoteMaxArchiveBytes,
+		maxJSON:      defaultRemoteMaxJSONBytes,
+		maxWorkspace: defaultRemoteMaxFileBytes,
 	}
 }
 
 func (s *RemoteStore) List(ctx context.Context) ([]Template, error) {
-	var payload []apitypes.HubTemplate
+	var payload remoteCodeListResponse
 	if err := s.getJSON(ctx, s.templatesURL(), &payload); err != nil {
 		return nil, err
 	}
-	items := make([]Template, 0, len(payload))
-	for _, item := range payload {
-		items = append(items, templateFromAPI(item))
+
+	items := make([]Template, 0, len(payload.Data))
+	for _, repository := range payload.Data {
+		id, err := normalizeRemoteTemplateID(repository.Path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid remote hub template path %q: %w", repository.Path, err)
+		}
+		item, err := s.getTemplate(ctx, id, repository)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
 	}
 	return items, nil
 }
 
 func (s *RemoteStore) Get(ctx context.Context, id string) (Template, error) {
-	id = strings.TrimSpace(id)
-	if err := validateLocalTemplateID(id); err != nil {
+	id, err := normalizeRemoteTemplateID(id)
+	if err != nil {
 		return Template{}, err
 	}
-	var payload apitypes.HubTemplate
+
+	var payload remoteCodeResponse
 	if err := s.getJSON(ctx, s.templateURL(id), &payload); err != nil {
 		return Template{}, err
 	}
-	if strings.TrimSpace(payload.ID) == "" {
-		payload.ID = id
+	return s.getTemplate(ctx, id, payload.Data)
+}
+
+func (s *RemoteStore) getTemplate(ctx context.Context, id string, repository remoteCodeRepository) (Template, error) {
+	branch := strings.TrimSpace(repository.DefaultBranch)
+	if branch == "" {
+		var payload remoteCodeResponse
+		if err := s.getJSON(ctx, s.templateURL(id), &payload); err != nil {
+			return Template{}, err
+		}
+		repository = payload.Data
+		branch = strings.TrimSpace(repository.DefaultBranch)
 	}
-	return templateFromAPI(payload), nil
+	if branch == "" {
+		branch = "main"
+	}
+
+	manifest, err := s.fetchManifest(ctx, id, branch)
+	if err != nil {
+		return Template{}, err
+	}
+	updatedAt, err := parseManifestUpdatedAt(manifest.UpdatedAt)
+	if err != nil {
+		return Template{}, fmt.Errorf("validate remote hub manifest %q: %w", id, err)
+	}
+	if updatedAt.IsZero() {
+		updatedAt = repository.UpdatedAt
+	}
+	description := strings.TrimSpace(manifest.Description)
+	if description == "" {
+		description = strings.TrimSpace(repository.Description)
+	}
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		name = strings.TrimSpace(repository.Nickname)
+	}
+	if name == "" {
+		name = strings.TrimSpace(repository.Name)
+	}
+	return Template{
+		ID:           remoteTemplateName(id),
+		Name:         name,
+		Description:  description,
+		Role:         normalizeTemplateRole(manifest.Role),
+		RuntimeKind:  strings.TrimSpace(manifest.RuntimeKind),
+		Version:      strings.TrimSpace(manifest.Version),
+		Image:        manifestImageRef(manifest.Image),
+		ImageEnv:     manifestImageEnv(manifest.Image),
+		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir},
+		UpdatedAt:    updatedAt,
+	}, nil
+}
+
+func (s *RemoteStore) fetchManifest(ctx context.Context, id, branch string) (templateManifest, error) {
+	data, err := s.fetchBlob(ctx, id, remoteManifestFileName, branch)
+	if err != nil {
+		return templateManifest{}, err
+	}
+	var manifest templateManifest
+	if err := toml.Unmarshal(data, &manifest); err != nil {
+		return templateManifest{}, fmt.Errorf("decode remote hub manifest %q: %w", id, err)
+	}
+	if err := validateManifest(manifest); err != nil {
+		return templateManifest{}, fmt.Errorf("validate remote hub manifest %q: %w", id, err)
+	}
+	return manifest, nil
 }
 
 func (s *RemoteStore) FetchWorkspace(ctx context.Context, id string) (WorkspaceRef, error) {
-	id = strings.TrimSpace(id)
-	if err := validateLocalTemplateID(id); err != nil {
-		return WorkspaceRef{}, err
-	}
-	archive, err := s.download(ctx, s.workspaceArchiveURL(id))
+	id, err := normalizeRemoteTemplateID(id)
 	if err != nil {
 		return WorkspaceRef{}, err
 	}
+
+	branch, err := s.defaultBranch(ctx, id)
+	if err != nil {
+		return WorkspaceRef{}, err
+	}
+
 	tmpDir, err := os.MkdirTemp("", "csgclaw-hub-remote-*")
 	if err != nil {
 		return WorkspaceRef{}, fmt.Errorf("create remote hub workspace temp dir: %w", err)
 	}
-	if err := extractWorkspaceTarGz(archive, tmpDir, s.maxArchive); err != nil {
+	var totalBytes int64
+	if err := s.fetchWorkspaceTree(ctx, id, branch, remoteWorkspaceDirName, tmpDir, &totalBytes); err != nil {
 		_ = os.RemoveAll(tmpDir)
+		if errors.Is(err, ErrTemplateNotFound) {
+			return WorkspaceRef{}, nil
+		}
 		return WorkspaceRef{}, err
 	}
 	return WorkspaceRef{Kind: WorkspaceKindDir, Path: tmpDir}, nil
+}
+
+func (s *RemoteStore) ListWorkspace(
+	ctx context.Context,
+	id string,
+	workspacePath string,
+) (apitypes.WorkspaceListing, error) {
+	id, err := normalizeRemoteTemplateID(id)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+	cleanPath, err := normalizeRemoteWorkspacePath(workspacePath)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+	branch, err := s.defaultBranch(ctx, id)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+
+	treePath := remoteWorkspaceDirName
+	if cleanPath != "" {
+		treePath += "/" + cleanPath
+	}
+	entries := make([]apitypes.WorkspaceEntry, 0)
+	cursor := ""
+	for {
+		var payload remoteTreeResponse
+		if err := s.getJSON(ctx, s.treeURL(id, branch, treePath, cursor), &payload); err != nil {
+			if cleanPath == "" && errors.Is(err, ErrTemplateNotFound) {
+				return apitypes.WorkspaceListing{Kind: WorkspaceKindDir}, nil
+			}
+			return apitypes.WorkspaceListing{}, err
+		}
+		for _, entry := range payload.Data.Files {
+			entryPath := strings.Trim(strings.TrimSpace(entry.Path), "/")
+			if !strings.HasPrefix(entryPath, remoteWorkspaceDirName+"/") {
+				return apitypes.WorkspaceListing{}, fmt.Errorf("%w: %s", ErrWorkspacePathUnsafe, entryPath)
+			}
+			relativePath := strings.TrimPrefix(entryPath, remoteWorkspaceDirName+"/")
+			if path.Dir(relativePath) != path.Clean(cleanPath) && !(cleanPath == "" && !strings.Contains(relativePath, "/")) {
+				continue
+			}
+			entryType := "file"
+			if entry.Type == "dir" || entry.Type == "tree" {
+				entryType = "dir"
+			}
+			entries = append(entries, apitypes.WorkspaceEntry{
+				Path:  relativePath,
+				Name:  entry.Name,
+				Type:  entryType,
+				Depth: strings.Count(relativePath, "/"),
+				Size:  entry.Size,
+			})
+		}
+		cursor = strings.TrimSpace(payload.Data.Cursor)
+		if cursor == "" {
+			break
+		}
+	}
+	return apitypes.WorkspaceListing{
+		Kind:    WorkspaceKindDir,
+		Path:    cleanPath,
+		Entries: entries,
+	}, nil
+}
+
+func (s *RemoteStore) ReadWorkspaceFile(
+	ctx context.Context,
+	id string,
+	workspacePath string,
+) (apitypes.WorkspaceFile, error) {
+	id, err := normalizeRemoteTemplateID(id)
+	if err != nil {
+		return apitypes.WorkspaceFile{}, err
+	}
+	cleanPath, err := normalizeRemoteWorkspacePath(workspacePath)
+	if err != nil || cleanPath == "" {
+		return apitypes.WorkspaceFile{}, ErrWorkspacePathUnsafe
+	}
+	branch, err := s.defaultBranch(ctx, id)
+	if err != nil {
+		return apitypes.WorkspaceFile{}, err
+	}
+	data, err := s.fetchBlob(ctx, id, remoteWorkspaceDirName+"/"+cleanPath, branch)
+	if err != nil {
+		return apitypes.WorkspaceFile{}, err
+	}
+	file := apitypes.WorkspaceFile{Path: cleanPath, Size: int64(len(data))}
+	preview := data
+	if len(preview) > remoteFilePreviewMaxBytes {
+		preview = preview[:remoteFilePreviewMaxBytes]
+		file.Truncated = true
+		validPreview := false
+		for trim := 0; trim < utf8.UTFMax && trim < len(preview); trim++ {
+			candidate := preview[:len(preview)-trim]
+			if utf8.Valid(candidate) {
+				preview = candidate
+				validPreview = true
+				break
+			}
+		}
+		if !validPreview {
+			file.Binary = true
+			return file, nil
+		}
+	}
+	if !utf8.Valid(preview) {
+		file.Binary = true
+		return file, nil
+	}
+	file.Content = string(preview)
+	return file, nil
+}
+
+func (s *RemoteStore) defaultBranch(ctx context.Context, id string) (string, error) {
+	var payload remoteCodeResponse
+	if err := s.getJSON(ctx, s.templateURL(id), &payload); err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(payload.Data.DefaultBranch)
+	if branch == "" {
+		branch = "main"
+	}
+	return branch, nil
+}
+
+func (s *RemoteStore) fetchWorkspaceTree(
+	ctx context.Context,
+	id string,
+	branch string,
+	treePath string,
+	dstRoot string,
+	totalBytes *int64,
+) error {
+	cursor := ""
+	for {
+		var payload remoteTreeResponse
+		if err := s.getJSON(ctx, s.treeURL(id, branch, treePath, cursor), &payload); err != nil {
+			return err
+		}
+		for _, entry := range payload.Data.Files {
+			entryPath := strings.Trim(strings.TrimSpace(entry.Path), "/")
+			if entryPath != remoteWorkspaceDirName &&
+				!strings.HasPrefix(entryPath, remoteWorkspaceDirName+"/") {
+				return fmt.Errorf("%w: %s", ErrWorkspacePathUnsafe, entryPath)
+			}
+			rel := strings.TrimPrefix(entryPath, remoteWorkspaceDirName+"/")
+			if entryPath == remoteWorkspaceDirName {
+				rel = ""
+			}
+			if rel != "" {
+				if err := validateWorkspaceRelativePath(filepath.FromSlash(rel)); err != nil {
+					return err
+				}
+			}
+			switch strings.ToLower(strings.TrimSpace(entry.Type)) {
+			case "dir", "tree":
+				if rel != "" {
+					if err := os.MkdirAll(filepath.Join(dstRoot, filepath.FromSlash(rel)), 0o755); err != nil {
+						return fmt.Errorf("create remote hub workspace dir %q: %w", rel, err)
+					}
+				}
+				if err := s.fetchWorkspaceTree(ctx, id, branch, entryPath, dstRoot, totalBytes); err != nil {
+					return err
+				}
+			case "file", "blob":
+				data, err := s.fetchBlob(ctx, id, entryPath, branch)
+				if err != nil {
+					return err
+				}
+				*totalBytes += int64(len(data))
+				if *totalBytes > s.maxWorkspace {
+					return fmt.Errorf("remote hub workspace exceeds %d bytes", s.maxWorkspace)
+				}
+				target := filepath.Join(dstRoot, filepath.FromSlash(rel))
+				if err := ensurePathInsideRoot(dstRoot, target); err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+					return fmt.Errorf("create remote hub workspace parent %q: %w", filepath.Dir(target), err)
+				}
+				if err := os.WriteFile(target, data, 0o644); err != nil {
+					return fmt.Errorf("write remote hub workspace file %q: %w", target, err)
+				}
+			}
+		}
+		cursor = strings.TrimSpace(payload.Data.Cursor)
+		if cursor == "" {
+			return nil
+		}
+	}
+}
+
+func (s *RemoteStore) fetchBlob(ctx context.Context, id, filePath, branch string) ([]byte, error) {
+	var payload remoteBlobResponse
+	if err := s.getJSON(ctx, s.blobURL(id, filePath, branch), &payload); err != nil {
+		return nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(payload.Data.Content)
+	if err != nil {
+		return nil, fmt.Errorf("decode remote hub blob %q: %w", filePath, err)
+	}
+	if int64(len(data)) > s.maxWorkspace {
+		return nil, fmt.Errorf("remote hub blob %q exceeds %d bytes", filePath, s.maxWorkspace)
+	}
+	return data, nil
 }
 
 func (s *RemoteStore) Publish(context.Context, PublishSpec) (Template, error) {
@@ -101,15 +439,28 @@ func (s *RemoteStore) Delete(context.Context, string) error {
 }
 
 func (s *RemoteStore) templatesURL() string {
-	return s.baseURL + "/api/v1/hub/templates"
+	return s.hubBaseURL + "/api/v1/organization/" + url.PathEscape(officialTemplateNamespace) + "/codes"
 }
 
 func (s *RemoteStore) templateURL(id string) string {
-	return s.baseURL + "/api/v1/hub/templates/" + url.PathEscape(id)
+	return s.contentBaseURL + "/api/v1/codes/" + escapeRemotePath(id)
 }
 
-func (s *RemoteStore) workspaceArchiveURL(id string) string {
-	return s.templateURL(id) + "/workspace.tar.gz"
+func (s *RemoteStore) treeURL(id, branch, treePath, cursor string) string {
+	endpoint := s.templateURL(id) + "/refs/" + url.PathEscape(branch) + "/tree/"
+	if treePath != "" {
+		endpoint += escapeRemotePath(treePath)
+	}
+	query := url.Values{}
+	query.Set("cursor", cursor)
+	query.Set("limit", "500")
+	return endpoint + "?" + query.Encode()
+}
+
+func (s *RemoteStore) blobURL(id, filePath, branch string) string {
+	query := url.Values{}
+	query.Set("ref", branch)
+	return s.templateURL(id) + "/blob/" + escapeRemotePath(filePath) + "?" + query.Encode()
 }
 
 func (s *RemoteStore) getJSON(ctx context.Context, endpoint string, out any) error {
@@ -132,23 +483,6 @@ func (s *RemoteStore) getJSON(ctx context.Context, endpoint string, out any) err
 	return nil
 }
 
-func (s *RemoteStore) download(ctx context.Context, endpoint string) ([]byte, error) {
-	body, status, err := s.request(ctx, http.MethodGet, endpoint, s.maxArchive+1)
-	if err != nil {
-		return nil, err
-	}
-	if status == http.StatusNotFound {
-		return nil, fmt.Errorf("%w", ErrTemplateNotFound)
-	}
-	if status < 200 || status >= 300 {
-		return nil, fmt.Errorf("remote hub workspace download failed with status %d: %s", status, truncateRemoteBody(body))
-	}
-	if int64(len(body)) > s.maxArchive {
-		return nil, fmt.Errorf("remote hub workspace archive exceeds %d bytes", s.maxArchive)
-	}
-	return body, nil
-}
-
 func (s *RemoteStore) request(ctx context.Context, method, endpoint string, maxBody int64) ([]byte, int, error) {
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
 	if err != nil {
@@ -157,7 +491,7 @@ func (s *RemoteStore) request(ctx context.Context, method, endpoint string, maxB
 	if s.token != "" {
 		req.Header.Set("Authorization", "Bearer "+s.token)
 	}
-	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
@@ -176,97 +510,55 @@ func (s *RemoteStore) request(ctx context.Context, method, endpoint string, maxB
 	return body, resp.StatusCode, nil
 }
 
-func templateFromAPI(item apitypes.HubTemplate) Template {
-	kind := strings.TrimSpace(item.Workspace.Kind)
-	return Template{
-		ID:           strings.TrimSpace(item.ID),
-		Name:         strings.TrimSpace(item.Name),
-		Description:  strings.TrimSpace(item.Description),
-		Role:         normalizeTemplateRole(item.Role),
-		RuntimeKind:  strings.TrimSpace(item.RuntimeKind),
-		Version:      strings.TrimSpace(item.Version),
-		Image:        strings.TrimSpace(item.Image),
-		ImageEnv:     append([]apitypes.ImageEnvContract(nil), item.ImageEnv...),
-		WorkspaceRef: WorkspaceRef{Kind: kind},
-		UpdatedAt:    item.UpdatedAt,
+func remoteContentBaseURL(hubBaseURL string) string {
+	hubBaseURL = strings.TrimRight(strings.TrimSpace(hubBaseURL), "/")
+	if hubBaseURL == stagingHubBaseURL {
+		return stagingContentBaseURL
 	}
+	return hubBaseURL
 }
 
-func extractWorkspaceTarGz(archive []byte, dstRoot string, maxBytes int64) error {
-	if int64(len(archive)) > maxBytes {
-		return fmt.Errorf("hub workspace archive exceeds %d bytes", maxBytes)
+func normalizeRemoteTemplateID(id string) (string, error) {
+	id = strings.Trim(strings.TrimSpace(id), "/")
+	if id == "" {
+		return "", ErrTemplateIDRequired
 	}
-	dstRoot = strings.TrimSpace(dstRoot)
-	if dstRoot == "" {
-		return ErrWorkspaceDirRequired
+	if !strings.Contains(id, "/") {
+		id = officialTemplateNamespace + "/" + id
 	}
-	dstRoot = filepath.Clean(dstRoot)
-
-	gz, err := gzip.NewReader(bytes.NewReader(archive))
-	if err != nil {
-		return fmt.Errorf("open remote hub workspace gzip: %w", err)
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 || parts[0] != officialTemplateNamespace {
+		return "", ErrWorkspacePathUnsafe
 	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("read remote hub workspace tar: %w", err)
-		}
-		if hdr == nil {
-			continue
-		}
-		switch hdr.Typeflag {
-		case tar.TypeSymlink, tar.TypeLink:
-			return fmt.Errorf("%w: %s", ErrWorkspaceSymlinkDenied, hdr.Name)
-		}
-
-		rel := filepath.Clean(filepath.FromSlash(strings.TrimSpace(hdr.Name)))
-		if rel == "." || rel == string(filepath.Separator) {
-			continue
-		}
-		if err := validateWorkspaceRelativePath(rel); err != nil {
-			return err
-		}
-		target := filepath.Join(dstRoot, rel)
-		if err := ensurePathInsideRoot(dstRoot, target); err != nil {
-			return err
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0o755); err != nil {
-				return fmt.Errorf("create remote hub workspace dir %q: %w", target, err)
-			}
-		case tar.TypeReg, tar.TypeRegA:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-				return fmt.Errorf("create remote hub workspace parent %q: %w", filepath.Dir(target), err)
-			}
-			mode := hdr.FileInfo().Mode().Perm()
-			if mode == 0 {
-				mode = 0o644
-			}
-			mode |= 0o200
-			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-			if err != nil {
-				return fmt.Errorf("create remote hub workspace file %q: %w", target, err)
-			}
-			if _, err := io.Copy(out, tr); err != nil {
-				_ = out.Close()
-				return fmt.Errorf("write remote hub workspace file %q: %w", target, err)
-			}
-			if err := out.Close(); err != nil {
-				return fmt.Errorf("close remote hub workspace file %q: %w", target, err)
-			}
-		default:
-			continue
+	for _, part := range parts {
+		if err := validateLocalTemplateID(part); err != nil {
+			return "", err
 		}
 	}
-	return nil
+	return strings.Join(parts, "/"), nil
+}
+
+func escapeRemotePath(value string) string {
+	parts := strings.Split(strings.Trim(value, "/"), "/")
+	for index := range parts {
+		parts[index] = url.PathEscape(parts[index])
+	}
+	return path.Join(parts...)
+}
+
+func remoteTemplateName(id string) string {
+	return strings.TrimPrefix(id, officialTemplateNamespace+"/")
+}
+
+func normalizeRemoteWorkspacePath(value string) (string, error) {
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	if value == "" {
+		return "", nil
+	}
+	if err := validateWorkspaceRelativePath(filepath.FromSlash(value)); err != nil {
+		return "", err
+	}
+	return path.Clean(value), nil
 }
 
 func ensurePathInsideRoot(root, target string) error {
@@ -283,9 +575,10 @@ func ensurePathInsideRoot(root, target string) error {
 }
 
 func truncateRemoteBody(body []byte) string {
+	const limit = 512
 	text := strings.TrimSpace(string(body))
-	if len(text) > 256 {
-		return text[:256] + "..."
+	if len(text) <= limit {
+		return text
 	}
-	return text
+	return text[:limit] + "..."
 }

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -27,8 +27,6 @@ const (
 	officialTemplateNamespace = "Agentic"
 	remoteManifestFileName    = "agent.toml"
 	remoteWorkspaceDirName    = "workspace"
-	stagingHubBaseURL         = "https://hub.opencsg-stg.com"
-	stagingContentBaseURL     = "https://opencsg-stg.com"
 	remoteFilePreviewMaxBytes = 256 * 1024
 )
 
@@ -88,7 +86,7 @@ func NewRemoteStore(baseURL, token string) *RemoteStore {
 	hubBaseURL := strings.TrimSpace(strings.TrimRight(baseURL, "/"))
 	return &RemoteStore{
 		hubBaseURL:     hubBaseURL,
-		contentBaseURL: remoteContentBaseURL(hubBaseURL),
+		contentBaseURL: hubBaseURL,
 		token:          strings.TrimSpace(token),
 		httpClient: &http.Client{
 			Timeout: defaultRemoteHTTPTimeout,
@@ -508,14 +506,6 @@ func (s *RemoteStore) request(ctx context.Context, method, endpoint string, maxB
 		return nil, resp.StatusCode, fmt.Errorf("read remote hub response: %w", err)
 	}
 	return body, resp.StatusCode, nil
-}
-
-func remoteContentBaseURL(hubBaseURL string) string {
-	hubBaseURL = strings.TrimRight(strings.TrimSpace(hubBaseURL), "/")
-	if hubBaseURL == stagingHubBaseURL {
-		return stagingContentBaseURL
-	}
-	return hubBaseURL
 }
 
 func normalizeRemoteTemplateID(id string) (string, error) {

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -106,11 +107,13 @@ func (s *RemoteStore) List(ctx context.Context) ([]Template, error) {
 	for _, repository := range payload.Data {
 		id, err := normalizeRemoteTemplateID(repository.Path)
 		if err != nil {
-			return nil, fmt.Errorf("invalid remote hub template path %q: %w", repository.Path, err)
+			slog.Warn("skip invalid remote hub template path", "path", repository.Path, "error", err)
+			continue
 		}
 		item, err := s.getTemplate(ctx, id, repository)
 		if err != nil {
-			return nil, err
+			slog.Warn("skip invalid remote hub template", "id", id, "error", err)
+			continue
 		}
 		items = append(items, item)
 	}

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -162,6 +162,55 @@ func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {
 	}
 }
 
+func TestRemoteStoreListSkipsInvalidRepositories(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/organization/Agentic/codes":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{
+						"name":           "gitlab-assistant",
+						"path":           "Agentic/gitlab-assistant",
+						"default_branch": "main",
+					},
+					{
+						"name":           "broken-manifest",
+						"path":           "Agentic/broken-manifest",
+						"default_branch": "main",
+					},
+					{
+						"name":           "other-namespace",
+						"path":           "Other/other-namespace",
+						"default_branch": "main",
+					},
+				},
+				"total": 3,
+			})
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/blob/agent.toml":
+			writeRemoteBlob(t, w, "agent.toml", []byte(remoteTestManifest))
+		case r.URL.Path == "/api/v1/codes/Agentic/broken-manifest/blob/agent.toml":
+			writeRemoteBlob(t, w, "agent.toml", []byte("name = \"broken-manifest\"\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	store := NewRemoteStore(srv.URL, "")
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Fatalf("len(List()) = %d, want %d; items=%#v", got, want, items)
+	}
+	if got, want := items[0].ID, "gitlab-assistant"; got != want {
+		t.Fatalf("List()[0].ID = %q, want %q", got, want)
+	}
+}
+
 func TestDefaultStoreFactoryCreatesRemoteStore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -162,31 +162,12 @@ func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {
 	}
 }
 
-func TestRemoteContentBaseURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{input: "https://hub.opencsg.com", want: "https://hub.opencsg.com"},
-		{input: "https://hub.opencsg-stg.com", want: "https://opencsg-stg.com"},
-		{input: "https://hub.example.com/", want: "https://hub.example.com"},
-		{input: "http://127.0.0.1:18080", want: "http://127.0.0.1:18080"},
-	}
-	for _, tt := range tests {
-		if got := remoteContentBaseURL(tt.input); got != tt.want {
-			t.Errorf("remoteContentBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestDefaultStoreFactoryCreatesRemoteStore(t *testing.T) {
 	t.Parallel()
 
 	store, err := DefaultStoreFactory(config.HubRegistryConfig{
 		Kind:  RegistryKindRemote,
-		URL:   "https://hub.opencsg-stg.com",
+		URL:   "https://hub.opencsg.com",
 		Token: "secret",
 	})
 	if err != nil {
@@ -196,7 +177,7 @@ func TestDefaultStoreFactoryCreatesRemoteStore(t *testing.T) {
 	if !ok {
 		t.Fatalf("store type = %T, want *RemoteStore", store)
 	}
-	if got, want := remote.contentBaseURL, "https://opencsg-stg.com"; got != want {
+	if got, want := remote.contentBaseURL, "https://hub.opencsg.com"; got != want {
 		t.Fatalf("content base URL = %q, want %q", got, want)
 	}
 }

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -1,77 +1,90 @@
 package template
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"csgclaw/internal/apitypes"
 	"csgclaw/internal/config"
 )
+
+const remoteTestManifest = `name = "gitlab-assistant"
+role = "worker"
+description = "GitLab assistant"
+runtime_kind = "openclaw_sandbox"
+version = "2026.6.16.0"
+updated_at = "2026-05-19T07:25:31Z"
+
+[image]
+ref = "registry.example.com/openclaw-glab:2026.6.16.0"
+
+[[image.env]]
+name = "GITLAB_TOKEN"
+required = true
+secret = true
+description = "GitLab personal access token"
+`
 
 func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {
 	t.Parallel()
 
-	var archive []byte
-	{
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		tw := tar.NewWriter(gz)
-		if err := tw.WriteHeader(&tar.Header{
-			Name:     "AGENTS.md",
-			Mode:     0o644,
-			Size:     5,
-			Typeflag: tar.TypeReg,
-		}); err != nil {
-			t.Fatalf("WriteHeader() error = %v", err)
-		}
-		if _, err := tw.Write([]byte("hello")); err != nil {
-			t.Fatalf("Write() error = %v", err)
-		}
-		if err := tw.Close(); err != nil {
-			t.Fatalf("tar Close() error = %v", err)
-		}
-		if err := gz.Close(); err != nil {
-			t.Fatalf("gzip Close() error = %v", err)
-		}
-		archive = buf.Bytes()
-	}
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/hub/templates":
-			_ = json.NewEncoder(w).Encode([]apitypes.HubTemplate{
-				{
-					ID:          "review-bot",
-					Name:        "review-bot",
-					Role:        "worker",
-					RuntimeKind: "codex",
-					Source:      apitypes.HubTemplateSource{Name: config.DefaultOfficialHubRegistryName, Kind: "remote"},
-					Workspace:   apitypes.HubTemplateWorkspace{Kind: "dir"},
+		switch {
+		case r.URL.Path == "/api/v1/organization/Agentic/codes":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					"name":           "gitlab-assistant",
+					"nickname":       "gitlab-assistant",
+					"description":    "repository description",
+					"path":           "Agentic/gitlab-assistant",
+					"default_branch": "",
+					"updated_at":     "2026-06-25T02:00:02Z",
+				}},
+				"total": 1,
+			})
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"name":           "gitlab-assistant",
+					"path":           "Agentic/gitlab-assistant",
+					"default_branch": "main",
 				},
 			})
-		case "/api/v1/hub/templates/review-bot":
-			_ = json.NewEncoder(w).Encode(apitypes.HubTemplate{
-				ID:          "review-bot",
-				Name:        "review-bot",
-				Description: "code review helper",
-				Role:        "worker",
-				RuntimeKind: "codex",
-				Source:      apitypes.HubTemplateSource{Name: config.DefaultOfficialHubRegistryName, Kind: "remote"},
-				Workspace:   apitypes.HubTemplateWorkspace{Kind: "dir"},
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/blob/agent.toml":
+			assertQueryValue(t, r.URL, "ref", "main")
+			writeRemoteBlob(t, w, "agent.toml", []byte(remoteTestManifest))
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/refs/main/tree/workspace":
+			assertQueryValue(t, r.URL, "limit", "500")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"Files": []map[string]any{
+						{"name": "AGENTS.md", "type": "file", "path": "workspace/AGENTS.md"},
+						{"name": "skills", "type": "dir", "path": "workspace/skills"},
+					},
+					"Cursor": "",
+				},
 			})
-		case "/api/v1/hub/templates/review-bot/workspace.tar.gz":
-			w.Header().Set("Content-Type", "application/gzip")
-			_, _ = w.Write(archive)
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/refs/main/tree/workspace/skills":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"Files": []map[string]any{
+						{"name": "review.md", "type": "file", "path": "workspace/skills/review.md"},
+					},
+					"Cursor": "",
+				},
+			})
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/blob/workspace/AGENTS.md":
+			writeRemoteBlob(t, w, "workspace/AGENTS.md", []byte("hello"))
+		case r.URL.Path == "/api/v1/codes/Agentic/gitlab-assistant/blob/workspace/skills/review.md":
+			writeRemoteBlob(t, w, "workspace/skills/review.md", []byte("review"))
 		default:
 			http.NotFound(w, r)
 		}
@@ -86,22 +99,47 @@ func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {
 	if got, want := len(items), 1; got != want {
 		t.Fatalf("len(List()) = %d, want %d", got, want)
 	}
-	if got, want := items[0].ID, "review-bot"; got != want {
+	if got, want := items[0].ID, "gitlab-assistant"; got != want {
 		t.Fatalf("List()[0].ID = %q, want %q", got, want)
 	}
+	if got, want := items[0].RuntimeKind, "openclaw_sandbox"; got != want {
+		t.Fatalf("List()[0].RuntimeKind = %q, want %q", got, want)
+	}
 
-	item, err := store.Get(context.Background(), "review-bot")
+	item, err := store.Get(context.Background(), "gitlab-assistant")
 	if err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if got, want := item.Description, "code review helper"; got != want {
+	if got, want := item.Description, "GitLab assistant"; got != want {
 		t.Fatalf("Get().Description = %q, want %q", got, want)
 	}
 	if got, want := item.Role, TemplateRoleWorker; got != want {
 		t.Fatalf("Get().Role = %q, want %q", got, want)
 	}
+	if got, want := item.ImageEnv[0].Name, "GITLAB_TOKEN"; got != want {
+		t.Fatalf("Get().ImageEnv[0].Name = %q, want %q", got, want)
+	}
 
-	workspace, err := store.FetchWorkspace(context.Background(), "review-bot")
+	listing, err := store.ListWorkspace(context.Background(), "gitlab-assistant", "")
+	if err != nil {
+		t.Fatalf("ListWorkspace() error = %v", err)
+	}
+	if got, want := len(listing.Entries), 2; got != want {
+		t.Fatalf("len(ListWorkspace().Entries) = %d, want %d", got, want)
+	}
+	if got, want := listing.Entries[0].Path, "AGENTS.md"; got != want {
+		t.Fatalf("ListWorkspace().Entries[0].Path = %q, want %q", got, want)
+	}
+
+	file, err := store.ReadWorkspaceFile(context.Background(), "gitlab-assistant", "AGENTS.md")
+	if err != nil {
+		t.Fatalf("ReadWorkspaceFile() error = %v", err)
+	}
+	if got, want := file.Content, "hello"; got != want {
+		t.Fatalf("ReadWorkspaceFile().Content = %q, want %q", got, want)
+	}
+
+	workspace, err := store.FetchWorkspace(context.Background(), "Agentic/gitlab-assistant")
 	if err != nil {
 		t.Fatalf("FetchWorkspace() error = %v", err)
 	}
@@ -110,12 +148,36 @@ func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {
 	if got, want := workspace.Kind, WorkspaceKindDir; got != want {
 		t.Fatalf("FetchWorkspace().Kind = %q, want %q", got, want)
 	}
-	data, err := os.ReadFile(filepath.Join(workspace.Path, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read extracted AGENTS.md: %v", err)
+	for name, want := range map[string]string{
+		"AGENTS.md":        "hello",
+		"skills/review.md": "review",
+	} {
+		data, err := os.ReadFile(filepath.Join(workspace.Path, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("read extracted %s: %v", name, err)
+		}
+		if got := string(data); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
 	}
-	if got, want := string(data), "hello"; got != want {
-		t.Fatalf("AGENTS.md = %q, want %q", got, want)
+}
+
+func TestRemoteContentBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "https://hub.opencsg.com", want: "https://hub.opencsg.com"},
+		{input: "https://hub.opencsg-stg.com", want: "https://opencsg-stg.com"},
+		{input: "https://hub.example.com/", want: "https://hub.example.com"},
+		{input: "http://127.0.0.1:18080", want: "http://127.0.0.1:18080"},
+	}
+	for _, tt := range tests {
+		if got := remoteContentBaseURL(tt.input); got != tt.want {
+			t.Errorf("remoteContentBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }
 
@@ -124,14 +186,18 @@ func TestDefaultStoreFactoryCreatesRemoteStore(t *testing.T) {
 
 	store, err := DefaultStoreFactory(config.HubRegistryConfig{
 		Kind:  RegistryKindRemote,
-		URL:   "https://hub.example.com",
+		URL:   "https://hub.opencsg-stg.com",
 		Token: "secret",
 	})
 	if err != nil {
 		t.Fatalf("DefaultStoreFactory() error = %v", err)
 	}
-	if _, ok := store.(*RemoteStore); !ok {
+	remote, ok := store.(*RemoteStore)
+	if !ok {
 		t.Fatalf("store type = %T, want *RemoteStore", store)
+	}
+	if got, want := remote.contentBaseURL, "https://opencsg-stg.com"; got != want {
+		t.Fatalf("content base URL = %q, want %q", got, want)
 	}
 }
 
@@ -142,11 +208,11 @@ func TestRemoteStoreGetJSONRejectsOversizedResponse(t *testing.T) {
 	for i := range oversized {
 		oversized[i] = ' '
 	}
-	oversized[0] = '['
-	oversized[len(oversized)-1] = ']'
+	oversized[0] = '{'
+	oversized[len(oversized)-1] = '}'
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/hub/templates" {
+		if r.URL.Path != "/api/v1/organization/Agentic/codes" {
 			http.NotFound(w, r)
 			return
 		}
@@ -170,5 +236,24 @@ func TestDefaultStoreFactoryRemoteRequiresURL(t *testing.T) {
 	_, err := DefaultStoreFactory(config.HubRegistryConfig{Kind: RegistryKindRemote})
 	if !errors.Is(err, ErrRegistryURLRequired) {
 		t.Fatalf("DefaultStoreFactory() error = %v, want ErrRegistryURLRequired", err)
+	}
+}
+
+func writeRemoteBlob(t *testing.T, w http.ResponseWriter, name string, data []byte) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"path":    name,
+			"content": base64.StdEncoding.EncodeToString(data),
+		},
+	}); err != nil {
+		t.Fatalf("encode blob response: %v", err)
+	}
+}
+
+func assertQueryValue(t *testing.T, values *url.URL, key, want string) {
+	t.Helper()
+	if got := values.Query().Get(key); got != want {
+		t.Fatalf("query %s = %q, want %q", key, got, want)
 	}
 }

--- a/internal/template/service.go
+++ b/internal/template/service.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 
+	"csgclaw/internal/agentworkspace"
+	"csgclaw/internal/apitypes"
 	"csgclaw/internal/config"
 )
 
@@ -26,6 +29,11 @@ type Store interface {
 	FetchWorkspace(ctx context.Context, id string) (WorkspaceRef, error)
 	Publish(ctx context.Context, spec PublishSpec) (Template, error)
 	Delete(ctx context.Context, id string) error
+}
+
+type WorkspaceBrowser interface {
+	ListWorkspace(ctx context.Context, id, workspacePath string) (apitypes.WorkspaceListing, error)
+	ReadWorkspaceFile(ctx context.Context, id, workspacePath string) (apitypes.WorkspaceFile, error)
 }
 
 type StoreFactory func(cfg config.HubRegistryConfig) (Store, error)
@@ -127,6 +135,51 @@ func (s *Service) FetchWorkspace(ctx context.Context, id string) (WorkspaceRef, 
 		return WorkspaceRef{}, fmt.Errorf("fetch hub workspace %q from %q: %w", templateID, cfgStore.ref.Name, err)
 	}
 	return workspace, nil
+}
+
+func (s *Service) ListWorkspace(ctx context.Context, id, workspacePath string) (apitypes.WorkspaceListing, error) {
+	cfgStore, templateID, err := s.resolveRead(id)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+	if browser, ok := cfgStore.store.(WorkspaceBrowser); ok {
+		return browser.ListWorkspace(ctx, templateID, workspacePath)
+	}
+	workspace, err := cfgStore.store.FetchWorkspace(ctx, templateID)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+	if normalizeRegistryKind(cfgStore.ref.Kind) != RegistryKindLocal {
+		defer os.RemoveAll(workspace.Path)
+	}
+	if strings.TrimSpace(workspace.Path) == "" {
+		if strings.TrimSpace(workspacePath) == "" {
+			return apitypes.WorkspaceListing{Kind: WorkspaceKindDir}, nil
+		}
+		return apitypes.WorkspaceListing{}, ErrWorkspaceDirRequired
+	}
+	return agentworkspace.ListDirectory(workspace.Path, workspacePath)
+}
+
+func (s *Service) ReadWorkspaceFile(ctx context.Context, id, workspacePath string) (apitypes.WorkspaceFile, error) {
+	cfgStore, templateID, err := s.resolveRead(id)
+	if err != nil {
+		return apitypes.WorkspaceFile{}, err
+	}
+	if browser, ok := cfgStore.store.(WorkspaceBrowser); ok {
+		return browser.ReadWorkspaceFile(ctx, templateID, workspacePath)
+	}
+	workspace, err := cfgStore.store.FetchWorkspace(ctx, templateID)
+	if err != nil {
+		return apitypes.WorkspaceFile{}, err
+	}
+	if normalizeRegistryKind(cfgStore.ref.Kind) != RegistryKindLocal {
+		defer os.RemoveAll(workspace.Path)
+	}
+	if strings.TrimSpace(workspace.Path) == "" {
+		return apitypes.WorkspaceFile{}, ErrWorkspaceDirRequired
+	}
+	return agentworkspace.ReadFile(workspace.Path, workspacePath)
 }
 
 func (s *Service) Publish(ctx context.Context, spec PublishSpec) (Template, error) {

--- a/internal/utils/filebrowse/filebrowse.go
+++ b/internal/utils/filebrowse/filebrowse.go
@@ -86,6 +86,67 @@ func List(root, relativePath string) (apitypes.WorkspaceListing, error) {
 	}, nil
 }
 
+func ListDirectory(root, relativePath string) (apitypes.WorkspaceListing, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return apitypes.WorkspaceListing{}, fmt.Errorf("workspace root is required")
+	}
+	cleanPath, err := cleanRelativePath(relativePath)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, err
+	}
+	base := root
+	if cleanPath != "" {
+		base = filepath.Join(root, filepath.FromSlash(cleanPath))
+	}
+	info, err := os.Lstat(base)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, fmt.Errorf("stat workspace %q: %w", cleanPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return apitypes.WorkspaceListing{}, fmt.Errorf("workspace path %q is a symlink", cleanPath)
+	}
+	if !info.IsDir() {
+		return apitypes.WorkspaceListing{}, fmt.Errorf("workspace path %q is not a directory", cleanPath)
+	}
+
+	children, err := os.ReadDir(base)
+	if err != nil {
+		return apitypes.WorkspaceListing{}, fmt.Errorf("read workspace directory %q: %w", cleanPath, err)
+	}
+	entries := make([]apitypes.WorkspaceEntry, 0, len(children))
+	for _, child := range children {
+		if child.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		childInfo, err := child.Info()
+		if err != nil {
+			return apitypes.WorkspaceListing{}, fmt.Errorf("read workspace entry %q: %w", child.Name(), err)
+		}
+		entryPath := child.Name()
+		if cleanPath != "" {
+			entryPath = cleanPath + "/" + child.Name()
+		}
+		entry := apitypes.WorkspaceEntry{
+			Path:  entryPath,
+			Name:  child.Name(),
+			Type:  "file",
+			Depth: strings.Count(entryPath, "/"),
+			Size:  childInfo.Size(),
+		}
+		if child.IsDir() {
+			entry.Type = "dir"
+			entry.Size = 0
+		}
+		entries = append(entries, entry)
+	}
+	return apitypes.WorkspaceListing{
+		Kind:    "dir",
+		Path:    cleanPath,
+		Entries: entries,
+	}, nil
+}
+
 func ReadFile(root, relativePath string) (apitypes.WorkspaceFile, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {

--- a/web/app/src/api/hub.ts
+++ b/web/app/src/api/hub.ts
@@ -1,5 +1,5 @@
 import { del, get, post } from "@/api/client";
-import type { HubTemplate, HubWorkspaceFile } from "@/models/hubWorkspace";
+import type { HubTemplate, HubWorkspaceFile, HubWorkspaceListing } from "@/models/hubWorkspace";
 
 const HUB_TEMPLATES_PATH = "/api/v1/hub/templates";
 
@@ -13,6 +13,11 @@ export function fetchHubTemplates(): Promise<HubTemplate[]> {
 
 export function fetchHubTemplate(templateID: string): Promise<HubTemplate> {
   return get<HubTemplate>(hubTemplatePath(templateID));
+}
+
+export function fetchHubWorkspace(templateID: string, workspacePath = ""): Promise<HubWorkspaceListing> {
+  const query = workspacePath ? `?path=${encodeURIComponent(workspacePath)}` : "";
+  return get<HubWorkspaceListing>(`${hubTemplatePath(templateID)}/workspace${query}`);
 }
 
 export function fetchHubWorkspaceFile(templateID: string, workspacePath: string): Promise<HubWorkspaceFile> {

--- a/web/app/src/components/business/WorkspaceFileTree/WorkspaceFileTree.tsx
+++ b/web/app/src/components/business/WorkspaceFileTree/WorkspaceFileTree.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronRight, FileText, Folder } from "lucide-react";
+import { ChevronRight, FileText, Folder, LoaderCircle } from "lucide-react";
 import {
   buildInitialCollapsedWorkspaceDirs,
   buildVisibleWorkspaceEntries,
@@ -15,7 +15,9 @@ type WorkspaceFileTreeProps = {
   loading?: boolean;
   loadingText: string;
   selectedPath?: string;
+  loadingPaths?: ReadonlySet<string>;
   onSelectFile?: (path: string) => void;
+  onToggleDir?: (path: string) => void | Promise<void>;
 };
 
 export function WorkspaceFileTree({
@@ -25,13 +27,20 @@ export function WorkspaceFileTree({
   loading = false,
   loadingText,
   selectedPath = "",
+  loadingPaths,
   onSelectFile,
+  onToggleDir,
 }: WorkspaceFileTreeProps) {
   const [collapsedDirs, setCollapsedDirs] = useState<CollapsedWorkspaceDirs>({});
   const visibleEntries = useMemo(() => buildVisibleWorkspaceEntries(entries, collapsedDirs), [entries, collapsedDirs]);
 
   useEffect(() => {
-    setCollapsedDirs(buildInitialCollapsedWorkspaceDirs(entries));
+    const initial = buildInitialCollapsedWorkspaceDirs(entries);
+    setCollapsedDirs((current) =>
+      Object.fromEntries(
+        Object.keys(initial).map((path) => [path, Object.hasOwn(current, path) ? current[path] : true]),
+      ),
+    );
   }, [entries]);
 
   useEffect(() => {
@@ -56,6 +65,9 @@ export function WorkspaceFileTree({
   }, [selectedPath]);
 
   function toggleDir(path: string) {
+    if (collapsedDirs[path]) {
+      void onToggleDir?.(path);
+    }
     setCollapsedDirs((current) => ({
       ...current,
       [path]: !current[path],
@@ -72,6 +84,7 @@ export function WorkspaceFileTree({
         visibleEntries.map((entry) => {
           const isDir = entry.type === "dir";
           const collapsed = isDir && Boolean(collapsedDirs[entry.path]);
+          const dirLoading = isDir && loadingPaths?.has(entry.path);
           return (
             <button
               key={entry.path}
@@ -84,7 +97,11 @@ export function WorkspaceFileTree({
               aria-expanded={isDir ? !collapsed : undefined}
             >
               <span className={`workspace-tree-toggle ${!isDir ? "spacer" : ""}`.trim()} aria-hidden="true">
-                {isDir ? <ChevronRight className={collapsed ? "collapsed" : ""} size={14} strokeWidth={2} /> : null}
+                {dirLoading ? (
+                  <LoaderCircle className="animate-spin" size={14} strokeWidth={2} />
+                ) : isDir ? (
+                  <ChevronRight className={collapsed ? "collapsed" : ""} size={14} strokeWidth={2} />
+                ) : null}
               </span>
               <span className="workspace-tree-glyph" aria-hidden="true">
                 {isDir ? <Folder size={16} strokeWidth={2} /> : <FileText size={16} strokeWidth={2} />}

--- a/web/app/src/hooks/workspace/useWorkspaceHubSelection.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubSelection.ts
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { errorMessage } from "@/api/client";
+import { fetchHubWorkspace } from "@/api/hub";
 import { hasSkillName } from "@/models/skillhub";
+import { flattenWorkspaceDirectoryListings } from "@/models/workspace";
+import type { WorkspaceDirectoryListings } from "@/models/workspace";
 import { useWorkspaceUiStore } from "./workspaceUiStore";
 import {
+  workspaceQueryKeys,
   useWorkspaceHubTemplateQuery,
+  useWorkspaceHubWorkspaceQuery,
   useWorkspaceHubWorkspaceFileQuery,
   useWorkspaceSkillFileQuery,
   useWorkspaceSkillsQuery,
@@ -20,6 +26,7 @@ export function useWorkspaceHubSelection({
   refreshTemplates,
   t,
 }: UseWorkspaceHubSelectionArgs) {
+  const queryClient = useQueryClient();
   const hubTemplates = useMemo(() => templates ?? [], [templates]);
   const selectedHubTemplateId = useWorkspaceUiStore((state) => state.selectedHubTemplateId);
   const setSelectedHubTemplateId = useWorkspaceUiStore((state) => state.setSelectedHubTemplateId);
@@ -33,6 +40,12 @@ export function useWorkspaceHubSelection({
   const setSelectedHubResourceType = useWorkspaceUiStore((state) => state.setSelectedHubResourceType);
   const skillsQuery = useWorkspaceSkillsQuery();
   const skills = useMemo(() => skillsQuery.data ?? [], [skillsQuery.data]);
+  const [workspaceListingsState, setWorkspaceListingsState] = useState<{
+    templateID: string;
+    listings: WorkspaceDirectoryListings;
+  }>({ templateID: "", listings: {} });
+  const [loadingWorkspaceDirs, setLoadingWorkspaceDirs] = useState<ReadonlySet<string>>(new Set());
+  const [workspaceDirectoryError, setWorkspaceDirectoryError] = useState("");
 
   useEffect(() => {
     if (!hubTemplates.length) {
@@ -77,10 +90,12 @@ export function useWorkspaceHubSelection({
   }, [hubTemplates.length, selectedHubResourceType, setSelectedHubResourceType, skills.length]);
 
   const hubTemplateDetailQuery = useWorkspaceHubTemplateQuery(selectedHubTemplateId);
+  const hubWorkspaceQuery = useWorkspaceHubWorkspaceQuery(selectedHubTemplateId);
   const hubWorkspaceFileQuery = useWorkspaceHubWorkspaceFileQuery(selectedHubTemplateId, selectedHubWorkspacePath);
   const skillTreeQuery = useWorkspaceSkillTreeQuery(selectedHubSkillName);
   const skillFileQuery = useWorkspaceSkillFileQuery(selectedHubSkillPath);
   const refetchHubTemplateDetail = hubTemplateDetailQuery.refetch;
+  const refetchHubWorkspace = hubWorkspaceQuery.refetch;
   const refetchSkills = skillsQuery.refetch;
   const refetchSkillTree = skillTreeQuery.refetch;
 
@@ -95,6 +110,64 @@ export function useWorkspaceHubSelection({
 
   const selectedHubTemplateView =
     hubTemplateDetailQuery.data?.id === selectedHubTemplateId ? hubTemplateDetailQuery.data : selectedHubTemplate;
+  const workspaceListings = useMemo(
+    () => (workspaceListingsState.templateID === selectedHubTemplateId ? workspaceListingsState.listings : {}),
+    [selectedHubTemplateId, workspaceListingsState],
+  );
+  const workspaceEntries = useMemo(() => flattenWorkspaceDirectoryListings(workspaceListings), [workspaceListings]);
+
+  useEffect(() => {
+    setWorkspaceListingsState({ templateID: selectedHubTemplateId, listings: {} });
+    setLoadingWorkspaceDirs(new Set());
+    setWorkspaceDirectoryError("");
+  }, [selectedHubTemplateId]);
+
+  useEffect(() => {
+    if (!selectedHubTemplateId || !hubWorkspaceQuery.data) {
+      return;
+    }
+    setWorkspaceListingsState({
+      templateID: selectedHubTemplateId,
+      listings: { "": hubWorkspaceQuery.data.entries ?? [] },
+    });
+  }, [hubWorkspaceQuery.data, selectedHubTemplateId]);
+
+  const loadWorkspaceDirectory = useCallback(
+    async (workspacePath: string) => {
+      if (!selectedHubTemplateId || Object.hasOwn(workspaceListings, workspacePath)) {
+        return;
+      }
+      setLoadingWorkspaceDirs((current) => new Set(current).add(workspacePath));
+      setWorkspaceDirectoryError("");
+      try {
+        const listing = await queryClient.fetchQuery({
+          queryKey: workspaceQueryKeys.hubWorkspace(selectedHubTemplateId, workspacePath),
+          queryFn: () => fetchHubWorkspace(selectedHubTemplateId, workspacePath),
+        });
+        setWorkspaceListingsState((current) => {
+          if (current.templateID !== selectedHubTemplateId) {
+            return current;
+          }
+          return {
+            ...current,
+            listings: {
+              ...current.listings,
+              [workspacePath]: listing.entries ?? [],
+            },
+          };
+        });
+      } catch (error) {
+        setWorkspaceDirectoryError(errorMessage(error, t("hubWorkspaceLoadFailed")));
+      } finally {
+        setLoadingWorkspaceDirs((current) => {
+          const next = new Set(current);
+          next.delete(workspacePath);
+          return next;
+        });
+      }
+    },
+    [queryClient, selectedHubTemplateId, t, workspaceListings],
+  );
 
   const selectWorkspaceFile = useCallback(
     (workspacePath: string) => {
@@ -113,6 +186,9 @@ export function useWorkspaceHubSelection({
   const detailError = hubTemplateDetailQuery.error
     ? errorMessage(hubTemplateDetailQuery.error, t("hubWorkspaceLoadFailed"))
     : "";
+  const workspaceTreeError = hubWorkspaceQuery.error
+    ? errorMessage(hubWorkspaceQuery.error, t("hubWorkspaceLoadFailed"))
+    : workspaceDirectoryError;
   const workspaceFileError = hubWorkspaceFileQuery.error
     ? errorMessage(hubWorkspaceFileQuery.error, t("hubWorkspaceFileLoadFailed"))
     : "";
@@ -126,6 +202,7 @@ export function useWorkspaceHubSelection({
     }
     if (selectedHubTemplateId) {
       await refetchHubTemplateDetail();
+      await refetchHubWorkspace();
     }
     await refetchSkills();
     if (selectedHubSkillName) {
@@ -133,6 +210,7 @@ export function useWorkspaceHubSelection({
     }
   }, [
     refetchHubTemplateDetail,
+    refetchHubWorkspace,
     refetchSkillTree,
     refetchSkills,
     refreshTemplates,
@@ -146,7 +224,7 @@ export function useWorkspaceHubSelection({
     loaded,
     listError,
     skillsError,
-    error: listError || detailError || skillsError || skillTreeError,
+    error: listError || detailError || workspaceTreeError || skillsError || skillTreeError,
     selectedHubTemplateId,
     setSelectedHubTemplateId,
     selectedHubTemplate,
@@ -164,6 +242,11 @@ export function useWorkspaceHubSelection({
     hubTemplateDetailError: detailError,
     refetchHubTemplateDetail,
     selectedHubWorkspacePath,
+    workspaceEntries,
+    workspaceTreeLoading: hubWorkspaceQuery.isFetching,
+    workspaceTreeError,
+    loadingWorkspaceDirs,
+    loadWorkspaceDirectory,
     setSelectedHubWorkspacePath,
     selectWorkspaceFile,
     hubWorkspaceFile: hubWorkspaceFileQuery.data ?? null,
@@ -190,8 +273,10 @@ export function useWorkspaceHubSelection({
       selectedSkillPath: selectedHubSkillPath,
       selectedResourceType: selectedHubResourceType,
       loaded,
-      error: listError || detailError || skillsError || skillTreeError,
-      detailLoading: hubTemplateDetailQuery.isFetching,
+      error: listError || detailError || workspaceTreeError || skillsError || skillTreeError,
+      workspaceEntries,
+      workspaceTreeLoading: hubWorkspaceQuery.isFetching,
+      loadingWorkspaceDirs,
       selectedWorkspacePath: selectedHubWorkspacePath,
       workspaceFile: hubWorkspaceFileQuery.data ?? null,
       workspaceFileLoading: hubWorkspaceFileQuery.isFetching,
@@ -217,6 +302,7 @@ export function useWorkspaceHubSelection({
         }
       },
       onSelectWorkspaceFile: selectWorkspaceFile,
+      onToggleWorkspaceDir: loadWorkspaceDirectory,
       onSelectSkillFile: selectSkillFile,
     },
   };

--- a/web/app/src/hooks/workspace/workspaceQueries.ts
+++ b/web/app/src/hooks/workspace/workspaceQueries.ts
@@ -4,7 +4,7 @@ import { fetchAgentProfileModels, fetchAgentWorkspace, fetchAgentWorkspaceFile, 
 import type { AgentProfileModelRequest } from "@/api/agents";
 import { fetchBootstrap, fetchBootstrapConfig, fetchRuntimeImages, fetchVersion } from "@/api/app";
 import type { FetchVersionOptions } from "@/api/app";
-import { fetchHubTemplate, fetchHubTemplates, fetchHubWorkspaceFile } from "@/api/hub";
+import { fetchHubTemplate, fetchHubTemplates, fetchHubWorkspace, fetchHubWorkspaceFile } from "@/api/hub";
 import { fetchModelProviders } from "@/api/modelProviders";
 import { fetchSkillFile, fetchSkills, fetchSkillTree } from "@/api/skills";
 import { fetchManagerProfile } from "@/api/agents";
@@ -19,7 +19,7 @@ import {
 import type { AgentLike, AgentProfileLike, AgentProfileModelsResponse, RuntimeBootstrapConfig } from "@/models/agents";
 import { normalizeIMData } from "@/models/conversations";
 import type { IMData } from "@/models/conversations";
-import type { HubTemplate, HubWorkspaceFile } from "@/models/hubWorkspace";
+import type { HubTemplate, HubWorkspaceFile, HubWorkspaceListing } from "@/models/hubWorkspace";
 import type { ModelProviderCatalog } from "@/models/modelProviders";
 import type { SkillFile, SkillSummary, SkillTree } from "@/models/skillhub";
 import type { WorkspaceFile, WorkspaceListing } from "@/models/workspace";
@@ -38,6 +38,8 @@ export const workspaceQueryKeys = {
   hubTemplates: () => [WORKSPACE_QUERY_SCOPE, "hub-templates"] as const,
   hubTemplate: (templateID: string | null | undefined) =>
     [WORKSPACE_QUERY_SCOPE, "hub-template", templateID || ""] as const,
+  hubWorkspace: (templateID: string | null | undefined, workspacePath: string | null | undefined) =>
+    [WORKSPACE_QUERY_SCOPE, "hub-workspace", templateID || "", workspacePath || ""] as const,
   hubWorkspaceFile: (templateID: string | null | undefined, workspacePath: string | null | undefined) =>
     [WORKSPACE_QUERY_SCOPE, "hub-workspace-file", templateID || "", workspacePath || ""] as const,
   skills: () => [WORKSPACE_QUERY_SCOPE, "skills"] as const,
@@ -178,6 +180,17 @@ export function useWorkspaceHubTemplateQuery(templateID: string): UseQueryResult
   return useQuery<HubTemplate>({
     queryKey: workspaceQueryKeys.hubTemplate(templateID),
     queryFn: () => fetchHubTemplate(templateID),
+    enabled: Boolean(templateID),
+  });
+}
+
+export function useWorkspaceHubWorkspaceQuery(
+  templateID: string,
+  workspacePath = "",
+): UseQueryResult<HubWorkspaceListing> {
+  return useQuery<HubWorkspaceListing>({
+    queryKey: workspaceQueryKeys.hubWorkspace(templateID, workspacePath),
+    queryFn: () => fetchHubWorkspace(templateID, workspacePath),
     enabled: Boolean(templateID),
   });
 }

--- a/web/app/src/models/hubWorkspace.ts
+++ b/web/app/src/models/hubWorkspace.ts
@@ -1,9 +1,10 @@
 import type { AgentTemplateLike } from "@/models/agents";
 import type { LocaleCode, TranslateFn } from "@/models/conversations";
-import type { WorkspaceEntry, WorkspaceFile } from "@/models/workspace";
+import type { WorkspaceEntry, WorkspaceFile, WorkspaceListing } from "@/models/workspace";
 
 export type HubWorkspaceEntry = WorkspaceEntry;
 export type HubWorkspaceFile = WorkspaceFile;
+export type HubWorkspaceListing = WorkspaceListing;
 
 export const HUB_REGISTRY_KIND_LOCAL = "local";
 export const HUB_REGISTRY_KIND_REMOTE = "remote";

--- a/web/app/src/models/workspace.ts
+++ b/web/app/src/models/workspace.ts
@@ -27,6 +27,21 @@ export type WorkspaceTreeDepthStyle = CSSProperties & {
 };
 
 export type CollapsedWorkspaceDirs = Record<string, boolean>;
+export type WorkspaceDirectoryListings = Record<string, readonly WorkspaceEntry[]>;
+
+export function flattenWorkspaceDirectoryListings(listings: WorkspaceDirectoryListings): WorkspaceEntry[] {
+  const output: WorkspaceEntry[] = [];
+  const appendDirectory = (directoryPath: string) => {
+    for (const entry of listings[directoryPath] ?? []) {
+      output.push(entry);
+      if (entry.type === "dir" && Object.hasOwn(listings, entry.path)) {
+        appendDirectory(entry.path);
+      }
+    }
+  };
+  appendDirectory("");
+  return output;
+}
 
 export function workspaceAncestorDirs(path: unknown): string[] {
   const normalized = typeof path === "string" ? path.trim() : "";

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -24,7 +24,7 @@ const EMPTY_WORKSPACE_ENTRIES: readonly WorkspaceEntry[] = [];
 type HubDetailPaneHub = {
   detailPaneProps: {
     deleteBusy?: boolean;
-    detailLoading: boolean;
+    detailLoading?: boolean;
     error: string;
     loaded: boolean;
     onDeleteSkill?: (item: SkillSummary | null | undefined) => Promise<boolean> | boolean;
@@ -34,6 +34,7 @@ type HubDetailPaneHub = {
     onSelectSkillFile?: (path: string) => void;
     onSelectTemplate?: (item: HubTemplate | null | undefined) => void;
     onSelectWorkspaceFile: (workspacePath: string) => void;
+    onToggleWorkspaceDir?: (workspacePath: string) => void | Promise<void>;
     selectedResourceType?: "skill" | "template";
     selectedSkill: SkillSummary | null;
     selectedSkillPath: string;
@@ -52,17 +53,20 @@ type HubDetailPaneHub = {
     workspaceFile: WorkspaceFile | null;
     workspaceFileError: string;
     workspaceFileLoading: boolean;
+    workspaceEntries?: readonly WorkspaceEntry[];
+    workspaceTreeLoading?: boolean;
+    loadingWorkspaceDirs?: ReadonlySet<string>;
   };
 };
 
 const EMPTY_HUB_DETAIL_PROPS: HubDetailPaneHub["detailPaneProps"] = {
   deleteBusy: false,
-  detailLoading: false,
   error: "",
   loaded: false,
   onRetry: () => {},
   onSelectSkillFile: () => {},
   onSelectWorkspaceFile: () => {},
+  onToggleWorkspaceDir: () => {},
   selectedResourceType: "template",
   selectedSkill: null,
   selectedSkillPath: "",
@@ -81,6 +85,9 @@ const EMPTY_HUB_DETAIL_PROPS: HubDetailPaneHub["detailPaneProps"] = {
   workspaceFile: null,
   workspaceFileError: "",
   workspaceFileLoading: false,
+  workspaceEntries: [],
+  workspaceTreeLoading: false,
+  loadingWorkspaceDirs: new Set(),
 };
 
 function HubPreviewEmptyIcon() {
@@ -127,12 +134,12 @@ export function HubDetailPane({
     templates,
     skills,
     selectedTemplate,
+    selectedTemplateId,
     selectedSkill,
     selectedSkillPath,
     selectedResourceType = "template",
     loaded,
     error,
-    detailLoading,
     selectedWorkspacePath,
     workspaceFile,
     workspaceFileLoading,
@@ -144,6 +151,10 @@ export function HubDetailPane({
     skillFileLoading,
     skillFileError,
     onSelectWorkspaceFile,
+    onToggleWorkspaceDir,
+    workspaceEntries = EMPTY_WORKSPACE_ENTRIES,
+    workspaceTreeLoading = false,
+    loadingWorkspaceDirs,
     onSelectSkillFile,
     onDeleteSkill,
     onDeleteTemplate,
@@ -152,7 +163,6 @@ export function HubDetailPane({
   } = hub?.detailPaneProps ?? EMPTY_HUB_DETAIL_PROPS;
   const canDeleteTemplate = isDeletableHubTemplate(selectedTemplate);
   const canDeleteSkill = Boolean(selectedSkill && !selectedSkill.readonly && selectedSkill.source !== "system");
-  const workspaceEntries = selectedTemplate?.workspace?.entries ?? EMPTY_WORKSPACE_ENTRIES;
   const skillEntries = skillTree?.entries ?? EMPTY_WORKSPACE_ENTRIES;
   const activeResourceType = useMemo(() => {
     if (selectedResourceType === "skill" && skills.length) {
@@ -277,13 +287,16 @@ export function HubDetailPane({
                 <span className="hub-section-label">{t("hubWorkspaceTemplateLabel")}</span>
                 <div className="hub-workspace-panels">
                   <WorkspaceFileTree
+                    key={selectedTemplateId}
                     className="hub-workspace-tree"
                     entries={workspaceEntries}
-                    loading={detailLoading}
+                    loading={workspaceTreeLoading}
                     loadingText={t("hubWorkspaceLoading")}
                     emptyText={t("hubWorkspacePreviewHint")}
                     selectedPath={selectedWorkspacePath}
+                    loadingPaths={loadingWorkspaceDirs}
                     onSelectFile={onSelectWorkspaceFile}
+                    onToggleDir={onToggleWorkspaceDir}
                   />
                   <WorkspaceFilePreview
                     className="hub-workspace-preview"

--- a/web/app/tests/api/hub.test.ts
+++ b/web/app/tests/api/hub.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import { deleteHubTemplateRequest, fetchHubTemplate, fetchHubWorkspaceFile } from "@/api/hub";
+import { deleteHubTemplateRequest, fetchHubTemplate, fetchHubWorkspace, fetchHubWorkspaceFile } from "@/api/hub";
 
 function mockFetch(): Mock<typeof fetch> {
   const fetchMock = vi.fn<typeof fetch>(async (_input, _init) => new Response("{}", { status: 200 }));
@@ -39,6 +39,17 @@ describe("hub API", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "api/v1/hub/templates/builtin.openclaw-manager/workspace/file?path=skills%2Fcustom%2FSKILL.md",
+      expect.any(Object),
+    );
+  });
+
+  it("loads workspace directories by path", async () => {
+    const fetchMock = mockFetch();
+
+    await fetchHubWorkspace("official.gitlab-assistant", "skills/custom");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "api/v1/hub/templates/official.gitlab-assistant/workspace?path=skills%2Fcustom",
       expect.any(Object),
     );
   });

--- a/web/app/tests/components/WorkspaceFileTreeLazyLoad.test.tsx
+++ b/web/app/tests/components/WorkspaceFileTreeLazyLoad.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceFileTree } from "@/components/business/WorkspaceFileTree";
+
+describe("WorkspaceFileTree lazy loading", () => {
+  it("loads a directory when it is expanded and keeps it open when children arrive", async () => {
+    const user = userEvent.setup();
+    const onToggleDir = vi.fn();
+    const { rerender } = render(
+      <WorkspaceFileTree
+        emptyText="empty"
+        entries={[{ path: "skills", name: "skills", type: "dir" }]}
+        loadingText="loading"
+        onToggleDir={onToggleDir}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /skills/i }));
+    expect(onToggleDir).toHaveBeenCalledWith("skills");
+
+    rerender(
+      <WorkspaceFileTree
+        emptyText="empty"
+        entries={[
+          { path: "skills", name: "skills", type: "dir" },
+          { path: "skills/SKILL.md", name: "SKILL.md", type: "file" },
+        ]}
+        loadingText="loading"
+        onToggleDir={onToggleDir}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /SKILL\.md/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /skills/i })).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/web/app/tests/models/workspaceLazyTree.test.ts
+++ b/web/app/tests/models/workspaceLazyTree.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { flattenWorkspaceDirectoryListings } from "@/models/workspace";
+
+describe("flattenWorkspaceDirectoryListings", () => {
+  it("places loaded children directly after their directory", () => {
+    expect(
+      flattenWorkspaceDirectoryListings({
+        "": [
+          { path: "skills", name: "skills", type: "dir" },
+          { path: "USER.md", name: "USER.md", type: "file" },
+        ],
+        skills: [
+          { path: "skills/custom", name: "custom", type: "dir" },
+          { path: "skills/README.md", name: "README.md", type: "file" },
+        ],
+        "skills/custom": [{ path: "skills/custom/SKILL.md", name: "SKILL.md", type: "file" }],
+      }).map((entry) => entry.path),
+    ).toEqual(["skills", "skills/custom", "skills/custom/SKILL.md", "skills/README.md", "USER.md"]);
+  });
+
+  it("does not invent children for directories that have not been loaded", () => {
+    expect(
+      flattenWorkspaceDirectoryListings({
+        "": [{ path: "skills", name: "skills", type: "dir" }],
+      }).map((entry) => entry.path),
+    ).toEqual(["skills"]);
+  });
+});


### PR DESCRIPTION
- Switch the official template registry to the OpenCSG hub API and add staging override support.
- Load hub template workspace directories and file previews on demand instead of during template detail fetches.