### PR TITLE
fix(web): keep chat messages auto-following

### DIFF
--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { errorMessage } from "@/api/client";
 import {
@@ -62,11 +62,11 @@ import {
 import { skillDescriptionFromMarkdown, skillOptionsFromWorkspace, type SlashSkillOption } from "@/models/slashCommands";
 import { localizeError } from "@/shared/i18n";
 import { AgentActivityKinds, AgentActivityMsgTypes } from "@/shared/constants/messages";
-import { MESSAGE_LIST_BOTTOM_THRESHOLD } from "@/shared/constants/workspace";
 import type { AgentLike } from "@/models/agents";
 import type { IMConversation, IMMessage, IMServerEvent, IMUser, ThreadView, UsersById } from "@/models/conversations";
 import type { SlashPickerCandidate } from "@/models/slashCommands";
 import type { UseConversationControllerArgs } from "./types";
+import { messageListScrollKey, useMessageListAutoScroll } from "./useMessageListAutoScroll";
 import type { ConversationWorkingParticipant } from "@/components/business/ConversationPane";
 
 const slashSkillOptionsCache = new Map<string, SlashSkillOption[]>();
@@ -381,15 +381,6 @@ function mergeWorkingParticipants(
   return Array.from(byID.values()).sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function scrollMessageListToBottom(el: HTMLElement, behavior: "auto" | "smooth" = "auto"): void {
-  const top = el.scrollHeight;
-  if (behavior === "smooth" && typeof el.scrollTo === "function") {
-    el.scrollTo({ top, behavior: "smooth" });
-    return;
-  }
-  el.scrollTop = top;
-}
-
 export function useConversationController({
   activeConversationId,
   activePane,
@@ -461,8 +452,6 @@ export function useConversationController({
   const messageListRef = useRef<HTMLElement | null>(null);
   const memberMenuRef = useRef<HTMLDivElement | null>(null);
   const channelToolsRef = useRef<HTMLDivElement | null>(null);
-  const shouldAutoScrollRef = useRef(true);
-  const autoScrollConversationRef = useRef(activeConversationId);
   const activeThreadKeyRef = useRef("");
   const messageWorkingTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
@@ -482,6 +471,7 @@ export function useConversationController({
       return showToolCalls || !isToolCallMessage(message);
     });
   }, [activeConversation, showToolCalls]);
+  const visibleMessageScrollKey = useMemo(() => messageListScrollKey(visibleMessages), [visibleMessages]);
   const channels = useMemo(() => rooms.filter((room) => !isDirectConversation(room)), [rooms]);
   const directMessages = useMemo(() => rooms.filter((room) => isDirectConversation(room)), [rooms]);
   const threadGroups = useMemo(
@@ -957,57 +947,12 @@ export function useConversationController({
     preferredFallbackConversationId,
   ]);
 
-  useEffect(() => {
-    if (!messageListActive) {
-      return;
-    }
-    const el = messageListRef.current;
-    if (!el) {
-      return;
-    }
-    const updateAutoScrollState = () => {
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      shouldAutoScrollRef.current = distanceFromBottom <= MESSAGE_LIST_BOTTOM_THRESHOLD;
-    };
-    updateAutoScrollState();
-    el.addEventListener("scroll", updateAutoScrollState);
-    return () => el.removeEventListener("scroll", updateAutoScrollState);
-  }, [activeConversationId, messageListActive, selectedConversationID]);
-
-  useLayoutEffect(() => {
-    if (!messageListActive) {
-      return;
-    }
-    if (activePane.type !== WorkspacePaneTypes.conversation) {
-      return;
-    }
-    if (!selectedConversationID) {
-      return;
-    }
-    const el = messageListRef.current;
-    if (!el) {
-      return;
-    }
-    autoScrollConversationRef.current = activeConversationId;
-    scrollMessageListToBottom(el);
-    shouldAutoScrollRef.current = true;
-  }, [activePane.type, activeConversationId, messageListActive, selectedConversationID]);
-
-  useEffect(() => {
-    if (!messageListActive) {
-      return;
-    }
-    const el = messageListRef.current;
-    if (autoScrollConversationRef.current !== activeConversationId) {
-      autoScrollConversationRef.current = activeConversationId;
-      shouldAutoScrollRef.current = false;
-      return;
-    }
-    if (!el || !shouldAutoScrollRef.current) {
-      return;
-    }
-    scrollMessageListToBottom(el, "smooth");
-  }, [visibleMessages.length, activeConversationId, messageListActive]);
+  const messageListAutoScroll = useMessageListAutoScroll({
+    active: messageListActive && activePane.type === WorkspacePaneTypes.conversation && Boolean(selectedConversationID),
+    conversationId: activeConversationId,
+    messageListRef,
+    visibleMessagesKey: visibleMessageScrollKey,
+  });
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -1068,6 +1013,7 @@ export function useConversationController({
         content,
       });
       setBootstrapData((current) => appendMessageToData(current, activeConversation.id, created));
+      messageListAutoScroll.follow("smooth");
       markMessageWorkingParticipants(activeConversation.id, workingTargets);
       clearComposer();
     } catch (err) {

--- a/web/app/src/hooks/workspace/useMessageListAutoScroll.ts
+++ b/web/app/src/hooks/workspace/useMessageListAutoScroll.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+import type { IMMessage } from "@/models/conversations";
+import { MESSAGE_LIST_BOTTOM_THRESHOLD } from "@/shared/constants/workspace";
+
+type MessageListScrollBehavior = "auto" | "smooth";
+
+export type UseMessageListAutoScrollArgs = {
+  active: boolean;
+  conversationId: string;
+  messageListRef: RefObject<HTMLElement | null>;
+  visibleMessagesKey: string;
+};
+
+export type MessageListAutoScrollController = {
+  follow: (behavior?: MessageListScrollBehavior) => void;
+};
+
+function scrollMessageListToBottom(el: HTMLElement, behavior: MessageListScrollBehavior = "auto"): void {
+  const top = el.scrollHeight;
+  if (behavior === "smooth" && typeof el.scrollTo === "function") {
+    el.scrollTo({ top, behavior: "smooth" });
+    return;
+  }
+  el.scrollTop = top;
+}
+
+function requestBrowserAnimationFrame(callback: () => void): number | null {
+  if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+    callback();
+    return null;
+  }
+  return window.requestAnimationFrame(callback);
+}
+
+function cancelBrowserAnimationFrame(frame: number | null): void {
+  if (frame === null || typeof window === "undefined" || typeof window.cancelAnimationFrame !== "function") {
+    return;
+  }
+  window.cancelAnimationFrame(frame);
+}
+
+function messageScrollKey(message: IMMessage, index: number): string {
+  return [
+    message.id || index,
+    message.created_at || "",
+    message.sender_id || "",
+    message.kind || "",
+    message.content || "",
+    message.thread?.reply_count ?? "",
+    message.thread?.latest_reply?.id || "",
+    message.thread?.latest_reply?.created_at || "",
+    message.thread?.latest_reply?.content || "",
+  ].join("\u0001");
+}
+
+export function messageListScrollKey(messages: readonly IMMessage[]): string {
+  return messages.map((message, index) => messageScrollKey(message, index)).join("\u0002");
+}
+
+export function useMessageListAutoScroll({
+  active,
+  conversationId,
+  messageListRef,
+  visibleMessagesKey,
+}: UseMessageListAutoScrollArgs): MessageListAutoScrollController {
+  const shouldAutoScrollRef = useRef(true);
+  const autoScrollConversationRef = useRef(conversationId);
+  const autoScrollStateFrameRef = useRef<number | null>(null);
+  const messageListResizeObserverRef = useRef<ResizeObserver | null>(null);
+  const messageListMutationObserverRef = useRef<MutationObserver | null>(null);
+  const messageListScrollFrameRef = useRef<number | null>(null);
+  const observedMessageListRef = useRef<HTMLElement | null>(null);
+
+  const updateAutoScrollState = useCallback(() => {
+    const el = observedMessageListRef.current;
+    if (!el) {
+      return;
+    }
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    shouldAutoScrollRef.current = distanceFromBottom <= MESSAGE_LIST_BOTTOM_THRESHOLD;
+  }, []);
+
+  const scheduleAutoScrollStateUpdate = useCallback(() => {
+    if (autoScrollStateFrameRef.current !== null) {
+      return;
+    }
+    autoScrollStateFrameRef.current = requestBrowserAnimationFrame(() => {
+      autoScrollStateFrameRef.current = null;
+      updateAutoScrollState();
+    });
+  }, [updateAutoScrollState]);
+
+  const scrollToBottomAfterLayout = useCallback(
+    (behavior: MessageListScrollBehavior = "auto") => {
+      const scroll = () => {
+        const el = messageListRef.current;
+        if (!el) {
+          return;
+        }
+        scrollMessageListToBottom(el, behavior);
+      };
+      cancelBrowserAnimationFrame(messageListScrollFrameRef.current);
+      messageListScrollFrameRef.current = null;
+      scroll();
+      messageListScrollFrameRef.current = requestBrowserAnimationFrame(() => {
+        messageListScrollFrameRef.current = null;
+        scroll();
+      });
+    },
+    [messageListRef],
+  );
+
+  const disconnectMessageListElement = useCallback(() => {
+    const observed = observedMessageListRef.current;
+    if (observed) {
+      observed.removeEventListener("scroll", scheduleAutoScrollStateUpdate);
+    }
+    messageListResizeObserverRef.current?.disconnect();
+    messageListMutationObserverRef.current?.disconnect();
+    cancelBrowserAnimationFrame(autoScrollStateFrameRef.current);
+    cancelBrowserAnimationFrame(messageListScrollFrameRef.current);
+    observedMessageListRef.current = null;
+    messageListResizeObserverRef.current = null;
+    messageListMutationObserverRef.current = null;
+    autoScrollStateFrameRef.current = null;
+    messageListScrollFrameRef.current = null;
+  }, [scheduleAutoScrollStateUpdate]);
+
+  useLayoutEffect(() => {
+    const nextElement = active ? messageListRef.current : null;
+    if (observedMessageListRef.current === nextElement) {
+      return;
+    }
+    disconnectMessageListElement();
+    if (!nextElement) {
+      return;
+    }
+
+    observedMessageListRef.current = nextElement;
+    updateAutoScrollState();
+    nextElement.addEventListener("scroll", scheduleAutoScrollStateUpdate, { passive: true });
+
+    if (typeof ResizeObserver === "function") {
+      const resizeObserver = new ResizeObserver(() => {
+        if (shouldAutoScrollRef.current) {
+          scrollToBottomAfterLayout();
+        }
+      });
+      const observeMessageListContent = () => {
+        resizeObserver.disconnect();
+        resizeObserver.observe(nextElement);
+        Array.from(nextElement.children).forEach((child) => resizeObserver.observe(child));
+      };
+      observeMessageListContent();
+      messageListResizeObserverRef.current = resizeObserver;
+
+      if (typeof MutationObserver === "function") {
+        const mutationObserver = new MutationObserver(observeMessageListContent);
+        mutationObserver.observe(nextElement, { childList: true });
+        messageListMutationObserverRef.current = mutationObserver;
+      }
+    }
+  });
+
+  useEffect(() => () => disconnectMessageListElement(), [disconnectMessageListElement]);
+
+  const follow = useCallback(
+    (behavior: MessageListScrollBehavior = "auto") => {
+      shouldAutoScrollRef.current = true;
+      scrollToBottomAfterLayout(behavior);
+    },
+    [scrollToBottomAfterLayout],
+  );
+
+  useLayoutEffect(() => {
+    if (!active || !conversationId) {
+      return;
+    }
+    autoScrollConversationRef.current = conversationId;
+    follow();
+  }, [active, conversationId, follow]);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    if (autoScrollConversationRef.current !== conversationId) {
+      autoScrollConversationRef.current = conversationId;
+      shouldAutoScrollRef.current = false;
+      return;
+    }
+    if (!messageListRef.current || !shouldAutoScrollRef.current) {
+      return;
+    }
+    scrollToBottomAfterLayout("smooth");
+  }, [active, conversationId, messageListRef, scrollToBottomAfterLayout, visibleMessagesKey]);
+
+  return { follow };
+}

--- a/web/app/tests/hooks/useConversationController.test.tsx
+++ b/web/app/tests/hooks/useConversationController.test.tsx
@@ -43,12 +43,27 @@ const directConversation: IMConversation = {
   title: "demo",
 };
 
-function createScrollableMessageList(scrollHeight: number, clientHeight: number): HTMLElement {
+type ScrollableMessageList = HTMLElement & {
+  setScrollHeight: (value: number) => void;
+};
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(() => resolve());
+      return;
+    }
+    window.setTimeout(resolve, 0);
+  });
+}
+
+function createScrollableMessageList(scrollHeight: number, clientHeight: number): ScrollableMessageList {
   const element = document.createElement("section");
+  let scrollHeightValue = scrollHeight;
   let scrollTop = 0;
   Object.defineProperties(element, {
     clientHeight: { configurable: true, get: () => clientHeight },
-    scrollHeight: { configurable: true, get: () => scrollHeight },
+    scrollHeight: { configurable: true, get: () => scrollHeightValue },
     scrollTop: {
       configurable: true,
       get: () => scrollTop,
@@ -57,7 +72,11 @@ function createScrollableMessageList(scrollHeight: number, clientHeight: number)
       },
     },
   });
