### PR TITLE
fix: harden runtime defaults and Feishu reconnects

### DIFF
--- a/internal/agent/image_migration.go
+++ b/internal/agent/image_migration.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	hub "csgclaw/internal/template"
+	hubtemplates "csgclaw/internal/template/embed"
 )
 
 func (s *Service) withRuntimeImageMigrationStatus(ctx context.Context, a Agent) Agent {
@@ -109,6 +110,17 @@ func (s *Service) currentDefaultImageForAgent(ctx context.Context, a Agent) (def
 			}
 		}
 	}
+	if hubSvc != nil {
+		if candidate, ok := workerTemplateImageFromList(ctx, hubSvc, a.RuntimeKind, true); ok {
+			return candidate, true
+		}
+		if candidate, ok := builtinWorkerTemplateImageForRuntime(ctx, hubSvc, a.RuntimeKind); ok {
+			return candidate, true
+		}
+		if candidate, ok := workerTemplateImageFromList(ctx, hubSvc, a.RuntimeKind, false); ok {
+			return candidate, true
+		}
+	}
 
 	return defaultAgentImage{}, false
 }
@@ -172,6 +184,61 @@ func managerTemplateImageFromList(ctx context.Context, hubSvc templateService, r
 
 func managerTemplateImageForRuntime(item hub.Template, runtimeKind string) (defaultAgentImage, bool) {
 	if normalizeRole(item.Role) != RoleManager {
+		return defaultAgentImage{}, false
+	}
+	templateRuntimeKind := strings.TrimSpace(item.RuntimeKind)
+	if runtimeKind != "" && templateRuntimeKind != runtimeKind {
+		return defaultAgentImage{}, false
+	}
+	image := strings.TrimSpace(item.Image)
+	if image == "" {
+		return defaultAgentImage{}, false
+	}
+	return defaultAgentImage{
+		image:   image,
+		version: strings.TrimSpace(item.Version),
+	}, true
+}
+
+func workerTemplateImageFromList(ctx context.Context, hubSvc templateService, runtimeKind string, builtinOnly bool) (defaultAgentImage, bool) {
+	if hubSvc == nil {
+		return defaultAgentImage{}, false
+	}
+	items, err := hubSvc.List(ctx)
+	if err != nil {
+		return defaultAgentImage{}, false
+	}
+	for _, item := range items {
+		if builtinOnly && strings.TrimSpace(item.Source.Kind) != hub.RegistryKindBuiltin {
+			continue
+		}
+		if candidate, ok := workerTemplateImageForRuntime(item, runtimeKind); ok {
+			return candidate, true
+		}
+	}
+	return defaultAgentImage{}, false
+}
+
+func builtinWorkerTemplateImageForRuntime(ctx context.Context, hubSvc templateService, runtimeKind string) (defaultAgentImage, bool) {
+	if hubSvc == nil {
+		return defaultAgentImage{}, false
+	}
+	runtimeKind = strings.TrimSpace(runtimeKind)
+	for _, item := range hubtemplates.Builtins() {
+		if item.Role != RoleWorker || strings.TrimSpace(item.RuntimeKind) != runtimeKind {
+			continue
+		}
+		templateItem, err := hubSvc.Get(ctx, hub.RegistryKindBuiltin+"."+item.ID)
+		if err != nil {
+			return defaultAgentImage{}, false
+		}
+		return workerTemplateImageForRuntime(templateItem, runtimeKind)
+	}
+	return defaultAgentImage{}, false
+}
+
+func workerTemplateImageForRuntime(item hub.Template, runtimeKind string) (defaultAgentImage, bool) {
+	if normalizeRole(item.Role) != RoleWorker {
 		return defaultAgentImage{}, false
 	}
 	templateRuntimeKind := strings.TrimSpace(item.RuntimeKind)

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -5499,6 +5499,72 @@ func TestUpgradeUsesLatestDefaultTemplateImage(t *testing.T) {
 	}
 }
 
+func TestUpgradeUsesBuiltinWorkerImageForAgentRuntimeWhenDefaultWorkerTemplateDiffers(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
+
+	hubSvc, err := hub.NewService(config.HubConfig{}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
+	}
+	openClawTemplate, err := hubSvc.Get(context.Background(), "builtin.openclaw-worker")
+	if err != nil {
+		t.Fatalf("Get(openclaw-worker) error = %v", err)
+	}
+
+	var newImage string
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		WithHubService(hubSvc),
+		WithBootstrapDefaultTemplates(config.BootstrapConfig{DefaultWorkerTemplate: "builtin.picoclaw-worker"}),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindOpenClawSandbox,
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				newImage = spec.Image
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "box-alice-new"}, nil
+			},
+			info: func(_ context.Context, h agentruntime.Handle) (agentruntime.Info, error) {
+				return agentruntime.Info{HandleID: h.HandleID, State: agentruntime.StateRunning, CreatedAt: time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC)}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{
+		ID:          "u-alice",
+		Name:        "alice",
+		RuntimeID:   "rt-u-alice",
+		RuntimeKind: RuntimeKindOpenClawSandbox,
+		Image:       "custom.example/alice-openclaw:2026.05.27",
+		BoxID:       "box-alice-old",
+		Role:        RoleWorker,
+		Status:      string(agentruntime.StateRunning),
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			Provider:        ProviderCodex,
+			ModelID:         "gpt-5.5",
+			ProfileComplete: true,
+		},
+		ProfileComplete: true,
+	}
+
+	recreated, err := svc.Upgrade(context.Background(), "u-alice")
+	if err != nil {
+		t.Fatalf("Upgrade() error = %v", err)
+	}
+	if newImage != openClawTemplate.Image {
+		t.Fatalf("runtime New() image = %q, want builtin OpenClaw worker image %q", newImage, openClawTemplate.Image)
+	}
+	if recreated.Image != openClawTemplate.Image {
+		t.Fatalf("Upgrade().Image = %q, want builtin OpenClaw worker image %q", recreated.Image, openClawTemplate.Image)
+	}
+}
+
 func TestRecreateRefreshesBuiltInSkillsAndPreservesUserSkills(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -136,6 +136,54 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	}
 }
 
