### PR TITLE
fix(config): back up store before migration rewrites

### DIFF
--- a/internal/localstore/migrate_ids.go
+++ b/internal/localstore/migrate_ids.go
@@ -2277,6 +2277,12 @@ func CreateSiblingBackup(root string, now time.Time) (string, error) {
 func copyDir(src, dst string) error {
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if rel, relErr := filepath.Rel(src, path); relErr == nil && isVolatileBackupEntry(rel) {
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
 			return err
 		}
 		rel, err := filepath.Rel(src, path)
@@ -2287,17 +2293,26 @@ func copyDir(src, dst string) error {
 		if d.IsDir() {
 			info, err := d.Info()
 			if err != nil {
+				if isVolatileBackupEntry(rel) {
+					return filepath.SkipDir
+				}
 				return err
 			}
 			return os.MkdirAll(target, info.Mode().Perm())
 		}
 		info, err := d.Info()
 		if err != nil {
+			if isVolatileBackupEntry(rel) {
+				return nil
+			}
 			return err
 		}
 		if info.Mode()&fs.ModeSymlink != 0 {
 			linkTarget, err := os.Readlink(path)
 			if err != nil {
+				if isVolatileBackupEntry(rel) {
+					return nil
+				}
 				return err
 			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
@@ -2305,8 +2320,22 @@ func copyDir(src, dst string) error {
 			}
 			return os.Symlink(linkTarget, target)
 		}
-		return copyFile(path, target, info.Mode().Perm())
+		if err := copyFile(path, target, info.Mode().Perm()); err != nil {
+			if isVolatileBackupEntry(rel) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	})
+}
+
+func isVolatileBackupEntry(rel string) bool {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	return len(parts) >= 4 &&
+		parts[0] == "agents" &&
+		parts[2] == ".openclaw" &&
+		parts[3] == "plugin-skills"
 }
 
 func copyFile(src, dst string, mode fs.FileMode) error {

--- a/internal/localstore/migrate_ids_test.go
+++ b/internal/localstore/migrate_ids_test.go
@@ -368,6 +368,36 @@ func TestMigrateTypedIDsBacksUpBrokenSymlinks(t *testing.T) {
 	}
 }
 
+func TestMigrateTypedIDsSkipsUnreadableOpenClawPluginSkillBackupEntry(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, ".csgclaw")
+	pluginPath := filepath.Join(root, "agents", "feishu-assi", ".openclaw", "plugin-skills", "browser-automation")
+	mustMkdir(t, filepath.Dir(pluginPath))
+	writeFile(t, pluginPath, "container plugin placeholder")
+	if err := os.Chmod(pluginPath, 0); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(pluginPath, 0o600) })
+	writeJSON(t, filepath.Join(root, "state.json"), map[string]any{
+		"version":         1,
+		"model_providers": map[string]any{"default_model": map[string]any{"model_provider_id": "openai", "model_id": "gpt-4.1"}, "items": map[string]any{}},
+		"agents":          map[string]any{"items": []any{}},
+		"participants":    map[string]any{"items": []any{}},
+	})
+
+	result, err := MigrateTypedIDs(MigrateOptions{
+		Root: root,
+		Now:  func() time.Time { return time.Date(2026, 6, 24, 12, 0, 0, 0, time.Local) },
+	})
+	if err != nil {
+		t.Fatalf("MigrateTypedIDs() error = %v", err)
+	}
+	if result.BackupPath == "" {
+		t.Fatal("BackupPath is empty, want backup despite unreadable volatile plugin entry")
+	}
+	assertMissing(t, filepath.Join(result.BackupPath, "agents", "feishu-assi", ".openclaw", "plugin-skills", "browser-automation"))
+}
+
 func TestMigrateTypedIDsCollapsesLegacyLocalIdentityAliases(t *testing.T) {
 	m := newTypedIDMigrator(t.TempDir())
 


### PR DESCRIPTION
## Summary

- Skip unreadable OpenClaw plugin-skill runtime entries during migration backup