-  return element;
+  return Object.assign(element, {
+    setScrollHeight(value: number) {
+      scrollHeightValue = value;
+    },
+  });
 }
 
 function dataWithMessages(messages: IMMessage[]): IMData {
@@ -281,6 +300,147 @@ describe("useConversationController", () => {
     });
 
     await waitFor(() => expect(messageList.scrollTop).toBe(1120));
+  });
+
+  it("keeps an active message list pinned when an existing visible message changes", async () => {
+    const firstMessage: IMMessage = {
+      id: "msg-1",
+      content: "loading",
+      created_at: "2026-06-16T10:00:00Z",
+      sender_id: "u-demo",
+    };
+    const initialData = dataWithMessages([firstMessage]);
+    const { result, rerender } = renderConversationController({
+      data: initialData,
+      messageListActive: false,
+    });
+    const messageList = createScrollableMessageList(900, 240);
+    result.current.conversationViewProps.messageListRef.current = messageList;
+    rerender({ data: initialData, messageListActive: true });
+
+    messageList.setScrollHeight(1120);
+    rerender({
+      data: dataWithMessages([{ ...firstMessage, content: "final answer with more rendered content" }]),
+      messageListActive: true,
+    });
+
+    await waitFor(() => expect(messageList.scrollTop).toBe(1120));
+  });
+
+  it("does not follow incoming messages when the user has scrolled away from the bottom", async () => {
+    const firstMessage: IMMessage = {
+      id: "msg-1",
+      content: "hello",
+      created_at: "2026-06-16T10:00:00Z",
+      sender_id: "u-admin",
+    };
+    const secondMessage: IMMessage = {
+      id: "msg-2",
+      content: "reply",
+      created_at: "2026-06-16T10:01:00Z",
+      sender_id: "u-demo",
+    };
+    const initialData = dataWithMessages([firstMessage]);
+    const { result, rerender } = renderConversationController({
+      data: initialData,
+      messageListActive: false,
+    });
+    const messageList = createScrollableMessageList(900, 240);
+    result.current.conversationViewProps.messageListRef.current = messageList;
+    rerender({ data: initialData, messageListActive: true });
+    await nextAnimationFrame();
+
+    act(() => {
+      messageList.scrollTop = 120;
+      messageList.dispatchEvent(new Event("scroll"));
+    });
+    await act(async () => {
+      await nextAnimationFrame();
+    });
+
+    messageList.setScrollHeight(1120);
+    rerender({
+      data: dataWithMessages([firstMessage, secondMessage]),
+      messageListActive: true,
+    });
+    await act(async () => {
+      await nextAnimationFrame();
+    });
+
+    expect(messageList.scrollTop).toBe(120);
+  });
+
+  it("follows an outgoing message even when the user has scrolled away from the bottom", async () => {
+    const firstMessage: IMMessage = {
+      id: "msg-1",
+      content: "hello",
+      created_at: "2026-06-16T10:00:00Z",
+      sender_id: "u-demo",
+    };
+    const initialData = dataWithMessages([firstMessage]);
+    apiMocks.sendMessageRequest.mockResolvedValue({
+      id: "msg-user",
+      content: "my reply",
+      created_at: "2026-06-16T10:01:00Z",
+      sender_id: "u-admin",
+    });
+    const { result, rerender } = renderConversationController({
+      data: initialData,
+      messageListActive: false,
+    });
+    const messageList = createScrollableMessageList(900, 240);
+    result.current.conversationViewProps.messageListRef.current = messageList;
+    rerender({ data: initialData, messageListActive: true });
+    await nextAnimationFrame();
+
+    act(() => {
+      messageList.scrollTop = 120;
+      messageList.dispatchEvent(new Event("scroll"));
+    });
+    await act(async () => {
+      await nextAnimationFrame();
+    });
+    messageList.setScrollHeight(1120);
+
+    const editor = document.createElement("div");
+    editor.textContent = "my reply";
+    act(() => {
+      result.current.conversationViewProps.editorRef.current = editor;
+      result.current.conversationViewProps.onSyncComposer();
+    });
+    await act(async () => {
+      await result.current.conversationViewProps.onSendMessage();
+    });
+
+    await waitFor(() => expect(messageList.scrollTop).toBe(1120));
+  });
+
+  it("keeps a single message-list scroll listener across data rerenders", () => {
+    const firstMessage: IMMessage = {
+      id: "msg-1",
+      content: "hello",
+      created_at: "2026-06-16T10:00:00Z",
+      sender_id: "u-admin",
+    };
+    const secondMessage: IMMessage = {
+      id: "msg-2",
+      content: "reply",
+      created_at: "2026-06-16T10:01:00Z",
+      sender_id: "u-demo",
+    };
+    const initialData = dataWithMessages([firstMessage]);
+    const { result, rerender } = renderConversationController({
+      data: initialData,
+      messageListActive: false,
+    });
+    const messageList = createScrollableMessageList(900, 240);
+    const addEventListenerSpy = vi.spyOn(messageList, "addEventListener");
+    result.current.conversationViewProps.messageListRef.current = messageList;
+
+    rerender({ data: initialData, messageListActive: true });
+    rerender({ data: dataWithMessages([firstMessage, secondMessage]), messageListActive: true });
+
+    expect(addEventListenerSpy.mock.calls.filter(([event]) => event === "scroll")).toHaveLength(1);
   });
 
   it("does not open its own IM event subscription", () => {


### PR DESCRIPTION
- Fixes chat message auto-follow so a user-sent message always brings the conversation to the latest message.
- Keeps the message list pinned to the bottom when an existing Agent message is updated, thread reply metadata changes, or rendered content increases the list height.
- Avoids duplicate scroll listeners and throttles scroll-state updates while preserving the intended behavior from #50: follow new messages only when the user is already near the bottom.
- Also improves the similar message-following issue described in OpenCSGs/csgclaw#50.
