### PR TITLE
feat(web): add long message collapse

### DIFF
--- a/web/app/src/components/business/ConversationPane/ConversationMessageList.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationMessageList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo } from "react";
+import { Fragment, memo, useState } from "react";
 import type { ReactNode, RefObject } from "react";
 import { AgentAvatarContent } from "@/components/business/AgentAvatar";
 import { MessageContent, MessagePreviewText } from "@/components/business/MessageContent";
@@ -67,6 +67,8 @@ export const ConversationMessageList = memo(function ConversationMessageList({
   onOpenThread,
   onPreviewUser,
 }: ConversationMessageListProps) {
+  const [expandedLongMessages, setExpandedLongMessages] = useState<Record<string, boolean>>({});
+
   return (
     <section ref={messageListRef} className="messages">
       {conversation.messages.length === 0 ? (
@@ -115,6 +117,7 @@ export const ConversationMessageList = memo(function ConversationMessageList({
           : avatarFallbackText(user.avatar, user.name, user.id);
         const threadSummary = message.thread;
         const latestThreadReply = threadSummary?.latest_reply;
+        const messageStateKey = longMessageStateKey(conversation, message, index);
         return (
           <Fragment key={message.id || `message-${index}`}>
             {showDivider ? <MessageTimeDivider parts={timestampParts} /> : null}
@@ -167,7 +170,19 @@ export const ConversationMessageList = memo(function ConversationMessageList({
                     message={message}
                     actionBusy={messageActionBusy}
                     actionError={messageActionError}
+                    enableLongMessageCollapse={own}
+                    longMessageExpanded={own ? expandedLongMessages[messageStateKey] === true : undefined}
                     onAction={onMessageAction}
+                    onLongMessageExpandedChange={
+                      own
+                        ? (expanded) =>
+                            setExpandedLongMessages((current) => ({
+                              ...current,
+                              [messageStateKey]: expanded,
+                            }))
+                        : undefined
+                    }
+                    t={t}
                   />
                 </div>
                 {threadSummary ? (
@@ -199,6 +214,12 @@ export const ConversationMessageList = memo(function ConversationMessageList({
     </section>
   );
 });
+
+function longMessageStateKey(conversation: IMConversation, message: IMMessage, index: number): string {
+  const conversationKey = String(conversation.id || "conversation");
+  const messageKey = String(message.id || `${message.created_at || "message"}:${index}`);
+  return `${conversationKey}:${messageKey}`;
+}
 
 function resolveMessageAgent(
   agents: readonly AgentLike[],

--- a/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
@@ -499,7 +499,7 @@ function ThreadMessage({
           <MessageTimestamp parts={timestampParts} />
         </div>
         <div className="thread-message-bubble">
-          <MessageContent key={`${message.id}:${theme}`} content={message.content} message={message} />
+          <MessageContent key={`${message.id}:${theme}`} content={message.content} message={message} t={t} />
         </div>
       </div>
     </div>

--- a/web/app/src/components/business/MessageContent/LongMessageCollapse.tsx
+++ b/web/app/src/components/business/MessageContent/LongMessageCollapse.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useLayoutEffect, useId, useRef, useState } from "react";
+import { Button } from "@/components/ui";
+import { classNames } from "@/shared/lib/classNames";
+import type { TranslateFn } from "@/models/conversations";
+import { prepareMermaidBlocks, renderMermaidBlocks } from "./mermaid";
+
+const COLLAPSE_CHAR_LIMIT = 300;
+const COLLAPSE_MAX_HEIGHT_PX = 200;
+const COLLAPSE_LINE_COUNT = 8;
+type LongMessageCollapseProps = {
+  expanded?: boolean;
+  html: string;
+  onExpandedChange?: (expanded: boolean) => void;
+  t: TranslateFn;
+};
+
+type LongMessageMetrics = {
+  collapseHeight: number;
+  expandedHeight: number;
+  shouldCollapse: boolean;
+};
+
+export function LongMessageCollapse({ expanded, html, onExpandedChange, t }: LongMessageCollapseProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [internalExpanded, setInternalExpanded] = useState(false);
+  const [metrics, setMetrics] = useState<LongMessageMetrics | null>(null);
+  const [renderPass, setRenderPass] = useState(0);
+  const contentId = useId();
+  const isExpandedControlled = typeof expanded === "boolean";
+  const isExpanded = isExpandedControlled ? expanded : internalExpanded;
+  const setExpandedState = (value: boolean) => {
+    if (!isExpandedControlled) {
+      setInternalExpanded(value);
+    }
+    onExpandedChange?.(value);
+  };
+
+  useEffect(() => {
+    const container = contentRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const diagrams = prepareMermaidBlocks(container);
+    let cancelled = false;
+    renderMermaidBlocks(diagrams)
+      ?.then(() => {
+        if (!cancelled) {
+          setRenderPass((value) => value + 1);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn("Failed to render Mermaid diagram", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [html]);
+
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    let frame = 0;
+    const measure = () => {
+      const nextMetrics = calculateMetrics(element);
+      setMetrics((current) => {
+        if (nextMetrics.shouldCollapse) {
+          return nextMetrics;
+        }
+        return current?.shouldCollapse ? nextMetrics : null;
+      });
+      if (!nextMetrics.shouldCollapse && isExpanded) {
+        setExpandedState(false);
+      }
+    };
+
+    measure();
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            if (typeof window.requestAnimationFrame !== "function") {
+              measure();
+              return;
+            }
+            if (typeof window.cancelAnimationFrame === "function") {
+              window.cancelAnimationFrame(frame);
+            }
+            frame = window.requestAnimationFrame(measure);
+          });
+
+    resizeObserver?.observe(element);
+
+    return () => {
+      if (typeof window.cancelAnimationFrame === "function") {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [html, isExpanded, renderPass]);
+
+  if (!metrics?.shouldCollapse) {
+    return (
+      <div ref={contentRef} className="message-content long-message-content" dangerouslySetInnerHTML={{ __html: html }} />
+    );
+  }
+
+  const collapsed = !isExpanded;
+  const toggleExpanded = () => {
+    if (!isExpanded) {
+      const element = contentRef.current;
+      if (element) {
+        const nextExpandedHeight = Math.ceil(element.scrollHeight);
+        setMetrics((current) =>
+          current
+            ? {
+                ...current,
+                expandedHeight: nextExpandedHeight,
+              }
+            : current,
+        );
+      }
+    }
+    setExpandedState(!isExpanded);
+  };
+  const containerStyle = {
+    maxHeight: `${isExpanded ? metrics.expandedHeight : metrics.collapseHeight}px`,
+    transitionDuration: "0ms",
+  } as const;
+  const toggleLabel = isExpanded ? t("messageLongCollapse") : t("messageLongExpand");
+
+  return (
+    <div
+      className={classNames("long-message-collapse", collapsed && "is-collapsed", isExpanded && "is-expanded")}
+    >
+      <div
+        ref={contentRef}
+        id={contentId}
+        className="message-content long-message-content"
+        style={containerStyle}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <div className="long-message-actions">
+        <Button
+          type="button"
+          variant="secondaryGray"
+          size="sm"
+          aria-controls={contentId}
+          aria-expanded={isExpanded}
+          className="long-message-toggle"
+          onClick={toggleExpanded}
+        >
+          {toggleLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function calculateMetrics(element: HTMLDivElement): LongMessageMetrics {
+  const expandedHeight = Math.ceil(element.scrollHeight);
+  const computedStyle = window.getComputedStyle(element);
+  const lineHeight = measureLineHeight(computedStyle);
+  const collapseHeight = Math.max(1, Math.min(COLLAPSE_MAX_HEIGHT_PX, Math.ceil(lineHeight * COLLAPSE_LINE_COUNT)));
+  const textLength = normalizedTextLength(element.textContent || "");
+  const hasMediaContent = hasImageLikeContent(element);
+  const shouldCollapse = !hasMediaContent && (expandedHeight > collapseHeight || expandedHeight > COLLAPSE_MAX_HEIGHT_PX || textLength > COLLAPSE_CHAR_LIMIT);
+
+  return {
+    collapseHeight,
+    expandedHeight,
+    shouldCollapse,
+  };
+}
+
+function hasImageLikeContent(element: HTMLDivElement): boolean {
+  return Boolean(element.querySelector("img, picture, video"));
+}
+
+function normalizedTextLength(value: string): number {
+  return value.replace(/\s+/g, " ").trim().length;
+}
+
+function measureLineHeight(computedStyle: CSSStyleDeclaration): number {
+  const rawLineHeight = Number.parseFloat(computedStyle.lineHeight);
+  if (Number.isFinite(rawLineHeight) && rawLineHeight > 0) {
+    return rawLineHeight;
+  }
+  const fontSize = Number.parseFloat(computedStyle.fontSize);
+  if (Number.isFinite(fontSize) && fontSize > 0) {
+    return fontSize * 1.5;
+  }
+  return 24;
+}

--- a/web/app/src/components/business/MessageContent/MessageContent.css
+++ b/web/app/src/components/business/MessageContent/MessageContent.css
@@ -174,6 +174,67 @@
   margin-bottom: 0;
 }
 
+.message-bubble {
+  position: relative;
+  isolation: isolate;
+}
+
+.long-message-collapse {
+  position: relative;
+  width: 100%;
+}
+
+.long-message-content {
+  display: block;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  transition:
+    max-height 120ms ease-out,
+    padding-bottom 120ms ease-out;
+  will-change: max-height;
+}
+
+.long-message-collapse.is-collapsed .long-message-content {
+  padding-bottom: 44px;
+}
+
+.message-bubble:has(.long-message-collapse.is-collapsed)::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.94));
+  pointer-events: none;
+  z-index: 2;
+}
+
+.long-message-actions {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+  z-index: 3;
+}
+
+.long-message-collapse.is-collapsed .long-message-actions {
+  position: absolute;
+  left: 50%;
+  bottom: 8px;
+  margin-top: 0;
+  transform: translateX(-50%);
+}
+
+.long-message-toggle {
+  position: relative;
+  z-index: 4;
+  box-shadow: var(--shadow-soft);
+}
+
+:root[data-theme="dark"] .message-bubble:has(.long-message-collapse.is-collapsed)::after {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.96));
+}
+
 .message-content p,
 .message-content ul,
 .message-content ol,
@@ -210,7 +271,8 @@
 
 .message-content pre {
   max-width: 100%;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: visible;
   padding: 12px 14px;
   border-radius: 14px;
   background: rgba(15, 23, 42, 0.92);

--- a/web/app/src/components/business/MessageContent/MessageContent.tsx
+++ b/web/app/src/components/business/MessageContent/MessageContent.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef } from "react";
 import { ActionCard } from "./ActionCard";
 import { AgentActivityCard } from "./AgentActivityCard";
+import { LongMessageCollapse } from "./LongMessageCollapse";
 import { renderMarkdown } from "./markdown";
-import { prepareMermaidBlocks, renderMermaidBlocks } from "./mermaid";
 import { SlashCommandCard } from "./SlashCommandCard";
 import { parseSlashCommand } from "./slashCommands";
 import { StructuredMessageCard } from "./StructuredMessageCard";
@@ -10,9 +10,20 @@ import { parseStructuredMessage } from "./structuredMessages";
 import type { ActionCardPayload, MessageContentProps } from "./types";
 import { mentionMarkupPattern, escapeHTML } from "./mentions";
 import { parseAgentActivity } from "@/models/agentActivity";
+import { prepareMermaidBlocks, renderMermaidBlocks } from "./mermaid";
 import "./MessageContent.css";
 
-export function MessageContent({ content, message, actionBusy, actionError, onAction }: MessageContentProps) {
+export function MessageContent({
+  content,
+  message,
+  actionBusy,
+  actionError,
+  enableLongMessageCollapse = false,
+  longMessageExpanded,
+  onAction,
+  onLongMessageExpandedChange,
+  t,
+}: MessageContentProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const blankTurnPlaceholder = isBlankTurnPlaceholder(content);
   const activity = useMemo(
@@ -31,6 +42,10 @@ export function MessageContent({ content, message, actionBusy, actionError, onAc
   );
 
   useEffect(() => {
+    if (enableLongMessageCollapse && t) {
+      return undefined;
+    }
+
     const container = containerRef.current;
     if (!container) {
       return undefined;
@@ -47,7 +62,7 @@ export function MessageContent({ content, message, actionBusy, actionError, onAc
     return () => {
       cancelled = true;
     };
-  }, [markup]);
+  }, [enableLongMessageCollapse, markup, t]);
 
   if (blankTurnPlaceholder) {
     return (
@@ -86,7 +101,16 @@ export function MessageContent({ content, message, actionBusy, actionError, onAc
     return <StructuredMessageCard data={structured} />;
   }
 
-  return <div ref={containerRef} className="message-content" dangerouslySetInnerHTML={{ __html: markup }} />;
+  return enableLongMessageCollapse && t ? (
+    <LongMessageCollapse
+      expanded={longMessageExpanded}
+      html={markup}
+      onExpandedChange={onLongMessageExpandedChange}
+      t={t}
+    />
+  ) : (
+    <div ref={containerRef} className="message-content" dangerouslySetInnerHTML={{ __html: markup }} />
+  );
 }
 
 function isBlankTurnPlaceholder(content: string | null | undefined): boolean {

--- a/web/app/src/components/business/MessageContent/types.ts
+++ b/web/app/src/components/business/MessageContent/types.ts
@@ -1,3 +1,5 @@
+import type { TranslateFn } from "@/models/conversations";
+
 export type MessageLike = {
   id?: string;
   [key: string]: unknown;
@@ -40,6 +42,10 @@ export type MessageContentProps = {
   actionBusy?: string;
   actionError?: MessageActionError | null;
   content?: string | null;
+  enableLongMessageCollapse?: boolean;
+  longMessageExpanded?: boolean;
   message?: MessageLike | null;
+  onLongMessageExpandedChange?: (expanded: boolean) => void;
   onAction?: (action: MessageAction, message?: MessageLike | null) => void;
+  t?: TranslateFn;
 };

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -466,6 +466,8 @@ export const messages = {
     inputPlaceholder: "输入消息，使用 @ 选择成员",
     send: "发送",
     composerTip: "Enter 发送，Shift + Enter 换行。支持房间、私信和 @ 提及。",
+    messageLongExpand: "展开全文",
+    messageLongCollapse: "收起",
     profileSetupTitle: "配置 Manager Profile",
     profileSetupSubtitle: "自动检测没有找到可用模型。请完成 Manager 的运行配置后再开始对话。",
     profileProvider: "服务商",
@@ -1318,6 +1320,8 @@ export const messages = {
     inputPlaceholder: "Type a message and use @ to mention members",
     send: "Send",
     composerTip: "Press Enter to send and Shift + Enter for a new line. Supports rooms, DMs, and @ mentions.",
+    messageLongExpand: "Expand full text",
+    messageLongCollapse: "Collapse",
     profileSetupTitle: "Manager Profile",
     profileSetupSubtitle:
       "Auto-detection did not find a usable model. Complete the manager runtime profile before chatting.",

--- a/web/app/tests/components/MessageContent.test.tsx
+++ b/web/app/tests/components/MessageContent.test.tsx
@@ -9,7 +9,33 @@ import {
   CSGCLAW_NOTIFY_CARD_TYPE,
 } from "@/shared/constants/messages";
 
+const longMessageLabels: Record<string, string> = {
+  messageLongCollapse: "收起",
+  messageLongExpand: "展开全文",
+};
+
+function longMessageT(key: string): string {
+  return longMessageLabels[key] ?? key;
+}
+
+function mockLongMessageLayout() {
+  const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function (this: HTMLElement) {
+    const text = (this.textContent || "").replace(/\s+/g, " ").trim();
+    if (!text) {
+      return 0;
+    }
+    return text.length > 100 ? 520 : 120;
+  });
+  return () => {
+    scrollHeightSpy.mockRestore();
+  };
+}
+
 describe("MessageContent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders an animated three-dot indicator for blank turn placeholders", () => {
     render(<MessageContent content={"\u200b"} />);
 
@@ -27,6 +53,120 @@ describe("MessageContent", () => {
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
     expect(document.querySelector("script")).toBeNull();
+  });
+
+  it("automatically collapses long markdown messages and toggles them in place", async () => {
+    const restoreLayout = mockLongMessageLayout();
+    const user = userEvent.setup();
+    const longText =
+      "今天整理了一下整个Agent系统的设计，包含对话能力、工具调用、MCP支持、资源管理、消息流转、权限控制、任务编排、模型选择、运行时配置与会话状态保持。" +
+      "为了确保这个消息在聊天区域中不会占据太多空间，我们需要默认折叠它，并允许用户按需展开查看完整内容。".repeat(4);
+
+    const { container } = render(<MessageContent content={longText} enableLongMessageCollapse t={longMessageT} />);
+
+    const expandButton = await screen.findByRole("button", { name: "展开全文" });
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    expect(container.querySelector(".long-message-collapse")).toHaveClass("is-collapsed");
+    const content = container.querySelector(".long-message-content") as HTMLElement;
+    const collapsedHeight = Number.parseInt(content.style.maxHeight, 10);
+    expect(collapsedHeight).toBeGreaterThan(0);
+
+    await user.click(expandButton);
+
+    const collapseButton = screen.getByRole("button", { name: "收起" });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelector(".long-message-collapse")).toHaveClass("is-expanded");
+    const expandedHeight = Number.parseInt(content.style.maxHeight, 10);
+    expect(expandedHeight).toBeGreaterThan(collapsedHeight);
+
+    await user.click(collapseButton);
+
+    expect(screen.getByRole("button", { name: "展开全文" })).toHaveAttribute("aria-expanded", "false");
+    restoreLayout();
+  });
+
+  it("does not collapse image-only markdown messages", async () => {
+    const restoreLayout = mockLongMessageLayout();
+
+    const { container } = render(
+      <MessageContent content={"![](https://example.com/image.png)"} enableLongMessageCollapse t={longMessageT} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "展开全文" })).not.toBeInTheDocument();
+    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/image.png");
+    restoreLayout();
+  });
+
+  it("does not collapse markdown messages that include images", () => {
+    const restoreLayout = mockLongMessageLayout();
+    const content = `这是一条带图片的消息，图片消息不参与长文本折叠规则。\n\n![diagram](https://example.com/image.png)\n\n${"图片说明文字".repeat(40)}`;
+
+    const { container } = render(<MessageContent content={content} enableLongMessageCollapse t={longMessageT} />);
+
+    expect(screen.queryByRole("button", { name: "展开全文" })).not.toBeInTheDocument();
+    expect(container.querySelector(".long-message-collapse")).toBeNull();
+    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/image.png");
+    restoreLayout();
+  });
+
+  it("collapses long code blocks as part of the whole message", async () => {
+    const restoreLayout = mockLongMessageLayout();
+    const code = Array.from({ length: 24 }, (_, index) => `const item${index} = "line ${index}";`).join("\n");
+
+    const { container } = render(
+      <MessageContent content={`代码块需要参与整体折叠：\n\n\`\`\`ts\n${code}\n\`\`\``} enableLongMessageCollapse t={longMessageT} />,
+    );
+
+    expect(await screen.findByRole("button", { name: "展开全文" })).toBeInTheDocument();
+    expect(container.querySelector(".long-message-collapse")).toHaveClass("is-collapsed");
+    expect(container.querySelector("pre")).toBeInTheDocument();
+    restoreLayout();
+  });
+
+  it("does not collapse long messages unless explicitly enabled", () => {
+    const restoreLayout = mockLongMessageLayout();
+    const longText = "收到的长消息默认保持完整展示，只有当前用户自己发送的长文本才需要折叠。".repeat(12);
+
+    const { container } = render(<MessageContent content={longText} t={longMessageT} />);
+
+    expect(screen.queryByRole("button", { name: "展开全文" })).not.toBeInTheDocument();
+    expect(container.querySelector(".long-message-collapse")).toBeNull();
+    restoreLayout();
+  });
+
+  it("supports externally controlled long message expansion state", async () => {
+    const restoreLayout = mockLongMessageLayout();
+    const user = userEvent.setup();
+    const onExpandedChange = vi.fn();
+    const longText = "用户自己发送的长消息展开状态需要在当前会话内保持。".repeat(12);
+
+    const { container, rerender } = render(
+      <MessageContent
+        content={longText}
+        enableLongMessageCollapse
+        longMessageExpanded={false}
+        onLongMessageExpandedChange={onExpandedChange}
+        t={longMessageT}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "展开全文" }));
+
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <MessageContent
+        content={longText}
+        enableLongMessageCollapse
+        longMessageExpanded
+        onLongMessageExpandedChange={onExpandedChange}
+        t={longMessageT}
+      />,
+    );
+
+    expect(container.querySelector(".long-message-collapse")).toHaveClass("is-expanded");
+    expect(screen.getByRole("button", { name: "收起" })).toHaveAttribute("aria-expanded", "true");
+    restoreLayout();
   });
 
   it("renders canonical slash command prefixes with the prompt outside the XML element", () => {


### PR DESCRIPTION
## Summary
- add long message collapse for the current user's long text messages
- keep expanded state in memory for the current session
- handle markdown, code blocks, image messages, and existing structured/tool content separately

## Validation
- pnpm --dir web/app typecheck
- pnpm --dir web/app exec vitest run tests/components/MessageContent.test.tsx