### PR TITLE
fix(ui): improve skill upload dark mode contrast

### DIFF
--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
@@ -103,6 +103,11 @@
   line-height: 18px;
 }
 
+:root[data-theme="dark"] .hub-skill-upload-copy strong,
+:root[data-theme="dark"] .hub-skill-upload-copy small {
+  color: var(--white);
+}
+
 .hub-skill-upload-input {
   display: none;
 }
@@ -160,6 +165,11 @@
   background: var(--white);
 }
 
+:root[data-theme="dark"] .hub-skill-remote-row {
+  border-color: var(--gray-700);
+  background: var(--panel-soft);
+}
+
 .hub-skill-remote-list-state {
   display: flex;
   align-items: center;
@@ -198,6 +208,11 @@
   color: var(--gray-600);
   font-size: 12px;
   line-height: 18px;
+}
+
+:root[data-theme="dark"] .hub-skill-remote-title,
+:root[data-theme="dark"] .hub-skill-remote-meta {
+  color: var(--white);
 }
 
 .hub-skill-remote-state {


### PR DESCRIPTION
## Summary
- Keep the remote skill list dark in the skill upload dialog when dark mode is active.
- Use white text for the zip upload hints and remote skill list labels in dark mode.

## Root Cause
The skill upload dialog used light-theme colors for the upload hint and remote skill rows, which made dark-mode text hard to read and made the remote list appear visually inconsistent.

## Validation
- pnpm exec prettier --check src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceSidebar.css
- git diff --check

Related: product/agentichub/requirements#2745