### PR TITLE
fix(agent): recreate legacy-named sandboxes on startup

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -637,6 +637,29 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 
 	var info sandbox.Info
 	createdBootstrapManagerBox := false
+	if box != nil {
+		info, err = s.boxInfo(ctx, box)
+		if err != nil {
+			return Agent{}, fmt.Errorf("read bootstrap manager box info: %w", err)
+		}
+		if info.State != sandbox.StateRunning {
+			if err := s.startBox(ctx, box); err != nil {
+				return Agent{}, fmt.Errorf("start bootstrap manager box: %w", err)
+			}
+			info, err = s.boxInfo(ctx, box)
+			if err != nil {
+				return Agent{}, fmt.Errorf("read bootstrap manager box info after start: %w", err)
+			}
+		}
+		if !forceRecreate && sandboxInfoNeedsCanonicalAgentName(ManagerUserID, managerDisplayName, info, "") {
+			log.Printf("bootstrap manager box %q uses legacy sandbox name %q; recreating as %q", managerDisplayName, strings.TrimSpace(info.Name), sandboxNameForAgentID(ManagerUserID))
+			if err := s.removeResolvedGatewayBox(ctx, rt, box, info, ""); err != nil {
+				return Agent{}, fmt.Errorf("remove legacy-named bootstrap manager box: %w", err)
+			}
+			box = nil
+			info = sandbox.Info{}
+		}
+	}
 	if box == nil {
 		log.Printf("bootstrap manager box %q not found, creating it with image %q", managerDisplayName, managerImage)
 		log.Printf("if the image is not present locally, the first pull may take a while")
@@ -661,20 +684,6 @@ func (s *Service) ensureManager(ctx context.Context, forceRecreate bool, imageOv
 		}
 		createdBootstrapManagerBox = true
 		log.Printf("bootstrap manager box %q created", managerDisplayName)
-	} else {
-		info, err = s.boxInfo(ctx, box)
-		if err != nil {
-			return Agent{}, fmt.Errorf("read bootstrap manager box info: %w", err)
-		}
-		if info.State != sandbox.StateRunning {
-			if err := s.startBox(ctx, box); err != nil {
-				return Agent{}, fmt.Errorf("start bootstrap manager box: %w", err)
-			}
-			info, err = s.boxInfo(ctx, box)
-			if err != nil {
-				return Agent{}, fmt.Errorf("read bootstrap manager box info after start: %w", err)
-			}
-		}
 	}
 	defer func() {
 		_ = s.closeBox(box)
@@ -1519,6 +1528,129 @@ func (s *Service) stopAndForceRemoveBox(ctx context.Context, rt sandbox.Runtime,
 	return nil
 }
 
+func (s *Service) removeResolvedGatewayBox(ctx context.Context, rt sandbox.Runtime, box sandbox.Instance, info sandbox.Info, resolvedKey string) error {
+	removeKey := gatewayBoxRemoveKey(info, resolvedKey)
+	if removeKey == "" {
+		return fmt.Errorf("agent box identifier is required")
+	}
+	if box != nil {
+		if err := s.stopBox(ctx, box, sandbox.StopOptions{}); err != nil && !sandbox.IsNotFound(err) {
+			_ = s.closeBox(box)
+			return fmt.Errorf("stop agent box: %w", err)
+		}
+		_ = s.closeBox(box)
+	}
+	if err := s.forceRemoveBox(ctx, rt, removeKey); err != nil && !sandbox.IsNotFound(err) {
+		return fmt.Errorf("remove agent box: %w", err)
+	}
+	return nil
+}
+
+func gatewayBoxRemoveKey(info sandbox.Info, resolvedKey string) string {
+	for _, key := range []string{resolvedKey, info.ID, info.Name} {
+		if key = strings.TrimSpace(key); key != "" {
+			return key
+		}
+	}
+	return ""
+}
+
+func sandboxInfoNeedsCanonicalAgentName(agentID, displayName string, info sandbox.Info, resolvedKey string) bool {
+	canonicalName := strings.TrimSpace(sandboxNameForAgentID(agentID))
+	if canonicalName == "" {
+		return false
+	}
+	if name := strings.TrimSpace(info.Name); name != "" {
+		return name != canonicalName
+	}
+	key := strings.TrimSpace(resolvedKey)
+	if key == "" || key == canonicalName || key == strings.TrimSpace(info.ID) {
+		return false
+	}
+	if display := strings.TrimSpace(displayName); display != "" && key == display {
+		return true
+	}
+	if suffix := strings.TrimPrefix(canonicalAgentID(agentID), AgentIDPrefix); suffix != "" && key == suffix {
+		return true
+	}
+	return false
+}
+
+func (s *Service) recreateLegacyNamedGatewayAgentBox(ctx context.Context, got Agent) (Agent, bool, error) {
+	if !isGatewayRuntimeKind(strings.TrimSpace(got.RuntimeKind)) {
+		return got, false, nil
+	}
+	rt, err := s.ensureRuntime(got.ID)
+	if err != nil {
+		return got, false, err
+	}
+	runtimeHome, err := s.sandboxRuntimeHome(got.ID)
+	if err != nil {
+		return got, false, err
+	}
+	defer func() {
+		_ = s.closeRuntime(runtimeHome, rt)
+	}()
+
+	box, resolvedKey, err := s.resolveAgentBox(ctx, rt, got)
+	if err != nil {
+		if sandbox.IsNotFound(err) {
+			return got, false, nil
+		}
+		return got, false, err
+	}
+	info, err := s.boxInfo(ctx, box)
+	if err != nil {
+		_ = s.closeBox(box)
+		return got, false, fmt.Errorf("read agent box info: %w", err)
+	}
+	if !sandboxInfoNeedsCanonicalAgentName(got.ID, got.Name, info, resolvedKey) {
+		_ = s.closeBox(box)
+		return got, false, nil
+	}
+
+	startProfile := s.hydrateProfileFromCatalog(normalizeProfileForAgentRuntime(got.AgentProfile, got.RuntimeOptions, got.Name, got.Description, got.RuntimeKind, nil))
+	if err := s.validateRuntimeConfig(ctx, strings.TrimSpace(got.RuntimeKind), runtimeConfigSnapshotForAgent(startProfile, got.RuntimeOptions)); err != nil {
+		_ = s.closeBox(box)
+		return got, false, err
+	}
+	runtimeImpl, err := s.runtimeForKind(strings.TrimSpace(got.RuntimeKind))
+	if err != nil {
+		_ = s.closeBox(box)
+		return got, false, err
+	}
+	if err := s.provisionRuntimeForAgent(ctx, runtimeImpl, got, ""); err != nil {
+		_ = s.closeBox(box)
+		return got, false, fmt.Errorf("provision agent runtime: %w", err)
+	}
+
+	log.Printf("agent %s sandbox %q uses legacy sandbox name %q; recreating as %q", got.ID, gatewayBoxRemoveKey(info, resolvedKey), strings.TrimSpace(info.Name), sandboxNameForAgentID(got.ID))
+	if err := s.removeResolvedGatewayBox(ctx, rt, box, info, resolvedKey); err != nil {
+		return got, false, err
+	}
+	box = nil
+
+	newBox, newInfo, err := s.createGatewayBox(ctx, rt, got.Image, got.Name, got.ID, startProfile)
+	if err != nil {
+		return got, false, fmt.Errorf("create agent box with canonical name: %w", err)
+	}
+	defer func() {
+		_ = s.closeBox(newBox)
+	}()
+	updated, err := s.updateRuntimeState(got.ID, agentruntime.Info{
+		HandleID:  strings.TrimSpace(newInfo.ID),
+		State:     agentruntime.State(newInfo.State),
+		CreatedAt: newInfo.CreatedAt.UTC(),
+	})
+	if err != nil {
+		return got, false, err
+	}
+	if err := s.syncLifecycleForAgent(ctx, updated); err != nil {
+		return got, false, err
+	}
+	return updated, true, nil
+}
+
 func sandboxNameForAgentID(agentID string) string {
 	return agentruntime.SandboxNameForAgentID(canonicalAgentID(agentID))
 }
@@ -1578,6 +1710,14 @@ func (s *Service) StartConfiguredAgents(ctx context.Context) error {
 			return err
 		}
 		live := s.hydrateAgentStatus(ctx, a)
+		_, reconciled, err := s.recreateLegacyNamedGatewayAgentBox(ctx, live)
+		if err != nil {
+			startErr = errors.Join(startErr, fmt.Errorf("%s: %w", live.Name, err))
+			continue
+		}
+		if reconciled {
+			continue
+		}
 		if isRuntimeRunning(live) {
 			continue
 		}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -5885,13 +5885,13 @@ func TestStartConfiguredAgentsStartsStoppedCompleteWorkersAndLeavesRunningWorker
 	infos := map[string]sandbox.Info{
 		"box-alice": {
 			ID:        "box-alice",
-			Name:      "alice",
+			Name:      "csgclaw-agent-alice",
 			State:     sandbox.StateStopped,
 			CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
 		},
 		"box-carol": {
 			ID:        "box-carol",
-			Name:      "carol",
+			Name:      "csgclaw-agent-carol",
 			State:     sandbox.StateRunning,
 			CreatedAt: time.Date(2026, 4, 1, 13, 0, 0, 0, time.UTC),
 		},
@@ -6001,6 +6001,137 @@ func TestStartConfiguredAgentsStartsStoppedCompleteWorkersAndLeavesRunningWorker
 	}
 	if carol.Status != string(sandbox.StateRunning) {
 		t.Fatalf("Agent(u-carol).Status = %q, want running", carol.Status)
+	}
+}
+
+func TestStartConfiguredAgentsRecreatesRunningLegacyNamedWorkerBox(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		runtimeKind string
+	}{
+		{name: "picoclaw", runtimeKind: RuntimeKindPicoClawSandbox},
+		{name: "openclaw", runtimeKind: RuntimeKindOpenClawSandbox},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			rt := &fakeRuntime{}
+			infos := map[string]sandbox.Info{
+				"box-alice": {
+					ID:        "box-alice",
+					Name:      "alice",
+					State:     sandbox.StateRunning,
+					CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+				},
+				"alice": {
+					ID:        "box-alice",
+					Name:      "alice",
+					State:     sandbox.StateRunning,
+					CreatedAt: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+				},
+			}
+			var created []string
+			SetTestHooks(
+				func(_ *Service, _ string) (sandbox.Runtime, error) { return rt, nil },
+				func(_ *Service, _ context.Context, _ sandbox.Runtime, image, name, botID string, profile AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+					if image != "worker-image:1" {
+						t.Fatalf("createGatewayBox() image = %q, want %q", image, "worker-image:1")
+					}
+					if name != "alice" {
+						t.Fatalf("createGatewayBox() name = %q, want %q", name, "alice")
+					}
+					if botID != "agent-alice" {
+						t.Fatalf("createGatewayBox() botID = %q, want %q", botID, "agent-alice")
+					}
+					if !profile.ProfileComplete || profile.Provider != ProviderCodex || profile.ModelID != "gpt-5.5" {
+						t.Fatalf("createGatewayBox() profile = %+v, want complete codex gpt-5.5", profile)
+					}
+					created = append(created, botID)
+					info := sandbox.Info{
+						ID:        "box-canonical-alice",
+						Name:      "csgclaw-agent-alice",
+						State:     sandbox.StateRunning,
+						CreatedAt: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+					}
+					infos[info.ID] = info
+					infos[info.Name] = info
+					return &fakeInfoInstance{info: info}, info, nil
+				},
+			)
+			defer ResetTestHooks()
+
+			var gotKeys []string
+			testGetBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
+				gotKeys = append(gotKeys, idOrName)
+				info, ok := infos[idOrName]
+				if !ok {
+					return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+				}
+				return &fakeInfoInstance{info: info}, nil
+			}
+			testBoxInfoHook = func(_ *Service, _ context.Context, box sandbox.Instance) (sandbox.Info, error) {
+				return box.Info(context.Background())
+			}
+			var started []string
+			testStartBoxHook = func(_ *Service, _ context.Context, box sandbox.Instance) error {
+				info, err := box.Info(context.Background())
+				if err != nil {
+					return err
+				}
+				started = append(started, info.ID)
+				return nil
+			}
+			var removed []string
+			testForceRemoveBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) error {
+				removed = append(removed, idOrName)
+				delete(infos, idOrName)
+				delete(infos, "alice")
+				return nil
+			}
+
+			svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
+			if err != nil {
+				t.Fatalf("NewService() error = %v", err)
+			}
+			completeAlice := AgentProfile{Name: "alice", Provider: ProviderCodex, ModelID: "gpt-5.5", ProfileComplete: true}
+			svc.agents["agent-alice"] = Agent{
+				ID:              "agent-alice",
+				Name:            "alice",
+				Role:            RoleWorker,
+				RuntimeKind:     tt.runtimeKind,
+				Image:           "worker-image:1",
+				BoxID:           "box-alice",
+				Status:          string(sandbox.StateRunning),
+				AgentProfile:    completeAlice,
+				ProfileComplete: true,
+				CreatedAt:       time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+			}
+
+			if err := svc.StartConfiguredAgents(context.Background()); err != nil {
+				t.Fatalf("StartConfiguredAgents() error = %v", err)
+			}
+			if strings.Join(created, ",") != "agent-alice" {
+				t.Fatalf("created boxes = %q, want agent-alice", created)
+			}
+			if strings.Join(removed, ",") != "box-alice" {
+				t.Fatalf("removed boxes = %q, want box-alice", removed)
+			}
+			if len(started) != 0 {
+				t.Fatalf("startBox() calls = %q, want none because old running box is recreated", started)
+			}
+			if len(gotKeys) < 1 || gotKeys[0] != "box-alice" {
+				t.Fatalf("getBox() leading keys = %q, want box-alice first", gotKeys)
+			}
+			got, ok := svc.Agent("agent-alice")
+			if !ok {
+				t.Fatal("Agent() missing agent-alice")
+			}
+			if got.BoxID != "box-canonical-alice" {
+				t.Fatalf("Agent().BoxID = %q, want %q", got.BoxID, "box-canonical-alice")
+			}
+			if got.Status != string(sandbox.StateRunning) {
+				t.Fatalf("Agent().Status = %q, want running", got.Status)
+			}
+		})
 	}
 }
 
