### PR TITLE
fix(web): use full language option labels

### DIFF
--- a/web/app/src/pages/SettingsPage/SettingsPage.module.css
+++ b/web/app/src/pages/SettingsPage/SettingsPage.module.css
@@ -223,8 +223,8 @@
 }
 
 .textSegmentButton {
-  min-width: 52px;
-  padding: 0 16px;
+  min-width: 104px;
+  padding: 0 18px;
 }
 
 .segmentButton:last-child,

--- a/web/app/src/pages/SettingsPage/SettingsPage.tsx
+++ b/web/app/src/pages/SettingsPage/SettingsPage.tsx
@@ -242,7 +242,7 @@ export function SettingsPage() {
                   aria-pressed={sidebar.locale === "zh"}
                   onClick={() => sidebar.onLocaleChange("zh")}
                 >
-                  ZH
+                  {sidebar.t("languageOptionZh")}
                 </button>
                 <button
                   type="button"
@@ -250,7 +250,7 @@ export function SettingsPage() {
                   aria-pressed={sidebar.locale === "en"}
                   onClick={() => sidebar.onLocaleChange("en")}
                 >
-                  EN
+                  {sidebar.t("languageOptionEn")}
                 </button>
               </div>
             </div>

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.module.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.module.css
@@ -170,12 +170,13 @@
 }
 
 .textSegmented {
-  grid-template-columns: repeat(2, 34px);
+  grid-template-columns: repeat(2, max-content);
 }
 
 .textSegmented :global(.btn) {
-  width: 34px;
-  min-width: 34px;
+  width: auto;
+  min-width: 68px;
+  padding: 0 10px;
   font-size: var(--text-xs-size);
   font-weight: var(--font-weight-semibold);
 }

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SidebarUserButton.tsx
@@ -300,7 +300,7 @@ export function SidebarUserButton({
                 aria-pressed={locale === "zh"}
                 onClick={() => onLocaleChange?.("zh")}
               >
-                中
+                {t("languageOptionZh")}
               </Button>
               <Button
                 variant="ghost"
@@ -308,7 +308,7 @@ export function SidebarUserButton({
                 aria-pressed={locale === "en"}
                 onClick={() => onLocaleChange?.("en")}
               >
-                EN
+                {t("languageOptionEn")}
               </Button>
             </div>
           </div>

--- a/web/app/tests/components/SidebarUserButton.test.tsx
+++ b/web/app/tests/components/SidebarUserButton.test.tsx
@@ -5,6 +5,8 @@ import type { UpgradeStatus } from "@/models/upgradeStatus";
 
 const labels: Record<string, string> = {
   appearanceSettings: "Appearance",
+  languageOptionEn: "English",
+  languageOptionZh: "简体中文",
   languageSwitcher: "Language",
   settings: "Settings",
   themeDark: "Dark",
@@ -61,6 +63,36 @@ const updateAvailableStatus: UpgradeStatus = {
 describe("SidebarUserButton", () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  it("uses full language option labels", async () => {
+    const user = userEvent.setup();
+    const onLocaleChange = vi.fn();
+
+    render(
+      <SidebarUserButton
+        appVersion="v0.3.0"
+        showUpgradeControls={false}
+        locale="en"
+        onOpenUpgrade={() => {}}
+        onOpenConfigSettings={() => {}}
+        onLocaleChange={onLocaleChange}
+        onThemeChange={() => {}}
+        t={t}
+        theme="light"
+        upgradeStatus={updateAvailableStatus}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(screen.getByRole("button", { name: "简体中文" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "English" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "ZH" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "EN" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "简体中文" }));
+    expect(onLocaleChange).toHaveBeenLastCalledWith("zh");
   });
 
   it("keeps the current version visible when upgrade controls are hidden", async () => {


### PR DESCRIPTION
- Updates language controls to show full Simplified Chinese and English labels instead of abbreviated options.
- Adjusts segmented control sizing so the longer labels fit cleanly in the sidebar menu and settings page.
