### PR TITLE
fix(web): sync agent detail draft on profile refresh

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -323,6 +323,28 @@ export function useAgentController({
     }
     return agentItems.find((item) => item.id === activePane.id) ?? null;
   }, [agentItems, activePane]);
+  const selectedAgentForPageDraftSignature = useMemo(() => {
+    if (!selectedAgentForPage) {
+      return "";
+    }
+    return JSON.stringify({
+      id: selectedAgentForPage.id || "",
+      name: selectedAgentForPage.name || "",
+      description: selectedAgentForPage.description || "",
+      instructions: selectedAgentForPage.instructions || "",
+      profile: selectedAgentForPage.profile || "",
+      profile_complete:
+        selectedAgentForPage.profile_complete ?? selectedAgentForPage.agent_profile?.profile_complete ?? null,
+      provider: selectedAgentForPage.provider || selectedAgentForPage.agent_profile?.provider || "",
+      model_provider_id:
+        selectedAgentForPage.model_provider_id || selectedAgentForPage.agent_profile?.model_provider_id || "",
+      model_id: selectedAgentForPage.model_id || selectedAgentForPage.agent_profile?.model_id || "",
+      reasoning_effort:
+        selectedAgentForPage.reasoning_effort || selectedAgentForPage.agent_profile?.reasoning_effort || "",
+      enable_fast_mode:
+        selectedAgentForPage.enable_fast_mode ?? selectedAgentForPage.agent_profile?.enable_fast_mode ?? false,
+    });
+  }, [selectedAgentForPage]);
   const selectedFeishuPendingRegistration = useMemo(() => {
     const agentID = String(selectedAgentForPage?.id || "").trim();
     if (!agentID) {
@@ -519,10 +541,11 @@ export function useAgentController({
       setAgentPagePublishBusy(false);
       return;
     }
+    if (agentPageHasUnsavedChanges) {
+      return;
+    }
     loadAgentPageDraft(selectedAgentForPage);
-    // Reload only when the routed agent changes; form draft edits should not refetch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedAgentForPage?.id]);
+  }, [agentPageHasUnsavedChanges, selectedAgentForPage?.id, selectedAgentForPageDraftSignature]);
 
   async function refreshManagerProfile(): Promise<void> {
     await refreshWorkspaceManagerProfile();

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -157,9 +157,8 @@ function useAgentControllerHarness(
     managerProfile?: AgentProfileLike | null;
   } = {},
 ) {
-  const initialAgents = options.agents ?? [oldAgent];
-  const [agents, setAgents] = useState<AgentLike[]>(initialAgents);
-  const refreshWorkspaceAgentsRef = useRef(vi.fn(async () => initialAgents));
+  const [agents, setAgents] = useState<AgentLike[]>(options.agents ?? [oldAgent]);
+  const refreshWorkspaceAgentsRef = useRef(vi.fn(async () => options.agents ?? [oldAgent]));
   const refreshWorkspaceBootstrapRef = useRef(vi.fn(async () => null));
   const refreshWorkspaceBootstrapConfigRef = useRef(vi.fn(async () => null));
   const refreshWorkspaceManagerProfileRef = useRef(vi.fn(async () => null));
@@ -172,6 +171,12 @@ function useAgentControllerHarness(
   const selectConversationRef = useRef(vi.fn());
   const selectConversation = selectConversationRef.current;
   const data = options.data ?? null;
+
+  useEffect(() => {
+    if (options.agents) {
+      setAgents(options.agents);
+    }
+  }, [options.agents]);
 
   const controller = useAgentController({
     activeConversationId: "",
@@ -396,6 +401,68 @@ describe("useAgentController", () => {
     );
     expect(result.current.refreshWorkspaceBootstrap).not.toHaveBeenCalled();
     expect(fetchAgentSkills).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads the selected agent draft when the same routed agent gains profile fields and there are no unsaved edits", async () => {
+    const partialAgent: AgentLike = {
+      id: "u-worker",
+      name: "worker",
+      role: "worker",
+      runtime_kind: "picoclaw_sandbox",
+      status: "running",
+      image: "worker:latest",
+      instructions: "reply briefly",
+      profile_complete: false,
+    };
+    const fullAgent: AgentLike = {
+      ...partialAgent,
+      agent_profile: {
+        provider: "csghub_lite",
+        model_provider_id: "csghub-lite",
+        model_id: "MiniMax-M2.5",
+        reasoning_effort: "medium",
+        enable_fast_mode: false,
+        profile_complete: true,
+      },
+      profile: "csghub-lite.MiniMax-M2.5",
+      profile_complete: true,
+      provider: "csghub_lite",
+      model_provider_id: "csghub-lite",
+      model_id: "MiniMax-M2.5",
+    };
+
+    vi.mocked(fetchAgent).mockReset();
+    vi.mocked(fetchAgentProfile).mockReset();
+    vi.mocked(fetchAgent)
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockResolvedValueOnce(fullAgent)
+      .mockResolvedValue(fullAgent);
+    vi.mocked(fetchAgentProfile)
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockResolvedValue(fullAgent.agent_profile ?? {});
+
+    const { result, rerender } = renderHook(
+      ({ agents }) =>
+        useAgentControllerHarness({
+          activePane: { type: WorkspacePaneTypes.agent, id: "u-worker" },
+          agents,
+        }).controller,
+      {
+        initialProps: {
+          agents: [partialAgent],
+        },
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.agentViewProps.draft?.model_id).toBe(""));
+
+    rerender({
+      agents: [fullAgent],
+    });
+
+    await waitFor(() => expect(result.current.agentViewProps.draft?.model_id).toBe("MiniMax-M2.5"));
+    await waitFor(() => expect(result.current.agentViewProps.savedDraft?.model_id).toBe("MiniMax-M2.5"));
   });
 
   it("loads global skill candidates and filters already-installed agent skills", async () => {


### PR DESCRIPTION
## Summary
- refresh the agent detail draft when the routed agent profile fields change for the same agent id
- skip the automatic reload when the page already has unsaved edits
- add a regression test covering delayed profile hydration for the selected agent detail page

## Root Cause
The agent detail page only reloaded its draft when the routed agent id changed. When the same agent later received a fuller profile payload, the page could keep an older draft baseline and miss dirty-state transitions in the model section.

## Validation
- `pnpm --dir web/app exec vitest run tests/hooks/useAgentController.test.tsx -t "reloads the selected agent draft"`
- `pnpm --dir web/app exec vitest run tests/components/AgentActions.test.tsx`

## Impact
This fixes the intermittent case where editing model settings on the agent detail page would not surface an enabled `Save changes` button.