@@ -6485,7 +6616,7 @@ func TestEnsureBootstrapStateReusesStoredManagerBoxIDWithoutForce(t *testing.T) 
 	testBoxInfoHook = func(_ *Service, _ context.Context, _ sandbox.Instance) (sandbox.Info, error) {
 		return sandbox.Info{
 			ID:        "box-old",
-			Name:      ManagerName,
+			Name:      "csgclaw-agent-manager",
 			State:     sandbox.StateRunning,
 			CreatedAt: time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC),
 		}, nil
@@ -6517,6 +6648,106 @@ func TestEnsureBootstrapStateReusesStoredManagerBoxIDWithoutForce(t *testing.T) 
 	}
 	if created {
 		t.Fatal("createGatewayBox() called, want existing manager box to be reused")
+	}
+}
+
+func TestEnsureBootstrapStateRecreatesLegacyNamedManagerBoxWithoutForce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	SetTestHooks(nil, nil)
+	defer ResetTestHooks()
+
+	primaryRT := &fakeRuntime{}
+	testEnsureRuntimeAtHomeHook = func(_ *Service, home string) (sandbox.Runtime, error) {
+		return primaryRT, nil
+	}
+
+	var created bool
+	testCreateGatewayBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string, name, botID string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+		created = true
+		if name != ManagerName {
+			t.Fatalf("createGatewayBox() name = %q, want %q", name, ManagerName)
+		}
+		if botID != ManagerUserID {
+			t.Fatalf("createGatewayBox() botID = %q, want %q", botID, ManagerUserID)
+		}
+		info := sandbox.Info{
+			ID:        "box-canonical-manager",
+			Name:      "csgclaw-agent-manager",
+			State:     sandbox.StateRunning,
+			CreatedAt: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC),
+		}
+		return &fakeInfoInstance{info: info}, info, nil
+	}
+	testGetBoxHook = func(_ *Service, _ context.Context, rt sandbox.Runtime, idOrName string) (sandbox.Instance, error) {
+		if rt == primaryRT && idOrName == "box-old" {
+			return &fakeInfoInstance{info: sandbox.Info{
+				ID:        "box-old",
+				Name:      ManagerName,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC),
+			}}, nil
+		}
+		return nil, fmt.Errorf("%w: missing", sandbox.ErrNotFound)
+	}
+	var removed []string
+	testForceRemoveBoxHook = func(_ *Service, _ context.Context, _ sandbox.Runtime, idOrName string) error {
+		removed = append(removed, idOrName)
+		return nil
+	}
+	testStartBoxHook = func(_ *Service, _ context.Context, _ sandbox.Instance) error { return nil }
+	testBoxInfoHook = func(_ *Service, _ context.Context, box sandbox.Instance) (sandbox.Info, error) {
+		return box.Info(context.Background())
+	}
+
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "agents.json")
+	data, err := json.Marshal(persistedState{
+		Agents: []persistedAgent{
+			{
+				ID:          ManagerUserID,
+				Name:        ManagerName,
+				RuntimeKind: RuntimeKindPicoClawSandbox,
+				Role:        RoleManager,
+				BoxID:       "box-old",
+				CreatedAt:   time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+				AgentProfile: AgentProfile{
+					Name:            ManagerName,
+					Provider:        ProviderCodex,
+					ModelID:         "gpt-5.5",
+					ProfileComplete: true,
+				},
+				ProfileComplete: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	if err := EnsureBootstrapState(context.Background(), statePath, config.ServerConfig{}, config.ModelConfig{}, "manager-image:test", false); err != nil {
+		t.Fatalf("EnsureBootstrapState() error = %v", err)
+	}
+	if !created {
+		t.Fatal("createGatewayBox() was not called for legacy-named manager box")
+	}
+	if strings.Join(removed, ",") != "box-old" {
+		t.Fatalf("removed boxes = %q, want box-old", removed)
+	}
+
+	reloaded, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", statePath)
+	if err != nil {
+		t.Fatalf("NewService() reload error = %v", err)
+	}
+	got, ok := reloaded.Agent(ManagerUserID)
+	if !ok {
+		t.Fatal("Agent() missing manager")
+	}
+	if got.BoxID != "box-canonical-manager" {
+		t.Fatalf("Agent().BoxID = %q, want box-canonical-manager", got.BoxID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recreate manager and worker gateway sandboxes that still use legacy display-name container names.
- Keep canonical sandbox reuse idempotent and cover PicoClaw and OpenClaw legacy-name migration with agent service tests.
