### PR TITLE
fix(web): keep model provider page scrollable

### DIFF
--- a/web/app/src/components/business/ProfileControls/ProfileControls.css
+++ b/web/app/src/components/business/ProfileControls/ProfileControls.css
@@ -423,6 +423,22 @@
   border: 1px solid var(--line);
   border-radius: 12px;
   background: var(--field);
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-400) transparent;
+}
+
+.model-provider-model-list::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.model-provider-model-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.model-provider-model-list::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--gray-400) 70%, transparent);
 }
 
 .model-provider-model-row {

--- a/web/app/src/pages/ModelProviderPage/ModelProviderPage.css
+++ b/web/app/src/pages/ModelProviderPage/ModelProviderPage.css
@@ -1,13 +1,31 @@
 .model-provider-page {
   --model-provider-content-width: min(100%, 1520px);
 
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
   display: grid;
   align-content: start;
   justify-items: center;
   gap: 14px;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 24px 32px 28px;
   background: linear-gradient(180deg, var(--white) 0, var(--white) 138px, transparent 138px), var(--gray-25);
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-400) transparent;
+}
+
+.model-provider-page::-webkit-scrollbar {
+  width: 6px;
+}
+
+.model-provider-page::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.model-provider-page::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--gray-400) 70%, transparent);
 }
 
 .model-provider-page.empty {

--- a/web/app/tests/legacy-contract.test.ts
+++ b/web/app/tests/legacy-contract.test.ts
@@ -16,6 +16,11 @@ function readTree(dir: string, pattern: RegExp): string {
 const source: string = readTree(resolve(process.cwd(), "src"), /\.(js|jsx|ts|tsx)$/);
 const styles: string = readTree(resolve(process.cwd(), "src"), /\.css$/);
 
+function styleRule(selector: string): string {
+  const pattern = new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{([^}]*)\\}`);
+  return styles.match(pattern)?.[1] ?? "";
+}
+
 describe("legacy UI contract", () => {
   it("keeps the manager rebuild action card contract", () => {
     expect(source).toContain('const CSGCLAW_ACTION_CARD_TYPE = "csgclaw.action_card";');
@@ -140,6 +145,19 @@ describe("legacy UI contract", () => {
     expect(styles).not.toContain("top: -24px;");
     expect(styles).toMatch(/\.profile-editor-shell\s*\{[\s\S]*overflow-y:\s*auto;/);
     expect(styles).toMatch(/\.agent-modal > \.modal-actions\s*\{[\s\S]*flex:\s*0 0 auto;/);
+  });
+
+  it("keeps the model provider page scrollable inside the fixed workspace panel", () => {
+    const pageRule = styleRule(".model-provider-page");
+    const modelListRule = styleRule(".model-provider-model-list");
+
+    expect(pageRule).toMatch(/(?:^|[;\s])height:\s*100%;/);
+    expect(pageRule).toContain("min-height: 0;");
+    expect(pageRule).toContain("overflow-x: hidden;");
+    expect(pageRule).toContain("overflow-y: auto;");
+    expect(modelListRule).toContain("scrollbar-width: thin;");
+    expect(styles).toContain(".model-provider-page::-webkit-scrollbar");
+    expect(styles).toContain(".model-provider-model-list::-webkit-scrollbar");
   });
 
   it("shows agent running status dots in direct message rows", () => {


### PR DESCRIPTION
## Summary

- Keep the model provider detail page scrollable inside the fixed workspace panel.
- Add slim scrollbars and a regression guard for the model list.
