### PR TITLE
fix(template): keep requester in manager-created rooms

### DIFF
--- a/internal/template/embed/manager/openclaw/workspace/skills/basics/SKILL.md
+++ b/internal/template/embed/manager/openclaw/workspace/skills/basics/SKILL.md
@@ -45,10 +45,11 @@ For hub template selection and `--from-template` creation, use `agent-creator` i
 Create a room:
 
 ```bash
-csgclaw-cli room create --title test-room --creator-id manager --member-ids manager,dev --channel csgclaw
+csgclaw-cli room create --title test-room --creator-id admin --member-ids manager,<worker-participant-id> --channel csgclaw
 ```
 
-Use participant IDs in room, member, and message commands. The default manager participant is `manager`; its backing agent ID is `u-manager`. For Feishu room creation, pass Feishu participant IDs; CSGClaw resolves the configured app credentials internally.
+Use participant IDs in room, member, and message commands. The default human requester is `admin`; use the actual requester participant ID if it is different. The default manager participant is `manager`; its backing agent ID is `u-manager`. For Feishu room creation, pass Feishu participant IDs; CSGClaw resolves the configured app credentials internally.
+Resolve worker participant IDs with `participant list` before using them. Do not copy sample names unless they appear as real participant IDs.
 
 List rooms and check whether a room is direct:
 
@@ -84,9 +85,9 @@ If the current room is direct in the local `csgclaw` channel, do not try to add 
 
 ```bash
 csgclaw-cli room create \
-  --title "manager-dev-alex" \
-  --creator-id manager \
-  --member-ids manager,dev,alex \
+  --title "admin-manager-workers" \
+  --creator-id admin \
+  --member-ids manager,<worker-participant-id>,<another-worker-participant-id> \
   --channel csgclaw
 ```
 
@@ -94,9 +95,9 @@ For Feishu, keep the same participant ID boundary:
 
 ```bash
 csgclaw-cli room create \
-  --title "manager-dev-alex" \
-  --creator-id manager \
-  --member-ids manager,dev,alex \
+  --title "admin-manager-workers" \
+  --creator-id admin \
+  --member-ids manager,<worker-participant-id>,<another-worker-participant-id> \
   --channel feishu
 ```
 
@@ -145,6 +146,8 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 - When a **new** worker is needed, use `agent-creator`; do not run bare `participant create --bind create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added participant as a new member. Create a new room with `--member-ids` containing the existing DM participants and the new participant.
+- When creating a room from a direct/private chat with admin or another human requester, preserve the requester as `--creator-id` (default `admin`) and include `manager` plus the requested participants in `--member-ids`. Do not use `manager` as the creator just because the manager runs the CLI command.
+- Replace `<worker-participant-id>` placeholders with actual IDs from `participant list`; a display name such as `dev` or `qa` is not necessarily a valid participant ID.
 - For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist; it creates the chat first, then invites configured worker bot apps. Use `member create` only for an existing Feishu group. Both paths require manager app scopes such as `im:chat.members:write_only` or `im:chat`.
 - Use participant IDs at the CLI boundary. For the local CSGClaw manager use `manager`; use `u-manager` only when calling an agent route or the Feishu credential config API field that still names its key `bot_id`.
 - Never notify a worker with plain-text `@name`; always use `message create --mention-id` and verify `<at user_id="...">` in `message list`.

--- a/internal/template/embed/manager/openclaw/workspace/skills/feishu/SKILL.md
+++ b/internal/template/embed/manager/openclaw/workspace/skills/feishu/SKILL.md
@@ -82,10 +82,11 @@ CSGClaw cannot silently grant Feishu/Lark app scopes from inside the OpenClaw ru
 For new Feishu groups, after the manager and worker Feishu configs exist, prefer creating the group with all participant IDs already included:
 
 ```bash
