### PR TITLE
fix(web): prevent env editor draft crashes

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -57,6 +57,7 @@ import {
   defaultManagerRebuildImageForRuntime,
   defaultWorkerImageForRuntime,
   draftRuntimeOptionsForSave,
+  draftToProfileComparePayload,
   draftToProfile,
   ensureNotifierPullSubscriptionDraft,
   feishuAgentParticipant,
@@ -1072,7 +1073,7 @@ export function useAgentController({
       return "";
     }
     return JSON.stringify(
-      draftToProfile(normalized, {
+      draftToProfileComparePayload(normalized, {
         name: normalized.name,
         description: normalized.description,
       }),

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -1158,6 +1158,23 @@ export function draftToProfile(draft: AgentDraft, options: DraftProfileOptions =
   };
 }
 
+export function draftToProfileComparePayload(draft: AgentDraft, options: DraftProfileOptions = {}): JSONRecord {
+  void options;
+  const requestOptions = parseJSONMapForCompare(draft.requestOptionsText);
+  const modelProviderID = String(draft.model_provider_id || "").trim();
+  return {
+    model_provider_id: modelProviderID,
+    base_url: "",
+    api_key: "",
+    model_id: draft.model_id,
+    reasoning_effort: draft.reasoning_effort || DEFAULT_REASONING_EFFORT,
+    enable_fast_mode: Boolean(draft.enable_fast_mode),
+    headers: {},
+    request_options: requestOptions,
+    env: envRowsToMapForCompare(draft.envRows),
+  };
+}
+
 export function draftNotifierDetailsFromDraft(draft: Partial<AgentDraft> | null | undefined): JSONRecord | null {
   if (!draft) {
     return null;
@@ -1392,6 +1409,40 @@ export function envRowsToMap(rows: readonly EnvKeyValueRow[] | null | undefined)
   return result;
 }
 
+function envRowsToMapForCompare(rows: readonly EnvKeyValueRow[] | null | undefined): JSONRecord {
+  const result: Record<string, string> = {};
+  const invalidRows: EnvKeyValueRow[] = [];
+  const seen = new Set<string>();
+  for (const row of rows ?? []) {
+    const key = String(row?.key ?? "").trim();
+    const value = String(row?.value ?? "");
+    if (!key && !value.trim()) {
+      continue;
+    }
+    if (!key) {
+      invalidRows.push({ key, value });
+      continue;
+    }
+    if (!value.trim()) {
+      continue;
+    }
+    const normalized = key.toUpperCase();
+    if (seen.has(normalized)) {
+      invalidRows.push({ key, value });
+      continue;
+    }
+    seen.add(normalized);
+    result[key] = value;
+  }
+  if (invalidRows.length === 0) {
+    return result;
+  }
+  return {
+    ...result,
+    __invalid_env_rows: invalidRows,
+  };
+}
+
 export function isAgentRunning(item: AgentLike | null | undefined): boolean {
   if (isNotificationBotAgent(item)) {
     return item?.available === true;
@@ -1426,7 +1477,7 @@ export function llmProfilePayloadForCompare(draft: AgentDraft | null | undefined
     return "";
   }
   const normalized = ensureNotifierPullSubscriptionDraft(draft);
-  const profile = draftToProfile(normalized, {
+  const profile = draftToProfileComparePayload(normalized, {
     name: normalized.name,
     description: normalized.description,
   });
@@ -1560,6 +1611,16 @@ export function parseJSONMap(text: unknown): JSONRecord {
     throw new Error("Expected a JSON object");
   }
   return parsed as JSONRecord;
+}
+
+function parseJSONMapForCompare(text: unknown): JSONRecord {
+  try {
+    return parseJSONMap(text);
+  } catch {
+    return {
+      __invalid_json_text: String(text ?? ""),
+    };
+  }
 }
 
 export function normalizeAuthProviderName(provider: unknown): string {

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -15,6 +15,7 @@ import {
   draftNotifierRuntimeOptionsForSave,
   draftRuntimeOptionsForSave,
   draftToProfile,
+  draftToProfileComparePayload,
   ensureNotifierPullSubscriptionDraft,
   envRowsToMap,
   formatProviderLabel,
@@ -116,6 +117,28 @@ describe("agent model helpers", () => {
         { key: "PATH", value: "two" },
       ]),
     ).toThrow("Duplicate environment variable: PATH");
+  });
+
+  it("keeps draft comparison tolerant while env rows are still being edited", () => {
+    const savedDraft = agentToDraft({
+      agent_profile: {
+        env: { GITLAB_BASE_URL: "https://git-devops.opencsg.com" },
+        model_id: "gpt-test",
+        model_provider_id: "openai",
+      },
+      id: "worker-1",
+      name: "Worker",
+      role: "worker",
+    });
+    const editingDraft = {
+      ...savedDraft,
+      envRows: [...savedDraft.envRows, { key: "", value: "pending" }],
+    };
+
+    expect(() => draftToProfileComparePayload(editingDraft)).not.toThrow();
+    expect(agentPageLLMProfileChanged(editingDraft, savedDraft)).toBe(true);
+    expect(agentProfilePageSaveDisabled(editingDraft, { id: "worker-1" }, { savedDraft })).toBe(false);
+    expect(() => envRowsToMap(editingDraft.envRows)).toThrow("Environment variable key is required");
   });
 
   it("merges a fresh action response into the existing agent list", () => {


### PR DESCRIPTION
## Summary
- keep agent profile draft comparison tolerant of incomplete environment variable rows
- preserve strict env and JSON validation for save payloads
- add a regression test for editing an env row with a missing key

## Validation
- pnpm --dir web/app test -- tests/models/agents.test.ts
- pnpm --dir web/app typecheck
- pnpm --dir web/app lint
- pnpm --dir web/app format:check
- make build-web

## Impact
Prevents the Agent profile advanced environment variable editor from crashing while users are still typing a new row.