### PR TITLE
fix(openclaw): use compact gateway activity verbosity

### DIFF
--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -7576,8 +7576,8 @@ func TestGatewayProvisionRequestBuildsOpenClawWorkerAssets(t *testing.T) {
 	if !strings.Contains(cfgText, `"security": "full"`) || !strings.Contains(cfgText, `"ask": "off"`) {
 		t.Fatalf("openclaw config should disable exec approval prompts (tools.exec security=full ask=off), got:\n%s", cfgText)
 	}
-	if !strings.Contains(cfgText, `"verboseDefault": "full"`) {
-		t.Fatalf("openclaw config should set agents.defaults.verboseDefault to full for tool stream visibility, got:\n%s", cfgText)
+	if !strings.Contains(cfgText, `"verboseDefault": "on"`) {
+		t.Fatalf("openclaw config should set agents.defaults.verboseDefault to on for compact default channel activity, got:\n%s", cfgText)
 	}
 	approvalsRaw, err := os.ReadFile(filepath.Join(wantOpenClawRoot, openclawsandbox.HostExecApproval))
 	if err != nil {

--- a/internal/runtime/openclawsandbox/config_test.go
+++ b/internal/runtime/openclawsandbox/config_test.go
@@ -80,7 +80,7 @@ func TestRenderAgentOpenClawConfigUsesBridgeForMinimaxBaseURL(t *testing.T) {
 	if _, ok := defaults["thinkingDefault"]; ok {
 		t.Fatalf("thinkingDefault should be omitted for non-reasoning OpenAI-compatible bridge model: %#v", defaults["thinkingDefault"])
 	}
-	if got, want := defaults["verboseDefault"], "full"; got != want {
+	if got, want := defaults["verboseDefault"], "on"; got != want {
 		t.Fatalf("verboseDefault = %v, want %v", got, want)
 	}
 	if runtime.GOOS == "windows" {
@@ -142,7 +142,7 @@ func TestRenderAgentOpenClawConfigUsesBridgeForInfiniMaaS(t *testing.T) {
 	if got, want := model["primary"], "csgclaw-llm/minimax-m2.5"; got != want {
 		t.Fatalf("primary model = %v, want %v", got, want)
 	}
-	if got, want := defaults["verboseDefault"], "full"; got != want {
+	if got, want := defaults["verboseDefault"], "on"; got != want {
 		t.Fatalf("verboseDefault = %v, want %v", got, want)
 	}
 	text := string(data)

--- a/internal/runtime/openclawsandbox/defaults/openclaw-gateway.json
+++ b/internal/runtime/openclawsandbox/defaults/openclaw-gateway.json
@@ -50,7 +50,7 @@
       "subagents": {
         "maxConcurrent": 8
       },
-      "verboseDefault": "full"
+      "verboseDefault": "on"
     }
   },
   "tools": {


### PR DESCRIPTION
- Set the OpenClaw gateway verboseDefault to on for compact default activity output.
- Update agent provisioning and OpenClaw sandbox config tests for the compact verbosity default.
- Validation: env GOCACHE=/Users/jared/opencsg-workspace/csgclaw-workspace/csgclaw/.gocache go test ./internal/runtime/openclawsandbox ./internal/agent
