### PR TITLE
fix(web): tighten task activity polling

### DIFF
--- a/web/app/src/hooks/workspace/useConversationController.test.ts
+++ b/web/app/src/hooks/workspace/useConversationController.test.ts
@@ -42,6 +42,14 @@ function agentTextMessage(content: string): IMMessage {
   };
 }
 
+function agentPlaceholderMessage(): IMMessage {
+  return {
+    id: "agent-placeholder",
+    sender_id: "pt-dev",
+    content: "\u200b",
+  };
+}
+
 function conversationWithMessages(messages: IMMessage[]): IMConversation {
   return {
     id: "room-1",
@@ -95,6 +103,17 @@ describe("activityWorkingParticipantsForConversation", () => {
     );
 
     expect(participants).toEqual([]);
+  });
+
+  it("keeps a structured tool active after the agent turn placeholder arrives", () => {
+    const participants = activityWorkingParticipantsForConversation(
+      conversationWithMessages([toolActivityMessage("running"), agentPlaceholderMessage()]),
+      "user-admin",
+      agents,
+      usersById,
+    );
+
+    expect(participants).toEqual([{ id: "pt-dev", name: "dev" }]);
   });
 
   it("keeps an agent working after a PicoClaw legacy tool message without status", () => {

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -95,6 +95,7 @@ type WorkingParticipantsByConversationId = Record<string, ConversationWorkingPar
 
 const MESSAGE_WORKING_TIMEOUT_MS = 120_000;
 const WORKING_PARTICIPANT_KEY_SEPARATOR = "\u0000";
+const PARTICIPANT_ACTIVITY_TURN_PLACEHOLDER = "\u200b";
 
 function clearThreadDraftsForConversation(current: DraftsByThreadKey, conversationID: string): DraftsByThreadKey {
   const prefix = `${conversationID}:`;
@@ -123,6 +124,10 @@ function conversationHasLocalIdentity(
 
 function workingParticipantKey(conversationID: string, participantID: string): string {
   return `${conversationID}${WORKING_PARTICIPANT_KEY_SEPARATOR}${participantID}`;
+}
+
+function isParticipantActivityTurnPlaceholder(message: IMMessage | null | undefined): boolean {
+  return String(message?.content || "") === PARTICIPANT_ACTIVITY_TURN_PLACEHOLDER;
 }
 
 function participantIDFromWorkingKey(conversationID: string, key: string): string {
@@ -208,7 +213,7 @@ function derivedMessageWorkingParticipants(
   const repliedTargetIDs = new Set<string>();
   for (let index = conversation.messages.length - 1; index >= 0; index -= 1) {
     const message = conversation.messages[index];
-    if (isThreadReply(message) || isToolCallMessage(message)) {
+    if (isThreadReply(message) || isToolCallMessage(message) || isParticipantActivityTurnPlaceholder(message)) {
       continue;
     }
 
@@ -302,7 +307,7 @@ export function activityWorkingParticipantsForConversation(
       return;
     }
 
-    if (target && !isToolCallMessage(message)) {
+    if (target && !isToolCallMessage(message) && !isParticipantActivityTurnPlaceholder(message)) {
       activeToolKeysByParticipantID.delete(target.id);
       activeLegacyCommandCountsByParticipantID.delete(target.id);
     }
@@ -734,7 +739,7 @@ export function useConversationController({
         if (threadMessageKey(payload.room_id, payload.message) === activeThreadKeyRef.current) {
           setActiveThreadView((current) => appendReplyToThreadView(current, payload.message) ?? null);
         }
-        if (!isToolCallMessage(payload.message)) {
+        if (!isToolCallMessage(payload.message) && !isParticipantActivityTurnPlaceholder(payload.message)) {
           clearMessageWorkingParticipants(payload.room_id, payload.message.sender_id);
         }
       }

--- a/web/app/src/hooks/workspace/useTaskController.ts
+++ b/web/app/src/hooks/workspace/useTaskController.ts
@@ -21,7 +21,7 @@ import {
 import { WorkspacePaneTypes } from "@/models/routing";
 import { errorMessage, type ApiError } from "@/api/client";
 import { rootTaskForTask, type WorkspaceTask, rootTasks, shouldPollTransitionalTasks } from "@/models/tasks";
-import type { WorkspaceScheduledTaskRun } from "@/models/scheduledTasks";
+import type { WorkspaceScheduledTask, WorkspaceScheduledTaskRun } from "@/models/scheduledTasks";
 import { workspaceQueryKeys } from "./workspaceQueries";
 import type { AgentLike } from "@/models/agents";
 import type { IMConversation, TranslateFn } from "@/models/conversations";
@@ -96,7 +96,7 @@ export function useTaskController({
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
   const scheduledTasks = useMemo(() => scheduledTasksQuery.data ?? [], [scheduledTasksQuery.data]);
   const visibleScheduledTaskID = selectedScheduledTaskID || scheduledTasks[0]?.id || "";
-  const scheduledTaskIDsKey = useMemo(() => scheduledTaskIDsCacheKey(scheduledTasks), [scheduledTasks]);
+  const scheduledTaskRunsCacheKey = useMemo(() => scheduledTaskRunsMetadataCacheKey(scheduledTasks), [scheduledTasks]);
   const scheduledTaskRunsQuery = useQuery({
     queryKey: scheduledTaskRunsQueryKey(visibleScheduledTaskID),
     queryFn: () => fetchScheduledTaskRuns(visibleScheduledTaskID),
@@ -104,7 +104,7 @@ export function useTaskController({
   });
   const scheduledTaskRuns = useMemo(() => scheduledTaskRunsQuery.data ?? [], [scheduledTaskRunsQuery.data]);
   const scheduledTaskRunQueries = useQuery({
-    queryKey: scheduledTaskRunsAllQueryKey(scheduledTaskIDsKey),
+    queryKey: scheduledTaskRunsAllQueryKey(scheduledTaskRunsCacheKey),
     queryFn: async () => {
       const runs = await Promise.all(scheduledTasks.map((item) => fetchScheduledTaskRuns(item.id)));
       return runs.flat();
@@ -118,6 +118,10 @@ export function useTaskController({
   const allScheduledTaskRuns = useMemo(
     () => mergeScheduledTaskRuns(scheduledTaskRuns, scheduledTaskRunQueries.data ?? []),
     [scheduledTaskRuns, scheduledTaskRunQueries.data],
+  );
+  const visibleScheduledTaskRuns = useMemo(
+    () => allScheduledTaskRuns.filter((run) => run.scheduled_task_id === visibleScheduledTaskID),
+    [allScheduledTaskRuns, visibleScheduledTaskID],
   );
   const scheduledGeneratedTaskIDs = useMemo(
     () => new Set(allScheduledTaskRuns.map((run) => run.task_id).filter(Boolean)),
@@ -174,11 +178,11 @@ export function useTaskController({
   const refreshScheduledTaskState = useCallback(async () => {
     const taskResult = await refetchScheduledTasks();
     const nextScheduledTasks = taskResult.data ?? scheduledTasks;
-    const nextTaskIDsKey = scheduledTaskIDsCacheKey(nextScheduledTasks);
+    const nextRunsCacheKey = scheduledTaskRunsMetadataCacheKey(nextScheduledTasks);
     const nextRuns = nextScheduledTasks.length
       ? (await Promise.all(nextScheduledTasks.map((item) => fetchScheduledTaskRuns(item.id)))).flat()
       : [];
-    queryClient.setQueryData<WorkspaceScheduledTaskRun[]>(scheduledTaskRunsAllQueryKey(nextTaskIDsKey), nextRuns);
+    queryClient.setQueryData<WorkspaceScheduledTaskRun[]>(scheduledTaskRunsAllQueryKey(nextRunsCacheKey), nextRuns);
     const nextVisibleScheduledTaskID = selectedScheduledTaskID || nextScheduledTasks[0]?.id || "";
     if (nextVisibleScheduledTaskID) {
       queryClient.setQueryData<WorkspaceScheduledTaskRun[]>(
@@ -397,7 +401,7 @@ export function useTaskController({
         mergeScheduledTaskRuns([run], current),
       );
       queryClient.setQueryData<WorkspaceScheduledTaskRun[]>(
-        scheduledTaskRunsAllQueryKey(scheduledTaskIDsCacheKey(scheduledTasks)),
+        scheduledTaskRunsAllQueryKey(scheduledTaskRunsMetadataCacheKey(scheduledTasks)),
         (current = []) => mergeScheduledTaskRuns([run], current),
       );
       await refreshScheduledTaskState();
@@ -567,7 +571,7 @@ export function useTaskController({
       taskEvents,
       teams,
       scheduledTasks,
-      scheduledTaskRuns,
+      scheduledTaskRuns: visibleScheduledTaskRuns,
       selectedScheduledTaskID: visibleScheduledTaskID,
       activeView: taskBoardView,
       createTaskModalView,
@@ -725,8 +729,10 @@ function mergeScheduledTaskRuns(
   return Array.from(byID.values()).sort((left, right) => right.triggered_at.localeCompare(left.triggered_at));
 }
 
-function scheduledTaskIDsCacheKey(tasks: readonly { id: string }[]): string {
-  return tasks.map((item) => item.id).join("|");
+function scheduledTaskRunsMetadataCacheKey(tasks: readonly WorkspaceScheduledTask[]): string {
+  return tasks
+    .map((item) => [item.id, item.last_run_at, item.updated_at, item.next_run_at, item.enabled ? "1" : "0"].join(":"))
+    .join("|");
 }
 
 function workspaceTasksEqual(left: WorkspaceTask, right: WorkspaceTask): boolean {

--- a/web/app/src/hooks/workspace/useTaskController.ts
+++ b/web/app/src/hooks/workspace/useTaskController.ts
@@ -76,6 +76,7 @@ export function useTaskController({
   const [taskActionError, setTaskActionError] = useState("");
   const [parentDetailTaskID, setParentDetailTaskID] = useState("");
   const lastTaskTabRevalidateAttemptAt = useRef(0);
+  const scheduledTaskViewActive = activePane.type === WorkspacePaneTypes.task && taskBoardView === "scheduled";
   const tasksQuery = useQuery({
     queryKey: TASKS_QUERY_KEY,
     queryFn: fetchGlobalTasks,
@@ -83,7 +84,7 @@ export function useTaskController({
   const scheduledTasksQuery = useQuery({
     queryKey: SCHEDULED_TASKS_QUERY_KEY,
     queryFn: fetchScheduledTasks,
-    refetchInterval: taskBoardView === "scheduled" ? TASK_BOARD_POLL_DELAY_MS : false,
+    refetchInterval: scheduledTaskViewActive ? TASK_BOARD_POLL_DELAY_MS : false,
   });
   const { refetch: refetchScheduledTasks } = scheduledTasksQuery;
   const { dataUpdatedAt: tasksDataUpdatedAt, isFetching: tasksFetching, refetch: refetchTasks } = tasksQuery;
@@ -99,8 +100,7 @@ export function useTaskController({
   const scheduledTaskRunsQuery = useQuery({
     queryKey: scheduledTaskRunsQueryKey(visibleScheduledTaskID),
     queryFn: () => fetchScheduledTaskRuns(visibleScheduledTaskID),
-    enabled: Boolean(visibleScheduledTaskID),
-    refetchInterval: taskBoardView === "scheduled" && visibleScheduledTaskID ? TASK_BOARD_POLL_DELAY_MS : false,
+    enabled: scheduledTaskViewActive && Boolean(visibleScheduledTaskID),
   });
   const scheduledTaskRuns = useMemo(() => scheduledTaskRunsQuery.data ?? [], [scheduledTaskRunsQuery.data]);
   const scheduledTaskRunQueries = useQuery({
@@ -109,8 +109,11 @@ export function useTaskController({
       const runs = await Promise.all(scheduledTasks.map((item) => fetchScheduledTaskRuns(item.id)));
       return runs.flat();
     },
-    enabled: scheduledTasks.length > 0,
-    refetchInterval: taskBoardView === "scheduled" && scheduledTasks.length > 0 ? TASK_BOARD_POLL_DELAY_MS : false,
+    enabled: scheduledTaskViewActive && scheduledTasks.length > 0,
+    refetchInterval: (query) =>
+      shouldPollScheduledTaskRuns(scheduledTaskViewActive, query.state.data ?? [], tasks)
+        ? TASK_BOARD_POLL_DELAY_MS
+        : false,
   });
   const allScheduledTaskRuns = useMemo(
     () => mergeScheduledTaskRuns(scheduledTaskRuns, scheduledTaskRunQueries.data ?? []),
@@ -149,12 +152,13 @@ export function useTaskController({
   const shouldPollActiveTaskBoard = useMemo(() => shouldPollTaskBoard(tasks, activeRootTask), [activeRootTask, tasks]);
   const shouldPollScheduledGeneratedTasks = useMemo(
     () =>
+      scheduledTaskViewActive &&
       Array.from(scheduledGeneratedTaskIDs).some((taskID) => {
         const task = tasks.find((item) => item.id === taskID) ?? null;
         const root = rootTaskForTask(tasks, task);
         return shouldPollTaskBoard(tasks, root);
       }),
-    [scheduledGeneratedTaskIDs, tasks],
+    [scheduledGeneratedTaskIDs, scheduledTaskViewActive, tasks],
   );
   const shouldPollTasks = useMemo(
     () => shouldPollActiveTaskBoard || shouldPollScheduledGeneratedTasks || shouldPollTransitionalTasks(tasks),
@@ -220,7 +224,6 @@ export function useTaskController({
         queryClient.setQueryData<WorkspaceTask[]>(TASKS_QUERY_KEY, (current) =>
           mergeWorkspaceTaskList(current ?? [], nextTasks),
         );
-        await refreshScheduledTaskState();
       } catch {
         return;
       }
@@ -235,7 +238,7 @@ export function useTaskController({
         window.clearTimeout(timer);
       }
     };
-  }, [queryClient, refreshScheduledTaskState, shouldPollTasks]);
+  }, [queryClient, shouldPollTasks]);
 
   useEffect(() => {
     if (taskBoardView !== "scheduled") {
@@ -667,6 +670,34 @@ function shouldPollTaskBoard(tasks: readonly WorkspaceTask[], root: WorkspaceTas
     return true;
   }
   return tasks.some((task) => task.parent_id === root.id && TASK_BOARD_POLL_STATUSES.has(task.status));
+}
+
+function shouldPollScheduledTaskRuns(
+  scheduledTaskViewActive: boolean,
+  runs: readonly WorkspaceScheduledTaskRun[],
+  tasks: readonly WorkspaceTask[],
+): boolean {
+  return scheduledTaskViewActive && runs.some((run) => scheduledTaskRunNeedsPolling(run, tasks));
+}
+
+function scheduledTaskRunNeedsPolling(run: WorkspaceScheduledTaskRun, tasks: readonly WorkspaceTask[]): boolean {
+  const status = String(run.status || "")
+    .trim()
+    .toLowerCase();
+  if (["failed", "completed", "done", "canceled", "cancelled"].includes(status)) {
+    return false;
+  }
+
+  const taskID = String(run.task_id || "").trim();
+  if (!taskID) {
+    return true;
+  }
+  const task = tasks.find((item) => item.id === taskID) ?? null;
+  if (!task) {
+    return true;
+  }
+  const root = rootTaskForTask(tasks, task);
+  return shouldPollTaskBoard(tasks, root);
 }
 
 function isSchedulerGeneratedTask(task: WorkspaceTask): boolean {

--- a/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
+++ b/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
@@ -463,6 +463,10 @@ export function TasksView({
   const availableRoomIDs = useMemo(() => (rooms ? new Set(rooms.map((room) => room.id)) : null), [rooms]);
 
   useEffect(() => {
+    setConversationOpenError("");
+  }, [activeView, selectedScheduledTask?.id]);
+
+  useEffect(() => {
     if (!showCreateTaskModal) {
       return;
     }
@@ -639,12 +643,19 @@ export function TasksView({
 
   function openRootTaskDetail(task: WorkspaceTask) {
     setParentDialogTaskID(task.id);
+    setConversationOpenError("");
   }
 
   function closeRootTaskDetail() {
     setParentDialogTaskID("");
+    setConversationOpenError("");
     onCloseParentTaskDetail?.();
     void onCloseTaskDetails?.();
+  }
+
+  function selectScheduledTask(taskID: string) {
+    setConversationOpenError("");
+    onSelectScheduledTask(taskID);
   }
 
   function openRunTask(taskID: string) {
@@ -766,7 +777,7 @@ export function TasksView({
                             type="button"
                             className={styles.scheduledTaskRow}
                             data-active={selectedScheduledTask?.id === item.id ? true : undefined}
-                            onClick={() => onSelectScheduledTask(item.id)}
+                            onClick={() => selectScheduledTask(item.id)}
                           >
                             <span>
                               <CalendarClock size={15} aria-hidden="true" />

--- a/web/app/tests/hooks/useTaskController.test.tsx
+++ b/web/app/tests/hooks/useTaskController.test.tsx
@@ -207,7 +207,7 @@ describe("useTaskController", () => {
     expect(fetchGlobalTasks).toHaveBeenCalledTimes(1);
   });
 
-  it("refreshes scheduled task state while background task polling is active", async () => {
+  it("refreshes scheduled task state while background task polling is active in the scheduled view", async () => {
     vi.useFakeTimers();
     try {
       const queryClient = createQueryClient();
@@ -226,6 +226,12 @@ describe("useTaskController", () => {
       await vi.waitFor(() => {
         expect(result.current.taskViewProps.tasks).toHaveLength(1);
       });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([nextRun]);
+      });
       vi.mocked(fetchScheduledTasks).mockClear();
       vi.mocked(fetchScheduledTaskRuns).mockClear();
 
@@ -243,42 +249,226 @@ describe("useTaskController", () => {
     }
   });
 
+  it("does not refresh scheduled task state during background task polling outside the scheduled view", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const activeTask = task({ status: "in_progress" });
+      const item = scheduledTask();
+      const run = scheduledRun();
+      vi.mocked(fetchGlobalTasks).mockResolvedValue([activeTask]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
+
+      const { result } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: activeTask.id,
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.tasks).toHaveLength(1);
+      });
+      vi.mocked(fetchScheduledTasks).mockClear();
+      vi.mocked(fetchScheduledTaskRuns).mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(fetchScheduledTasks).not.toHaveBeenCalled();
+      expect(fetchScheduledTaskRuns).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops scheduled run polling after the generated task is complete", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const item = scheduledTask();
+      const run = scheduledRun();
+      const generatedTask = task({
+        id: run.task_id,
+        assignment_type: "agent",
+        assignment_id: item.agent_id,
+        team_id: "",
+        created_by: "scheduler",
+        status: "completed",
+      });
+      vi.mocked(fetchGlobalTasks).mockResolvedValue([generatedTask]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
+
+      const { result } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: "",
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([item]);
+      });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
+      });
+      vi.mocked(fetchScheduledTaskRuns).mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(fetchScheduledTaskRuns).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps scheduled run polling while the generated task is active", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const item = scheduledTask();
+      const run = scheduledRun();
+      const generatedTask = task({
+        id: run.task_id,
+        assignment_type: "agent",
+        assignment_id: item.agent_id,
+        team_id: "",
+        created_by: "scheduler",
+        status: "in_progress",
+      });
+      vi.mocked(fetchGlobalTasks).mockResolvedValue([generatedTask]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
+
+      const { result } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: "",
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([item]);
+      });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
+      });
+      vi.mocked(fetchScheduledTaskRuns).mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      await vi.waitFor(() => {
+        expect(fetchScheduledTaskRuns).toHaveBeenCalled();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops scheduled run polling after leaving the scheduled task view", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const item = scheduledTask();
+      const run = scheduledRun();
+      const generatedTask = task({
+        id: run.task_id,
+        assignment_type: "agent",
+        assignment_id: item.agent_id,
+        team_id: "",
+        created_by: "scheduler",
+        status: "in_progress",
+      });
+      vi.mocked(fetchGlobalTasks).mockResolvedValue([generatedTask]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
+
+      const { result, rerender } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: "",
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([item]);
+      });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
+      });
+
+      await act(async () => {
+        rerender({ pane: { type: WorkspacePaneTypes.conversation, id: "room-1" } });
+      });
+      vi.mocked(fetchScheduledTaskRuns).mockClear();
+      vi.mocked(fetchScheduledTasks).mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(fetchScheduledTaskRuns).not.toHaveBeenCalled();
+      expect(fetchScheduledTasks).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("refetches tasks when a scheduled run references a missing generated task", async () => {
-    const queryClient = createQueryClient();
-    const item = scheduledTask();
-    const run = scheduledRun();
-    const generatedTask = task({
-      id: run.task_id,
-      assignment_type: "agent",
-      assignment_id: item.agent_id,
-      team_id: "",
-      created_by: "scheduler",
-      status: "assigned",
-    });
-    vi.mocked(fetchGlobalTasks).mockResolvedValueOnce([]).mockResolvedValueOnce([generatedTask]);
-    vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
-    vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const item = scheduledTask();
+      const run = scheduledRun();
+      const generatedTask = task({
+        id: run.task_id,
+        assignment_type: "agent",
+        assignment_id: item.agent_id,
+        team_id: "",
+        created_by: "scheduler",
+        status: "assigned",
+      });
+      vi.mocked(fetchGlobalTasks).mockResolvedValueOnce([]).mockResolvedValueOnce([generatedTask]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValue([item]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValue([run]);
 
-    const { result } = renderTaskController(queryClient, {
-      type: WorkspacePaneTypes.task,
-      id: "",
-    });
+      const { result } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: "",
+      });
 
-    await waitFor(() => {
-      expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
-    });
-    expect(fetchGlobalTasks).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([item]);
+      });
+      expect(fetchGlobalTasks).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
-      result.current.taskViewProps.onSelectTaskBoardView("scheduled");
-    });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
 
-    await waitFor(() => {
-      expect(fetchGlobalTasks).toHaveBeenCalledTimes(2);
-    });
-    await waitFor(() => {
-      expect(result.current.taskViewProps.tasks).toEqual([generatedTask]);
-    });
+      await vi.waitFor(() => {
+        expect(fetchGlobalTasks).toHaveBeenCalledTimes(2);
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.tasks).toEqual([generatedTask]);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows a localized message when a scheduled task has already been triggered", async () => {

--- a/web/app/tests/hooks/useTaskController.test.tsx
+++ b/web/app/tests/hooks/useTaskController.test.tsx
@@ -326,6 +326,51 @@ describe("useTaskController", () => {
     }
   });
 
+  it("refetches scheduled runs when scheduled task metadata changes", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = createQueryClient();
+      const item = scheduledTask({ last_run_at: "" });
+      const updatedItem = scheduledTask({ last_run_at: "2026-07-08T09:00:00Z" });
+      const run = scheduledRun();
+      vi.mocked(fetchGlobalTasks).mockResolvedValue([]);
+      vi.mocked(fetchScheduledTasks).mockResolvedValueOnce([item]).mockResolvedValue([updatedItem]);
+      vi.mocked(fetchScheduledTaskRuns).mockResolvedValueOnce([]).mockResolvedValue([run]);
+
+      const { result } = renderTaskController(queryClient, {
+        type: WorkspacePaneTypes.task,
+        id: "",
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([item]);
+      });
+      await act(async () => {
+        result.current.taskViewProps.onSelectTaskBoardView("scheduled");
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([]);
+      });
+      vi.mocked(fetchScheduledTaskRuns).mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTasks).toEqual([updatedItem]);
+      });
+      await vi.waitFor(() => {
+        expect(fetchScheduledTaskRuns).toHaveBeenCalledWith(updatedItem.id);
+      });
+      await vi.waitFor(() => {
+        expect(result.current.taskViewProps.scheduledTaskRuns).toEqual([run]);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps scheduled run polling while the generated task is active", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
- keep agent working indicators visible while turn placeholder messages are present
- limit scheduled task run polling to the active scheduled task view and active generated runs
- clear stale task conversation errors when switching task views or details
- cover polling and placeholder edge cases with focused regression tests