### PR TITLE
fix(agent): install default system skills by agent id

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -2035,7 +2035,7 @@ func (s *Service) provisionRuntime(ctx context.Context, rt agentruntime.Runtime,
 	if err := s.provisionRuntimeRequest(ctx, rt, runtimeKind, req); err != nil {
 		return err
 	}
-	if err := s.installDefaultSystemSkills(req.AgentName, runtimeKind); err != nil {
+	if err := s.installDefaultSystemSkills(req.AgentID, runtimeKind); err != nil {
 		return fmt.Errorf("install default system skills: %w", err)
 	}
 	return nil

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1659,8 +1659,8 @@ func TestCreateWorkerInstallsDefaultSystemSkills(t *testing.T) {
 	SetTestHooks(
 		func(_ *Service, _ string) (sandbox.Runtime, error) { return &fakeRuntime{}, nil },
 		func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string, name, botID string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
-			if name != "alice" || botID != "agent-alice" {
-				t.Fatalf("createGatewayBox() name=%q botID=%q, want alice/agent-alice", name, botID)
+			if name != "alice" || botID != "agent-worker-123" {
+				t.Fatalf("createGatewayBox() name=%q botID=%q, want alice/agent-worker-123", name, botID)
 			}
 			info := sandbox.Info{
 				ID:        "box-alice",
@@ -1683,8 +1683,8 @@ func TestCreateWorkerInstallsDefaultSystemSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
-	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{
-		ID:          "u-alice",
+	created, err := svc.CreateWorker(context.Background(), CreateAgentSpec{
+		ID:          "agent-worker-123",
 		Name:        "alice",
 		RuntimeKind: RuntimeKindOpenClawSandbox,
 		Image:       "worker-image:test",
@@ -1700,7 +1700,7 @@ func TestCreateWorkerInstallsDefaultSystemSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorker() error = %v", err)
 	}
-	skillsRoot, err := svc.agentSkillsRoot("alice", RuntimeKindOpenClawSandbox)
+	skillsRoot, err := svc.agentSkillsRoot(created.ID, RuntimeKindOpenClawSandbox)
 	if err != nil {
 		t.Fatalf("agentSkillsRoot() error = %v", err)
 	}
@@ -1768,7 +1768,7 @@ func TestPreserveWorkspaceSkillsDropsDefaultSystemSkills(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(skillsRoot, "skill-installer", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("old skill-installer restored unexpectedly, err=%v", err)
 	}
-	if err := svc.installDefaultSystemSkills("alice", RuntimeKindOpenClawSandbox); err != nil {
+	if err := svc.installDefaultSystemSkills("agent-alice", RuntimeKindOpenClawSandbox); err != nil {
 		t.Fatalf("installDefaultSystemSkills() error = %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(skillsRoot, "skill-installer", "SKILL.md"))
@@ -4467,8 +4467,8 @@ func TestStartInstallsDefaultSystemSkillsAfterProvision(t *testing.T) {
 			kind: RuntimeKindOpenClawSandbox,
 			provision: func(_ context.Context, req agentruntime.ProvisionRequest) error {
 				callOrder = append(callOrder, "provision")
-				if req.RuntimeID != "rt-agent-alice" || req.AgentID != "agent-alice" || req.AgentName != "alice" {
-					t.Fatalf("Provision() request = %+v, want alice runtime identity", req)
+				if req.RuntimeID != "rt-agent-worker-123" || req.AgentID != "agent-worker-123" || req.AgentName != "alice" {
+					t.Fatalf("Provision() request = %+v, want worker runtime identity", req)
 				}
 				if req.Gateway == nil {
 					t.Fatalf("Provision() gateway = nil, want gateway request")
@@ -4487,11 +4487,11 @@ func TestStartInstallsDefaultSystemSkillsAfterProvision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
-	svc.agents["agent-alice"] = Agent{
-		ID:              "agent-alice",
+	svc.agents["agent-worker-123"] = Agent{
+		ID:              "agent-worker-123",
 		Name:            "alice",
 		Role:            RoleWorker,
-		RuntimeID:       "rt-agent-alice",
+		RuntimeID:       "rt-agent-worker-123",
 		RuntimeKind:     RuntimeKindOpenClawSandbox,
 		BoxID:           "box-alice",
 		Status:          string(agentruntime.StateStopped),
@@ -4499,13 +4499,13 @@ func TestStartInstallsDefaultSystemSkillsAfterProvision(t *testing.T) {
 		ProfileComplete: true,
 	}
 
-	if _, err := svc.Start(context.Background(), "agent-alice"); err != nil {
+	if _, err := svc.Start(context.Background(), "agent-worker-123"); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
 	if got, want := strings.Join(callOrder, ","), "provision,start"; got != want {
 		t.Fatalf("call order = %q, want %q", got, want)
 	}
-	skillsRoot, err := svc.agentSkillsRoot("alice", RuntimeKindOpenClawSandbox)
+	skillsRoot, err := svc.agentSkillsRoot("agent-worker-123", RuntimeKindOpenClawSandbox)
 	if err != nil {
 		t.Fatalf("agentSkillsRoot() error = %v", err)
 	}

--- a/internal/agent/skills.go
+++ b/internal/agent/skills.go
@@ -124,7 +124,7 @@ func resolveAgentSkillSource(root, name string) (fs.FS, string, error) {
 	return source.FS, source.RootPath, nil
 }
 
-func (s *Service) installDefaultSystemSkills(agentName, runtimeKind string) error {
+func (s *Service) installDefaultSystemSkills(agentID, runtimeKind string) error {
 	if !isGatewayRuntimeKind(strings.TrimSpace(runtimeKind)) {
 		return nil
 	}
@@ -135,7 +135,7 @@ func (s *Service) installDefaultSystemSkills(agentName, runtimeKind string) erro
 	if len(names) == 0 {
 		return nil
 	}
-	targetRoot, err := s.agentSkillsRoot(agentName, runtimeKind)
+	targetRoot, err := s.agentSkillsRoot(agentID, runtimeKind)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Install embedded default system skills into the runtime skills directory resolved from the agent ID, not the display name.
- Update create/start regression coverage so the worker ID and display name differ, matching real typed-ID agent creation.

## Root Cause

- #235 introduced embedded system skills and default installation during agent create/start/recreate. That path installed skills using `req.AgentName`.
- #245 migrated durable agent/workspace/runtime paths to immutable typed agent IDs. Runtime provisioning now materializes the agent home from `AgentID`, but the default system skill installer still used `AgentName`.
- For workers whose generated ID differs from their display name, system skills such as `skill-installer` and `skill-creator` could be copied to a sibling name-derived directory instead of the active runtime skills directory.

## Fix

- Pass `req.AgentID` to `installDefaultSystemSkills` from runtime provisioning.
- Rename the helper parameter to `agentID` to reflect the storage contract.
- Adjust tests to use `agent-worker-123` with display name `alice`, so the regression fails if ID/name paths drift again.

## Validation

- `env GOCACHE=/tmp/gocache go test ./internal/agent`
- `env GOCACHE=/tmp/gocache go test ./internal/agent ./internal/api`