### PR TITLE
fix(agent): stabilize codex agent setup flows

### DIFF
--- a/cli/csgclawcli/app_test.go
+++ b/cli/csgclawcli/app_test.go
@@ -255,6 +255,65 @@ func TestExecuteTeamTaskListUsesHTTPClient(t *testing.T) {
 	}
 }
 
+func TestExecuteTeamTaskCreateBatchFromTitlePreservesUnicode(t *testing.T) {
+	var stdout bytes.Buffer
+	app := &App{
+		stdout: &stdout,
+		stderr: &bytes.Buffer{},
+		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("method = %q, want %q", req.Method, http.MethodPost)
+			}
+			if req.URL.String() != "http://example.test/api/v1/teams/team-1/tasks/batch" {
+				t.Fatalf("url = %q, want %q", req.URL.String(), "http://example.test/api/v1/teams/team-1/tasks/batch")
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			tasks, ok := payload["tasks"].([]any)
+			if !ok || len(tasks) != 1 {
+				t.Fatalf("tasks = %v, want one task; payload=%v", payload["tasks"], payload)
+			}
+			task, ok := tasks[0].(map[string]any)
+			if !ok {
+				t.Fatalf("task = %v, want object", tasks[0])
+			}
+			for key, want := range map[string]string{
+				"created_by":        "manager",
+				"execution_channel": "csgclaw",
+			} {
+				if payload[key] != want {
+					t.Fatalf("%s = %v, want %q; payload=%v", key, payload[key], want, payload)
+				}
+			}
+			for key, want := range map[string]string{
+				"title": "开发坦克小游戏",
+				"body":  "由 QA 验证",
+			} {
+				if task[key] != want {
+					t.Fatalf("%s = %v, want %q; task=%v", key, task[key], want, task)
+				}
+				if strings.Contains(fmt.Sprint(task[key]), "?") {
+					t.Fatalf("%s was corrupted: %v", key, task[key])
+				}
+			}
+			return jsonResponse(http.StatusCreated, `{"tasks":[{"id":"task-1","team_id":"team-1","title":"开发坦克小游戏","body":"由 QA 验证","status":"pending","created_by":"manager","created_at":"2026-05-30T00:00:00Z","updated_at":"2026-05-30T00:00:00Z"}]}`), nil
+		}),
+	}
+
+	if err := app.Execute(context.Background(), []string{"--endpoint", "http://example.test", "team", "task", "create-batch", "--team", "team-1", "--created-by", "manager", "--execution-channel", "csgclaw", "--title", "开发坦克小游戏", "--body", "由 QA 验证"}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "开发坦克小游戏") {
+		t.Fatalf("stdout = %q, want rendered unicode title", stdout.String())
+	}
+}
+
 func TestExecuteTaskListUsesGlobalTasksRoute(t *testing.T) {
 	var stdout bytes.Buffer
 	app := &App{

--- a/cli/team/team.go
+++ b/cli/team/team.go
@@ -56,7 +56,7 @@ func (c cmd) usage(run *command.Context) {
 		"list                        List teams",
 		"create                      Create a reusable agent team",
 		"task list                   List tasks for a team",
-		"task create-batch           Create tasks from a JSON file",
+		"task create-batch           Create tasks from JSON or direct flags",
 		"task plan                   Plan child tasks for a parent task",
 		"task start                  Start a parent task and dispatch ready subtasks",
 		"task claim-next             Claim the next available task",
@@ -112,7 +112,7 @@ func (c cmd) runTask(ctx context.Context, run *command.Context, args []string, g
 	if len(args) == 0 || command.IsHelpArg(args[0]) {
 		run.UsageCommandGroup(subcommandGroup("team task", "Manage team tasks."), run.Program+" team task <subcommand> [flags]", []string{
 			"list                        List tasks for a team",
-			"create-batch                Create tasks from a JSON file",
+			"create-batch                Create tasks from JSON or direct flags",
 			"plan                        Plan child tasks for a parent task",
 			"start                       Start a parent task and dispatch ready subtasks",
 			"assign                      Reassign a task to a worker",
@@ -164,11 +164,14 @@ func (c cmd) runTaskList(ctx context.Context, run *command.Context, args []strin
 }
 
 func (c cmd) runTaskCreateBatch(ctx context.Context, run *command.Context, args []string, globals command.GlobalOptions) error {
-	fs := run.NewFlagSet("team task create-batch", run.Program+" team task create-batch --team <id> --created-by <participant> --file <tasks.json>", "Create a batch of tasks from a JSON file.")
+	fs := run.NewFlagSet("team task create-batch", run.Program+" team task create-batch --team <id> --created-by <participant> (--file <tasks.json> | --title <title>)", "Create tasks from a JSON file or direct single-task flags.")
 	teamID := fs.String("team", "", "team id")
 	createdBy := fs.String("created-by", "", "creator participant id")
 	executionChannel := fs.String("execution-channel", teampkg.DefaultExecutionChannel, "execution channel: csgclaw or feishu")
 	filePath := fs.String("file", "", "path to tasks JSON file")
+	idRef := fs.String("id-ref", "", "single task id_ref")
+	title := fs.String("title", "", "single task title")
+	body := fs.String("body", "", "single task body")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -181,16 +184,27 @@ func (c cmd) runTaskCreateBatch(ctx context.Context, run *command.Context, args 
 	if *createdBy == "" {
 		return fmt.Errorf("created_by is required")
 	}
-	if *filePath == "" {
-		return fmt.Errorf("file is required")
-	}
-	data, err := os.ReadFile(*filePath)
-	if err != nil {
-		return err
-	}
 	var req apitypes.CreateTeamTasksBatchRequest
-	if err := json.Unmarshal(data, &req); err != nil {
-		return fmt.Errorf("decode batch file: %w", err)
+	if *filePath != "" {
+		if *idRef != "" || *title != "" || *body != "" {
+			return fmt.Errorf("file cannot be combined with id-ref, title, or body")
+		}
+		data, err := os.ReadFile(*filePath)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, &req); err != nil {
+			return fmt.Errorf("decode batch file: %w", err)
+		}
+	} else {
+		if *title == "" {
+			return fmt.Errorf("file or title is required")
+		}
+		req.Tasks = []apitypes.CreateTeamBatchTaskRequest{{
+			IDRef: *idRef,
+			Title: *title,
+			Body:  *body,
+		}}
 	}
 	req.CreatedBy = *createdBy
 	req.ExecutionChannel = *executionChannel

--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -65,22 +64,7 @@ func ListOpenAIModelsWithClient(ctx context.Context, client *http.Client, baseUR
 		client = &http.Client{Timeout: 2 * time.Second}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, openAIModelsURL(baseURL), nil)
-	if err != nil {
-		return nil, fmt.Errorf("build models request: %w", err)
-	}
-	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
-	for key, value := range headers {
-		key = strings.TrimSpace(key)
-		if key == "" || strings.EqualFold(key, "authorization") || strings.EqualFold(key, "content-type") {
-			continue
-		}
-		req.Header.Set(key, value)
-	}
-
-	resp, err := client.Do(req)
+	resp, err := requestOpenAIModels(ctx, client, baseURL+"/models", apiKey, headers)
 	if err != nil {
 		return nil, fmt.Errorf("request models from %s: %w", baseURL, err)
 	}
@@ -113,21 +97,22 @@ func ListOpenAIModelsWithClient(ctx context.Context, client *http.Client, baseUR
 	return models, nil
 }
 
-func openAIModelsURL(baseURL string) string {
-	modelsURL := baseURL + "/models"
-	if !strings.Contains(strings.ToLower(modelsURL), "opencsg") {
-		return modelsURL
-	}
-	// Temporary OpenCSG AIGateway pagination workaround. Remove this after
-	// OpenCSG AIGateway returns the full model list without pagination.
-	parsed, err := url.Parse(modelsURL)
+func requestOpenAIModels(ctx context.Context, client *http.Client, modelsURL, apiKey string, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
 	if err != nil {
-		return modelsURL
+		return nil, fmt.Errorf("build models request: %w", err)
 	}
-	query := parsed.Query()
-	query.Set("per", "100")
-	parsed.RawQuery = query.Encode()
-	return parsed.String()
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for key, value := range headers {
+		key = strings.TrimSpace(key)
+		if key == "" || strings.EqualFold(key, "authorization") || strings.EqualFold(key, "content-type") {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+	return client.Do(req)
 }
 
 func CheckResponsesAPI(ctx context.Context, baseURL, apiKey, modelID string, headers map[string]string) error {

--- a/internal/modelprovider/openai_test.go
+++ b/internal/modelprovider/openai_test.go
@@ -17,7 +17,7 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
-func TestListOpenAIModelsWithClientAddsPageSizeForOpenCSG(t *testing.T) {
+func TestListOpenAIModelsWithClientDoesNotAddPageSizeForOpenCSG(t *testing.T) {
 	var gotURL string
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		gotURL = req.URL.String()
@@ -37,7 +37,7 @@ func TestListOpenAIModelsWithClientAddsPageSizeForOpenCSG(t *testing.T) {
 	if got, want := strings.Join(models, ","), "Qwen/Qwen3"; got != want {
 		t.Fatalf("models = %v, want %s", models, want)
 	}
-	if got, want := gotURL, "https://aigateway.opencsg.com/v1/models?per=100"; got != want {
+	if got, want := gotURL, "https://aigateway.opencsg.com/v1/models"; got != want {
 		t.Fatalf("request URL = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -32,6 +32,8 @@ const (
 	workspaceDirName       = "workspace"
 	homeDirName            = "home"
 	logPollInterval        = 200 * time.Millisecond
+	runtimeDirRemoveDelay  = 100 * time.Millisecond
+	runtimeDirRemoveTries  = 6
 	codexProxyProviderName = "proxy"
 	codexModelProviderName = "codex"
 )
@@ -304,7 +306,7 @@ func (r *Runtime) Delete(ctx context.Context, h agentruntime.Handle) error {
 	if err != nil {
 		return err
 	}
-	if err := r.removeAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := r.removeRuntimeDir(ctx, dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil
@@ -1073,6 +1075,34 @@ func (r *Runtime) removeAll(path string) error {
 		return r.deps.RemoveAll(path)
 	}
 	return os.RemoveAll(path)
+}
+
+func (r *Runtime) removeRuntimeDir(ctx context.Context, path string) error {
+	var err error
+	for attempt := 0; attempt < runtimeDirRemoveTries; attempt++ {
+		err = r.removeAll(path)
+		if err == nil || errors.Is(err, os.ErrNotExist) || !isTransientRuntimeDirRemoveError(err) {
+			return err
+		}
+		if attempt == runtimeDirRemoveTries-1 {
+			break
+		}
+		timer := time.NewTimer(runtimeDirRemoveDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return err
+}
+
+func isTransientRuntimeDirRemoveError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "being used by another process") ||
+		strings.Contains(msg, "the process cannot access the file") ||
+		strings.Contains(msg, "access is denied")
 }
 
 func (r *Runtime) openFile(path string, flag int, mode os.FileMode) (*os.File, error) {

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -730,7 +730,7 @@ func TestBuildSessionEnvOnlyInjectsOpenAIAPIKey(t *testing.T) {
 	}
 }
 
-func TestDeleteReturnsRuntimeDirRemovalError(t *testing.T) {
+func TestDeleteRetriesTransientRuntimeDirRemovalError(t *testing.T) {
 	root := t.TempDir()
 	rt := New(Dependencies{
 		BinaryProvider: fakeBinaryProvider{path: "/tmp/codex"},
@@ -784,17 +784,20 @@ func TestDeleteReturnsRuntimeDirRemovalError(t *testing.T) {
 	rt.deps.RemoveAll = func(path string) error {
 		removeCalls++
 		if path == runtimeDir && removeCalls == 1 {
-			return &os.PathError{Op: "unlinkat", Path: filepath.Join(runtimeDir, "home", "logs_2.sqlite"), Err: errors.New("The process cannot access the file because it is being used by another process.")}
+			return &os.PathError{Op: "unlinkat", Path: filepath.Join(runtimeDir, "home", "stderr.log"), Err: errors.New("The process cannot access the file because it is being used by another process.")}
 		}
 		return os.RemoveAll(path)
 	}
 
 	err = rt.Delete(context.Background(), handle)
-	if err == nil || !strings.Contains(err.Error(), "being used by another process") {
-		t.Fatalf("Delete() error = %v, want locked file error", err)
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
 	}
-	if removeCalls != 1 {
-		t.Fatalf("RemoveAll() calls = %d, want 1", removeCalls)
+	if removeCalls != 2 {
+		t.Fatalf("RemoveAll() calls = %d, want 2", removeCalls)
+	}
+	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime dir stat error = %v, want not exist", err)
 	}
 }
 

--- a/internal/template/builtin_store.go
+++ b/internal/template/builtin_store.go
@@ -78,7 +78,7 @@ func (s *BuiltinStore) FetchWorkspace(_ context.Context, id string) (WorkspaceRe
 		return WorkspaceRef{}, nil
 	}
 	root := s.workspacePath(id)
-	tmpDir, err := os.MkdirTemp("", "csgclaw-hub-builtin-*")
+	tmpDir, err := mkdirHubWorkspaceTemp("csgclaw-hub-builtin-*")
 	if err != nil {
 		return WorkspaceRef{}, fmt.Errorf("create builtin hub workspace temp dir: %w", err)
 	}

--- a/internal/template/builtin_store_test.go
+++ b/internal/template/builtin_store_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
+	"strings"
 	"testing"
 
 	"csgclaw/internal/config"
@@ -87,6 +89,27 @@ func TestBuiltinStoreListGetAndFetchWorkspace(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Fatal("FetchWorkspace() copied empty AGENT.md")
+	}
+}
+
+func TestMkdirHubWorkspaceTempFallsBackToSlashTmpWhenEnvTempRootIsMissing(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("slash-tmp fallback is only meaningful on Unix-like hosts")
+	}
+
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("TMPDIR", missingRoot)
+	t.Setenv("TMP", "")
+	t.Setenv("TEMP", "")
+
+	dir, err := mkdirHubWorkspaceTemp("csgclaw-hub-test-*")
+	if err != nil {
+		t.Fatalf("mkdirHubWorkspaceTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	if got, wantPrefix := filepath.Clean(dir), filepath.Clean(fallbackTempRoot)+string(os.PathSeparator); !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("mkdirHubWorkspaceTemp() = %q, want under %q", dir, fallbackTempRoot)
 	}
 }
 

--- a/internal/template/embed/manager/codex/workspace/skills/agent-teams/SKILL.md
+++ b/internal/template/embed/manager/codex/workspace/skills/agent-teams/SKILL.md
@@ -17,7 +17,7 @@ For executable multi-worker work:
 2. Resolve the current channel context. Use `csgclaw` by default; use `feishu` when the user request came from Feishu.
 3. Ensure selected workers have participant bindings in that execution channel. If a required worker is missing or unavailable, use `agent-creator` first, then return here after provisioning finishes.
 4. Ensure a team member pool exists (`team create` or reuse an existing `team_id`).
-5. Create one main task (`team task create-batch --execution-channel <channel>`) for the user-visible goal. This creates the execution room for the main task.
+5. Create one main task (`team task create-batch --execution-channel <channel> --title ... --body ...`) for the user-visible goal. This creates the execution room for the main task.
 6. Plan and start it with `team task plan --start`; this uses the server planner, creates child tasks, creates dependencies, and dispatches ready child tasks.
 7. Use `team task start` only when the parent already has subtasks but is not started yet. When `create-batch` creates a parent and runnable subtasks in the same batch, the server auto-starts the parent and projects dispatches.
 8. Verify dispatch through `team task list` or recent room messages when reporting success.
@@ -48,6 +48,12 @@ Create one or more tasks:
 
 ```bash
 csgclaw-cli team task create-batch --team <team_id> --created-by <manager_participant_id> --execution-channel <csgclaw|feishu> --file <tasks.json>
+```
+
+Create the default single main task:
+
+```bash
+csgclaw-cli team task create-batch --team <team_id> --created-by <manager_participant_id> --execution-channel <csgclaw|feishu> --title "<task_title>" --body "<goal/context>"
 ```
 
 Start an existing parent task after subtasks are attached:
@@ -114,7 +120,9 @@ csgclaw-cli team approval resolve --team <team_id> --approval <approval_id> --st
 - For any team task that creates, inspects, or updates a project, use `./projects/{name}` under the active Codex workspace as the shared project directory. Check there first before creating a new project path.
 - Keep project artifacts, notes, and generated files under the same `./projects/{name}` tree so managers and workers can inspect the same content.
 - Default to one top-level main task for each user-visible goal, then add execution items as child tasks.
+- For the default single main task, prefer `--title` and `--body` instead of writing `tasks.json`. On Windows this avoids shell codepage corruption of non-ASCII task names.
 - In the same batch, prefer `id_ref` + `parent_ref` to build the hierarchy clearly.
+- When a JSON batch is needed for multiple tasks or dependencies, write it as UTF-8 with a UTF-8-aware tool. Do not use `echo ... > tasks.json`, `cmd` redirection, or shell text redirection that may use the Windows active code page.
 - Add `depends_on_refs` when testing, QA, review, validation, or release checks must wait for implementation work.
 - Use task dependencies for sequential handoff; do not write or ask workers to update tracker files.
 - Use `parent_id` only when attaching a child task to an already-existing main task.

--- a/internal/template/embed/manager_basics_test.go
+++ b/internal/template/embed/manager_basics_test.go
@@ -59,6 +59,25 @@ func TestManagerInstructionsPreferAgentTasksForSingleWorkerDispatch(t *testing.T
 	}
 }
 
+func TestManagerAgentTeamsUsesUTF8SafeTaskCreation(t *testing.T) {
+	data, err := fs.ReadFile(FS(), path.Join(CodexManagerRoot, WorkspaceDirName, "skills/agent-teams/SKILL.md"))
+	if err != nil {
+		t.Fatalf("read codex manager agent-teams skill: %v", err)
+	}
+	skill := string(data)
+
+	for _, want := range []string{
+		`--title "<task_title>" --body "<goal/context>"`,
+		"prefer `--title` and `--body` instead of writing `tasks.json`",
+		"UTF-8",
+		"Do not use `echo ... > tasks.json`",
+	} {
+		if !strings.Contains(skill, want) {
+			t.Fatalf("agent-teams skill missing UTF-8-safe task creation guidance %q", want)
+		}
+	}
+}
+
 func TestWorkerInstructionsMentionDirectAgentTaskCLI(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -209,7 +209,7 @@ func (s *RemoteStore) FetchWorkspace(ctx context.Context, id string) (WorkspaceR
 		return WorkspaceRef{}, err
 	}
 
-	tmpDir, err := os.MkdirTemp("", "csgclaw-hub-remote-*")
+	tmpDir, err := mkdirHubWorkspaceTemp("csgclaw-hub-remote-*")
 	if err != nil {
 		return WorkspaceRef{}, fmt.Errorf("create remote hub workspace temp dir: %w", err)
 	}

--- a/internal/template/workspace_copy.go
+++ b/internal/template/workspace_copy.go
@@ -12,6 +12,37 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
+const fallbackTempRoot = "/tmp"
+
+func mkdirHubWorkspaceTemp(pattern string) (string, error) {
+	dir, err := os.MkdirTemp("", pattern)
+	if err == nil {
+		return dir, nil
+	}
+
+	tempRoot := os.TempDir()
+	if !tempRootMissing(tempRoot) || filepath.Clean(tempRoot) == filepath.Clean(fallbackTempRoot) {
+		return "", err
+	}
+	fallbackInfo, statErr := os.Stat(fallbackTempRoot)
+	if statErr != nil || !fallbackInfo.IsDir() {
+		return "", err
+	}
+	dir, fallbackErr := os.MkdirTemp(fallbackTempRoot, pattern)
+	if fallbackErr != nil {
+		return "", fmt.Errorf("%w; fallback temp dir %q failed: %v", err, fallbackTempRoot, fallbackErr)
+	}
+	return dir, nil
+}
+
+func tempRootMissing(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}
+
 func copyWorkspaceTree(srcRoot, dstRoot string) error {
 	srcRoot = strings.TrimSpace(srcRoot)
 	if srcRoot == "" {

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -1779,6 +1779,9 @@ export function agentRuntimePollSettled(item: AgentLike | null | undefined): boo
 }
 
 export function isAgentUpgradeNeeded(item: AgentLike | null | undefined): boolean {
+  if (agentRuntimeKind(item) === "codex") {
+    return false;
+  }
   const profile = agentProfileConfig(item);
   return Boolean(item?.image_upgrade_required || profile?.image_upgrade_required);
 }

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -448,7 +448,7 @@ export function AgentDetailPane({
             >
               {t("openDM")}
             </Button>
-            {onUpgrade ? (
+            {onUpgrade && upgradeNeeded ? (
               <Button
                 variant="primary"
                 size="md"

--- a/web/app/src/pages/AgentPage/components/AgentList/AgentList.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentList/AgentList.tsx
@@ -184,7 +184,7 @@ export function AgentRow({
         ) : null}
         {!isNotification ? (
           <>
-            {onUpgrade ? (
+            {onUpgrade && upgradeNeeded ? (
               <Button
                 className="agent-action-text"
                 disabled={busyKey.startsWith(busyPrefix) || incomplete}

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -104,7 +104,7 @@ describe("agent action visibility", () => {
 
     expect(screen.getByText("Recreate required")).toBeInTheDocument();
     expect(screen.getByText("Complete")).toHaveClass("ready");
-    expect(screen.getByRole("button", { name: "Upgrade", hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Upgrade", hidden: true })).not.toBeInTheDocument();
   });
 
   it("shows an upgrade warning when only the agent image is outdated", () => {
@@ -128,12 +128,12 @@ describe("agent action visibility", () => {
     expect(screen.queryByText("Recreate required")).not.toBeInTheDocument();
   });
 
-  it("shows upgrade and recreate for worker rows even when lifecycle actions are hidden", async () => {
+  it("shows upgrade and recreate for outdated worker rows even when lifecycle actions are hidden", async () => {
     const user = userEvent.setup();
     const onUpgrade = vi.fn();
     render(
       <AgentRow
-        item={worker}
+        item={{ ...worker, image_upgrade_required: true }}
         t={t}
         activeRoom={null}
         busyKey=""
@@ -153,12 +153,12 @@ describe("agent action visibility", () => {
     expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
   });
 
-  it("shows upgrade and recreate for worker detail panes even when lifecycle actions are hidden", async () => {
+  it("shows upgrade and recreate for outdated worker detail panes even when lifecycle actions are hidden", async () => {
     const user = userEvent.setup();
     const onUpgrade = vi.fn();
     render(
       <AgentDetailPane
-        item={worker}
+        item={{ ...worker, image_upgrade_required: true }}
         t={t}
         activeRoom={null}
         busyKey=""
@@ -525,7 +525,7 @@ describe("agent action visibility", () => {
     expect(screen.getByRole("button", { name: "Open Feishu" })).toBeInTheDocument();
   });
 
-  it("keeps upgrade action visible in worker detail panes when backend marks an agent restart required", () => {
+  it("hides upgrade action in worker detail panes when only recreate is required", () => {
     render(
       <AgentDetailPane
         item={{ ...worker, env_restart_required: true }}
@@ -556,7 +556,7 @@ describe("agent action visibility", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).not.toBeInTheDocument();
     expect(screen.getByText("Recreate required")).toBeInTheDocument();
   });
 
@@ -627,7 +627,43 @@ describe("agent action visibility", () => {
     );
 
     expect(screen.getByText("Upgrade required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
     expect(screen.queryByText("Recreate required")).not.toBeInTheDocument();
+  });
+
+  it("hides upgrade controls for codex agents without images", () => {
+    render(
+      <AgentDetailPane
+        item={{ ...worker, runtime_kind: "codex", image_upgrade_required: true }}
+        t={t}
+        activeRoom={null}
+        busyKey=""
+        error=""
+        draft={null}
+        models={[]}
+        modelBusy={false}
+        saving={false}
+        publishBusy={false}
+        saveError=""
+        authStatuses={{}}
+        authBusyProvider=""
+        notifierWebhookPublicOrigin="http://127.0.0.1:18080"
+        onDraftChange={vi.fn()}
+        onSave={vi.fn()}
+        onPublish={vi.fn()}
+        onProviderLogin={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onRecreate={vi.fn()}
+        onUpgrade={vi.fn()}
+        onDelete={vi.fn()}
+        onInvite={vi.fn()}
+        onOpenDM={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Upgrade required")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).not.toBeInTheDocument();
   });
 
   it("trusts complete notifier profile state when gating recreate in detail panes", async () => {

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -50,6 +50,7 @@ import {
   runtimeOptionSchemasForAgent,
   localizedRuntimeOptionLabel,
   localizedRuntimeOptionDescription,
+  isAgentUpgradeNeeded,
   shouldWaitForManagerRuntimeAfterProfileSave,
   workerSelectableTemplates,
 } from "@/models/agents";
@@ -182,6 +183,26 @@ describe("agent model helpers", () => {
       },
       { id: "u-alice", image: "registry.example/worker:2026.06.03" },
     ]);
+  });
+
+  it("does not mark codex agents as upgradeable even when an image flag is present", () => {
+    expect(
+      isAgentUpgradeNeeded({
+        id: "worker-codex",
+        runtime_kind: "codex",
+        image_upgrade_required: true,
+        agent_profile: {
+          image_upgrade_required: true,
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isAgentUpgradeNeeded({
+        id: "worker-picoclaw",
+        runtime_kind: "picoclaw_sandbox",
+        image_upgrade_required: true,
+      }),
+    ).toBe(true);
   });
 
   it("syncs readonly runtime fields from a fresh action response into the agent page draft", () => {


### PR DESCRIPTION
- Fall back to /tmp when the hub workspace temp root disappears during template fetches.
- Retry transient Windows file-lock failures when rebuilding Codex agent runtime directories.
- Hide upgrade actions for Codex agents that do not have image metadata.
- Preserve Unicode task titles for manager agent-teams on Windows by avoiding shell-written task JSON for the default path.