+func TestFinalizeFeishuRegistrationUpdatesCanonicalAdminParticipant(t *testing.T) {
+	accounts := newFakeFeishuAccountsServer(t, map[string]any{
+		"client_id":     "cli_dev",
+		"client_secret": "dev-secret",
+		"user_info": map[string]any{
+			"open_id": "ou_admin",
+		},
+	})
+	defer accounts.Close()
+	withFeishuRegistrationAccountsBaseURL(t, accounts.URL)
+
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{completeWorkerAgent("u-dev", "dev")},
+		agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindPicoClawSandbox}),
+	)
+	participantSvc := participant.NewService(participant.NewMemoryStore([]apitypes.Participant{{
+		ID:              participant.BootstrapAdminParticipantID,
+		Channel:         participant.ChannelFeishu,
+		Type:            participant.TypeHuman,
+		Name:            "admin",
+		ChannelUserRef:  "ou_old_admin",
+		ChannelUserKind: participant.ChannelUserKindOpenID,
+	}}), participant.WithAgentService(agentSvc))
+	srv := &Handler{
+		svc:                        agentSvc,
+		participant:                participantSvc,
+		feishuRegistrationStateDir: filepath.Join(t.TempDir(), "registrations"),
+	}
+	registrationID := startFeishuRegistrationForTest(t, srv, "u-dev")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/channels/feishu/registrations/"+url.PathEscape(registrationID)+":finalize", nil)
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	admin, ok := participantSvc.Get(participant.ChannelFeishu, participant.BootstrapAdminParticipantID)
+	if !ok {
+		t.Fatal("canonical feishu admin participant was not stored")
+	}
+	if admin.ChannelUserRef != "ou_admin" {
+		t.Fatalf("admin channel_user_ref = %q, want registration open_id", admin.ChannelUserRef)
+	}
+	if _, ok := participantSvc.Get(participant.ChannelFeishu, "pt-dev"); !ok {
+		t.Fatal("feishu:dev participant was not stored")
+	}
+}
+
 func TestFinalizeFeishuRegistrationResolvesAdminNameFromFeishuOpenAPI(t *testing.T) {
 	accounts := newFakeFeishuAccountsServerWithOpenAPI(t, map[string]any{
 		"client_id":     "cli_dev",

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -458,7 +458,36 @@ func bootstrapConfigView(ctx context.Context, cfg config.Config, hubSvc *hub.Ser
 	if defaults.WorkerRuntimeKind != "" && defaults.WorkerImage != "" {
 		resp.RuntimeDefaultImages[defaults.WorkerRuntimeKind] = defaults.WorkerImage
 	}
+	fillBuiltinWorkerRuntimeDefaultImages(ctx, &resp, hubSvc)
 	return resp
+}
+
+func fillBuiltinWorkerRuntimeDefaultImages(ctx context.Context, resp *bootstrapConfigResponse, hubSvc *hub.Service) {
+	if resp == nil || hubSvc == nil {
+		return
+	}
+	if resp.RuntimeDefaultImages == nil {
+		resp.RuntimeDefaultImages = map[string]string{}
+	}
+	builtinWorkerTemplates := map[string]string{
+		agent.RuntimeKindPicoClawSandbox: "builtin.picoclaw-worker",
+		agent.RuntimeKindOpenClawSandbox: "builtin.openclaw-worker",
+	}
+	for runtimeKind, templateID := range builtinWorkerTemplates {
+		if strings.TrimSpace(resp.RuntimeDefaultImages[runtimeKind]) != "" {
+			continue
+		}
+		item, err := hubSvc.Get(ctx, templateID)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(item.RuntimeKind) != runtimeKind {
+			continue
+		}
+		if image := strings.TrimSpace(item.Image); image != "" {
+			resp.RuntimeDefaultImages[runtimeKind] = image
+		}
+	}
 }
 
 func (h *Handler) bootstrapConfigView(ctx context.Context, cfg config.Config) bootstrapConfigResponse {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -364,6 +364,23 @@ func TestHandlerBootstrapConfigIncludesRuntimeOptionSchemas(t *testing.T) {
 	}
 }
 
+func TestBootstrapConfigIncludesBuiltinOpenClawRuntimeDefaultImage(t *testing.T) {
+	hubSvc, err := hub.NewService(config.HubConfig{}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
+	}
+
+	got := bootstrapConfigView(context.Background(), config.Config{}, hubSvc, nil)
+
+	openclawImage := got.RuntimeDefaultImages[agent.RuntimeKindOpenClawSandbox]
+	if openclawImage == "" {
+		t.Fatalf("RuntimeDefaultImages[%q] = empty; defaults=%#v", agent.RuntimeKindOpenClawSandbox, got.RuntimeDefaultImages)
+	}
+	if !strings.Contains(openclawImage, "/opencsghq/openclaw:") {
+		t.Fatalf("RuntimeDefaultImages[%q] = %q, want builtin OpenClaw image", agent.RuntimeKindOpenClawSandbox, openclawImage)
+	}
+}
+
 func TestHandleAgentIncludesRuntimeOptionSchemas(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "agents.json")
 	if err := writeSeededAgents(statePath, []agent.Agent{

--- a/internal/participant/feishubind/bind.go
+++ b/internal/participant/feishubind/bind.go
@@ -267,11 +267,6 @@ func findParticipantByID(participantSvc *participant.Service, channel, id string
 	if participantSvc == nil {
 		return participant.Participant{}, false, fmt.Errorf("participant service is required")
 	}
-	items := participantSvc.List(participant.ListOptions{Channel: channel})
-	for _, item := range items {
-		if item.ID == id {
-			return item, true, nil
-		}
-	}
-	return participant.Participant{}, false, nil
+	item, ok := participantSvc.Get(channel, id)
+	return item, ok, nil
 }

--- a/internal/runtime/sandboxgateway/runtime.go
+++ b/internal/runtime/sandboxgateway/runtime.go
@@ -332,13 +332,39 @@ func (r *Runtime) CreateGatewayBox(ctx context.Context, rt sandbox.Runtime, imag
 	info, err := r.deps.BoxInfo(ctx, box)
 	if err != nil {
 		_ = r.deps.CloseBox(box)
+		if removeErr := r.forceRemoveCreatedGatewayBox(ctx, rt, sandbox.Info{Name: spec.Name}, spec.Name); removeErr != nil {
+			return nil, sandbox.Info{}, fmt.Errorf("read gateway box info: %w; cleanup gateway box: %v", err, removeErr)
+		}
 		return nil, sandbox.Info{}, fmt.Errorf("read gateway box info: %w", err)
 	}
 	if err := r.waitForGatewayReady(ctx, box); err != nil {
 		_ = r.deps.CloseBox(box)
+		if removeErr := r.forceRemoveCreatedGatewayBox(ctx, rt, info, spec.Name); removeErr != nil {
+			return nil, sandbox.Info{}, fmt.Errorf("%w; cleanup gateway box: %v", err, removeErr)
+		}
 		return nil, sandbox.Info{}, err
 	}
 	return box, info, nil
+}
+
+func (r *Runtime) forceRemoveCreatedGatewayBox(ctx context.Context, rt sandbox.Runtime, info sandbox.Info, fallbackName string) error {
+	if r == nil || r.deps.ForceRemoveBox == nil || rt == nil {
+		return nil
+	}
+	target := strings.TrimSpace(info.ID)
+	if target == "" {
+		target = strings.TrimSpace(info.Name)
+	}
+	if target == "" {
+		target = strings.TrimSpace(fallbackName)
+	}
+	if target == "" {
+		return nil
+	}
+	if err := r.deps.ForceRemoveBox(ctx, rt, target); err != nil && !sandbox.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *Runtime) GatewayCreateSpec(image, name, botID string, profile agentruntime.Profile) (sandbox.CreateSpec, error) {

--- a/internal/runtime/sandboxgateway/runtime_test.go
+++ b/internal/runtime/sandboxgateway/runtime_test.go
@@ -98,6 +98,37 @@ func TestCreateGatewayBoxSkipsReadinessForBoxlite(t *testing.T) {
 	}
 }
 
+func TestCreateGatewayBoxForceRemovesDockerBoxWhenReadinessFails(t *testing.T) {
+	deps := testGatewayDeps(func() string { return "docker" }, func(_ context.Context, _ sandbox.Instance, _ string, _ []string, _ io.Writer) (int, error) {
+		return 127, fmt.Errorf("exec failed")
+	})
+	deps.BoxInfo = func(context.Context, sandbox.Instance) (sandbox.Info, error) {
+		return sandbox.Info{
+			ID:    "box-1",
+			Name:  "csgclaw-agent-alice",
+			State: sandbox.StateExited,
+		}, nil
+	}
+	var removed []string
+	deps.ForceRemoveBox = func(_ context.Context, _ sandbox.Runtime, idOrName string) error {
+		removed = append(removed, idOrName)
+		return nil
+	}
+	rt := New(deps)
+	rt.RememberPreparedGatewayProvision("u-alice", testPreparedGatewayProvision())
+
+	_, _, err := rt.CreateGatewayBox(context.Background(), testSandboxRuntime{}, "image:1", "alice", "u-alice", agentruntime.Profile{})
+	if err == nil {
+		t.Fatal("CreateGatewayBox() error = nil, want readiness failure")
+	}
+	if !strings.Contains(err.Error(), "sandbox exited before ready") {
+		t.Fatalf("CreateGatewayBox() error = %v, want sandbox exited context", err)
+	}
+	if strings.Join(removed, ",") != "box-1" {
+		t.Fatalf("ForceRemoveBox() targets = %#v, want [box-1]", removed)
+	}
+}
+
 func TestGatewayCreateSpecUsesAgentIDSandboxName(t *testing.T) {
 	rt := New(testGatewayDeps(func() string { return "docker" }, func(context.Context, sandbox.Instance, string, []string, io.Writer) (int, error) {
 		return 0, nil

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -54,6 +54,7 @@ import {
   availableManagerRebuildRuntimeOptions,
   collectManagerTemplateVariants,
   defaultManagerRebuildImageForRuntime,
+  defaultWorkerImageForRuntime,
   draftRuntimeOptionsForSave,
   draftToProfile,
   ensureNotifierPullSubscriptionDraft,
@@ -76,7 +77,6 @@ import {
   providerNeedsAuth,
   resolvedNotifierWebhookOrigin,
   resolveAgentChannelUserID,
-  runtimeImageForKind,
   shouldWaitForManagerRuntimeAfterProfileSave,
   startAgentCreateProgress,
 } from "@/models/agents";
@@ -140,6 +140,14 @@ function feishuRegistrationExpired(registration: FeishuRegistration | null | und
   return Number.isFinite(expiresAt) && expiresAt <= now;
 }
 
+function feishuRegistrationFinalizeClearsPending(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const status = Number((error as { status?: unknown }).status);
+  return status === 404 || status === 410;
+}
+
 function normalizeFeishuPendingRegistration(
   registration: FeishuRegistration | null | undefined,
   fallbackAgentID: string,
@@ -186,10 +194,14 @@ function loadFeishuPendingRegistrations(): Record<string, FeishuPendingRegistrat
     }
     const decoded = JSON.parse(raw);
     if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+      saveFeishuPendingRegistrations({});
       return {};
     }
-    return pruneFeishuPendingRegistrations(decoded as Record<string, FeishuPendingRegistration>);
+    const pruned = pruneFeishuPendingRegistrations(decoded as Record<string, FeishuPendingRegistration>);
+    saveFeishuPendingRegistrations(pruned);
+    return pruned;
   } catch {
+    saveFeishuPendingRegistrations({});
     return {};
   }
 }
@@ -937,7 +949,7 @@ export function useAgentController({
         ) || DEFAULT_RUNTIME_KIND;
       let draft = agentToDraft({
         avatar: selectUnusedAgentAvatar(createParticipantAvatarSources),
-        image: runtimeImageForKind(runtimeKind, bootstrapConfig, managerAgent?.image || ""),
+        image: defaultWorkerImageForRuntime(hubTemplates, runtimeKind, bootstrapConfig, managerAgent?.image || ""),
         runtime_kind: runtimeKind,
         bot_type: BOT_TYPE_NORMAL,
         agent_profile: defaults,
@@ -953,7 +965,7 @@ export function useAgentController({
         ) || DEFAULT_RUNTIME_KIND;
       let draft = agentToDraft({
         avatar: selectUnusedAgentAvatar(createParticipantAvatarSources),
-        image: runtimeImageForKind(runtimeKind, bootstrapConfig, managerAgent?.image || ""),
+        image: defaultWorkerImageForRuntime(hubTemplates, runtimeKind, bootstrapConfig, managerAgent?.image || ""),
         runtime_kind: runtimeKind,
         bot_type: BOT_TYPE_NORMAL,
         agent_profile: managerProfile,
@@ -1420,6 +1432,13 @@ export function useAgentController({
         await refreshAgentStateRef.current(agentID);
         showAgentPageNotice(t("feishuConnectConfigured"), "success");
       } catch (err) {
+        if (feishuRegistrationFinalizeClearsPending(err)) {
+          updateFeishuPendingRegistrations((current) => {
+            const next = { ...current };
+            delete next[agentID];
+            return next;
+          });
+        }
         if (!background) {
           setAgentPageError(errorMessage(err, t("feishuConnectFailed")));
         }
@@ -1449,6 +1468,26 @@ export function useAgentController({
       timers.forEach((timer) => window.clearTimeout(timer));
     };
   }, [agentActionBusy, completeFeishuPendingRegistration, feishuPendingRegistrations]);
+
+  const finalizeVisibleFeishuPendingRegistrations = useCallback(() => {
+    if (agentActionBusy) {
+      return;
+    }
+    Object.entries(feishuPendingRegistrations).forEach(([agentID, registration]) => {
+      const pending = normalizeFeishuPendingRegistration(registration, agentID);
+      if (!pending || feishuAutoFinalizeActiveRef.current.has(pending.registration_id)) {
+        return;
+      }
+      void completeFeishuPendingRegistration(pending, { background: true });
+    });
+  }, [agentActionBusy, completeFeishuPendingRegistration, feishuPendingRegistrations]);
+
+  useEffect(() => {
+    window.addEventListener("focus", finalizeVisibleFeishuPendingRegistrations);
+    return () => {
+      window.removeEventListener("focus", finalizeVisibleFeishuPendingRegistrations);
+    };
+  }, [finalizeVisibleFeishuPendingRegistrations]);
 
   async function startFeishuConnect(item: AgentLike | null | undefined): Promise<void> {
     const agentID = String(item?.id || "").trim();

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -1681,6 +1681,25 @@ export function runtimeImageForKind(
   return String(fallbackImage ?? "").trim();
 }
 
+export function defaultWorkerImageForRuntime(
+  templates: readonly AgentTemplateLike[] | null | undefined,
+  runtimeKind: unknown,
+  bootstrapConfig: RuntimeBootstrapConfig | null | undefined,
+  fallbackImage = "",
+): string {
+  const configuredImage = runtimeImageForKind(runtimeKind, bootstrapConfig, "");
+  if (configuredImage) {
+    return configuredImage;
+  }
+  const templateImage = String(
+    pickDefaultAgentTemplate(templates, normalizeRuntimeKind(runtimeKind), bootstrapConfig)?.image ?? "",
+  ).trim();
+  if (templateImage) {
+    return templateImage;
+  }
+  return String(fallbackImage ?? "").trim();
+}
+
 export function availableManagerRuntimeOptions(bootstrapConfig: RuntimeBootstrapConfig | null | undefined) {
   const configuredKinds = Array.isArray(bootstrapConfig?.supported_runtime_kinds)
     ? bootstrapConfig.supported_runtime_kinds

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/AgentProfileModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/AgentProfileModal.tsx
@@ -29,8 +29,8 @@ import {
   normalizeTemplateSelection,
   notifierFormIsComplete,
   pickDefaultAgentTemplate,
+  defaultWorkerImageForRuntime,
   runtimeOptionSchemasForAgent,
-  runtimeImageForKind,
   templateMatchesRuntime,
   workerSelectableTemplates,
 } from "@/models/agents";
@@ -191,7 +191,8 @@ export function AgentProfileModal({
           avatar: baseDraft.avatar || "",
           bot_type: BOT_TYPE_NORMAL,
           runtime_kind: runtimeKind,
-          image: runtimeImageForKind(
+          image: defaultWorkerImageForRuntime(
+            hubTemplates,
             runtimeKind,
             bootstrapConfig,
             managerAgent?.image || baseDraft.default_image || "",
@@ -367,7 +368,8 @@ export function AgentProfileModal({
                                 bot_type: BOT_TYPE_NORMAL,
                                 role: "worker",
                                 runtime_kind: runtimeKind,
-                                image: runtimeImageForKind(
+                                image: defaultWorkerImageForRuntime(
+                                  hubTemplates,
                                   runtimeKind,
                                   bootstrapConfig,
                                   agentDraft.default_image || managerAgent?.image || "",

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -448,6 +448,66 @@ describe("agent action visibility", () => {
     expect(screen.queryByRole("button", { name: "Complete connection" })).not.toBeInTheDocument();
   });
 
+  it("shows connected Feishu status while a reconnect authorization is pending", () => {
+    const connectedWorker = {
+      ...worker,
+      participants: [
+        {
+          agent_id: worker.id,
+          channel: "feishu",
+          channel_user_kind: "app_id",
+          id: "worker-feishu",
+          type: "agent",
+        },
+      ],
+    };
+    const draft = agentToDraft(connectedWorker);
+    render(
+      <AgentDetailPane
+        item={connectedWorker}
+        t={t}
+        activeRoom={null}
+        busyKey=""
+        error=""
+        draft={draft}
+        savedDraft={draft}
+        models={[]}
+        modelBusy={false}
+        saving={false}
+        publishBusy={false}
+        saveError=""
+        authStatuses={{}}
+        authBusyProvider=""
+        notifierWebhookPublicOrigin="http://127.0.0.1:18080"
+        feishuPendingRegistration={{
+          connect_url: "https://feishu.example/connect",
+          registration_id: "reg-worker",
+          status: "pending",
+        }}
+        onDraftChange={vi.fn()}
+        onSave={vi.fn()}
+        onPublish={vi.fn()}
+        onProviderLogin={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onRecreate={vi.fn()}
+        onUpgrade={vi.fn()}
+        onDelete={vi.fn()}
+        onInvite={vi.fn()}
+        onOpenDM={vi.fn()}
+        onStartFeishuConnect={vi.fn()}
+        onFinalizeFeishuConnect={vi.fn()}
+        onDisconnectFeishu={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(
+      screen.getByText("Waiting for Feishu authorization. CSGClaw will finish automatically."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open Feishu" })).toBeInTheDocument();
+  });
+
   it("keeps upgrade action visible in worker detail panes when backend marks an agent restart required", () => {
     render(
       <AgentDetailPane

--- a/web/app/tests/components/AgentProfileModal.test.tsx
+++ b/web/app/tests/components/AgentProfileModal.test.tsx
@@ -22,6 +22,8 @@ const labels: Record<string, string> = {
   profileRuntimeOptions: "Runtime Options",
   profileProvider: "Provider",
   profileRuntimeKind: "Runtime",
+  runtimeOpenclaw: "OpenClaw",
+  runtimePicoclaw: "PicoClaw",
   templateLabel: "Template",
   templateNone: "No template",
 };
@@ -267,6 +269,84 @@ describe("AgentProfileModal", () => {
     expect(screen.getByText("Handles coding tasks.")).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Manager" })).not.toBeInTheDocument();
     expect(screen.queryByText("Coordinates workers.")).not.toBeInTheDocument();
+  });
+
+  it("uses the matching worker template image when switching blank drafts to OpenClaw", async () => {
+    const user = userEvent.setup();
+    const onAgentDraftChange = vi.fn();
+    function TestModal() {
+      const [draft, setDraft] = useState<AgentDraft>({
+        ...agentToDraft(worker),
+        from_template: "",
+        image: "picoclaw:current",
+      });
+      return (
+        <AgentProfileModal
+          t={t}
+          agentModalMode="create"
+          editingAgent={null}
+          agentDraft={draft}
+          onAgentDraftChange={(update) => {
+            onAgentDraftChange(update);
+            setDraft((current) => {
+              const next = typeof update === "function" ? update(current) : update;
+              return next ?? current;
+            });
+          }}
+          onAgentModelsReset={vi.fn()}
+          hubTemplates={[
+            {
+              id: "builtin.picoclaw-worker",
+              name: "PicoClaw Worker",
+              role: "worker",
+              runtime_kind: "picoclaw_sandbox",
+              image: "picoclaw:worker",
+            },
+            {
+              id: "builtin.openclaw-worker",
+              name: "OpenClaw Worker",
+              role: "worker",
+              runtime_kind: "openclaw_sandbox",
+              image: "openclaw:worker",
+            },
+          ]}
+          bootstrapConfig={{
+            default_worker_template: "builtin.picoclaw-worker",
+            runtime_default_images: {
+              picoclaw_sandbox: "picoclaw:worker",
+            },
+            runtime_kind: "picoclaw_sandbox",
+          }}
+          managerAgent={{ ...worker, image: "picoclaw:manager" }}
+          agentModels={[]}
+          agentModelBusy={false}
+          locale="en"
+          authStatuses={{}}
+          authBusyProvider=""
+          agentCreateBotKind="worker"
+          onAgentCreateBotKindChange={vi.fn()}
+          notifierWebhookPublicOrigin="http://127.0.0.1:18080"
+          onProviderLogin={vi.fn()}
+          agentError=""
+          agentProgress={null}
+          agentBusy={false}
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+        />
+      );
+    }
+    render(<TestModal />);
+
+    await user.click(screen.getByRole("combobox", { name: "Runtime" }));
+    await user.click(screen.getByRole("option", { name: "OpenClaw" }));
+
+    expect(onAgentDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from_template: "",
+        image: "openclaw:worker",
+        runtime_kind: "openclaw_sandbox",
+      }),
+    );
   });
 
   it("shows provider logos only in the provider field, not in the model field", () => {

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -891,6 +891,95 @@ describe("useAgentController", () => {
     }
   });
 
+  it("keeps connected Feishu pending registration until background finalize completes", async () => {
+    vi.useFakeTimers();
+    const connectedWorker: AgentLike = {
+      ...oldAgent,
+      id: "u-dev",
+      name: "dev",
+      role: "worker",
+      participants: [
+        {
+          agent_id: "u-dev",
+          channel: "feishu",
+          channel_user_kind: "app_id",
+          id: "dev",
+          type: "agent",
+        },
+      ],
+    };
+    window.localStorage.setItem(
+      feishuRegistrationStorageKey,
+      JSON.stringify({
+        "u-dev": {
+          agent_id: "u-dev",
+          connect_url: "https://feishu.example/connect",
+          expires_at: "2999-01-01T00:00:00Z",
+          next_poll_seconds: 1,
+          participant_id: "dev",
+          registration_id: "reg-dev",
+        },
+      }),
+    );
+    vi.mocked(fetchAgent).mockReset();
+    vi.mocked(fetchAgent).mockResolvedValue(connectedWorker);
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useAgentControllerHarness({
+            activePane: { type: WorkspacePaneTypes.agent, id: "u-dev" },
+            agents: [connectedWorker],
+          }).controller,
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.agentViewProps.item?.participants?.[0]?.channel).toBe("feishu");
+      expect(result.current.agentViewProps.feishuPendingRegistration?.registration_id).toBe("reg-dev");
+      expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toContain("reg-dev");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      vi.useRealTimers();
+
+      expect(finalizeFeishuRegistrationRequest).toHaveBeenCalledWith("reg-dev");
+      expect(result.current.agentViewProps.notice).toBe("feishuConnectConfigured");
+      expect(result.current.agentViewProps.noticeTone).toBe("success");
+      expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears expired Feishu pending registration from localStorage on load", async () => {
+    window.localStorage.setItem(
+      feishuRegistrationStorageKey,
+      JSON.stringify({
+        "u-dev": {
+          agent_id: "u-dev",
+          connect_url: "https://feishu.example/connect",
+          expires_at: "2000-01-01T00:00:00Z",
+          participant_id: "dev",
+          registration_id: "reg-dev",
+        },
+      }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useAgentControllerHarness({
+          activePane: { type: WorkspacePaneTypes.agent, id: "u-dev" },
+          agents: [{ ...oldAgent, id: "u-dev", name: "dev", role: "worker" }],
+        }).controller,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.agentViewProps.item?.id).toBe("u-dev"));
+    expect(result.current.agentViewProps.feishuPendingRegistration).toBeNull();
+    expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toBeNull();
+  });
+
   it("finalizes Feishu connection and refreshes the selected agent participants", async () => {
     const workerAgent: AgentLike = {
       ...oldAgent,
@@ -1040,6 +1129,156 @@ describe("useAgentController", () => {
       await waitFor(() => expect(result.current.agentViewProps.item?.participants?.[0]?.channel).toBe("feishu"));
       expect(result.current.agentViewProps.notice).toBe("feishuConnectConfigured");
       expect(result.current.agentViewProps.noticeTone).toBe("success");
+      expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toBeNull();
+    } finally {
+      openSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("automatically finalizes a Feishu reconnect for an already connected agent", async () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const connectedWorker: AgentLike = {
+      ...oldAgent,
+      id: "u-dev",
+      name: "dev",
+      role: "worker",
+      participants: [
+        {
+          agent_id: "u-dev",
+          channel: "feishu",
+          channel_user_kind: "app_id",
+          id: "dev",
+          type: "agent",
+        },
+      ],
+    };
+    vi.mocked(fetchAgent).mockReset();
+    vi.mocked(fetchAgent).mockResolvedValue(connectedWorker);
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useAgentControllerHarness({
+            activePane: { type: WorkspacePaneTypes.agent, id: "u-dev" },
+            agents: [connectedWorker],
+          }).controller,
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.agentViewProps.onStartFeishuConnect?.(connectedWorker);
+      });
+
+      expect(startFeishuRegistrationRequest).toHaveBeenCalledWith("u-dev");
+      expect(openSpy).toHaveBeenCalledWith("https://feishu.example/connect", "_blank", "noopener,noreferrer");
+      expect(result.current.agentViewProps.feishuPendingRegistration?.registration_id).toBe("reg-dev");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      vi.useRealTimers();
+
+      expect(finalizeFeishuRegistrationRequest).toHaveBeenCalledWith("reg-dev");
+      expect(result.current.agentViewProps.notice).toBe("feishuConnectConfigured");
+      expect(result.current.agentViewProps.noticeTone).toBe("success");
+      expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toBeNull();
+    } finally {
+      openSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("finalizes a pending Feishu reconnect immediately when the page regains focus", async () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const connectedWorker: AgentLike = {
+      ...oldAgent,
+      id: "u-dev",
+      name: "dev",
+      role: "worker",
+      participants: [
+        {
+          agent_id: "u-dev",
+          channel: "feishu",
+          channel_user_kind: "app_id",
+          id: "dev",
+          type: "agent",
+        },
+      ],
+    };
+    vi.mocked(fetchAgent).mockReset();
+    vi.mocked(fetchAgent).mockResolvedValue(connectedWorker);
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useAgentControllerHarness({
+            activePane: { type: WorkspacePaneTypes.agent, id: "u-dev" },
+            agents: [connectedWorker],
+          }).controller,
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.agentViewProps.onStartFeishuConnect?.(connectedWorker);
+      });
+
+      expect(result.current.agentViewProps.feishuPendingRegistration?.registration_id).toBe("reg-dev");
+      expect(finalizeFeishuRegistrationRequest).not.toHaveBeenCalled();
+
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+        await Promise.resolve();
+      });
+      vi.useRealTimers();
+
+      expect(finalizeFeishuRegistrationRequest).toHaveBeenCalledWith("reg-dev");
+      expect(result.current.agentViewProps.notice).toBe("feishuConnectConfigured");
+      expect(result.current.agentViewProps.noticeTone).toBe("success");
+    } finally {
+      openSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears pending Feishu state when automatic finalize finds an expired registration", async () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const workerAgent: AgentLike = {
+      ...oldAgent,
+      id: "u-dev",
+      name: "dev",
+      role: "worker",
+    };
+    vi.mocked(finalizeFeishuRegistrationRequest).mockRejectedValueOnce({
+      message: "registration expired",
+      status: 410,
+    });
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useAgentControllerHarness({
+            activePane: { type: WorkspacePaneTypes.agent, id: "u-dev" },
+            agents: [workerAgent],
+          }).controller,
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.agentViewProps.onStartFeishuConnect?.(workerAgent);
+      });
+
+      expect(result.current.agentViewProps.feishuPendingRegistration?.registration_id).toBe("reg-dev");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(finalizeFeishuRegistrationRequest).toHaveBeenCalledWith("reg-dev");
+      expect(result.current.agentViewProps.feishuPendingRegistration).toBeNull();
       expect(window.localStorage.getItem(feishuRegistrationStorageKey)).toBeNull();
     } finally {
       openSpy.mockRestore();

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -7,6 +7,7 @@ import {
   availableManagerRuntimeOptions,
   collectManagerTemplateVariants,
   defaultManagerRebuildImageForRuntime,
+  defaultWorkerImageForRuntime,
   agentDraftWithRuntimeFieldsFromAgent,
   agentRuntimePollSettled,
   agentStatusLabel,
@@ -419,6 +420,9 @@ describe("agent model helpers", () => {
     );
     expect(pickDefaultAgentTemplate(templates, "notification", bootstrapConfig)).toBeNull();
     expect(runtimeImageForKind("openclaw_sandbox", bootstrapConfig, "fallback:worker")).toBe("openclaw:worker");
+    expect(defaultWorkerImageForRuntime(templates, "openclaw_sandbox", bootstrapConfig, "fallback:worker")).toBe(
+      "openclaw:worker",
+    );
     expect(runtimeImageForKind("codex", bootstrapConfig, "fallback:worker")).toBe("");
     expect(runtimeImageForKind("notification", bootstrapConfig, "fallback:worker")).toBe("");
 
@@ -447,6 +451,40 @@ describe("agent model helpers", () => {
       runtime_kind: "openclaw_sandbox",
       template_name: "openclaw-worker",
     });
+  });
+
+  it("falls back to matching worker template images when runtime bootstrap image defaults are stale", () => {
+    const templates = [
+      {
+        id: "builtin.picoclaw-worker",
+        name: "picoclaw-worker",
+        role: "worker",
+        runtime_kind: "picoclaw_sandbox",
+        image: "picoclaw:worker",
+      },
+      {
+        id: "builtin.openclaw-worker",
+        name: "openclaw-worker",
+        role: "worker",
+        runtime_kind: "openclaw_sandbox",
+        image: "openclaw:worker",
+      },
+    ];
+
+    expect(
+      defaultWorkerImageForRuntime(
+        templates,
+        "openclaw_sandbox",
+        {
+          default_worker_template: "builtin.picoclaw-worker",
+          runtime_default_images: {
+            picoclaw_sandbox: "picoclaw:worker",
+          },
+          runtime_kind: "picoclaw_sandbox",
+        },
+        "picoclaw:current",
+      ),
+    ).toBe("openclaw:worker");
   });
 
   it("excludes manager templates from worker template choices", () => {


### PR DESCRIPTION
## Summary

- Use runtime-specific worker defaults for OpenClaw/PicoClaw agent creation, upgrade, and bootstrap config.
- Automatically complete or clear pending Feishu reconnect state while preserving connected status.
- Remove failed gateway boxes when readiness checks fail.