### PR TITLE
fix(manager): stabilize codex manager and agent setup

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -1143,11 +1143,17 @@ func newParticipantService(agentSvc *agent.Service, imSvc *im.Service) (*partici
 	if err != nil {
 		return nil, err
 	}
-	return participant.NewService(
+	participantSvc := participant.NewService(
 		store,
 		participant.WithAgentService(agentSvc),
 		participant.WithIMService(imSvc),
-	), nil
+	)
+	if deleted, err := participantSvc.RepairDanglingCSGClawAgentParticipants(); err != nil {
+		return nil, err
+	} else if len(deleted) > 0 {
+		slog.Info("removed dangling CSGClaw agent participants", "count", len(deleted))
+	}
+	return participantSvc, nil
 }
 
 func newTeamService(imSvc *im.Service, feishuSvc *feishu.Service, participantSvc *participant.Service) (*team.Service, *team.AdapterRegistry, error) {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -135,7 +135,7 @@ func TestServeRunAutoBootstrapsWhenStateIncomplete(t *testing.T) {
 			ConfigPath: configPath,
 			Config: config.Config{
 				Bootstrap: config.BootstrapConfig{
-					DefaultManagerTemplate: "builtin.picoclaw-manager",
+					DefaultManagerTemplate: "builtin.manager-codex",
 					DefaultWorkerTemplate:  "builtin.picoclaw-worker",
 				},
 			},
@@ -813,7 +813,7 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 			ModelID: "model-test",
 		}),
 		Bootstrap: config.BootstrapConfig{
-			DefaultManagerTemplate: "builtin.picoclaw-manager",
+			DefaultManagerTemplate: "builtin.manager-codex",
 			DefaultWorkerTemplate:  "builtin.picoclaw-worker",
 		},
 	}
@@ -1199,7 +1199,7 @@ models = ["${MODEL_ID}"]
 		`advertise_base_url = "http://1.2.3.4:18080"`,
 		`access_token = "pc*********et"`,
 		`no_auth = true`,
