### PR TITLE
feat(web): clarify activity rows and conversation counts

### DIFF
--- a/web/app/src/components/business/ConversationPane/ConversationHeader.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationHeader.tsx
@@ -29,6 +29,7 @@ export type ConversationHeaderProps = {
   onToggleMemberList?: BooleanStateSetter;
   onToggleToolCalls: BooleanStateSetter;
   selectedMessageCount: number;
+  selectedVisibleMessageCount?: number;
   showChannelTools: boolean;
   showInviteAction: boolean;
   showMemberList?: boolean;
@@ -48,6 +49,7 @@ export const ConversationHeader = memo(function ConversationHeader({
   logModalOpen,
   memberMenuRef,
   selectedMessageCount,
+  selectedVisibleMessageCount,
   showChannelTools,
   showInviteAction,
   showMemberList = false,
@@ -63,6 +65,10 @@ export const ConversationHeader = memo(function ConversationHeader({
   onToggleMemberList,
   onToggleToolCalls,
 }: ConversationHeaderProps) {
+  const visibleCount = selectedVisibleMessageCount ?? selectedMessageCount;
+  const messageCountLabel =
+    visibleCount === selectedMessageCount ? String(selectedMessageCount) : `${visibleCount}/${selectedMessageCount}`;
+
   return (
     <header className="chat-header">
       <div className="chat-header-main">
@@ -71,7 +77,7 @@ export const ConversationHeader = memo(function ConversationHeader({
             <div className="chat-title-group">
               <div className="chat-kicker">
                 <span>{isDirectConversation(conversation) ? t("directMessagesSection") : t("conversationLabel")}</span>
-                <strong>{selectedMessageCount}</strong>
+                <strong title={messageCountLabel}>{messageCountLabel}</strong>
               </div>
               <div className="chat-title truncate">{conversation.title}</div>
               {showMemberListAction ? (

--- a/web/app/src/models/agentActivity.ts
+++ b/web/app/src/models/agentActivity.ts
@@ -260,7 +260,51 @@ export function statusLabel(status: string): string {
 }
 
 export function agentActivityToolMergeKey(tool: AgentActivityTool | null | undefined): string {
-  return firstNonEmpty(tool?.id, tool?.item_id, tool?.tool_call_id);
+  return agentActivityToolMergeKeys(tool)[0] ?? "";
+}
+
+export function agentActivityToolMergeKeys(tool: AgentActivityTool | null | undefined): string[] {
+  const keys: string[] = [];
+  const add = (value: string) => {
+    if (value && !keys.includes(value)) {
+      keys.push(value);
+    }
+  };
+  const addItemID = (value: unknown, options?: { ambiguous?: boolean }) => {
+    const id = stringValue(value);
+    if (!id) {
+      return;
+    }
+    add(normalizeToolItemMergeKey(id));
+    if (options?.ambiguous) {
+      add(`tool_call:${stripToolItemPrefix(id)}`);
+    }
+  };
+
+  // item_id is the canonical lifecycle identifier. id is retained as an alias
+  // because older producers used it for either an item id or a tool-call id.
+  addItemID(tool?.item_id);
+  addItemID(tool?.id, { ambiguous: true });
+  const toolCallID = stringValue(tool?.tool_call_id);
+  if (toolCallID) {
+    add(`tool_call:${stripToolItemPrefix(toolCallID)}`);
+  }
+  return keys;
+}
+
+export function agentActivityMessageToolMergeKey(message: IMMessage | null | undefined): string {
+  const toolCallID = openClawToolCallID(message);
+  return toolCallID ? `tool_call:${stripToolItemPrefix(toolCallID)}` : "";
+}
+
+function normalizeToolItemMergeKey(value: unknown): string {
+  const id = stringValue(value);
+  const stripped = stripToolItemPrefix(id);
+  return stripped !== id ? `tool_call:${stripped}` : id;
+}
+
+function stripToolItemPrefix(value: string): string {
+  return value.replace(/^(?:tool|command|patch):/i, "").trim();
 }
 
 export function isTerminalAgentActivityTool(tool: AgentActivityTool | null | undefined): boolean {

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.test.ts
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { IMConversation, IMMessage } from "@/models/conversations";
+import { CSGCLAW_AGENT_ACTIVITY_TYPE, AgentActivityMsgTypes } from "@/shared/constants/messages";
+import { activityEntriesFromRooms } from "./AgentActivityPanel";
+
+const room: IMConversation = {
+  id: "room-1",
+  members: ["agent-1"],
+  messages: [],
+  title: "Agent room",
+};
+
+function activityMessage(id: string, createdAt: string, tool: Record<string, unknown>, body = "Command"): IMMessage {
+  return {
+    id,
+    content: JSON.stringify({
+      channel: "openclaw",
+      content: {
+        body,
+        msgtype: AgentActivityMsgTypes.tool,
+        tool,
+      },
+      event_id: id,
+      origin_server_ts: Date.parse(createdAt),
+      room_id: room.id,
+      sender: "openclaw",
+      type: CSGCLAW_AGENT_ACTIVITY_TYPE,
+      version: 1,
+    }),
+    created_at: createdAt,
+    metadata: {
+      openclaw: {
+        request_id: "msg-user-1",
+        source_message_id: "msg-user-1",
+      },
+    },
+    sender_id: "agent-1",
+  };
+}
+
+function openClawToolMessage(
+  id: string,
+  createdAt: string,
+  toolCallID: string,
+  content: string,
+  requestID = "msg-user-1",
+): IMMessage {
+  return {
+    id,
+    content,
+    created_at: createdAt,
+    metadata: {
+      openclaw: {
+        delivery_info: { kind: "tool", toolCallId: toolCallID },
+        delivery_kind: "tool",
+        request_id: requestID,
+        tool_call_id: toolCallID,
+      },
+    },
+    sender_id: "agent-1",
+  };
+}
+
+function entries(messages: IMMessage[]) {
+  return activityEntriesFromRooms([{ room, messages }], ["agent-1"]);
+}
+
+describe("activityEntriesFromRooms", () => {
+  it("merges command lifecycle and output by canonical item id", () => {
+    const result = entries([
+      activityMessage("activity-start", "2026-07-10T10:00:00.000Z", {
+        id: "command:call-7",
+        input_summary: JSON.stringify({ command: "csgclaw-cli --version" }),
+        item_id: "command:call-7",
+        kind: "command",
+        phase: "start",
+        status: "running",
+        title: "Command",
+      }),
+      activityMessage("activity-end", "2026-07-10T10:00:01.000Z", {
+        command: "csgclaw-cli --version",
+        id: "call-7",
+        item_id: "command:call-7",
+        kind: "exec",
+        output: "csgclaw-cli v0.3.16",
+        output_summary: "csgclaw-cli v0.3.16",
+        phase: "end",
+        status: "completed",
+        title: "csgclaw-cli --version",
+        tool_call_id: "call-7",
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.activity?.content.tool).toMatchObject({
+      command: "csgclaw-cli --version",
+      output: "csgclaw-cli v0.3.16",
+      phase: "end",
+      status: "completed",
+    });
+  });
+
+  it("coalesces previously separate item and tool-call rows when a bridge event contains both ids", () => {
+    const result = entries([
+      activityMessage("item-start", "2026-07-10T10:00:00.000Z", {
+        id: "item-7",
+        input_summary: JSON.stringify({ command: "csgclaw-cli --help" }),
+        item_id: "item-7",
+        kind: "command",
+        phase: "start",
+        status: "running",
+        title: "Command",
+      }),
+      openClawToolMessage(
+        "plain-output",
+        "2026-07-10T10:00:00.500Z",
+        "call-7",
+        "csgclaw-cli --help\nusage: csgclaw-cli <command>",
+      ),
+      activityMessage("command-output", "2026-07-10T10:00:01.000Z", {
+        command: "csgclaw-cli --help",
+        id: "item-7",
+        item_id: "item-7",
+        kind: "exec",
+        output: "usage: csgclaw-cli <command>",
+        output_summary: "usage: csgclaw-cli <command>",
+        phase: "end",
+        status: "completed",
+        title: "csgclaw-cli --help",
+        tool_call_id: "call-7",
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.activity?.content.tool).toMatchObject({
+      command: "csgclaw-cli --help",
+      item_id: "item-7",
+      output: "usage: csgclaw-cli <command>",
+      tool_call_id: "call-7",
+    });
+  });
+
+  it("keeps concrete command output when a later lifecycle event only reports status", () => {
+    const result = entries([
+      activityMessage("command-output", "2026-07-10T10:00:00.000Z", {
+        command: "csgclaw-cli --version",
+        id: "item-7",
+        item_id: "item-7",
+        kind: "exec",
+        output: "csgclaw-cli v0.3.16",
+        output_summary: "csgclaw-cli v0.3.16",
+        phase: "end",
+        status: "completed",
+        title: "csgclaw-cli --version",
+        tool_call_id: "call-7",
+      }),
+      activityMessage("item-end", "2026-07-10T10:00:01.000Z", {
+        id: "item-7",
+        item_id: "item-7",
+        kind: "command",
+        output_summary: "Command completed",
+        phase: "end",
+        status: "completed",
+        title: "Command",
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.activity?.content.tool).toMatchObject({
+      output: "csgclaw-cli v0.3.16",
+      output_summary: "csgclaw-cli v0.3.16",
+    });
+  });
+
+  it("keeps repeated commands separate when OpenClaw provides different tool-call ids", () => {
+    const result = entries([
+      openClawToolMessage("call-one", "2026-07-10T10:00:00.000Z", "call-1", "csgclaw-cli --version"),
+      openClawToolMessage("call-two", "2026-07-10T10:00:01.000Z", "call-2", "csgclaw-cli --version"),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((entry) => entry.command?.command)).toEqual(["csgclaw-cli --version", "csgclaw-cli --version"]);
+  });
+
+  it("scopes reused tool-call ids to their source request", () => {
+    const result = entries([
+      openClawToolMessage("first-request", "2026-07-10T10:00:00.000Z", "call-1", "csgclaw-cli --version", "msg-user-1"),
+      openClawToolMessage(
+        "second-request",
+        "2026-07-10T10:01:00.000Z",
+        "call-1",
+        "csgclaw-cli --version",
+        "msg-user-2",
+      ),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+});

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownNarrowWide, ArrowUpNarrowWide, ChevronRight, Clock, Filter, RefreshCw } from "lucide-react";
 import { fetchMessagesRequest } from "@/api/im";
 import { errorMessage } from "@/api/client";
@@ -13,17 +13,19 @@ import {
   type TranslateFn,
 } from "@/models/conversations";
 import {
-  agentActivityToolMergeKey,
+  agentActivityMessageToolMergeKey,
+  agentActivityToolMergeKeys,
   type AgentActivityCommand,
   type AgentActivityKind,
-  isTerminalAgentActivityTool,
   parseAgentActivity,
   parseMessageActivityCommand,
+  parsePlainAgentCommand,
   statusLabel,
   type AgentActivityPayload,
   type AgentActivityTool,
 } from "@/models/agentActivity";
 import { AgentActivityKinds, AgentActivityMsgTypes } from "@/shared/constants/messages";
+import { subscribeIMEvents } from "@/shared/realtime/imEvents";
 import {
   Button,
   DropdownMenuCheckboxItem,
@@ -42,12 +44,12 @@ type AgentActivityPanelProps = {
   t: TranslateFn;
 };
 
-type AgentActivityRoomMessages = {
+export type AgentActivityRoomMessages = {
   messages: IMMessage[];
   room: IMConversation;
 };
 
-type AgentActivityEntry = {
+export type AgentActivityEntry = {
   activity: AgentActivityPayload | null;
   command: AgentActivityCommand | null;
   createdAt: string;
@@ -69,30 +71,34 @@ type AgentActivityFilterOption = {
   tone: AgentActivityKind;
 };
 
+const duplicateCommandWindowMs = 10_000;
+
 export function AgentActivityPanel({ item, locale, rooms = [], t }: AgentActivityPanelProps) {
+  const queryClient = useQueryClient();
   const [sortMode, setSortMode] = useState<AgentActivitySortMode>("newest_first");
   const [selectedFilters, setSelectedFilters] = useState<Set<string>>(() => new Set());
   const [selectedEntryID, setSelectedEntryID] = useState<string | null>(null);
   const rowRefs = useRef<Map<string, HTMLElement>>(new Map());
   const latestVisibleEntryIDRef = useRef<string | null>(null);
+  const liveMessagesRef = useRef<Map<string, IMMessage[]>>(new Map());
   const agentIdentity = useMemo(() => agentIdentityValues(item), [item]);
   const activityRooms = useMemo(
     () => rooms.filter((room) => room.members.some((memberID) => identityMatches(memberID, agentIdentity))),
     [agentIdentity, rooms],
   );
-  const roomSignature = useMemo(
-    () =>
-      activityRooms
-        .map((room) => {
-          const latest = room.messages.at(-1);
-          const latestThread = room.threads?.at(-1);
-          return [room.id, latest?.id || "", latest?.created_at || "", latestThread?.root_message_id || ""].join(":");
-        })
-        .join("|"),
-    [activityRooms],
+  const activityRoomIDSignature = useMemo(() => stableRoomIDs(activityRooms).join("\n"), [activityRooms]);
+  const activityRoomIDs = useMemo(
+    () => (activityRoomIDSignature ? activityRoomIDSignature.split("\n") : []),
+    [activityRoomIDSignature],
+  );
+  const activityRoomIDSet = useMemo(() => new Set(activityRoomIDs), [activityRoomIDs]);
+  const activityRoomsByID = useMemo(() => new Map(activityRooms.map((room) => [room.id, room])), [activityRooms]);
+  const activityQueryKey = useMemo(
+    () => ["agent-activity", item.id || "", activityRoomIDs] as const,
+    [activityRoomIDs, item.id],
   );
   const query = useQuery({
-    queryKey: ["agent-activity", item.id || "", roomSignature],
+    queryKey: activityQueryKey,
     queryFn: async (): Promise<AgentActivityRoomMessages[]> => {
       const pairs = await Promise.all(
         activityRooms.map(async (room) => ({
@@ -105,6 +111,50 @@ export function AgentActivityPanel({ item, locale, rooms = [], t }: AgentActivit
     enabled: activityRooms.length > 0,
     staleTime: 2_000,
   });
+
+  const mergeMessageIntoActivityCache = useCallback(
+    (roomID: string | null | undefined, message: IMMessage | null | undefined, options?: { remember?: boolean }) => {
+      const normalizedRoomID = String(roomID || "").trim();
+      if (!normalizedRoomID || !message || !activityRoomIDSet.has(normalizedRoomID)) {
+        return false;
+      }
+      const room = activityRoomsByID.get(normalizedRoomID);
+      if (!room || !identityMatches(message.sender_id, agentIdentity)) {
+        return false;
+      }
+      if (options?.remember) {
+        rememberLiveActivityMessage(liveMessagesRef.current, normalizedRoomID, message);
+      }
+      queryClient.setQueryData<AgentActivityRoomMessages[]>(activityQueryKey, (current) =>
+        current ? mergeActivityMessageIntoCache(current, room, message) : current,
+      );
+      return true;
+    },
+    [activityQueryKey, activityRoomIDSet, activityRoomsByID, agentIdentity, queryClient],
+  );
+
+  useEffect(() => {
+    if (!activityRoomIDs.length) {
+      return undefined;
+    }
+    return subscribeIMEvents((payload) => {
+      if (payload.type !== "message.created" || !payload.message) {
+        return;
+      }
+      mergeMessageIntoActivityCache(payload.room_id, payload.message, { remember: true });
+    });
+  }, [activityRoomIDs.length, mergeMessageIntoActivityCache]);
+
+  useEffect(() => {
+    if (!query.data) {
+      return;
+    }
+    queryClient.setQueryData<AgentActivityRoomMessages[]>(activityQueryKey, (current) =>
+      current
+        ? mergeActivityMessagesIntoCache(current, activityRooms, agentIdentity, liveMessagesRef.current)
+        : current,
+    );
+  }, [activityQueryKey, activityRooms, agentIdentity, query.data, queryClient]);
 
   const entries = useMemo(() => activityEntriesFromRooms(query.data ?? [], agentIdentity), [agentIdentity, query.data]);
   const filterOptions = useMemo(() => activityFilterOptions(entries, t), [entries, t]);
@@ -253,6 +303,118 @@ export function AgentActivityPanel({ item, locale, rooms = [], t }: AgentActivit
   );
 }
 
+function stableRoomIDs(rooms: readonly IMConversation[]): string[] {
+  return Array.from(new Set(rooms.map((room) => String(room.id || "").trim()).filter(Boolean))).sort();
+}
+
+function mergeActivityMessagesIntoCache(
+  current: readonly AgentActivityRoomMessages[],
+  rooms: readonly IMConversation[],
+  agentIdentity: readonly string[],
+  liveMessages: ReadonlyMap<string, readonly IMMessage[]>,
+): AgentActivityRoomMessages[] {
+  let next = current;
+  for (const room of rooms) {
+    for (const message of room.messages) {
+      if (identityMatches(message.sender_id, agentIdentity)) {
+        next = mergeActivityMessageIntoCache(next, room, message);
+      }
+    }
+    for (const message of liveMessages.get(room.id) ?? []) {
+      if (identityMatches(message.sender_id, agentIdentity)) {
+        next = mergeActivityMessageIntoCache(next, room, message);
+      }
+    }
+  }
+  return next as AgentActivityRoomMessages[];
+}
+
+function mergeActivityMessageIntoCache(
+  current: readonly AgentActivityRoomMessages[],
+  room: IMConversation,
+  message: IMMessage,
+): AgentActivityRoomMessages[] {
+  const roomIndex = current.findIndex((item) => item.room.id === room.id);
+  if (roomIndex < 0) {
+    return [{ room, messages: [message] }, ...current];
+  }
+  const roomMessages = current[roomIndex]?.messages ?? [];
+  const mergedMessages = upsertActivityMessage(roomMessages, message);
+  if (mergedMessages === roomMessages) {
+    return current as AgentActivityRoomMessages[];
+  }
+  return current.map((item, index) =>
+    index === roomIndex ? { room: { ...item.room, ...room }, messages: mergedMessages } : item,
+  );
+}
+
+function upsertActivityMessage(messages: readonly IMMessage[], message: IMMessage): IMMessage[] {
+  const nextKey = activityMessageMergeKey(message);
+  const existingIndex = messages.findIndex((item) => activityMessageMergeKey(item) === nextKey);
+  if (existingIndex >= 0) {
+    if (activityMessagesEquivalent(messages[existingIndex], message)) {
+      return messages as IMMessage[];
+    }
+    const next = messages.map((item, index) => (index === existingIndex ? message : item));
+    return sortActivityMessages(next);
+  }
+  return sortActivityMessages([...messages, message]);
+}
+
+function activityMessagesEquivalent(left: IMMessage | undefined, right: IMMessage): boolean {
+  if (!left) {
+    return false;
+  }
+  if (left === right) {
+    return true;
+  }
+  return (
+    activityMessageMergeKey(left) === activityMessageMergeKey(right) &&
+    String(left.content || "") === String(right.content || "") &&
+    String(left.created_at || "") === String(right.created_at || "") &&
+    String(left.sender_id || "") === String(right.sender_id || "") &&
+    String(left.relates_to?.rel_type || "") === String(right.relates_to?.rel_type || "") &&
+    String(left.relates_to?.event_id || "") === String(right.relates_to?.event_id || "") &&
+    JSON.stringify(left.metadata ?? null) === JSON.stringify(right.metadata ?? null)
+  );
+}
+
+function sortActivityMessages(messages: readonly IMMessage[]): IMMessage[] {
+  return messages
+    .map((message, index) => ({ index, message }))
+    .sort((left, right) => {
+      const timeDelta = activityTime(left.message.created_at || "") - activityTime(right.message.created_at || "");
+      if (timeDelta !== 0) {
+        return timeDelta;
+      }
+      return left.index - right.index;
+    })
+    .map((item) => item.message);
+}
+
+function activityMessageMergeKey(message: IMMessage): string {
+  const id = String(message.id || "").trim();
+  if (id) {
+    return `id:${id}`;
+  }
+  return [
+    "fallback",
+    String(message.sender_id || ""),
+    String(message.created_at || ""),
+    String(message.content || ""),
+    String(message.relates_to?.rel_type || ""),
+    String(message.relates_to?.event_id || ""),
+  ].join(":");
+}
+
+function rememberLiveActivityMessage(liveMessages: Map<string, IMMessage[]>, roomID: string, message: IMMessage): void {
+  const messages = liveMessages.get(roomID) ?? [];
+  const merged = upsertActivityMessage(messages, message);
+  if (merged !== messages) {
+    liveMessages.set(roomID, merged);
+  }
+}
+
 function agentIdentityValues(item: AgentLike): string[] {
   const out: string[] = [];
   const push = (value: unknown) => {
@@ -273,20 +435,22 @@ function agentIdentityValues(item: AgentLike): string[] {
   return out;
 }
 
-function activityEntriesFromRooms(
+// eslint-disable-next-line react-refresh/only-export-components -- exported for focused activity-merge regression tests.
+export function activityEntriesFromRooms(
   rooms: readonly AgentActivityRoomMessages[],
   agentIdentity: readonly string[],
 ): AgentActivityEntry[] {
   const entries: AgentActivityEntry[] = [];
   rooms.forEach(({ room, messages }) => {
     const pendingCommands = new Map<string, AgentActivityEntry[]>();
-    const pendingTools = new Map<string, AgentActivityEntry>();
+    const semanticCommandEntries = new Map<string, AgentActivityEntry>();
+    const toolEntries = new Map<string, AgentActivityEntry>();
     messages.forEach((message) => {
       if (!identityMatches(message.sender_id, agentIdentity)) {
         return;
       }
       const activity = parseAgentActivity(message.content);
-      const plainCommand = activity ? null : parseMessageActivityCommand(message);
+      const plainCommand = activity ? null : parseActivityCommand(message);
       const body = String(message.content || "")
         .replace(/\u200b/g, "")
         .trim();
@@ -294,12 +458,22 @@ function activityEntriesFromRooms(
         return;
       }
       if (activity?.content.msgtype === AgentActivityMsgTypes.tool && activity.content.tool) {
-        const toolKey = agentActivityToolMergeKey(activity.content.tool);
-        const existing = toolKey ? pendingTools.get(toolKey) : undefined;
-        if (existing?.activity) {
-          existing.activity = mergeToolActivity(existing.activity, activity);
-          if (isTerminalAgentActivityTool(activity.content.tool)) {
-            pendingTools.delete(toolKey);
+        const toolKeys = activityToolMergeKeys(activity.content.tool, message);
+        const semanticCommandKey = activityToolSemanticCommandKey(activity.content.tool, message);
+        const stableEntries = mappedActivityEntries(toolEntries, toolKeys);
+        const semanticEntry =
+          toolKeys.length === 0 && semanticCommandKey ? semanticCommandEntries.get(semanticCommandKey) : undefined;
+        const existing = coalesceActivityEntries(
+          entries,
+          stableEntries.length ? stableEntries : semanticEntry ? [semanticEntry] : [],
+          toolEntries,
+          semanticCommandEntries,
+        );
+        if (existing) {
+          mergeToolActivityIntoEntry(existing, activity, message);
+          registerActivityEntry(toolEntries, toolKeys, existing);
+          if (semanticCommandKey) {
+            semanticCommandEntries.set(semanticCommandKey, existing);
           }
           return;
         }
@@ -316,25 +490,45 @@ function activityEntriesFromRooms(
           type: "activity",
         };
         entries.push(entry);
-        if (toolKey && !isTerminalAgentActivityTool(activity.content.tool)) {
-          pendingTools.set(toolKey, entry);
+        registerActivityEntry(toolEntries, toolKeys, entry);
+        if (semanticCommandKey) {
+          semanticCommandEntries.set(semanticCommandKey, entry);
         }
         return;
       }
       if (plainCommand) {
-        if (plainCommand.output) {
-          const pending = pendingCommands.get(plainCommand.signature);
-          const startEntry = pending?.shift();
+        const stableToolKey = scopedActivityToolMergeKey(message, agentActivityMessageToolMergeKey(message));
+        const commandKey = activityCommandMergeKey(plainCommand);
+        const semanticCommandKey = openClawRequestCommandMergeKey(message, plainCommand.command);
+        const stableEntry = stableToolKey ? toolEntries.get(stableToolKey) : undefined;
+        const semanticEntry =
+          !stableToolKey && semanticCommandKey ? semanticCommandEntries.get(semanticCommandKey) : undefined;
+        const existing = stableEntry ?? semanticEntry;
+        if (existing) {
+          mergePlainCommandIntoEntry(existing, plainCommand, message);
+          if (stableToolKey) {
+            toolEntries.set(stableToolKey, existing);
+          }
+          return;
+        }
+        if (!stableToolKey && plainCommand.output) {
+          const pending = pendingCommands.get(commandKey);
+          const pendingIndex = pending ? pendingCommandMatchIndex(pending, message) : -1;
+          const startEntry = pendingIndex >= 0 ? pending?.splice(pendingIndex, 1)[0] : undefined;
           if (startEntry?.command) {
-            startEntry.command = {
-              ...startEntry.command,
-              output: plainCommand.output,
-            };
+            mergePlainCommandIntoEntry(startEntry, plainCommand, message);
+            if (semanticCommandKey) {
+              semanticCommandEntries.set(semanticCommandKey, startEntry);
+            }
             if (pending && pending.length === 0) {
-              pendingCommands.delete(plainCommand.signature);
+              pendingCommands.delete(commandKey);
             }
             return;
           }
+        }
+        const pending = pendingCommands.get(commandKey) ?? [];
+        if (!plainCommand.output && pending.some((entry) => isDuplicateCommandStart(entry, plainCommand, message))) {
+          return;
         }
         const entry: AgentActivityEntry = {
           activity: null,
@@ -349,10 +543,15 @@ function activityEntriesFromRooms(
           type: "message",
         };
         entries.push(entry);
-        if (!plainCommand.output) {
-          const pending = pendingCommands.get(plainCommand.signature) ?? [];
+        if (stableToolKey) {
+          toolEntries.set(stableToolKey, entry);
+        }
+        if (semanticCommandKey) {
+          semanticCommandEntries.set(semanticCommandKey, entry);
+        }
+        if (!stableToolKey && !plainCommand.output) {
           pending.push(entry);
-          pendingCommands.set(plainCommand.signature, pending);
+          pendingCommands.set(commandKey, pending);
         }
         return;
       }
@@ -387,6 +586,10 @@ function mergeToolActivity(base: AgentActivityPayload, next: AgentActivityPayloa
   if (!baseTool || !nextTool) {
     return next;
   }
+  const baseHasOutput = hasActivityToolExplicitOutput(baseTool);
+  const nextHasOutput = hasActivityToolExplicitOutput(nextTool);
+  const baseTerminal = isTerminalActivityTool(baseTool);
+  const nextTerminal = isTerminalActivityTool(nextTool);
   return {
     ...base,
     content: {
@@ -403,13 +606,314 @@ function mergeToolActivity(base: AgentActivityPayload, next: AgentActivityPayloa
         input_summary: firstNonEmpty(nextTool.input_summary, baseTool.input_summary),
         item_id: firstNonEmpty(nextTool.item_id, baseTool.item_id),
         output: nextTool.output ?? baseTool.output,
-        output_summary: firstNonEmpty(nextTool.output_summary, baseTool.output_summary),
-        phase: firstNonEmpty(nextTool.phase, baseTool.phase),
-        status: firstNonEmpty(nextTool.status, baseTool.status),
+        output_summary: nextHasOutput
+          ? firstNonEmpty(nextTool.output_summary, baseTool.output_summary)
+          : baseHasOutput
+            ? firstNonEmpty(baseTool.output_summary, nextTool.output_summary)
+            : firstNonEmpty(nextTool.output_summary, baseTool.output_summary),
+        phase: baseTerminal && !nextTerminal ? baseTool.phase : firstNonEmpty(nextTool.phase, baseTool.phase),
+        status: baseTerminal && !nextTerminal ? baseTool.status : firstNonEmpty(nextTool.status, baseTool.status),
         tool_call_id: firstNonEmpty(nextTool.tool_call_id, baseTool.tool_call_id),
       },
     },
   };
+}
+
+function mergeToolActivityIntoEntry(
+  entry: AgentActivityEntry,
+  activity: AgentActivityPayload,
+  message: IMMessage,
+): void {
+  const previousCommand = entry.command;
+  const previousMessage = entry.message;
+  entry.message = message;
+  if (entry.activity) {
+    entry.activity = mergeToolActivity(entry.activity, activity);
+  } else {
+    entry.activity = activity;
+    entry.command = null;
+    entry.kind = activityKind(activity);
+    entry.type = "activity";
+  }
+  if (previousCommand) {
+    mergePlainCommandIntoEntry(entry, previousCommand, previousMessage);
+  }
+}
+
+function mappedActivityEntries(
+  entries: ReadonlyMap<string, AgentActivityEntry>,
+  keys: readonly string[],
+): AgentActivityEntry[] {
+  const matches: AgentActivityEntry[] = [];
+  for (const key of keys) {
+    const entry = entries.get(key);
+    if (entry && !matches.includes(entry)) {
+      matches.push(entry);
+    }
+  }
+  return matches;
+}
+
+function activityToolMergeKeys(tool: AgentActivityTool, message: IMMessage): string[] {
+  return agentActivityToolMergeKeys(tool).map((key) => scopedActivityToolMergeKey(message, key));
+}
+
+function scopedActivityToolMergeKey(message: IMMessage, key: string): string {
+  const requestID = openClawRequestID(message);
+  return requestID && key ? `openclaw-request:${requestID}:${key}` : key;
+}
+
+function registerActivityEntry(
+  entries: Map<string, AgentActivityEntry>,
+  keys: readonly string[],
+  entry: AgentActivityEntry,
+): void {
+  keys.forEach((key) => entries.set(key, entry));
+}
+
+function coalesceActivityEntries(
+  entries: AgentActivityEntry[],
+  matches: readonly AgentActivityEntry[],
+  toolEntries: Map<string, AgentActivityEntry>,
+  semanticCommandEntries: Map<string, AgentActivityEntry>,
+): AgentActivityEntry | undefined {
+  if (matches.length === 0) {
+    return undefined;
+  }
+  const ordered = [...matches].sort((left, right) => entries.indexOf(left) - entries.indexOf(right));
+  const target = ordered[0];
+  if (!target) {
+    return undefined;
+  }
+  for (const duplicate of ordered.slice(1)) {
+    mergeActivityEntryIntoEntry(target, duplicate);
+    const duplicateIndex = entries.indexOf(duplicate);
+    if (duplicateIndex >= 0) {
+      entries.splice(duplicateIndex, 1);
+    }
+    replaceMappedActivityEntry(toolEntries, duplicate, target);
+    replaceMappedActivityEntry(semanticCommandEntries, duplicate, target);
+  }
+  return target;
+}
+
+function mergeActivityEntryIntoEntry(target: AgentActivityEntry, source: AgentActivityEntry): void {
+  if (source.activity) {
+    mergeToolActivityIntoEntry(target, source.activity, source.message);
+  }
+  if (source.command) {
+    mergePlainCommandIntoEntry(target, source.command, source.message);
+  }
+}
+
+function replaceMappedActivityEntry(
+  entries: Map<string, AgentActivityEntry>,
+  previous: AgentActivityEntry,
+  next: AgentActivityEntry,
+): void {
+  entries.forEach((entry, key) => {
+    if (entry === previous) {
+      entries.set(key, next);
+    }
+  });
+}
+
+function hasActivityToolExplicitOutput(tool: AgentActivityTool): boolean {
+  return tool.output !== undefined;
+}
+
+function isTerminalActivityTool(tool: AgentActivityTool): boolean {
+  const phase = String(tool.phase || "")
+    .trim()
+    .toLowerCase();
+  const status = String(tool.status || "")
+    .trim()
+    .toLowerCase();
+  return (
+    phase === "end" ||
+    ["completed", "done", "failed", "blocked", "canceled", "cancelled", "success", "succeeded"].includes(status)
+  );
+}
+
+function mergePlainCommandIntoEntry(
+  entry: AgentActivityEntry,
+  command: AgentActivityCommand,
+  message: IMMessage,
+): void {
+  const normalizedCommand = normalizeCommandText(command.command);
+  const output = firstNonEmpty(command.output);
+  if (entry.activity?.content.msgtype === AgentActivityMsgTypes.tool && entry.activity.content.tool) {
+    const tool = entry.activity.content.tool;
+    entry.activity = {
+      ...entry.activity,
+      content: {
+        ...entry.activity.content,
+        body: firstNonEmpty(output, entry.activity.content.body),
+        tool: {
+          ...tool,
+          command: firstNonEmpty(tool.command, normalizedCommand),
+          output: output || tool.output,
+          output_summary: firstNonEmpty(output, tool.output_summary),
+          phase: output ? "end" : tool.phase,
+          status: output ? "completed" : tool.status,
+        },
+      },
+    };
+    if (output) {
+      entry.message = message;
+    }
+    return;
+  }
+  if (entry.command) {
+    entry.command = {
+      ...entry.command,
+      command: firstNonEmpty(entry.command.command, normalizedCommand),
+      output: firstNonEmpty(output, entry.command.output) || undefined,
+    };
+    if (output) {
+      entry.message = message;
+    }
+  }
+}
+
+function activityToolSemanticCommandKey(tool: AgentActivityTool, message: IMMessage): string {
+  return openClawRequestCommandMergeKey(message, activityToolCommandForMerge(tool));
+}
+
+function activityToolCommandForMerge(tool: AgentActivityTool): string {
+  const kind = normalizeCommandSignature(tool.kind || "");
+  return normalizeCommandText(
+    firstNonEmpty(
+      summaryValue(tool.input_summary, "command", "cmd"),
+      summaryValue(tool.input, "command", "cmd"),
+      summaryText(tool.input_summary),
+      summaryText(tool.input),
+      tool.command,
+      toolTitleCommandForMerge(tool.title, kind),
+    ),
+  );
+}
+
+function toolTitleCommandForMerge(title: string, kind: string): string {
+  const text = title.trim();
+  if (!text) {
+    return "";
+  }
+  if ((kind === "command" || kind === "exec" || kind === "bash") && text.toLowerCase().startsWith(`${kind} `)) {
+    return text.slice(kind.length + 1).trim();
+  }
+  return /^command\s+/i.test(text) ? text : "";
+}
+
+function parseActivityCommand(message: IMMessage): AgentActivityCommand | null {
+  const command = parseMessageActivityCommand(message) ?? parsePlainOpenClawProgressCommand(message.content);
+  return command ? normalizeActivityCommand(command) : null;
+}
+
+function parsePlainOpenClawProgressCommand(content: unknown): AgentActivityCommand | null {
+  if (typeof content !== "string" || !isOpenClawProgressMarker(content)) {
+    return null;
+  }
+  return parsePlainAgentCommand(content);
+}
+
+function isOpenClawProgressMarker(content: string): boolean {
+  return /^(?:🛠️?|🔎|📄|📖|🧠|✍️?|🩹|📩)\s*/u.test(content.replace(/\u200b/g, "").trim());
+}
+
+function normalizeActivityCommand(command: AgentActivityCommand): AgentActivityCommand {
+  const normalizedCommand = normalizeCommandText(command.command);
+  if (normalizedCommand === command.command) {
+    return command;
+  }
+  return {
+    ...command,
+    command: normalizedCommand,
+    signature: command.signature.startsWith("openclaw-tool:")
+      ? command.signature
+      : normalizeCommandSignature(normalizedCommand),
+    title: commandTitleFromText(normalizedCommand),
+  };
+}
+
+function isDuplicateCommandStart(
+  entry: AgentActivityEntry,
+  command: AgentActivityCommand,
+  message: IMMessage,
+): boolean {
+  if (!entry.command || entry.command.output || command.output) {
+    return false;
+  }
+  if (activityCommandMergeKey(entry.command) !== activityCommandMergeKey(command)) {
+    return false;
+  }
+  const entryRequestID = openClawRequestID(entry.message);
+  const messageRequestID = openClawRequestID(message);
+  if (entryRequestID && messageRequestID) {
+    return entryRequestID === messageRequestID;
+  }
+  return Math.abs(activityTime(entry.createdAt) - activityTime(message.created_at || "")) <= duplicateCommandWindowMs;
+}
+
+function activityCommandMergeKey(command: AgentActivityCommand): string {
+  return command.signature.startsWith("openclaw-tool:")
+    ? normalizeCommandSignature(command.command)
+    : normalizeCommandSignature(command.signature || command.command);
+}
+
+function normalizeCommandText(command: string): string {
+  return command.replace(/^command\s+(.+)$/i, "$1").trim();
+}
+
+function normalizeCommandSignature(command: string): string {
+  return normalizeCommandText(command).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function pendingCommandMatchIndex(pending: readonly AgentActivityEntry[], message: IMMessage): number {
+  if (pending.length === 0) {
+    return -1;
+  }
+  const messageRequestID = openClawRequestID(message);
+  if (messageRequestID) {
+    const requestIndex = pending.findIndex((entry) => openClawRequestID(entry.message) === messageRequestID);
+    if (requestIndex >= 0) {
+      return requestIndex;
+    }
+  }
+  return 0;
+}
+
+function openClawRequestCommandMergeKey(message: IMMessage, command: string): string {
+  const requestID = openClawRequestID(message);
+  const commandKey = normalizeCommandSignature(command);
+  return requestID && commandKey ? `openclaw-request:${requestID}:command:${commandKey}` : "";
+}
+
+function openClawRequestID(message: IMMessage | null | undefined): string {
+  const metadata = isRecord(message?.metadata) ? message.metadata : undefined;
+  const openclaw = isRecord(metadata?.openclaw) ? metadata.openclaw : undefined;
+  const deliveryInfo = isRecord(openclaw?.delivery_info)
+    ? openclaw.delivery_info
+    : isRecord(openclaw?.deliveryInfo)
+      ? openclaw.deliveryInfo
+      : undefined;
+  return firstNonEmpty(
+    openclaw?.request_id,
+    openclaw?.requestId,
+    openclaw?.source_message_id,
+    openclaw?.sourceMessageId,
+    deliveryInfo?.request_id,
+    deliveryInfo?.requestId,
+  );
+}
+
+function commandTitleFromText(command: string): string {
+  const colon = command.indexOf(":");
+  if (colon > 0 && colon <= 32) {
+    return command.slice(0, colon).trim();
+  }
+  const words = command.split(/\s+/).slice(0, 2).join(" ").trim();
+  return words || AgentActivityKinds.execCommand;
 }
 
 function activityKind(activity: AgentActivityPayload | null): AgentActivityKind {
@@ -808,15 +1312,7 @@ function activityRowView(entry: AgentActivityEntry, t: TranslateFn) {
   if (activity?.content.msgtype === AgentActivityMsgTypes.action) {
     return {
       defaultExpanded: false,
-      detail: (
-        <MessageContent
-          content={entry.message.content}
-          message={entry.message}
-          actionBusy=""
-          actionError={{ key: "", message: "" }}
-          onAction={() => undefined}
-        />
-      ),
+      detail: <ActivityMessageDetail message={entry.message} t={t} />,
       label: AgentActivityKinds.other,
       summary: activity.content.action
         ? `${activity.content.action.title} · ${statusLabel(activity.content.action.status)}`
@@ -835,9 +1331,13 @@ function activityRowView(entry: AgentActivityEntry, t: TranslateFn) {
     };
   }
 
+  const messageText = String(entry.message.content || "")
+    .replace(/\u200b/g, "")
+    .trim();
+
   return {
     defaultExpanded: false,
-    detail: null,
+    detail: messageText ? <ActivityMessageDetail message={entry.message} t={t} /> : null,
     label: AgentActivityKinds.message,
     summary: summarizeReply(entry.message.content),
     tone: AgentActivityKinds.message,
@@ -902,11 +1402,29 @@ function PlainDetail({ value }: { value: string }) {
   return <pre className="agent-activity-plain-detail">{value}</pre>;
 }
 
+function ActivityMessageDetail({ message, t }: { message: IMMessage; t: TranslateFn }) {
+  return (
+    <MessageContent
+      content={message.content}
+      message={message}
+      actionBusy=""
+      actionError={{ key: "", message: "" }}
+      onAction={() => undefined}
+      t={t}
+    />
+  );
+}
+
 function toolCommandSummary(tool: AgentActivityTool): string {
-  return firstNonEmpty(
-    tool.command,
-    summaryValue(tool.input_summary, "command", "cmd"),
-    summaryValue(tool.input, "command", "cmd"),
+  return normalizeCommandText(
+    firstNonEmpty(
+      summaryValue(tool.input_summary, "command", "cmd"),
+      summaryValue(tool.input, "command", "cmd"),
+      summaryText(tool.input_summary),
+      summaryText(tool.input),
+      tool.command,
+      toolTitleCommandForMerge(tool.title, normalizeCommandSignature(tool.kind || "")),
+    ),
   );
 }
 

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
@@ -745,6 +745,36 @@
   background: color-mix(in srgb, var(--panel-strong) 84%, black);
 }
 
+:root[data-theme="dark"] .agent-activity-timeline-segment.message {
+  background: color-mix(in oklab, var(--success-500) 30%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-timeline-segment.message.selected {
+  background: color-mix(in oklab, var(--success-400) 54%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-timeline-segment.exec_command {
+  background: color-mix(in oklab, var(--brand-500) 34%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-timeline-segment.exec_command.selected {
+  background: color-mix(in oklab, var(--brand-400) 58%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-timeline-segment.other {
+  background: color-mix(in oklab, var(--gray-400) 26%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-timeline-segment.other.selected {
+  background: color-mix(in oklab, var(--gray-300) 44%, var(--panel-soft));
+}
+
+:root[data-theme="dark"] .agent-activity-type-badge.message {
+  background: color-mix(in oklab, var(--success-600) 34%, var(--panel-soft));
+  color: color-mix(in oklab, var(--success-100) 88%, var(--text));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--success-400) 22%, transparent);
+}
+
 :root[data-theme="dark"] .agent-activity-type-badge.exec_command {
   background: color-mix(in oklab, var(--brand-600) 28%, transparent);
   color: color-mix(in oklab, var(--brand-300) 92%, var(--text));
@@ -753,6 +783,20 @@
 :root[data-theme="dark"] .agent-activity-type-badge.other {
   background: color-mix(in srgb, var(--gray-300) 16%, transparent);
   color: color-mix(in oklab, var(--muted) 70%, var(--text));
+}
+
+:root[data-theme="dark"] .agent-activity-row-summary {
+  color: color-mix(in oklab, var(--text) 78%, var(--muted));
+}
+
+:root[data-theme="dark"] .agent-activity-row-chevron {
+  color: color-mix(in oklab, var(--muted) 82%, var(--text));
+}
+
+:root[data-theme="dark"] .agent-activity-row-room,
+:root[data-theme="dark"] .agent-activity-row-seq,
+:root[data-theme="dark"] .agent-activity-row-time {
+  color: color-mix(in oklab, var(--muted) 82%, var(--text));
 }
 
 :root[data-theme="dark"] .agent-activity-tool-section + .agent-activity-tool-section {

--- a/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
+++ b/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
@@ -215,6 +215,7 @@ export function ConversationPane({
         logAgent={logAgent}
         logModalOpen={logModalOpen}
         selectedMessageCount={selectedMessageCount}
+        selectedVisibleMessageCount={visibleMessages.length}
         showChannelTools={showChannelTools}
         showInviteAction={true}
         showMemberListAction={false}

--- a/web/app/src/pages/WorkspacePage/components/FloatingChat/FloatingChatPanel.tsx
+++ b/web/app/src/pages/WorkspacePage/components/FloatingChat/FloatingChatPanel.tsx
@@ -203,6 +203,7 @@ export function FloatingChatPanel({ agentName, chatProps, headerAccessory, onPic
         logModalOpen={logModalOpen}
         memberMenuRef={memberMenuRef}
         selectedMessageCount={selectedMessageCount}
+        selectedVisibleMessageCount={floatingVisibleMessages.length}
         showChannelTools={showChannelTools}
         showInviteAction={false}
         showMemberList={showMemberList}

--- a/web/app/tests/components/AgentActivityPanel.test.tsx
+++ b/web/app/tests/components/AgentActivityPanel.test.tsx
@@ -1,9 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { AgentActivityPanel } from "@/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel";
 import { AgentActivityMsgTypes, CSGCLAW_AGENT_ACTIVITY_TYPE } from "@/shared/constants/messages";
+import type { IMServerEvent } from "@/models/conversations";
+
+const subscribeIMEventsMock = vi.fn();
+
+vi.mock("@/shared/realtime/imEvents", () => ({
+  subscribeIMEvents: (handler: (payload: IMServerEvent) => void) => subscribeIMEventsMock(handler),
+}));
 
 const labels: Record<string, string> = {
   agentActivityAction: "Action",
@@ -49,11 +56,18 @@ function renderWithClient(ui: ReactElement) {
       queries: { retry: false },
     },
   });
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  const result = render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return {
+    ...result,
+    queryClient,
+    rerenderWithClient: (nextUI: ReactElement) =>
+      result.rerender(<QueryClientProvider client={queryClient}>{nextUI}</QueryClientProvider>),
+  };
 }
 
 describe("AgentActivityPanel", () => {
   afterEach(() => {
+    subscribeIMEventsMock.mockReset();
     vi.unstubAllGlobals();
   });
 
@@ -181,6 +195,266 @@ describe("AgentActivityPanel", () => {
     await user.click(screen.getByRole("button", { name: /ls web\/app/ }));
     expect(screen.getByText(/src/)).toBeInTheDocument();
     expect(screen.getByText(/tests/)).toBeInTheDocument();
+  });
+
+  it("allows message rows to expand and show the full message", async () => {
+    const user = userEvent.setup();
+    const fullMessage = [
+      "有进展了！项目目录里已经有之前的开发成果：已有文件 index.html、TEST_REPORT.md、tasks.json。",
+      "dev 正在继续开发，qa 等待测试，manager 会持续同步项目状态。",
+      "这段内容用于确认活动记录中的普通 message 也可以通过左侧展开按钮查看完整正文。",
+      "补充上下文：开发任务、测试任务、房间同步、文件状态和后续安排都会被折叠到活动记录摘要里。",
+      "补充上下文：这部分只是为了让摘要长度超过单行预览阈值，避免尾部内容直接出现在列表中。",
+      "最后一段：需要打开完整消息才能看到。",
+    ].join(" ");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: "reply-long",
+            sender_id: "manager",
+            created_at: "2026-07-01T10:00:00Z",
+            content: fullMessage,
+          },
+        ]),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(
+      <AgentActivityPanel
+        item={{
+          id: "agent-manager",
+          name: "manager",
+          role: "manager",
+          participants: [{ channel: "csgclaw", channel_user_ref: "manager", id: "manager" }],
+        }}
+        locale="zh-CN"
+        rooms={[
+          {
+            id: "room-1",
+            title: "Dev group",
+            members: ["manager", "u-admin"],
+            messages: [{ id: "root", sender_id: "u-admin", content: "please inspect" }],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    expect(await screen.findByText("message")).toBeInTheDocument();
+    expect(screen.queryByText(/最后一段/)).not.toBeInTheDocument();
+
+    const row = screen.getByRole("listitem");
+    const expandButton = within(row).getByRole("button", { name: /有进展了/ });
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(expandButton);
+
+    expect(expandButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/最后一段：需要打开完整消息才能看到。/)).toBeInTheDocument();
+  });
+
+  it("does not refetch full room history when the latest room message changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify([]), { headers: { "Content-Type": "application/json" }, status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const item = {
+      id: "agent-manager",
+      name: "manager",
+      role: "manager",
+      participants: [{ channel: "csgclaw", channel_user_ref: "manager", id: "manager" }],
+    };
+    const baseRoom = {
+      id: "room-1",
+      title: "Dev group",
+      members: ["manager", "u-admin"],
+      messages: [{ id: "root", sender_id: "u-admin", content: "please inspect" }],
+    };
+    const view = renderWithClient(<AgentActivityPanel item={item} locale="en" rooms={[baseRoom]} t={t} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    view.rerenderWithClient(
+      <AgentActivityPanel
+        item={item}
+        locale="en"
+        rooms={[
+          {
+            ...baseRoom,
+            messages: [
+              ...baseRoom.messages,
+              {
+                id: "user-latest",
+                sender_id: "u-admin",
+                created_at: "2026-07-01T10:00:01Z",
+                content: "Any update?",
+              },
+            ],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("merges a new agent room message into the activity cache without refetching", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify([]), { headers: { "Content-Type": "application/json" }, status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const item = {
+      id: "agent-manager",
+      name: "manager",
+      role: "manager",
+      participants: [{ channel: "csgclaw", channel_user_ref: "manager", id: "manager" }],
+    };
+    const baseRoom = {
+      id: "room-1",
+      title: "Dev group",
+      members: ["manager", "u-admin"],
+      messages: [{ id: "root", sender_id: "u-admin", content: "please inspect" }],
+    };
+    const view = renderWithClient(<AgentActivityPanel item={item} locale="en" rooms={[baseRoom]} t={t} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    view.rerenderWithClient(
+      <AgentActivityPanel
+        item={item}
+        locale="en"
+        rooms={[
+          {
+            ...baseRoom,
+            messages: [
+              ...baseRoom.messages,
+              {
+                id: "agent-live",
+                sender_id: "manager",
+                created_at: "2026-07-01T10:00:02Z",
+                content: "Live activity arrived.",
+              },
+            ],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    expect(await screen.findByText("Live activity arrived.")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates an agent message seen in both history and realtime room state", async () => {
+    const historyMessage = {
+      id: "reply-1",
+      sender_id: "manager",
+      created_at: "2026-07-01T10:00:00Z",
+      content: "Already loaded from history.",
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([historyMessage]), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const item = {
+      id: "agent-manager",
+      name: "manager",
+      role: "manager",
+      participants: [{ channel: "csgclaw", channel_user_ref: "manager", id: "manager" }],
+    };
+    const baseRoom = {
+      id: "room-1",
+      title: "Dev group",
+      members: ["manager", "u-admin"],
+      messages: [{ id: "root", sender_id: "u-admin", content: "please inspect" }],
+    };
+    const view = renderWithClient(<AgentActivityPanel item={item} locale="en" rooms={[baseRoom]} t={t} />);
+
+    expect(await screen.findByText("Already loaded from history.")).toBeInTheDocument();
+
+    view.rerenderWithClient(
+      <AgentActivityPanel
+        item={item}
+        locale="en"
+        rooms={[{ ...baseRoom, messages: [...baseRoom.messages, historyMessage] }]}
+        t={t}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(1));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges thread reply SSE messages without refetching full room history", async () => {
+    let eventHandler: ((payload: IMServerEvent) => void) | null = null;
+    subscribeIMEventsMock.mockImplementation((handler: (payload: IMServerEvent) => void) => {
+      eventHandler = handler;
+      return () => {
+        eventHandler = null;
+      };
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify([]), { headers: { "Content-Type": "application/json" }, status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(
+      <AgentActivityPanel
+        item={{
+          id: "agent-manager",
+          name: "manager",
+          role: "manager",
+          participants: [{ channel: "csgclaw", channel_user_ref: "manager", id: "manager" }],
+        }}
+        locale="en"
+        rooms={[
+          {
+            id: "room-1",
+            title: "Dev group",
+            members: ["manager", "u-admin"],
+            messages: [{ id: "root", sender_id: "u-admin", content: "please inspect" }],
+            threads: [{ root_message_id: "root" }],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(eventHandler).toBeTruthy();
+
+    act(() => {
+      eventHandler?.({
+        type: "message.created",
+        room_id: "room-1",
+        message: {
+          id: "thread-reply-1",
+          sender_id: "manager",
+          created_at: "2026-07-01T10:00:03Z",
+          content: "Thread reply activity.",
+          relates_to: { event_id: "root", rel_type: "m.thread" },
+        },
+      });
+    });
+
+    expect(await screen.findByText("Thread reply activity.")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("folds OpenClaw plain command output under the command row", async () => {
@@ -460,6 +734,250 @@ describe("AgentActivityPanel", () => {
     await user.click(screen.getByRole("button", { name: /run python3 inline script/ }));
     expect(screen.getByText("Result")).toBeInTheDocument();
     expect(screen.getByText("created issue")).toBeInTheDocument();
+  });
+
+  it("coalesces OpenClaw tool item, command item, and command output for one exec call", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: "tool-start",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:00Z",
+            content: JSON.stringify({
+              type: CSGCLAW_AGENT_ACTIVITY_TYPE,
+              channel: "openclaw",
+              sender: "openclaw",
+              content: {
+                msgtype: AgentActivityMsgTypes.tool,
+                body: "exec csgclaw-cli --version · running",
+                tool: {
+                  id: "tool:call-version",
+                  item_id: "tool:call-version",
+                  input_summary: "csgclaw-cli --version",
+                  kind: "exec",
+                  phase: "start",
+                  status: "running",
+                  title: "exec csgclaw-cli --version",
+                },
+              },
+            }),
+            metadata: { openclaw: { activity_kind: "item", delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "plain-command",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:00.500Z",
+            content: "🛠️ csgclaw-cli --version",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "command-end",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:01Z",
+            content: JSON.stringify({
+              type: CSGCLAW_AGENT_ACTIVITY_TYPE,
+              channel: "openclaw",
+              sender: "openclaw",
+              content: {
+                msgtype: AgentActivityMsgTypes.tool,
+                body: "csgclaw-cli available, version v0.3.16.",
+                tool: {
+                  id: "command:call-version",
+                  command: "command csgclaw-cli --version",
+                  item_id: "command:call-version",
+                  input_summary: "csgclaw-cli --version",
+                  kind: "exec",
+                  output_summary: "csgclaw-cli available, version v0.3.16.",
+                  phase: "end",
+                  status: "completed",
+                  title: "command csgclaw-cli --version",
+                },
+              },
+            }),
+            metadata: { openclaw: { activity_kind: "item", delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "command-output",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:02Z",
+            content: JSON.stringify({
+              type: CSGCLAW_AGENT_ACTIVITY_TYPE,
+              channel: "openclaw",
+              sender: "openclaw",
+              content: {
+                msgtype: AgentActivityMsgTypes.tool,
+                body: "csgclaw-cli available, version v0.3.16.",
+                tool: {
+                  id: "command:call-version",
+                  command: "command csgclaw-cli --version",
+                  item_id: "command:call-version",
+                  input_summary: "csgclaw-cli --version",
+                  tool_call_id: "call-version",
+                  kind: "exec",
+                  output: "csgclaw-cli available, version v0.3.16.",
+                  phase: "end",
+                  status: "completed",
+                  title: "command csgclaw-cli --version",
+                },
+              },
+            }),
+            metadata: { openclaw: { activity_kind: "command_output", delivery_kind: "tool", request_id: "msg-user" } },
+          },
+        ]),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(
+      <AgentActivityPanel
+        item={{
+          id: "agent-dev-openclaw",
+          name: "dev-openclaw",
+          role: "worker",
+          participants: [{ channel: "csgclaw", channel_user_ref: "dev-openclaw", id: "dev-openclaw" }],
+        }}
+        locale="zh-CN"
+        rooms={[
+          {
+            id: "room-dev-openclaw",
+            title: "dev-openclaw",
+            members: ["dev-openclaw", "admin"],
+            messages: [{ id: "root", sender_id: "admin", content: "运行一下 csgclaw cli" }],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    expect(await screen.findAllByText("exec_command")).toHaveLength(1);
+    expect(screen.getByText("1 events")).toBeInTheDocument();
+    expect(screen.getByText("csgclaw-cli --version")).toBeInTheDocument();
+    expect(screen.queryByText("command csgclaw-cli --version")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /csgclaw-cli --version/ }));
+
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("csgclaw-cli available, version v0.3.16.")).toBeInTheDocument();
+  });
+
+  it("deduplicates equivalent OpenClaw command wrapper lines for the same command", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: "help-wrapper",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:00Z",
+            content: "command csgclaw-cli --help",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "help-command",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:00Z",
+            content: "csgclaw-cli --help",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "version-wrapper",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:05Z",
+            content: "command csgclaw-cli --version",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "version-command",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:05Z",
+            content: "csgclaw-cli --version",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+        ]),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(
+      <AgentActivityPanel
+        item={{
+          id: "agent-dev-openclaw",
+          name: "dev-openclaw",
+          role: "worker",
+          participants: [{ channel: "csgclaw", channel_user_ref: "dev-openclaw", id: "dev-openclaw" }],
+        }}
+        locale="zh-CN"
+        rooms={[
+          {
+            id: "room-dev-openclaw",
+            title: "dev-openclaw",
+            members: ["dev-openclaw", "admin"],
+            messages: [{ id: "root", sender_id: "admin", content: "运行一下 csgclaw cli" }],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    expect(await screen.findAllByText("exec_command")).toHaveLength(2);
+    expect(screen.getByText("2 events")).toBeInTheDocument();
+    expect(screen.getByText("csgclaw-cli --help")).toBeInTheDocument();
+    expect(screen.getByText("csgclaw-cli --version")).toBeInTheDocument();
+    expect(screen.queryByText("command csgclaw-cli --help")).not.toBeInTheDocument();
+    expect(screen.queryByText("command csgclaw-cli --version")).not.toBeInTheDocument();
+  });
+
+  it("deduplicates repeated OpenClaw command deliveries for the same request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: "version-start",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:00Z",
+            content: "csgclaw-cli --version",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+          {
+            id: "version-repeat",
+            sender_id: "dev-openclaw",
+            created_at: "2026-07-01T10:00:04Z",
+            content: "csgclaw-cli --version",
+            metadata: { openclaw: { delivery_kind: "tool", request_id: "msg-user" } },
+          },
+        ]),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithClient(
+      <AgentActivityPanel
+        item={{
+          id: "agent-dev-openclaw",
+          name: "dev-openclaw",
+          role: "worker",
+          participants: [{ channel: "csgclaw", channel_user_ref: "dev-openclaw", id: "dev-openclaw" }],
+        }}
+        locale="zh-CN"
+        rooms={[
+          {
+            id: "room-dev-openclaw",
+            title: "dev-openclaw",
+            members: ["dev-openclaw", "admin"],
+            messages: [{ id: "root", sender_id: "admin", content: "运行一下 csgclaw cli" }],
+          },
+        ]}
+        t={t}
+      />,
+    );
+
+    expect(await screen.findAllByText("exec_command")).toHaveLength(1);
+    expect(screen.getByText("1 events")).toBeInTheDocument();
+    expect(screen.getByText("csgclaw-cli --version")).toBeInTheDocument();
   });
 
   it("shows OpenClaw progress lines as command activity instead of messages", async () => {

--- a/web/app/tests/components/ConversationPane.test.tsx
+++ b/web/app/tests/components/ConversationPane.test.tsx
@@ -120,6 +120,7 @@ function renderThreadPane({
   showToolCalls = false,
   mentionCandidates = [],
   mentionIndex = 0,
+  visibleMessages,
   memberActionBusyID = "",
   memberActionError = "",
   onClearMemberActionError = vi.fn(),
@@ -132,6 +133,7 @@ function renderThreadPane({
   conversationMembers?: IMUser[];
   isDirect?: boolean;
   messages?: IMConversation["messages"];
+  visibleMessages?: IMConversation["messages"];
   mentionCandidates?: IMUser[];
   mentionIndex?: number;
   onClearRoomMessages?: (id: string) => void;
@@ -242,7 +244,7 @@ function renderThreadPane({
         threadLoading={false}
         onThreadDraftChange={setThreadDraftSegments}
         usersById={usersByIdOverride}
-        visibleMessages={timelineMessages}
+        visibleMessages={visibleMessages ?? timelineMessages}
       />
     );
   }
@@ -251,6 +253,27 @@ function renderThreadPane({
 }
 
 describe("ConversationPane", () => {
+  it("shows visible and total message counts when some messages are filtered", () => {
+    const messages = [
+      {
+        content: "visible answer",
+        created_at: "2026-05-25T08:13:00Z",
+        id: "msg-visible",
+        sender_id: "u-manager",
+      },
+      {
+        content: toolActivityContent("hidden command"),
+        created_at: "2026-05-25T08:14:00Z",
+        id: "msg-hidden-tool",
+        sender_id: "u-manager",
+      },
+    ];
+
+    renderThreadPane({ messages, visibleMessages: [messages[0]] });
+
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+  });
+
   it("previews human message avatars on hover without opening details on click", async () => {
     const user = userEvent.setup();
     const onCancelProfilePreviewClose = vi.fn();


### PR DESCRIPTION
- This change improves the agent activity timeline by using multi-key, normalized merging (`item_id`, `id`, `tool_call_id`) so related command lifecycle/output messages are shown as one clean activity row instead of fragmented entries.
- It also updates conversation headers to show visible/total counts when messages are filtered and adds dark-theme polish to activity row/segment/badge styling for better readability.