-csgclaw-cli room create --title dev-ui-group --creator-id manager --member-ids manager,dev --channel feishu
+csgclaw-cli room create --title worker-group --creator-id admin --member-ids manager,<worker-participant-id> --channel feishu
 ```
 
 CSGClaw creates the Feishu chat first, then resolves those participant IDs to configured Feishu app credentials and invites the worker bot apps. This keeps the created `chat_id` visible if the invite fails, but it still requires manager app group scopes for chat creation and member invites.
+When creating the group from a direct/private request, keep the human requester as `--creator-id` (default `admin`) so the requester is recorded in the CSGClaw room members. Include `manager` plus the requested worker participant IDs in `--member-ids`, and replace `<worker-participant-id>` with IDs from `participant list`.
 
 For Feishu group operations, `room create --member-ids`, `csgclaw-cli member list`, and `member create` require manager app scopes such as:
 

--- a/internal/template/embed/manager/picoclaw/workspace/skills/basics/SKILL.md
+++ b/internal/template/embed/manager/picoclaw/workspace/skills/basics/SKILL.md
@@ -44,10 +44,11 @@ For hub template selection and `--from-template` creation, use `agent-creator` i
 Create a room:
 
 ```bash
-csgclaw-cli room create --title test-room --creator-id manager --member-ids manager,dev --channel csgclaw
+csgclaw-cli room create --title test-room --creator-id admin --member-ids manager,<worker-participant-id> --channel csgclaw
 ```
 
-Use CSGClaw participant IDs in CSGClaw-channel room, member, and message commands. The default manager participant is `manager`; its backing agent ID is `u-manager`.
+Use CSGClaw participant IDs in CSGClaw-channel room, member, and message commands. The default human requester is `admin`; use the actual requester participant ID if it is different. The default manager participant is `manager`; its backing agent ID is `u-manager`.
+Resolve worker participant IDs with `participant list` before using them. Do not copy sample names unless they appear as real participant IDs.
 
 List rooms and check whether a room is direct:
 
@@ -83,9 +84,9 @@ If the current room is direct in the local `csgclaw` channel, do not try to add 
 
 ```bash
 csgclaw-cli room create \
-  --title "manager-dev-alex" \
-  --creator-id manager \
-  --member-ids manager,dev,alex \
+  --title "admin-manager-workers" \
+  --creator-id admin \
+  --member-ids manager,<worker-participant-id>,<another-worker-participant-id> \
   --channel csgclaw
 ```
 
@@ -93,9 +94,9 @@ For Feishu, use the configured Feishu participant IDs:
 
 ```bash
 csgclaw-cli room create \
-  --title "manager-dev-alex" \
-  --creator-id manager \
-  --member-ids manager,dev,alex \
+  --title "admin-manager-workers" \
+  --creator-id admin \
+  --member-ids manager,<worker-participant-id>,<another-worker-participant-id> \
   --channel feishu
 ```
 
@@ -144,6 +145,8 @@ Do **not** post `@alex` plain text in the room instead of `--mention-id`.
 - When a **new** worker is needed, use `agent-creator`; do not run bare `participant create --bind create` from this skill.
 - Verify room membership with `member list` after adding a member when room presence matters.
 - A direct room cannot accept an added participant as a new member. Create a new room with `--member-ids` containing the existing DM participants and the new participant.
+- When creating a room from a direct/private chat with admin or another human requester, preserve the requester as `--creator-id` (default `admin`) and include `manager` plus the requested participants in `--member-ids`. Do not use `manager` as the creator just because the manager runs the CLI command.
+- Replace `<worker-participant-id>` placeholders with actual IDs from `participant list`; a display name such as `dev` or `qa` is not necessarily a valid participant ID.
 - For Feishu, prefer `room create --member-ids` for new groups after Feishu credentials exist; it creates the chat first, then invites configured worker bot apps. Use `member create` only for an existing Feishu group. Both paths require manager app scopes such as `im:chat.members:write_only` or `im:chat`.
 - Use participant IDs at the CLI boundary. For the local CSGClaw manager use `manager`; use `u-manager` only when calling an agent route or the Feishu credential config API field that still names its key `bot_id`.
 - Never notify a worker with plain-text `@name`; always use `message create --mention-id` and verify `<at user_id="...">` in `message list`.

--- a/internal/template/embed/manager/picoclaw/workspace/skills/feishu/SKILL.md
+++ b/internal/template/embed/manager/picoclaw/workspace/skills/feishu/SKILL.md
@@ -82,10 +82,11 @@ CSGClaw cannot silently grant Feishu/Lark app scopes from inside the PicoClaw ru
 For new Feishu groups, after the manager and worker Feishu configs exist, prefer creating the group with all participant IDs already included:
 
 ```bash