-		`default_manager_template = "builtin.picoclaw-manager"`,
+		`default_manager_template = "builtin.manager-codex"`,
 		`default_worker_template = "builtin.picoclaw-worker"`,
 	} {
 		if !strings.Contains(got, want) {
@@ -1245,7 +1245,7 @@ models = ["gpt-test"]
 	if err != nil {
 		t.Fatalf("loadConfig() error = %v", err)
 	}
-	if got, want := cfg.Bootstrap.DefaultManagerTemplate, "builtin.picoclaw-manager"; got != want {
+	if got, want := cfg.Bootstrap.DefaultManagerTemplate, "builtin.manager-codex"; got != want {
 		t.Fatalf("cfg.Bootstrap.DefaultManagerTemplate = %q, want %q", got, want)
 	}
 	if got, want := cfg.Bootstrap.DefaultWorkerTemplate, "builtin.picoclaw-worker"; got != want {
@@ -1258,7 +1258,7 @@ models = ["gpt-test"]
 	}
 	saved := string(data)
 	for _, want := range []string{
-		`default_manager_template = "builtin.picoclaw-manager"`,
+		`default_manager_template = "builtin.manager-codex"`,
 		`default_worker_template = "builtin.picoclaw-worker"`,
 	} {
 		if !strings.Contains(saved, want) {
@@ -1325,7 +1325,7 @@ func TestFormatEffectiveConfigFormatsSectionsWithoutExtraWhitespace(t *testing.T
 			ModelID: "local.minimax-m2.5",
 		}),
 		Bootstrap: config.BootstrapConfig{
-			DefaultManagerTemplate: "builtin.picoclaw-manager",
+			DefaultManagerTemplate: "builtin.manager-codex",
 			DefaultWorkerTemplate:  "builtin.picoclaw-worker",
 		},
 		Sandbox: config.SandboxConfig{
@@ -1360,7 +1360,7 @@ no_auth = true
 show_upgrade = true
 
 [bootstrap]
-default_manager_template = "builtin.picoclaw-manager"
+default_manager_template = "builtin.manager-codex"
 default_worker_template = "builtin.picoclaw-worker"
 
 [sandbox]
@@ -1425,7 +1425,7 @@ func TestFormatEffectiveConfigIncludesDefaultHubRegistriesWhenOmitted(t *testing
 			ShowUpgrade:      true,
 		},
 		Bootstrap: config.BootstrapConfig{
-			DefaultManagerTemplate: "builtin.picoclaw-manager",
+			DefaultManagerTemplate: "builtin.manager-codex",
 			DefaultWorkerTemplate:  "builtin.picoclaw-worker",
 		},
 		Sandbox: config.SandboxConfig{
@@ -1550,7 +1550,7 @@ func csgHubLiteServeConfig(baseURL string) config.Config {
 			},
 		},
 		Bootstrap: config.BootstrapConfig{
-			DefaultManagerTemplate: "builtin.picoclaw-manager",
+			DefaultManagerTemplate: "builtin.manager-codex",
 			DefaultWorkerTemplate:  "builtin.picoclaw-worker",
 		},
 	}

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -285,7 +285,6 @@ func apiKeyPreview(apiKey string) string {
 	const (
 		minPreviewRunes = 9
 		prefixRunes     = 4
-		suffixRunes     = 4
 	)
 
 	apiKey = strings.TrimSpace(apiKey)
@@ -296,7 +295,7 @@ func apiKeyPreview(apiKey string) string {
 	if len(runes) < minPreviewRunes {
 		return ""
 	}
-	return string(runes[:prefixRunes]) + "...." + string(runes[len(runes)-suffixRunes:])
+	return string(runes[:prefixRunes]) + "..."
 }
 
 func RedactedProfileView(profile AgentProfile, detection []ProfileDetectionResult) AgentProfileView {

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -567,6 +567,9 @@ func (s *Service) validateRuntimeConfig(ctx context.Context, runtimeKind string,
 	if s == nil {
 		return fmt.Errorf("agent service is required")
 	}
+	if err := validateRuntimeProfileAvailability(current); err != nil {
+		return err
+	}
 	runtimeKind = strings.TrimSpace(runtimeKind)
 	if runtimeKind == "" {
 		return nil
@@ -580,6 +583,16 @@ func (s *Service) validateRuntimeConfig(ctx context.Context, runtimeKind string,
 		return nil
 	}
 	return controller.ValidateConfig(ctx, current)
+}
+
+func validateRuntimeProfileAvailability(current agentruntime.RuntimeConfigSnapshot) error {
+	if normalizeProfileProvider(current.Profile.Provider) != ProviderCodex {
+		return nil
+	}
+	if _, err := locateCodexCLI(); err != nil {
+		return fmt.Errorf("codex model provider requires Codex CLI: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) runtimeConfigRestartRequired(runtimeKind string, change agentruntime.RuntimeConfigChange) (bool, error) {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -678,6 +678,48 @@ func TestCreateWorkerRejectsInvalidRuntime(t *testing.T) {
 	}
 }
 
+func TestCreateWorkerRejectsCodexModelProviderWhenCodexCLIMissing(t *testing.T) {
+	origLocateCodexCLI := locateCodexCLI
+	locateCodexCLI = func() (string, error) { return "", fmt.Errorf("codex missing") }
+	t.Cleanup(func() {
+		locateCodexCLI = origLocateCodexCLI
+	})
+	SetTestHooks(
+		func(_ *Service, _ string) (sandbox.Runtime, error) {
+			t.Fatal("ensureRuntime() should not be used when Codex provider is unavailable")
+			return nil, nil
+		},
+		func(_ *Service, _ context.Context, _ sandbox.Runtime, _ string, _ string, _ string, _ AgentProfile) (sandbox.Instance, sandbox.Info, error) {
+			t.Fatal("createGatewayBox() should not be used when Codex provider is unavailable")
+			return nil, sandbox.Info{}, nil
+		},
+	)
+	defer ResetTestHooks()
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{
+		Name:        "alice",
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		Image:       "worker-image:1",
+		AgentProfile: AgentProfile{
+			Name:            "alice",
+			ModelProviderID: ModelProviderIDCodex,
+			ModelID:         "gpt-5.5",
+			ProfileComplete: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("CreateWorker() error = nil, want Codex CLI missing error")
+	}
+	if !strings.Contains(err.Error(), "codex model provider requires Codex CLI") {
+		t.Fatalf("CreateWorker() error = %q, want Codex provider availability error", err)
+	}
+}
+
 func TestCreateWorkerUsesCodexRuntimeWhenRequested(t *testing.T) {
 	SetTestHooks(
 		func(_ *Service, _ string) (sandbox.Runtime, error) {
@@ -1243,6 +1285,49 @@ func TestUpdateAgentProfileCodexRuntimeFallbackRestartsActiveBridge(t *testing.T
 	}
 	if started.AgentProfile.EnvRestartRequired {
 		t.Fatal("Start().AgentProfile.EnvRestartRequired = true, want false after recreate")
+	}
+}
+
+func TestUpdateAgentProfileRejectsCodexModelProviderWhenCodexCLIMissing(t *testing.T) {
+	origLocateCodexCLI := locateCodexCLI
+	locateCodexCLI = func() (string, error) { return "", fmt.Errorf("codex missing") }
+	t.Cleanup(func() {
+		locateCodexCLI = origLocateCodexCLI
+	})
+
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	currentProfile := AgentProfile{
+		Name:            "dev",
+		Provider:        ProviderCSGHubLite,
+		ModelID:         "qwen3",
+		ProfileComplete: true,
+	}
+	svc.agents["u-dev"] = Agent{
+		ID:              "u-dev",
+		Name:            "dev",
+		RuntimeID:       "rt-u-dev",
+		RuntimeKind:     RuntimeKindPicoClawSandbox,
+		Image:           "worker-image:1",
+		Role:            RoleWorker,
+		Status:          string(agentruntime.StateStopped),
+		Profile:         profileSelector(currentProfile),
+		AgentProfile:    currentProfile,
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 5, 18, 9, 0, 0, 0, time.UTC),
+	}
+
+	_, err = svc.UpdateAgentProfile("u-dev", AgentProfile{
+		ModelProviderID: ModelProviderIDCodex,
+		ModelID:         "gpt-5.5",
+	})
+	if err == nil {
+		t.Fatal("UpdateAgentProfile() error = nil, want Codex CLI missing error")
+	}
+	if !strings.Contains(err.Error(), "codex model provider requires Codex CLI") {
+		t.Fatalf("UpdateAgentProfile() error = %q, want Codex provider availability error", err)
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1401,7 +1401,7 @@ func TestHandleAgentsListRedactsProfileAPIKey(t *testing.T) {
 	if !ok || profile["api_key_set"] != true {
 		t.Fatalf("model_config = %#v, want api_key_set true", got[0]["model_config"])
 	}
-	if got, want := profile["api_key_preview"], "secr....oken"; got != want {
+	if got, want := profile["api_key_preview"], "secr..."; got != want {
 		t.Fatalf("model_config api_key_preview = %#v, want %q", got, want)
 	}
 	if _, ok := profile["api_key"]; ok {

--- a/internal/api/participant_test.go
+++ b/internal/api/participant_test.go
@@ -88,6 +88,51 @@ func TestCreateCSGClawAgentParticipantViaAPI(t *testing.T) {
 	}
 }
 
+func TestCreateCSGClawAgentParticipantViaAPIRequiresAgentBinding(t *testing.T) {
+	agentSvc, _ := mustNewSeededServiceWithPath(t, nil)
+	imSvc := im.NewService()
+	participantSvc := participant.NewService(
+		participant.NewMemoryStore(nil),
+		participant.WithAgentService(agentSvc),
+		participant.WithIMService(imSvc),
+	)
+	srv := &Handler{
+		svc:         agentSvc,
+		im:          imSvc,
+		participant: participantSvc,
+	}
+
+	body := `{
+		"id": "gitlab-worker",
+		"type": "agent",
+		"name": "gitlab-worker",
+		"channel_user": {
+			"ref": "gitlab-worker",
+			"kind": "local_user_id"
+		}
+	}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/channels/csgclaw/participants", strings.NewReader(body))
+
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "agent_binding.mode") {
+		t.Fatalf("body = %s, want agent_binding.mode validation", rec.Body.String())
+	}
+	if got := participantSvc.List(participant.ListOptions{Channel: participant.ChannelCSGClaw}); len(got) != 0 {
+		t.Fatalf("participants = %+v, want none after missing agent binding", got)
+	}
+	if _, ok := imSvc.User("user-gitlab-worker"); ok {
+		t.Fatal("channel user was created despite missing agent binding")
+	}
+	if _, ok := agentSvc.Agent("agent-gitlab-worker"); ok {
+		t.Fatal("agent was created despite missing agent binding")
+	}
+}
+
 func TestCreateCSGClawAgentParticipantViaAPIReturnsConflictForDuplicateAgentName(t *testing.T) {
 	agentSvc, _ := mustNewSeededServiceWithPath(t, []agent.Agent{{
 		ID:          "u-existing",

--- a/internal/channelbridge/codexbridge/bridge.go
+++ b/internal/channelbridge/codexbridge/bridge.go
@@ -116,6 +116,7 @@ func (s *Service) StartBot(ctx context.Context, binding Binding) error {
 		queue:       make(chan BotEvent, s.queueSize),
 		queued:      make(map[string]struct{}),
 		contextSent: make(map[string]struct{}),
+		latest:      make(map[string]string),
 		seen:        newRecentSet(s.seenWindow),
 		cancel:      cancel,
 		done:        make(chan struct{}),
@@ -184,6 +185,7 @@ type worker struct {
 	mu          sync.Mutex
 	processing  string
 	lastEvent   string
+	latest      map[string]string
 	contextSent map[string]struct{}
 }
 
@@ -201,7 +203,18 @@ func (w *worker) run(ctx context.Context) {
 			return
 		case evt := <-w.queue:
 			w.beginProcessing(eventDedupKey(evt))
-			_ = w.handleEvent(ctx, evt, eventCh)
+			if !w.isSuperseded(evt) {
+				_ = w.handleEvent(ctx, evt, eventCh)
+			} else {
+				slog.Debug("codex bridge skipped superseded message",
+					"bot_id", w.binding.BotID,
+					"runtime_id", w.binding.RuntimeID,
+					"channel", strings.TrimSpace(evt.Channel),
+					"room_id", strings.TrimSpace(evt.RoomID),
+					"message_id", strings.TrimSpace(evt.MessageID),
+					"thread_root_id", strings.TrimSpace(evt.ThreadRootID),
+				)
+			}
 			w.finishProcessing(eventDedupKey(evt))
 		}
 	}
@@ -311,6 +324,18 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 	}
 	flushTurn := func() (string, error) {
 		cleanupProcessingReaction(ctx)
+		if w.isSuperseded(evt) {
+			slog.Debug("codex bridge suppressed superseded turn final",
+				"bot_id", w.binding.BotID,
+				"runtime_id", w.binding.RuntimeID,
+				"session_id", sessionID,
+				"channel", strings.TrimSpace(evt.Channel),
+				"room_id", strings.TrimSpace(evt.RoomID),
+				"message_id", strings.TrimSpace(evt.MessageID),
+				"thread_root_id", strings.TrimSpace(evt.ThreadRootID),
+			)
+			return "", nil
+		}
 		if generatedRootID != "" && len(renderer.FinalMessages()) == 0 {
 			return w.flushTurnWithEmptyCompletion(ctx, evt.RoomID, generatedRootID, renderer, nil)
 		}
@@ -348,6 +373,9 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 	handleRuntimeEvent := func(event runtimecodex.SessionEvent) (bool, error) {
 		if !matchesSession(event, w.binding.RuntimeID, sessionID) {
 			return false, nil
+		}
+		if w.isSuperseded(evt) {
+			return isTerminalEvent(event.Kind), nil
 		}
 		if commentaryText, ok := codexCommentaryText(event); ok {
 			slog.Debug("codex bridge captured commentary payload",
@@ -404,6 +432,10 @@ func (w *worker) handleEvent(ctx context.Context, evt BotEvent, runtimeEvents <-
 			}
 		case result := <-promptDone:
 			promptReturned = true
+			if w.isSuperseded(evt) {
+				cleanupProcessingReaction(ctx)
+				return nil
+			}
 			if result.err != nil {
 				renderer.SetPromptError(result.err.Error())
 				_, err := flushTurn()
@@ -811,6 +843,7 @@ func (w *worker) accept(evt BotEvent) bool {
 	if key == "" {
 		return true
 	}
+	scope := conversationKey(evt)
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -824,7 +857,23 @@ func (w *worker) accept(evt BotEvent) bool {
 		return false
 	}
 	w.queued[key] = struct{}{}
+	if scope != "" {
+		w.latest[scope] = key
+	}
 	return true
+}
+
+func (w *worker) isSuperseded(evt BotEvent) bool {
+	key := eventDedupKey(evt)
+	scope := conversationKey(evt)
+	if key == "" || scope == "" {
+		return false
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	latest := strings.TrimSpace(w.latest[scope])
+	return latest != "" && latest != key
 }
 
 func (w *worker) beginProcessing(messageID string) {

--- a/internal/channelbridge/codexbridge/bridge_test.go
+++ b/internal/channelbridge/codexbridge/bridge_test.go
@@ -1243,13 +1243,12 @@ func TestServiceWorkerOutlivesStartContext(t *testing.T) {
 	}
 }
 
-func TestServiceQueuesWhileBusy(t *testing.T) {
+func TestServiceSuppressesSupersededTurnWhileBusy(t *testing.T) {
 	t.Parallel()
 
-	stream := make(chan BotEvent, 2)
+	stream := make(chan BotEvent, 1)
 	errs := make(chan error)
 	stream <- BotEvent{MessageID: "m-1", RoomID: "room-1", Text: "first"}
-	stream <- BotEvent{MessageID: "m-2", RoomID: "room-1", Text: "second"}
 	close(errs)
 
 	sink := runtimecodex.NewEventSink()
@@ -1270,6 +1269,14 @@ func TestServiceQueuesWhileBusy(t *testing.T) {
 				case <-ctx.Done():
 					return ctx.Err()
 				}
+				sink.Publish(runtimecodex.SessionEvent{
+					RuntimeID:  handle.RuntimeID,
+					SessionID:  req.SessionID,
+					Kind:       runtimecodex.SessionEventToolCallStart,
+					ToolCallID: "tool-stale",
+					ToolTitle:  "Run shell command",
+					ToolStatus: "started",
+				})
 			}
 			sink.Publish(runtimecodex.SessionEvent{
 				RuntimeID: handle.RuntimeID,
@@ -1300,7 +1307,19 @@ func TestServiceQueuesWhileBusy(t *testing.T) {
 		t.Fatal("first prompt did not start")
 	}
 
-	time.Sleep(150 * time.Millisecond)
+	stream <- BotEvent{MessageID: "m-2", RoomID: "room-1", Text: "second"}
+	waitFor(t, func() bool {
+		svc.mu.Lock()
+		w := svc.workers["u-codex"]
+		svc.mu.Unlock()
+		if w == nil {
+			return false
+		}
+		w.mu.Lock()
+		latest := w.latest["room-1"]
+		w.mu.Unlock()
+		return latest == "room-1:m-2"
+	})
 	if got := prompter.texts(); !slices.Equal(got, []string{"first"}) {
 		t.Fatalf("prompt order before release = %v, want [first]", got)
 	}
@@ -1308,8 +1327,13 @@ func TestServiceQueuesWhileBusy(t *testing.T) {
 	close(firstRelease)
 	waitFor(t, func() bool {
 		return slices.Equal(prompter.texts(), []string{"first", "second"}) &&
-			slices.Equal(client.sentTexts(), []string{"reply:first", "reply:second"})
+			slices.Equal(client.sentTexts(), []string{"reply:second"})
 	})
+	records := client.sentRecords()
+	if len(records) != 1 {
+		t.Fatalf("sent records = %+v, want only latest final", records)
+	}
+	assertCodexFinalMetadata(t, records[0], "m-2")
 }
 
 func TestServiceFlushesAfterPromptSettlesWithoutTerminalEvent(t *testing.T) {

--- a/internal/onboard/onboard.go
+++ b/internal/onboard/onboard.go
@@ -196,6 +196,9 @@ func createManagerParticipant(ctx context.Context, agentsPath, imStatePath strin
 		participant.WithAgentService(agentSvc),
 		participant.WithIMService(imSvc),
 	)
+	if _, err := participantSvc.RepairDanglingCSGClawAgentParticipants(); err != nil {
+		return participant.Participant{}, err
+	}
 	if _, err := participantSvc.EnsureBootstrapAdmin(ctx); err != nil {
 		return participant.Participant{}, err
 	}

--- a/internal/participant/service.go
+++ b/internal/participant/service.go
@@ -520,6 +520,46 @@ func (s *Service) DeleteAgent(ctx context.Context, agentID string) ([]apitypes.P
 	return deleted, nil
 }
 
+func (s *Service) RepairDanglingCSGClawAgentParticipants() ([]apitypes.Participant, error) {
+	if s == nil || s.store == nil {
+		return nil, fmt.Errorf("participant store is required")
+	}
+	if s.agents == nil {
+		return nil, nil
+	}
+
+	deleted := []apitypes.Participant{}
+	for _, item := range s.store.List(ListOptions{Channel: ChannelCSGClaw, Type: TypeAgent}) {
+		if isManagerParticipant(item) {
+			continue
+		}
+		agentID := strings.TrimSpace(item.AgentID)
+		if agentID != "" {
+			if _, ok := s.agents.Agent(agentID); ok {
+				continue
+			}
+		}
+		removed, ok, err := s.store.Delete(item.Channel, item.ID)
+		if err != nil {
+			return deleted, err
+		}
+		if !ok {
+			continue
+		}
+		deleted = append(deleted, removed)
+		if err := s.deleteUnreferencedCSGClawAgentUser(removed); err != nil {
+			return deleted, err
+		}
+	}
+	return deleted, nil
+}
+
+func isManagerParticipant(item apitypes.Participant) bool {
+	return strings.TrimSpace(item.ID) == agent.ManagerParticipantID ||
+		strings.TrimSpace(item.AgentID) == agent.ManagerUserID ||
+		strings.TrimSpace(item.ChannelUserRef) == im.ManagerUserID
+}
+
 func (s *Service) getByID(channel, id string) (apitypes.Participant, string, bool) {
 	if s == nil || s.store == nil {
 		return apitypes.Participant{}, "", false
@@ -654,6 +694,9 @@ func (s *Service) normalizeCreateRequest(req CreateRequest) (normalizedCreateReq
 				return normalizedCreateRequest{}, fmt.Errorf("agent_binding.agent_id is required for reuse")
 			}
 		case BindingModeNone:
+			if channel == ChannelCSGClaw {
+				return normalizedCreateRequest{}, fmt.Errorf("csgclaw agent participants require agent_binding.mode %q or %q", BindingModeCreate, BindingModeReuse)
+			}
 		default:
 			return normalizedCreateRequest{}, fmt.Errorf("agent_binding.mode must be one of %q, %q, or %q", BindingModeCreate, BindingModeReuse, BindingModeNone)
 		}

--- a/internal/participant/service_test.go
+++ b/internal/participant/service_test.go
@@ -146,6 +146,126 @@ func TestCreateAgentParticipantCanReuseExistingAgentWithDifferentParticipantID(t
 	}
 }
 
+func TestCreateCSGClawAgentParticipantRequiresAgentBinding(t *testing.T) {
+	imSvc := im.NewService()
+	store := NewMemoryStore(nil)
+	svc := NewService(store, WithIMService(imSvc))
+
+	_, err := svc.Create(context.Background(), CreateRequest{
+		ID:      "gitlab-worker",
+		Channel: ChannelCSGClaw,
+		Type:    TypeAgent,
+		Name:    "gitlab-worker",
+	})
+	if err == nil {
+		t.Fatal("Create() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "agent_binding.mode") {
+		t.Fatalf("Create() error = %v, want agent_binding.mode validation", err)
+	}
+	if got := store.List(ListOptions{Channel: ChannelCSGClaw}); len(got) != 0 {
+		t.Fatalf("participants = %+v, want none after missing agent binding", got)
+	}
+	if _, ok := store.Get(ChannelCSGClaw, "pt-gitlab-worker"); ok {
+		t.Fatal("participant was saved despite missing agent binding")
+	}
+	if _, ok := imSvc.User("user-gitlab-worker"); ok {
+		t.Fatal("channel user was created despite missing agent binding")
+	}
+}
+
+func TestRepairDanglingCSGClawAgentParticipantsRemovesParticipantShells(t *testing.T) {
+	agentSvc := mustNewAgentService(t)
+	if _, err := agentSvc.Create(context.Background(), agent.CreateRequest{
+		Spec: agent.CreateAgentSpec{
+			ID:          "agent-qa",
+			Name:        "qa",
+			Role:        agent.RoleWorker,
+			RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+			Image:       "agent-image:test",
+		},
+	}); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	imSvc := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: im.AdminUserID,
+		Users: []im.User{
+			{ID: im.AdminUserID, Name: "admin", Role: "admin"},
+			{ID: "user-gitlab-worker", Name: "gitlab-worker", Role: "worker"},
+			{ID: "user-stale-worker", Name: "stale-worker", Role: "worker"},
+			{ID: "user-qa", Name: "qa", Role: "worker"},
+			{ID: im.ManagerUserID, Name: agent.ManagerName, Role: agent.RoleManager},
+		},
+	})
+	store := NewMemoryStore([]Participant{
+		{
+			ID:              "pt-gitlab-worker",
+			Channel:         ChannelCSGClaw,
+			Type:            TypeAgent,
+			Name:            "gitlab-worker",
+			ChannelUserRef:  "user-gitlab-worker",
+			ChannelUserKind: ChannelUserKindLocalUserID,
+		},
+		{
+			ID:              "pt-stale-worker",
+			Channel:         ChannelCSGClaw,
+			Type:            TypeAgent,
+			Name:            "stale-worker",
+			ChannelUserRef:  "user-stale-worker",
+			ChannelUserKind: ChannelUserKindLocalUserID,
+			AgentID:         "agent-stale-worker",
+		},
+		{
+			ID:              "pt-qa",
+			Channel:         ChannelCSGClaw,
+			Type:            TypeAgent,
+			Name:            "qa",
+			ChannelUserRef:  "user-qa",
+			ChannelUserKind: ChannelUserKindLocalUserID,
+			AgentID:         "agent-qa",
+		},
+		{
+			ID:              agent.ManagerParticipantID,
+			Channel:         ChannelCSGClaw,
+			Type:            TypeAgent,
+			Name:            agent.ManagerName,
+			ChannelUserRef:  im.ManagerUserID,
+			ChannelUserKind: ChannelUserKindLocalUserID,
+		},
+	})
+	svc := NewService(store, WithAgentService(agentSvc), WithIMService(imSvc))
+
+	deleted, err := svc.RepairDanglingCSGClawAgentParticipants()
+	if err != nil {
+		t.Fatalf("RepairDanglingCSGClawAgentParticipants() error = %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("deleted = %+v, want two dangling worker shells", deleted)
+	}
+	for _, id := range []string{"pt-gitlab-worker", "pt-stale-worker"} {
+		if _, ok := store.Get(ChannelCSGClaw, id); ok {
+			t.Fatalf("participant %q still exists after repair", id)
+		}
+	}
+	if _, ok := store.Get(ChannelCSGClaw, "pt-qa"); !ok {
+		t.Fatal("valid worker participant was deleted")
+	}
+	if _, ok := store.Get(ChannelCSGClaw, agent.ManagerParticipantID); !ok {
+		t.Fatal("manager participant was deleted")
+	}
+	for _, id := range []string{"user-gitlab-worker", "user-stale-worker"} {
+		if _, ok := imSvc.User(id); ok {
+			t.Fatalf("dangling user %q still exists after repair", id)
+		}
+	}
+	if _, ok := imSvc.User("user-qa"); !ok {
+		t.Fatal("valid worker user was deleted")
+	}
+	if _, ok := imSvc.User(im.ManagerUserID); !ok {
+		t.Fatal("manager user was deleted")
+	}
+}
+
 func TestCreateFeishuBotParticipantStoresChannelAppConfigWithoutOpenID(t *testing.T) {
 	svc := NewService(NewMemoryStore(nil))
 

--- a/internal/template/embed/manager/codex/workspace/AGENTS.md
+++ b/internal/template/embed/manager/codex/workspace/AGENTS.md
@@ -37,6 +37,7 @@ Prefer local Manager skills over external discovery.
 
 If the user wants to create, add, set up, or provision an agent, robot, bot, or worker, read `skills/agent-creator/SKILL.md` immediately.
 This includes capability-specific workers such as GitLab, frontend, backend, QA, review, or Feishu-connected workers.
+Never run `participant create --type agent` for a new CSGClaw worker unless it binds a real Agent with `--bind create` or `--bind reuse`.
 Never run `participant create --bind create` without `--from-template` for a new worker.
 
 ### Single-worker task assignment second

--- a/internal/template/embed/manager/codex/workspace/skills/agent-creator/SKILL.md
+++ b/internal/template/embed/manager/codex/workspace/skills/agent-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-creator
-description: Mandatory skill for provisioning any new CSGClaw agent-backed participant or worker. Use immediately when the user asks to create, add, set up, or provision an agent, robot, worker, or user-facing "bot" (including GitLab, frontend, backend, QA, or other specialized workers), when dispatch needs a missing worker, or when asking which hub template fits. Always template list + match + template get + participant create --type agent --bind create --from-template with --env for secrets. Never run participant create --bind create without --from-template for a new worker. Do NOT use for task dispatch to existing workers.
+description: Mandatory skill for provisioning any new CSGClaw agent-backed participant or worker. Use immediately when the user asks to create, add, set up, or provision an agent, robot, worker, or user-facing "bot" (including GitLab, frontend, backend, QA, or other specialized workers), when dispatch needs a missing worker, or when asking which hub template fits. Always template list + match + template get + participant create --type agent --bind create --from-template with --env for secrets. Never create a CSGClaw worker with --type agent unless it binds a real Agent. Never run participant create --bind create without --from-template for a new worker. Do NOT use for task dispatch to existing workers.
 ---
 
 # Agent Creator
@@ -37,12 +37,12 @@ Do **not** use this skill when:
 
 ## Forbidden
 
-Never run a bare worker create like:
+Never run `participant create --type agent` for a new CSGClaw worker without `--bind create` or `--bind reuse`.
 
-```bash
-# FORBIDDEN for new workers
-csgclaw-cli participant create --type agent --bind create --name gitlab-worker --role worker
-```
+Never omit `--from-template` when using `--bind create` for a new worker.
+
+Never create a CSGClaw worker as a participant-only shell.
+That produces a private-chat identity without a runnable Agent.
 
 Never tell the worker secrets in chat instead of `--env`.
 
@@ -90,7 +90,7 @@ Template env vars with `default` are injected by the server; pass `--env` only f
 
 ## Operating Rules
 
-- `--from-template` is **required** for every new worker created through this skill.
+- `--bind create` and `--from-template` are **required** for every new worker created through this skill.
 - For normal workers, pass `--id`, `--agent-id`, `--channel-user-ref`, and `--channel-user-kind`; do not rely on generated IDs.
 - Prefer `csgclaw-cli` over ad hoc HTTP.
 - Put global flags (`--output json`, `--endpoint`, `--token`) **before** the subcommand, e.g. `csgclaw-cli --output json template list` (not after `template list`).

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -98,7 +98,11 @@ import type {
 import { isDirectConversation, localIdentitiesMatch, upsertUserInData } from "@/models/conversations";
 import { displayTeam } from "@/models/tasks";
 import type { WorkspaceTeam } from "@/models/tasks";
-import { modelProviderOptionsFromCatalog, providerNameForProviderID } from "@/models/modelProviders";
+import {
+  modelProviderCatalogForAgentAvailability,
+  modelProviderOptionsFromCatalog,
+  providerNameForProviderID,
+} from "@/models/modelProviders";
 import type { ModelProviderOption } from "@/models/modelProviders";
 import { WorkspacePaneTypes } from "@/models/routing";
 import { skillDescriptionFromMarkdown, skillOptionsFromWorkspace } from "@/models/slashCommands";
@@ -355,10 +359,10 @@ function draftWithModelProviderFallback(draft: AgentDraft, options: readonly Mod
   }
   const providerID = String(draft.model_provider_id || "").trim();
   const modelID = String(draft.model_id || "").trim();
-  if (providerID && modelID) {
+  if (providerID && modelID && options.some((item) => item.providerID === providerID && item.modelID === modelID)) {
     return draft;
   }
-  const option = options.find((item) => {
+  let option = options.find((item) => {
     if (!item.providerID || !item.modelID) {
       return false;
     }
@@ -371,14 +375,16 @@ function draftWithModelProviderFallback(draft: AgentDraft, options: readonly Mod
     return true;
   });
   if (!option) {
+    option = options.find((item) => item.providerID && item.modelID);
+  }
+  if (!option) {
     return draft;
   }
-  const nextProviderID = providerID || option.providerID;
   return {
     ...draft,
-    provider: providerNameForProviderID(nextProviderID),
-    model_provider_id: nextProviderID,
-    model_id: modelID || option.modelID,
+    provider: providerNameForProviderID(option.providerID),
+    model_provider_id: option.providerID,
+    model_id: option.modelID,
   };
 }
 
@@ -633,8 +639,19 @@ export function useAgentController({
     queryFn: fetchTeams,
   });
 
-  const agentModelOptions = useMemo(() => modelProviderOptionsFromCatalog(modelProviders), [modelProviders]);
-  const agentPageModelOptions = useMemo(() => modelProviderOptionsFromCatalog(modelProviders), [modelProviders]);
+  const codexModelProviderAvailable = bootstrapConfig?.manager_runtime?.installed !== false;
+  const agentModelProviders = useMemo(
+    () =>
+      modelProviderCatalogForAgentAvailability(modelProviders, {
+        codexAvailable: codexModelProviderAvailable,
+      }),
+    [codexModelProviderAvailable, modelProviders],
+  );
+  const agentModelOptions = useMemo(() => modelProviderOptionsFromCatalog(agentModelProviders), [agentModelProviders]);
+  const agentPageModelOptions = useMemo(
+    () => modelProviderOptionsFromCatalog(agentModelProviders),
+    [agentModelProviders],
+  );
   const agentModelBusy = Boolean(showAgentModal && !modelProvidersLoaded);
   const agentPageModelBusy = Boolean(selectedAgentForPage && !modelProvidersLoaded);
   const agentPageModelError = "";
@@ -2086,7 +2103,7 @@ export function useAgentController({
       hasUnsavedChanges: agentPageHasUnsavedChanges,
       models: agentPageModelOptions.map((option) => option.modelID),
       modelOptions: agentPageModelOptions,
-      modelProviders,
+      modelProviders: agentModelProviders,
       modelBusy: agentPageModelBusy,
       modelError: agentPageModelError,
       saving: agentPageBusy,
@@ -2158,7 +2175,7 @@ export function useAgentController({
             managerAgent,
             agentModels: agentModelOptions.map((option) => option.modelID),
             agentModelOptions,
-            modelProviders,
+            modelProviders: agentModelProviders,
             agentModelBusy,
             authStatuses: cliproxyAuthStatuses,
             authBusyProvider: cliproxyAuthBusy,

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -94,7 +94,6 @@ type OpenCreateRoomOptions = {
 type WorkingParticipantsByConversationId = Record<string, ConversationWorkingParticipant[]>;
 
 const MESSAGE_WORKING_TIMEOUT_MS = 120_000;
-const WORKING_PARTICIPANT_KEY_SEPARATOR = "\u0000";
 const PARTICIPANT_ACTIVITY_TURN_PLACEHOLDER = "\u200b";
 
 function clearThreadDraftsForConversation(current: DraftsByThreadKey, conversationID: string): DraftsByThreadKey {
@@ -122,17 +121,8 @@ function conversationHasLocalIdentity(
   return (conversation?.members || []).some((memberID) => localIdentitiesMatch(memberID, id));
 }
 
-function workingParticipantKey(conversationID: string, participantID: string): string {
-  return `${conversationID}${WORKING_PARTICIPANT_KEY_SEPARATOR}${participantID}`;
-}
-
 function isParticipantActivityTurnPlaceholder(message: IMMessage | null | undefined): boolean {
   return String(message?.content || "") === PARTICIPANT_ACTIVITY_TURN_PLACEHOLDER;
-}
-
-function participantIDFromWorkingKey(conversationID: string, key: string): string {
-  const prefix = `${conversationID}${WORKING_PARTICIPANT_KEY_SEPARATOR}`;
-  return key.startsWith(prefix) ? key.slice(prefix.length) : "";
 }
 
 function agentTargetsForConversation(
@@ -460,7 +450,6 @@ export function useConversationController({
   const memberMenuRef = useRef<HTMLDivElement | null>(null);
   const channelToolsRef = useRef<HTMLDivElement | null>(null);
   const activeThreadKeyRef = useRef("");
-  const messageWorkingTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
   const usersById = useMemo(() => buildUsersById(data?.users), [data]);
   const activeConversation = useMemo(
@@ -642,18 +631,6 @@ export function useConversationController({
         return;
       }
       const senderID = String(participantID || "").trim();
-      const keyPrefix = `${roomID}${WORKING_PARTICIPANT_KEY_SEPARATOR}`;
-      messageWorkingTimersRef.current.forEach((timer, key) => {
-        if (!key.startsWith(keyPrefix)) {
-          return;
-        }
-        const workingParticipantID = participantIDFromWorkingKey(roomID, key);
-        if (senderID && !localIdentitiesMatch(workingParticipantID, senderID)) {
-          return;
-        }
-        clearTimeout(timer);
-        messageWorkingTimersRef.current.delete(key);
-      });
 
       setMessageWorkingByConversationId((current) => {
         const currentParticipants = current[roomID] ?? [];
@@ -708,20 +685,8 @@ export function useConversationController({
           [roomID]: Array.from(merged.values()).sort((left, right) => left.name.localeCompare(right.name)),
         };
       });
-
-      nextParticipants.forEach((participant) => {
-        const key = workingParticipantKey(roomID, participant.id);
-        const currentTimer = messageWorkingTimersRef.current.get(key);
-        if (currentTimer) {
-          clearTimeout(currentTimer);
-        }
-        const timer = setTimeout(() => {
-          clearMessageWorkingParticipants(roomID, participant.id);
-        }, MESSAGE_WORKING_TIMEOUT_MS);
-        messageWorkingTimersRef.current.set(key, timer);
-      });
     },
-    [clearMessageWorkingParticipants],
+    [],
   );
 
   useEffect(() => {
@@ -746,14 +711,6 @@ export function useConversationController({
     },
     [clearMessageWorkingParticipants],
   );
-
-  useEffect(() => {
-    const timers = messageWorkingTimersRef.current;
-    return () => {
-      timers.forEach((timer) => clearTimeout(timer));
-      timers.clear();
-    };
-  }, []);
 
   useEffect(() => {
     setMentionIndex(0);

--- a/web/app/src/models/modelProviders.ts
+++ b/web/app/src/models/modelProviders.ts
@@ -63,6 +63,10 @@ export type ModelProviderSelectOption = {
   value: string;
 };
 
+export type AgentModelProviderAvailability = {
+  codexAvailable?: boolean;
+};
+
 type RawCatalog = {
   providers?: unknown;
 };
@@ -220,6 +224,33 @@ export function modelProviderOptionsFromCatalog(
     }
   }
   return options;
+}
+
+export function modelProviderCatalogForAgentAvailability(
+  catalog: ModelProviderCatalog | null | undefined,
+  availability: AgentModelProviderAvailability = {},
+): ModelProviderCatalog | null {
+  if (!catalog) {
+    return null;
+  }
+  const providers = (catalog.providers ?? []).filter((provider) =>
+    modelProviderAvailableForAgent(provider.id, availability),
+  );
+  return {
+    providers,
+    builtinProviders: providers.filter((provider) => provider.builtin),
+    customProviders: providers.filter((provider) => !provider.builtin),
+  };
+}
+
+export function modelProviderAvailableForAgent(
+  providerID: string,
+  availability: AgentModelProviderAvailability = {},
+): boolean {
+  if (normalizeModelProviderID(providerID) === "codex" && availability.codexAvailable === false) {
+    return false;
+  }
+  return true;
 }
 
 export function modelProviderSelectOptionsFromCatalog(

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -29,7 +29,7 @@ import { createTeamRequest, fetchTeams } from "@/api/tasks";
 import { useAgentController } from "@/hooks/workspace/useAgentController";
 import { WorkspacePaneTypes } from "@/models/routing";
 import type { WorkspacePane } from "@/models/routing";
-import type { AgentLike, AgentProfileLike } from "@/models/agents";
+import type { AgentLike, AgentProfileLike, RuntimeBootstrapConfig } from "@/models/agents";
 import type { IMConversation, IMData, TranslateFn } from "@/models/conversations";
 import { normalizeModelProviderCatalog } from "@/models/modelProviders";
 import type { ModelProviderCatalog } from "@/models/modelProviders";
@@ -181,6 +181,7 @@ function useAgentControllerHarness(
     managerProfile?: AgentProfileLike | null;
     modelProviders?: ModelProviderCatalog | null;
     modelProvidersLoaded?: boolean;
+    bootstrapConfig?: RuntimeBootstrapConfig | null;
     t?: TranslateFn;
   } = {},
 ) {
@@ -221,7 +222,7 @@ function useAgentControllerHarness(
       isError: false,
       isFetched: true,
     } as UseQueryResult<AgentLike[]>,
-    bootstrapConfig: null,
+    bootstrapConfig: options.bootstrapConfig ?? null,
     data,
     hubTemplates: [],
     locale: "en",
@@ -1486,12 +1487,9 @@ describe("useAgentController", () => {
       role: "worker",
     };
 
-    const { result } = renderHook(
-      () => useAgentControllerHarness({ agents: [oldAgent, existingWorker] }).controller,
-      {
-        wrapper: createWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useAgentControllerHarness({ agents: [oldAgent, existingWorker] }).controller, {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.computerViewProps.onCreateAgent();
@@ -1551,12 +1549,9 @@ describe("useAgentController", () => {
       role: "worker",
     };
 
-    const { result } = renderHook(
-      () => useAgentControllerHarness({ agents: [oldAgent, existingWorker] }).controller,
-      {
-        wrapper: createWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useAgentControllerHarness({ agents: [oldAgent, existingWorker] }).controller, {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.computerViewProps.onCreateAgent();
@@ -1639,6 +1634,62 @@ describe("useAgentController", () => {
       provider: "codex",
       model_provider_id: "codex",
       model_id: "gpt-5.5",
+    });
+  });
+
+  it("does not offer Codex model provider for agent creation when Codex CLI is unavailable", async () => {
+    vi.mocked(fetchAgentProfileDefaults).mockResolvedValueOnce({
+      provider: "codex",
+      model_provider_id: "codex",
+      model_id: "gpt-5.5",
+      profile_complete: true,
+    });
+    const modelProviders = normalizeModelProviderCatalog({
+      providers: [
+        {
+          id: "codex",
+          kind: "codex",
+          builtin: true,
+          display_name: "Codex",
+          models: ["gpt-5.5"],
+        },
+        {
+          id: "opencsg",
+          kind: "opencsg",
+          builtin: true,
+          display_name: "OpenCSG",
+          models: ["deepseek-v4"],
+        },
+      ],
+    });
+    const { result } = renderHook(
+      () =>
+        useAgentControllerHarness({
+          bootstrapConfig: {
+            manager_runtime: {
+              name: "codex",
+              label: "Codex CLI",
+              installed: false,
+            },
+          },
+          modelProviders,
+          modelProvidersLoaded: true,
+        }).controller,
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.computerViewProps.onCreateAgent();
+    });
+
+    await waitFor(() => expect(result.current.agentProfileModalProps).not.toBeNull());
+    expect(result.current.agentProfileModalProps?.agentModelOptions.map((option) => option.providerID)).not.toContain(
+      "codex",
+    );
+    expect(result.current.agentProfileModalProps?.agentDraft).toMatchObject({
+      provider: "csghub",
+      model_provider_id: "opencsg",
+      model_id: "deepseek-v4",
     });
   });
 });

--- a/web/app/tests/hooks/useConversationController.test.tsx
+++ b/web/app/tests/hooks/useConversationController.test.tsx
@@ -214,6 +214,38 @@ describe("useConversationController", () => {
     expect(result.current.conversationViewProps.workingParticipants).toEqual([]);
   });
 
+  it("keeps a sent direct message working participant past the local timeout until the agent replies", async () => {
+    vi.useFakeTimers();
+    try {
+      apiMocks.sendMessageRequest.mockResolvedValue({
+        id: "msg-user",
+        content: "hi",
+        created_at: "2026-06-16T10:00:00Z",
+        sender_id: "u-admin",
+      });
+      const { result } = renderConversationController();
+      const editor = document.createElement("div");
+      editor.textContent = "hi";
+
+      act(() => {
+        result.current.conversationViewProps.editorRef.current = editor;
+        result.current.conversationViewProps.onSyncComposer();
+      });
+
+      await act(async () => {
+        await result.current.conversationViewProps.onSendMessage();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(121_000);
+      });
+
+      expect(result.current.conversationViewProps.workingParticipants).toEqual([{ id: "u-demo", name: "demo" }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("derives working participants from recent pending direct-message history after refresh", () => {
     const { result } = renderConversationController({
       data: dataWithMessages([

--- a/web/app/tests/models/modelProviders.test.ts
+++ b/web/app/tests/models/modelProviders.test.ts
@@ -1,5 +1,6 @@
 import {
   modelProviderDisplayNameExists,
+  modelProviderCatalogForAgentAvailability,
   modelProviderOptionsFromCatalog,
   modelProviderSelectOptionsFromCatalog,
   normalizeModelProviderCatalog,
@@ -94,6 +95,33 @@ describe("model provider catalog helpers", () => {
         builtin: true,
       },
     ]);
+  });
+
+  it("filters Codex from agent provider choices when Codex CLI is unavailable", () => {
+    const catalog = normalizeModelProviderCatalog({
+      providers: [
+        {
+          id: "codex",
+          kind: "codex",
+          builtin: true,
+          display_name: "Codex",
+          models: ["gpt-5.5"],
+        },
+        {
+          id: "opencsg",
+          kind: "opencsg",
+          builtin: true,
+          display_name: "OpenCSG",
+          models: ["deepseek-v4"],
+        },
+      ],
+    });
+
+    const filtered = modelProviderCatalogForAgentAvailability(catalog, { codexAvailable: false });
+
+    expect(filtered?.providers.map((provider) => provider.id)).toEqual(["opencsg"]);
+    expect(modelProviderOptionsFromCatalog(filtered).map((option) => option.providerID)).toEqual(["opencsg"]);
+    expect(modelProviderSelectOptionsFromCatalog(filtered).map((option) => option.id)).toEqual(["opencsg"]);
   });
 
   it("maps OpenCSG aliases and avatar as a built-in provider", () => {


### PR DESCRIPTION
## Summary

- Stabilize Codex manager conversations so superseded turns do not keep stale replies or activity state.
- Clean up stale CSGClaw agent participants during serve startup so manager-created workers are not left half-bound.
- Hide and reject Codex agent model provider choices when Codex CLI is unavailable.