### PR TITLE
fix(upgrade): improve failure diagnostics

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -585,7 +585,7 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 	if outcome, err := upgrade.ConsumeApplyStatus(configPath); err != nil {
 		slog.Warn("load upgrade helper failure", "error", err)
 	} else if outcome.Status == upgrade.ApplyStatusFailed && outcome.Message != "" {
-		upgradeManager.MarkUpgradeFailed(errors.New(outcome.Message))
+		upgradeManager.MarkUpgradeFailedWithDetails(errors.New(outcome.Message), outcome.ErrorKind, outcome.LogPath)
 	}
 	hubSvc, err := newAgentTemplateHubService(cfg.Hub)
 	if err != nil {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -910,8 +910,8 @@ func TestStartServerWithConfigPathLoadsPersistedUpgradeFailure(t *testing.T) {
 		if !strings.Contains(status.LastError, "restart daemon: boom") {
 			return fmt.Errorf("LastError = %q, want persisted failure", status.LastError)
 		}
-		if !strings.Contains(status.LastError, artifacts.LogPath) {
-			return fmt.Errorf("LastError = %q, want log path", status.LastError)
+		if status.LastErrorLogPath != artifacts.LogPath {
+			return fmt.Errorf("LastErrorLogPath = %q, want %q", status.LastErrorLogPath, artifacts.LogPath)
 		}
 		return nil
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -691,7 +691,7 @@ func (h *Handler) handleUpgradeStatus(w http.ResponseWriter, r *http.Request) {
 		switch outcome.Status {
 		case upgrade.ApplyStatusFailed:
 			if outcome.Message != "" {
-				h.upgradeManager.MarkUpgradeFailed(errors.New(outcome.Message))
+				h.upgradeManager.MarkUpgradeFailedWithDetails(errors.New(outcome.Message), outcome.ErrorKind, outcome.LogPath)
 			}
 		case upgrade.ApplyStatusManualRestartRequired:
 			h.upgradeManager.MarkManualRestartRequired()

--- a/internal/api/upgrade_test.go
+++ b/internal/api/upgrade_test.go
@@ -96,6 +96,42 @@ func TestHandleUpgradeStatusConsumesManualRestartRequired(t *testing.T) {
 	}
 }
 
+func TestHandleUpgradeStatusConsumesFailureMetadata(t *testing.T) {
+	dir := t.TempDir()
+	configPath := dir + "/config.toml"
+	artifacts, err := upgrade.ResolveApplyArtifacts(configPath)
+	if err != nil {
+		t.Fatalf("ResolveApplyArtifacts() error = %v", err)
+	}
+	if err := artifacts.RecordFailure(errors.New("write /tmp/csgclaw-upgrade/archive.tar.gz: stream error: stream ID 3")); err != nil {
+		t.Fatalf("RecordFailure() error = %v", err)
+	}
+
+	manager := upgrade.NewManager(stubUpgradeChecker{err: errors.New("unused")}, "v0.2.5", upgrade.ManagerOptions{})
+	srv := &Handler{}
+	srv.SetUpgradeManager(manager)
+	srv.SetUpgradeConfigPath(configPath)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/upgrade/status", nil)
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var got apitypes.UpgradeStatus
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.LastErrorKind != upgrade.UpgradeErrorNetworkDownload {
+		t.Fatalf("LastErrorKind = %q, want %q", got.LastErrorKind, upgrade.UpgradeErrorNetworkDownload)
+	}
+	if got.LastErrorLogPath != artifacts.LogPath {
+		t.Fatalf("LastErrorLogPath = %q, want %q", got.LastErrorLogPath, artifacts.LogPath)
+	}
+}
+
 func TestHandleUpgradeStatusServiceUnavailable(t *testing.T) {
 	srv := &Handler{}
 

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -179,6 +179,8 @@ type UpgradeStatus struct {
 	AutoUpgradeUnsupportedReason string     `json:"auto_upgrade_unsupported_reason,omitempty"`
 	LastCheckedAt                *time.Time `json:"last_checked_at,omitempty"`
 	LastError                    string     `json:"last_error,omitempty"`
+	LastErrorKind                string     `json:"last_error_kind,omitempty"`
+	LastErrorLogPath             string     `json:"last_error_log_path,omitempty"`
 }
 
 type UpgradeActionResponse struct {

--- a/internal/upgrade/apply_state.go
+++ b/internal/upgrade/apply_state.go
@@ -33,13 +33,16 @@ type ApplyArtifacts struct {
 type applyFailureRecord struct {
 	Status    string    `json:"status,omitempty"`
 	Message   string    `json:"message"`
+	ErrorKind string    `json:"error_kind,omitempty"`
 	LogPath   string    `json:"log_path,omitempty"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type ApplyStatusRecord struct {
-	Status  string
-	Message string
+	Status    string
+	Message   string
+	ErrorKind string
+	LogPath   string
 }
 
 func ResolveApplyArtifacts(configPath string) (ApplyArtifacts, error) {
@@ -109,6 +112,7 @@ func (a ApplyArtifacts) RecordFailure(err error) error {
 	record := applyFailureRecord{
 		Status:    ApplyStatusFailed,
 		Message:   err.Error(),
+		ErrorKind: ClassifyFailure(err),
 		LogPath:   strings.TrimSpace(a.LogPath),
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -170,20 +174,17 @@ func ConsumeApplyStatus(configPath string) (ApplyStatusRecord, error) {
 	if status == "" {
 		status = ApplyStatusFailed
 	}
-	if status == ApplyStatusFailed {
-		if message == "" {
-			return ApplyStatusRecord{}, nil
-		}
-		if logPath := strings.TrimSpace(record.LogPath); logPath != "" {
-			message = fmt.Sprintf("%s\nLog: %s", message, logPath)
-		}
+	if status == ApplyStatusFailed && message == "" {
+		return ApplyStatusRecord{}, nil
 	}
 	if message == "" && status != ApplyStatusManualRestartRequired {
 		return ApplyStatusRecord{}, nil
 	}
 	return ApplyStatusRecord{
-		Status:  status,
-		Message: message,
+		Status:    status,
+		Message:   message,
+		ErrorKind: strings.TrimSpace(record.ErrorKind),
+		LogPath:   strings.TrimSpace(record.LogPath),
 	}, nil
 }
 

--- a/internal/upgrade/apply_state_test.go
+++ b/internal/upgrade/apply_state_test.go
@@ -42,11 +42,37 @@ func TestConsumeApplyFailureReturnsMessageAndClearsStatus(t *testing.T) {
 	if !strings.Contains(got, "restart daemon: boom") {
 		t.Fatalf("message = %q, want failure text", got)
 	}
-	if !strings.Contains(got, artifacts.LogPath) {
-		t.Fatalf("message = %q, want log path", got)
-	}
 	if _, err := os.Stat(artifacts.StatusPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("status file still exists; stat err = %v", err)
+	}
+}
+
+func TestConsumeApplyStatusReturnsFailureMetadata(t *testing.T) {
+	dir := t.TempDir()
+	artifacts, err := ResolveApplyArtifacts(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("ResolveApplyArtifacts() error = %v", err)
+	}
+
+	if err := artifacts.RecordFailure(errors.New("write /tmp/csgclaw-upgrade/archive.tar.gz: stream error: stream ID 3")); err != nil {
+		t.Fatalf("RecordFailure() error = %v", err)
+	}
+
+	got, err := ConsumeApplyStatus(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("ConsumeApplyStatus() error = %v", err)
+	}
+	if got.Status != ApplyStatusFailed {
+		t.Fatalf("Status = %q, want %q", got.Status, ApplyStatusFailed)
+	}
+	if got.ErrorKind != UpgradeErrorNetworkDownload {
+		t.Fatalf("ErrorKind = %q, want %q", got.ErrorKind, UpgradeErrorNetworkDownload)
+	}
+	if got.LogPath != artifacts.LogPath {
+		t.Fatalf("LogPath = %q, want %q", got.LogPath, artifacts.LogPath)
+	}
+	if strings.Contains(got.Message, artifacts.LogPath) {
+		t.Fatalf("Message = %q, should keep log path separate", got.Message)
 	}
 }
 

--- a/internal/upgrade/error_hints.go
+++ b/internal/upgrade/error_hints.go
@@ -1,0 +1,119 @@
+package upgrade
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+const (
+	UpgradeErrorArchiveInvalid  = "archive_invalid"
+	UpgradeErrorDiskSpace       = "disk_space"
+	UpgradeErrorHTTPAsset       = "http_asset"
+	UpgradeErrorHTTPMetadata    = "http_metadata"
+	UpgradeErrorMissingPath     = "missing_path"
+	UpgradeErrorNetworkCheck    = "network_check"
+	UpgradeErrorNetworkDownload = "network_download"
+	UpgradeErrorPermission      = "permission"
+)
+
+// ClassifyFailure returns internal diagnostic kinds for upgrade helper failures.
+// The web UI maps these finer-grained kinds into broader user-facing messages.
+func ClassifyFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case isLikelyArchiveFailure(msg):
+		return UpgradeErrorArchiveInvalid
+	case isLikelyNetworkFailure(msg):
+		if isDownloadContext(msg) {
+			return UpgradeErrorNetworkDownload
+		}
+		return UpgradeErrorNetworkCheck
+	case isLikelyHTTPStatusFailure(msg):
+		if strings.Contains(msg, "download release asset") {
+			return UpgradeErrorHTTPAsset
+		}
+		return UpgradeErrorHTTPMetadata
+	case isLikelyDiskSpaceFailure(msg):
+		return UpgradeErrorDiskSpace
+	case isLikelyPermissionFailure(err, msg):
+		return UpgradeErrorPermission
+	case isLikelyMissingPathFailure(err, msg):
+		return UpgradeErrorMissingPath
+	default:
+		return ""
+	}
+}
+
+func isLikelyArchiveFailure(msg string) bool {
+	return containsAny(msg,
+		"read release archive",
+		"release archive contains",
+		"open release archive entry",
+		"close release archive entry",
+	)
+}
+
+func isLikelyNetworkFailure(msg string) bool {
+	return containsAny(msg,
+		"stream error",
+		"received from peer",
+		"connection reset",
+		"connection refused",
+		"connection aborted",
+		"unexpected eof",
+		"i/o timeout",
+		"timeout awaiting response headers",
+		"tls handshake timeout",
+		"context deadline exceeded",
+		"no such host",
+		"server misbehaving",
+		"network is unreachable",
+		"temporary failure in name resolution",
+		"proxyconnect",
+		"http2",
+		"server closed idle connection",
+		"use of closed network connection",
+		"broken pipe",
+	)
+}
+
+func isDownloadContext(msg string) bool {
+	return containsAny(msg, "download", "csgclaw-upgrade", ".tar.gz", ".zip")
+}
+
+func isLikelyHTTPStatusFailure(msg string) bool {
+	return strings.Contains(msg, "unexpected status") &&
+		(strings.Contains(msg, "fetch latest release metadata") || strings.Contains(msg, "download release asset"))
+}
+
+func isLikelyDiskSpaceFailure(msg string) bool {
+	return containsAny(msg,
+		"no space left on device",
+		"disk quota exceeded",
+		"not enough space",
+		"there is not enough space",
+	)
+}
+
+func isLikelyPermissionFailure(err error, msg string) bool {
+	return errors.Is(err, os.ErrPermission) ||
+		containsAny(msg, "permission denied", "operation not permitted", "access is denied")
+}
+
+func isLikelyMissingPathFailure(err error, msg string) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		containsAny(msg, "no such file or directory", "cannot find the file specified")
+}
+
+func containsAny(s string, patterns ...string) bool {
+	for _, pattern := range patterns {
+		if strings.Contains(s, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/upgrade/error_hints_test.go
+++ b/internal/upgrade/error_hints_test.go
@@ -1,0 +1,50 @@
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestClassifyFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "network download",
+			err:  errors.New("write /tmp/csgclaw-upgrade/archive.tar.gz: stream error: stream ID 3"),
+			want: UpgradeErrorNetworkDownload,
+		},
+		{
+			name: "archive unexpected eof",
+			err:  errors.New("read release archive entry: unexpected EOF"),
+			want: UpgradeErrorArchiveInvalid,
+		},
+		{
+			name: "permission",
+			err:  fmt.Errorf("open /Users/me/.csgclaw/logs/upgrade-helper.log: %w", os.ErrPermission),
+			want: UpgradeErrorPermission,
+		},
+		{
+			name: "disk space",
+			err:  errors.New("write /tmp/csgclaw-upgrade/archive.tar.gz: no space left on device"),
+			want: UpgradeErrorDiskSpace,
+		},
+		{
+			name: "http asset",
+			err:  errors.New("download release asset csgclaw_v0.3.15_darwin_arm64.tar.gz: unexpected status 404 Not Found"),
+			want: UpgradeErrorHTTPAsset,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyFailure(tt.err); got != tt.want {
+				t.Fatalf("ClassifyFailure() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/upgrade/manager.go
+++ b/internal/upgrade/manager.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -102,6 +103,8 @@ func (m *Manager) Refresh(ctx context.Context) {
 			m.status.LastError = m.stickyError
 		} else {
 			m.status.LastError = err.Error()
+			m.status.LastErrorKind = ""
+			m.status.LastErrorLogPath = ""
 		}
 		updated := copyStatus(m.status)
 		notify := shouldNotifyStatusChange(previous, updated)
@@ -116,6 +119,10 @@ func (m *Manager) Refresh(ctx context.Context) {
 	m.status.LatestVersion = result.LatestVersion
 	m.status.UpdateAvailable = result.UpdateAvailable
 	m.status.LastError = m.stickyError
+	if m.stickyError == "" {
+		m.status.LastErrorKind = ""
+		m.status.LastErrorLogPath = ""
+	}
 	updated := copyStatus(m.status)
 	notify := shouldNotifyStatusChange(previous, updated)
 	callback := m.onStatusChange
@@ -152,6 +159,8 @@ func (m *Manager) MarkUpgrading() apitypes.UpgradeStatus {
 	m.status.ManualRestartRequired = false
 	m.stickyError = ""
 	m.status.LastError = ""
+	m.status.LastErrorKind = ""
+	m.status.LastErrorLogPath = ""
 	updated := copyStatus(m.status)
 	notify := shouldNotifyStatusChange(previous, updated)
 	callback := m.onStatusChange
@@ -163,6 +172,10 @@ func (m *Manager) MarkUpgrading() apitypes.UpgradeStatus {
 }
 
 func (m *Manager) MarkUpgradeFailed(err error) apitypes.UpgradeStatus {
+	return m.MarkUpgradeFailedWithDetails(err, "", "")
+}
+
+func (m *Manager) MarkUpgradeFailedWithDetails(err error, kind, logPath string) apitypes.UpgradeStatus {
 	if m == nil {
 		return apitypes.UpgradeStatus{}
 	}
@@ -173,8 +186,13 @@ func (m *Manager) MarkUpgradeFailed(err error) apitypes.UpgradeStatus {
 	m.status.ManualRestartRequired = false
 	m.stickyError = ""
 	if err != nil {
+		if strings.TrimSpace(kind) == "" {
+			kind = ClassifyFailure(err)
+		}
 		m.stickyError = err.Error()
 		m.status.LastError = m.stickyError
+		m.status.LastErrorKind = strings.TrimSpace(kind)
+		m.status.LastErrorLogPath = strings.TrimSpace(logPath)
 	}
 	updated := copyStatus(m.status)
 	notify := shouldNotifyStatusChange(previous, updated)
@@ -197,6 +215,8 @@ func (m *Manager) MarkManualRestartRequired() apitypes.UpgradeStatus {
 	m.status.ManualRestartRequired = true
 	m.stickyError = ""
 	m.status.LastError = ""
+	m.status.LastErrorKind = ""
+	m.status.LastErrorLogPath = ""
 	updated := copyStatus(m.status)
 	notify := shouldNotifyStatusChange(previous, updated)
 	callback := m.onStatusChange
@@ -222,6 +242,8 @@ func shouldNotifyStatusChange(previous, current apitypes.UpgradeStatus) bool {
 		previous.Upgrading != current.Upgrading ||
 		previous.ManualRestartRequired != current.ManualRestartRequired ||
 		previous.LastError != current.LastError ||
+		previous.LastErrorKind != current.LastErrorKind ||
+		previous.LastErrorLogPath != current.LastErrorLogPath ||
 		previous.AutoUpgradeSupported != current.AutoUpgradeSupported ||
 		previous.AutoUpgradeUnsupportedReason != current.AutoUpgradeUnsupportedReason
 }

--- a/internal/upgrade/manager_test.go
+++ b/internal/upgrade/manager_test.go
@@ -133,6 +133,29 @@ func TestManagerRefreshPreservesUpgradeFailure(t *testing.T) {
 	}
 }
 
+func TestManagerPreservesUpgradeFailureMetadata(t *testing.T) {
+	manager := NewManager(fakeChecker{
+		check: func(_ context.Context, _ string) (CheckResult, error) {
+			return CheckResult{LatestVersion: "v0.2.7"}, nil
+		},
+	}, "v0.2.5", ManagerOptions{})
+
+	manager.MarkUpgradeFailedWithDetails(
+		errors.New("write /tmp/csgclaw-upgrade/archive.tar.gz: stream error: stream ID 3"),
+		UpgradeErrorNetworkDownload,
+		"/tmp/upgrade-helper.log",
+	)
+	manager.Refresh(context.Background())
+
+	status := manager.Status()
+	if got, want := status.LastErrorKind, UpgradeErrorNetworkDownload; got != want {
+		t.Fatalf("LastErrorKind = %q, want %q", got, want)
+	}
+	if got, want := status.LastErrorLogPath, "/tmp/upgrade-helper.log"; got != want {
+		t.Fatalf("LastErrorLogPath = %q, want %q", got, want)
+	}
+}
+
 func TestManagerRefreshSkipsLocalDevVersionWithoutError(t *testing.T) {
 	now := time.Date(2026, 5, 6, 16, 0, 0, 0, time.UTC)
 	manager := NewManager(fakeChecker{

--- a/web/app/src/hooks/workspace/useUpgradeController.ts
+++ b/web/app/src/hooks/workspace/useUpgradeController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { applyUpgradeRequest } from "@/api/upgrade";
-import { normalizeUpgradeStatus } from "@/models/upgradeStatus";
+import { normalizeUpgradeStatus, upgradeErrorMessage } from "@/models/upgradeStatus";
 import type { UpgradePhase } from "@/models/upgradeStatus";
 import type { UpgradeController, UseUpgradeControllerArgs } from "./types";
 
@@ -84,6 +84,8 @@ export function useUpgradeController({
               manual_restart_required: false,
               upgrading: false,
               last_error: "",
+              last_error_kind: "",
+              last_error_log_path: "",
             }));
             return;
           }
@@ -95,12 +97,13 @@ export function useUpgradeController({
             setShowUpgradeModal(true);
             return;
           }
-          if (latest?.last_error) {
+          const statusMessage = upgradeErrorMessage(latest, t);
+          if (statusMessage) {
             stopUpgradePoll();
             setUpgradeBusy(false);
             setUpgradePhase("error");
             setShowUpgradeModal(true);
-            setUpgradeError(`${t("upgradeApplyFailed")} ${latest.last_error}`.trim());
+            setUpgradeError(statusMessage);
             return;
           }
         } catch (_) {
@@ -112,8 +115,7 @@ export function useUpgradeController({
           setUpgradePhase("error");
           setShowUpgradeModal(true);
           const latest = await refreshUpgradeStatus();
-          const detail = latest?.last_error ? ` ${latest.last_error}` : "";
-          setUpgradeError(`${t("upgradeApplyFailed")}${detail}`);
+          setUpgradeError(upgradeErrorMessage(latest, t) || t("upgradeApplyFailed"));
         }
       };
       poll();
@@ -153,16 +155,32 @@ export function useUpgradeController({
         manual_restart_required: false,
         upgrading: true,
         last_error: "",
+        last_error_kind: "",
+        last_error_log_path: "",
       }));
       startUpgradeReconnectPoll(upgradeStatus?.latest_version);
       setShowUpgradeModal(false);
     } catch (err: unknown) {
       setUpgradeBusy(false);
       setUpgradePhase("error");
+      const latest = await refreshUpgradeStatus().catch(() => null);
+      const statusMessage = upgradeErrorMessage(latest, t);
+      if (statusMessage) {
+        setUpgradeError(statusMessage);
+        return;
+      }
       const detail = upgradeErrorDetail(err);
       setUpgradeError(`${t("upgradeApplyFailed")}${detail}`);
     }
-  }, [appVersion, setUpgradeStatusData, startUpgradeReconnectPoll, t, upgradeBusy, upgradeStatus]);
+  }, [
+    appVersion,
+    refreshUpgradeStatus,
+    setUpgradeStatusData,
+    startUpgradeReconnectPoll,
+    t,
+    upgradeBusy,
+    upgradeStatus,
+  ]);
 
   const openUpgradeModal = useCallback(() => {
     if (upgradePhase !== "error") {

--- a/web/app/src/models/upgradeStatus.ts
+++ b/web/app/src/models/upgradeStatus.ts
@@ -8,6 +8,8 @@ export type UpgradeStatus = {
   current_version: string;
   last_checked_at: unknown;
   last_error: string;
+  last_error_kind: string;
+  last_error_log_path: string;
   latest_version: string;
   manual_restart_required: boolean;
   update_available: boolean;
@@ -57,8 +59,51 @@ export function normalizeUpgradeStatus(status: unknown): UpgradeStatus | null {
     upgrading: Boolean(source.upgrading),
     last_checked_at: source.last_checked_at || "",
     last_error: typeof source.last_error === "string" ? source.last_error : "",
+    last_error_kind: typeof source.last_error_kind === "string" ? source.last_error_kind : "",
+    last_error_log_path: typeof source.last_error_log_path === "string" ? source.last_error_log_path : "",
     manual_restart_required: Boolean(source.manual_restart_required),
   };
+}
+
+export function upgradeErrorMessage(status: UpgradeStatus | null | undefined, t: TranslateFn): string {
+  if (!status?.last_error && !status?.last_error_kind && !status?.last_error_log_path) {
+    return "";
+  }
+  const detail = status.last_error.trim();
+  const logPath = status.last_error_log_path.trim();
+  const kind = status.last_error_kind.trim();
+  if (!kind) {
+    return [detail, logPath ? t("upgradeErrorLogPath", { path: logPath }) : ""].filter(Boolean).join("\n");
+  }
+
+  const parts = [upgradeErrorSummary(kind, t)];
+  if (detail) {
+    parts.push(t("upgradeErrorDetails", { detail }));
+  }
+  if (logPath) {
+    parts.push(t("upgradeErrorLogPath", { path: logPath }));
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+function upgradeErrorSummary(kind: string, t: TranslateFn): string {
+  switch (kind) {
+    case "archive_invalid":
+      return t("upgradeErrorArchiveInvalid");
+    case "disk_space":
+      return t("upgradeErrorDiskSpace");
+    case "http_asset":
+    case "http_metadata":
+    case "network_download":
+    case "network_check":
+      return t("upgradeErrorNetworkOrService");
+    case "missing_path":
+      return t("upgradeErrorLocalInstall");
+    case "permission":
+      return t("upgradeErrorPermission");
+    default:
+      return t("upgradeErrorUnknown");
+  }
 }
 
 export function upgradeStatusLabel(phase: UpgradePhase, t: TranslateFn): string {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -2061,6 +2061,8 @@
   padding: 10px 12px;
   background: color-mix(in oklab, var(--danger) 12%, var(--surface));
   color: color-mix(in oklab, var(--danger) 86%, var(--text));
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .entity-pane {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/UpgradeModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/UpgradeModal.tsx
@@ -1,5 +1,10 @@
 import { Button } from "@/components/ui";
-import { formatSidebarVersionLabel, isLocalBuildVersion, upgradeStatusLabel } from "@/models/upgradeStatus";
+import {
+  formatSidebarVersionLabel,
+  isLocalBuildVersion,
+  upgradeErrorMessage,
+  upgradeStatusLabel,
+} from "@/models/upgradeStatus";
 import type { UpgradePhase, UpgradeStatus } from "@/models/upgradeStatus";
 import type { TranslateFn } from "@/models/conversations";
 import { ModalCloseButton } from "./ModalCloseButton";
@@ -35,6 +40,8 @@ export function UpgradeModal({
       ? t("upgradeStatusManualUpgrade")
       : upgradeStatusLabel(upgradePhase, t);
   const subtitle = manualUpgradeRequired ? t("upgradeManualUpgradeSubtitle") : t("upgradeSubtitle");
+  const statusError = upgradeErrorMessage(upgradeStatus, t);
+  const visibleError = upgradeError || statusError;
   return (
     <div className="modal-backdrop">
       <div className="modal-card upgrade-modal" onClick={(event) => event.stopPropagation()}>
@@ -80,9 +87,7 @@ export function UpgradeModal({
                     : t("upgradeConfirmBody")}
           </p>
         </div>
-        {upgradeError || upgradeStatus?.last_error ? (
-          <div className="form-error">{upgradeError || upgradeStatus?.last_error}</div>
-        ) : null}
+        {visibleError ? <div className="form-error">{visibleError}</div> : null}
         <div className="modal-actions">
           {upgradePhase === "done" ? (
             <Button variant="primary" size="md" onClick={() => window.location.reload()}>

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
@@ -7,7 +7,12 @@ import type { AuthStatus } from "@/models/auth";
 import type { LocaleCode, TranslateFn } from "@/models/conversations";
 import { githubFeedbackIssueURL } from "@/models/feedback";
 import type { UpgradePhase, UpgradeStatus } from "@/models/upgradeStatus";
-import { formatSidebarVersionLabel, hasUpgradeAttention, isLocalBuildUpgradeStatus } from "@/models/upgradeStatus";
+import {
+  formatSidebarVersionLabel,
+  hasUpgradeAttention,
+  isLocalBuildUpgradeStatus,
+  upgradeErrorMessage,
+} from "@/models/upgradeStatus";
 import { classNames } from "@/shared/lib/classNames";
 import type { ThemeMode } from "@/shared/theme/theme";
 
@@ -65,8 +70,8 @@ export function SidebarUserButton({
     showUpgradeControls && !localBuild && upgradeStatus?.auto_upgrade_supported !== false;
   const upgradeAttention = upgradeControlsAvailable && hasUpgradeAttention(upgradeStatus, upgradePhase, upgradeBusy);
   const upgradeRunning = upgradeControlsAvailable ? upgradeBusy || Boolean(upgradeStatus?.upgrading) : false;
-  const upgradeIssue =
-    upgradeControlsAvailable && !suppressUpgradeIssue ? upgradeError || upgradeStatus?.last_error || "" : "";
+  const statusIssue = upgradeErrorMessage(upgradeStatus, t);
+  const upgradeIssue = upgradeControlsAvailable && !suppressUpgradeIssue ? upgradeError || statusIssue : "";
   const upgradeView = upgradeControlsAvailable
     ? {
         actionLabel: upgradeMenuActionText({

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
@@ -2469,6 +2469,7 @@
   font-size: 12px;
   line-height: 1.35;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .sidebar-feedback-link {

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -735,6 +735,14 @@ export const messages = {
     upgradeAction: "更新并重启",
     upgradeActionBusy: "更新中...",
     upgradeApplyFailed: "启动升级失败，请重试。",
+    upgradeErrorArchiveInvalid: "下载的升级包无效或已损坏，请重试；如果持续失败，请反馈该版本安装包问题。",
+    upgradeErrorDetails: "详情：{detail}",
+    upgradeErrorDiskSpace: "磁盘空间不足，无法完成升级。请清理临时目录或安装目录所在磁盘后重试。",
+    upgradeErrorLocalInstall: "本地安装目录或升级状态异常，请确认安装是否完整后重试。",
+    upgradeErrorLogPath: "日志：{path}",
+    upgradeErrorNetworkOrService: "网络或服务访问失败，请检查网络、代理或稍后重试。",
+    upgradeErrorPermission: "本地权限不足，无法准备或安装升级。请检查安装目录、配置/日志目录和系统临时目录的写入权限。",
+    upgradeErrorUnknown: "升级失败。请查看详情并重试。",
     upgradeTitle: "发现新版本",
     upgradeSubtitle: "可以直接在界面中完成升级，升级过程会短暂重启本地服务。",
     upgradeManualUpgradeSubtitle: "当前安装方式不支持界面内自动升级，需要手动完成升级。",
@@ -1534,6 +1542,18 @@ export const messages = {
     upgradeAction: "Update & Restart",
     upgradeActionBusy: "Updating...",
     upgradeApplyFailed: "Failed to start the upgrade. Please retry.",
+    upgradeErrorArchiveInvalid:
+      "The downloaded upgrade package is invalid or corrupted. Retry the upgrade; if it keeps failing, report the release package.",
+    upgradeErrorDetails: "Details: {detail}",
+    upgradeErrorDiskSpace:
+      "There is not enough disk space to complete the upgrade. Free space on the temp or install volume, then retry.",
+    upgradeErrorLocalInstall:
+      "The local installation directory or upgrade state looks abnormal. Check that the installation is complete, then retry.",
+    upgradeErrorLogPath: "Log: {path}",
+    upgradeErrorNetworkOrService: "Network or service access failed. Check your network or proxy, or retry later.",
+    upgradeErrorPermission:
+      "A local permission issue prevented the upgrade. Check write access to the install directory, config/log directory, and system temp directory.",
+    upgradeErrorUnknown: "The upgrade failed. Review the details and retry.",
     upgradeTitle: "New version available",
     upgradeSubtitle: "Upgrade directly from the app. The local service will restart briefly.",
     upgradeManualUpgradeSubtitle: "This installation does not support in-app upgrade and must be upgraded manually.",

--- a/web/app/tests/components/SidebarUserButton.test.tsx
+++ b/web/app/tests/components/SidebarUserButton.test.tsx
@@ -11,6 +11,9 @@ const labels: Record<string, string> = {
   themeLight: "Light",
   themeSwitcher: "Theme",
   upgradeAction: "Update & Restart",
+  upgradeErrorDetails: "Details: {detail}",
+  upgradeErrorLogPath: "Log: {path}",
+  upgradeErrorPermission: "Permission issue.",
   upgradeLocalBuild: "Local build",
   versionInfo: "Version",
   versionSettings: "Version and updates",
@@ -28,8 +31,8 @@ const labels: Record<string, string> = {
   csghubSignOut: "Sign out",
 };
 
-function t(key: string): string {
-  return labels[key] ?? key;
+function t(key: string, params: Record<string, string | number> = {}): string {
+  return (labels[key] ?? key).replace(/\{(\w+)\}/g, (_, name) => `${params[name] ?? ""}`);
 }
 
 const updateAvailableStatus: UpgradeStatus = {
@@ -39,6 +42,8 @@ const updateAvailableStatus: UpgradeStatus = {
   current_version: "v0.3.0",
   last_checked_at: "",
   last_error: "",
+  last_error_kind: "",
+  last_error_log_path: "",
   latest_version: "v0.3.1",
   manual_restart_required: false,
   update_available: true,

--- a/web/app/tests/components/UpgradeModal.test.tsx
+++ b/web/app/tests/components/UpgradeModal.test.tsx
@@ -8,6 +8,9 @@ const labels: Record<string, string> = {
   upgradeLatestVersion: "Latest version",
   upgradeManualUpgradeBody: "Use the official installer or release bundle to upgrade manually.",
   upgradeManualUpgradeSubtitle: "Manual upgrade is required for this installation.",
+  upgradeErrorDetails: "Details: {detail}",
+  upgradeErrorLogPath: "Log: {path}",
+  upgradeErrorNetworkOrService: "Network or service issue.",
   upgradeNoLatest: "Unknown",
   upgradeStatus: "Status",
   upgradeStatusManualUpgrade: "Manual upgrade required",
@@ -15,8 +18,8 @@ const labels: Record<string, string> = {
   upgradeTitle: "New version available",
 };
 
-function t(key: string): string {
-  return labels[key] ?? key;
+function t(key: string, params: Record<string, string | number> = {}): string {
+  return (labels[key] ?? key).replace(/\{(\w+)\}/g, (_, name) => `${params[name] ?? ""}`);
 }
 
 const manualUpgradeStatus: UpgradeStatus = {
@@ -26,6 +29,8 @@ const manualUpgradeStatus: UpgradeStatus = {
   current_version: "v0.3.10",
   last_checked_at: "",
   last_error: "",
+  last_error_kind: "",
+  last_error_log_path: "",
   latest_version: "v0.3.11",
   manual_restart_required: false,
   update_available: true,
@@ -48,5 +53,27 @@ describe("UpgradeModal", () => {
     expect(screen.getByText("Use the official installer or release bundle to upgrade manually.")).toBeInTheDocument();
     expect(screen.getByText("Manual upgrade required")).toBeInTheDocument();
     expect(screen.queryByText("Upgrade directly from the app.")).not.toBeInTheDocument();
+  });
+
+  it("renders localized classified upgrade errors with log path", () => {
+    render(
+      <UpgradeModal
+        onApply={() => {}}
+        onClose={() => {}}
+        t={t}
+        upgradePhase="error"
+        upgradeStatus={{
+          ...manualUpgradeStatus,
+          auto_upgrade_supported: true,
+          last_error: "write archive: stream error",
+          last_error_kind: "network_download",
+          last_error_log_path: "/tmp/upgrade-helper.log",
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Network or service issue/)).toBeInTheDocument();
+    expect(screen.getByText(/Details: write archive: stream error/)).toBeInTheDocument();
+    expect(screen.getByText(/Log: \/tmp\/upgrade-helper.log/)).toBeInTheDocument();
   });
 });

--- a/web/app/tests/models/upgradeStatus.test.ts
+++ b/web/app/tests/models/upgradeStatus.test.ts
@@ -4,6 +4,7 @@ import {
   isLocalBuildUpgradeStatus,
   isLocalBuildVersion,
   normalizeUpgradeStatus,
+  upgradeErrorMessage,
   upgradeStatusLabel,
 } from "@/models/upgradeStatus";
 import type { UpgradeStatus } from "@/models/upgradeStatus";
@@ -44,6 +45,8 @@ describe("upgrade status helpers", () => {
         current_version: "v0.2.0",
         last_checked_at: 123,
         last_error: 404,
+        last_error_kind: "network_download",
+        last_error_log_path: "/tmp/upgrade.log",
         latest_version: "v0.2.1",
         manual_restart_required: "yes",
         auto_upgrade_supported: false,
@@ -58,6 +61,8 @@ describe("upgrade status helpers", () => {
       current_version: "v0.2.0",
       last_checked_at: 123,
       last_error: "",
+      last_error_kind: "network_download",
+      last_error_log_path: "/tmp/upgrade.log",
       latest_version: "v0.2.1",
       manual_restart_required: true,
       update_available: true,
@@ -80,6 +85,65 @@ describe("upgrade status helpers", () => {
     expect(upgradeStatusLabel("idle", t)).toBe("label:upgradeStatusReady");
   });
 
+  it("formats classified upgrade errors through translations", () => {
+    const t = (key: string, params: Record<string, string | number> = {}) => {
+      const labels: Record<string, string> = {
+        upgradeErrorDetails: "Details: {detail}",
+        upgradeErrorLocalInstall: "Local install is abnormal.",
+        upgradeErrorLogPath: "Log: {path}",
+        upgradeErrorNetworkOrService: "Network or service failed.",
+      };
+      return (labels[key] ?? key).replace(/\{(\w+)\}/g, (_, name) => `${params[name] ?? ""}`);
+    };
+
+    expect(
+      upgradeErrorMessage(
+        {
+          ...baseUpgradeStatus,
+          last_error: "write archive: stream error",
+          last_error_kind: "network_download",
+          last_error_log_path: "/tmp/upgrade-helper.log",
+        },
+        t,
+      ),
+    ).toBe("Network or service failed.\nDetails: write archive: stream error\nLog: /tmp/upgrade-helper.log");
+    expect(
+      upgradeErrorMessage(
+        {
+          ...baseUpgradeStatus,
+          last_error: "fetch latest release metadata: unexpected status 503",
+          last_error_kind: "http_metadata",
+        },
+        t,
+      ),
+    ).toBe("Network or service failed.\nDetails: fetch latest release metadata: unexpected status 503");
+    expect(
+      upgradeErrorMessage(
+        {
+          ...baseUpgradeStatus,
+          last_error_kind: "missing_path",
+        },
+        t,
+      ),
+    ).toBe("Local install is abnormal.");
+  });
+
+  it("keeps log paths visible for unclassified upgrade errors", () => {
+    const t = (key: string, params: Record<string, string | number> = {}) =>
+      key === "upgradeErrorLogPath" ? `Log: ${params.path}` : key;
+
+    expect(
+      upgradeErrorMessage(
+        {
+          ...baseUpgradeStatus,
+          last_error: "restart daemon: boom",
+          last_error_log_path: "/tmp/upgrade-helper.log",
+        },
+        t,
+      ),
+    ).toBe("restart daemon: boom\nLog: /tmp/upgrade-helper.log");
+  });
+
   it("detects upgrade states that need settings attention", () => {
     expect(hasUpgradeAttention(null, "idle")).toBe(false);
     expect(hasUpgradeAttention({ ...baseUpgradeStatus, update_available: true }, "idle")).toBe(true);
@@ -100,6 +164,8 @@ const baseUpgradeStatus: UpgradeStatus = {
   current_version: "v0.2.0",
   last_checked_at: "",
   last_error: "",
+  last_error_kind: "",
+  last_error_log_path: "",
   latest_version: "v0.2.0",
   manual_restart_required: false,
   update_available: false,


### PR DESCRIPTION
## Summary

- classify common upgrade failures such as network, HTTP status, disk space, permission, missing path, and invalid archive errors
- persist structured upgrade failure metadata and log path separately from the raw error text
- render localized upgrade failure guidance in the modal and sidebar, including long log paths in light and dark themes
- add regression coverage for backend classification, API propagation, CLI output, and frontend formatting

## Root cause

The upgrade helper previously surfaced the raw download/write error directly, so stream/network failures and local filesystem problems were hard to distinguish. The log path was appended into the raw message instead of being exposed as structured status.

## Validation

- `go test ./...`
- `pnpm --dir web/app test -- upgradeStatus useUpgradeController UpgradeModal SidebarUserButton`
- `pnpm --dir web/app typecheck`
- `pnpm --dir web/app format:check`
- `pnpm --dir web/app lint`
- `git diff --check`