-csgclaw-cli room create --title dev-ui-group --creator-id manager --member-ids manager,dev --channel feishu
+csgclaw-cli room create --title worker-group --creator-id admin --member-ids manager,<worker-participant-id> --channel feishu
 ```
 
 CSGClaw creates the Feishu chat first, then resolves those participant IDs to configured Feishu app credentials and invites the worker bot apps. This keeps the created `chat_id` visible if the invite fails, but it still requires manager app group scopes for chat creation and member invites.
+When creating the group from a direct/private request, keep the human requester as `--creator-id` (default `admin`) so the requester is recorded in the CSGClaw room members. Include `manager` plus the requested worker participant IDs in `--member-ids`, and replace `<worker-participant-id>` with IDs from `participant list`.
 
 For Feishu group operations, `room create --member-ids`, `csgclaw-cli member list`, and `member create` require manager app scopes such as:
 

--- a/internal/template/embed/manager_basics_test.go
+++ b/internal/template/embed/manager_basics_test.go
@@ -1,0 +1,84 @@
+package templateembed
+
+import (
+	"io/fs"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestManagerBasicsRoomCreationKeepsRequesterAsCreator(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+	}{
+		{name: "picoclaw", root: PicoClawManagerRoot},
+		{name: "openclaw", root: OpenClawManagerRoot},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := fs.ReadFile(FS(), path.Join(tt.root, WorkspaceDirName, "skills/basics/SKILL.md"))
+			if err != nil {
+				t.Fatalf("read basics skill: %v", err)
+			}
+			skill := string(data)
+
+			for _, want := range []string{
+				"csgclaw-cli room create --title test-room --creator-id admin --member-ids manager,<worker-participant-id> --channel csgclaw",
+				"Resolve worker participant IDs with `participant list` before using them.",
+				"preserve the requester as `--creator-id`",
+				"include `manager` plus the requested participants in `--member-ids`",
+				"Do not use `manager` as the creator just because the manager runs the CLI command.",
+				"a display name such as `dev` or `qa` is not necessarily a valid participant ID.",
+			} {
+				if !strings.Contains(skill, want) {
+					t.Fatalf("basics skill missing requester creator guidance %q", want)
+				}
+			}
+			if strings.Contains(skill, "--creator-id manager") {
+				t.Fatalf("basics skill still teaches manager as room creator:\n%s", skill)
+			}
+			if strings.Contains(skill, "--member-ids manager,dev") {
+				t.Fatalf("basics skill still teaches sample dev as a literal participant ID:\n%s", skill)
+			}
+		})
+	}
+}
+
+func TestManagerFeishuSkillRoomCreationKeepsRequesterAsCreator(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+	}{
+		{name: "picoclaw", root: PicoClawManagerRoot},
+		{name: "openclaw", root: OpenClawManagerRoot},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := fs.ReadFile(FS(), path.Join(tt.root, WorkspaceDirName, "skills/feishu/SKILL.md"))
+			if err != nil {
+				t.Fatalf("read feishu skill: %v", err)
+			}
+			skill := string(data)
+
+			for _, want := range []string{
+				"csgclaw-cli room create --title worker-group --creator-id admin --member-ids manager,<worker-participant-id> --channel feishu",
+				"keep the human requester as `--creator-id`",
+				"Include `manager` plus the requested worker participant IDs in `--member-ids`",
+				"replace `<worker-participant-id>` with IDs from `participant list`",
+			} {
+				if !strings.Contains(skill, want) {
+					t.Fatalf("feishu skill missing requester creator guidance %q", want)
+				}
+			}
+			if strings.Contains(skill, "--creator-id manager") {
+				t.Fatalf("feishu skill still teaches manager as room creator:\n%s", skill)
+			}
+			if strings.Contains(skill, "--member-ids manager,dev") {
+				t.Fatalf("feishu skill still teaches sample dev as a literal participant ID:\n%s", skill)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Update manager basics and Feishu skill examples to keep the human requester as the room creator.
- Require manager-created rooms to include `manager` plus real worker participant IDs resolved from `participant list`.
- Add embed-template tests to prevent regressions to `--creator-id manager` or literal `manager,dev` examples.

## Impact

Manager-created rooms from a direct/private request now guide the agent to keep `admin` in the room, matching Web UI room creation behavior and preserving later member-management permissions.

## Validation

- `GOCACHE=/tmp/gocache go test ./internal/template/embed`
- `GOCACHE=/tmp/gocache go test ./internal/template/...`
- `GOCACHE=/tmp/gocache go test ./internal/channel/feishu`
