### PR TITLE
fix(web): dedupe model provider check error

### DIFF
--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateModelProviderModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateModelProviderModal.tsx
@@ -208,7 +208,7 @@ export function CreateModelProviderModal({
         : checkState === "empty"
           ? t("modelProviderCheckEmpty")
           : checkState === "error"
-            ? autoCheckWarning || t("modelProviderCheckFailed")
+            ? ""
             : t("modelProviderNotChecked");
 
   return (
@@ -321,10 +321,12 @@ export function CreateModelProviderModal({
                 </label>
                 {onCheckAccess ? (
                   <div className="field create-model-provider-span-2">
-                    <div className="create-model-provider-check-row">
-                      <Button variant="secondaryGray" size="sm" disabled={checkDisabled} onClick={handleCheckAccess}>
-                        {autoCheckBusy ? t("profileLoadingModels") : t("modelProviderCheck")}
-                      </Button>
+                    <div className="create-model-provider-check-block">
+                      <div className="create-model-provider-check-row">
+                        <Button variant="secondaryGray" size="sm" disabled={checkDisabled} onClick={handleCheckAccess}>
+                          {autoCheckBusy ? t("profileLoadingModels") : t("modelProviderCheck")}
+                        </Button>
+                      </div>
                       {autoCheckMessage ? (
                         <span className="create-model-provider-check-status success">{autoCheckMessage}</span>
                       ) : null}
@@ -346,11 +348,9 @@ export function CreateModelProviderModal({
                     models={modelList}
                     searchLabel={t("modelProviderModelSearch")}
                   />
-                  <small
-                    className={`field-hint create-model-provider-model-status ${checkState === "error" ? "warning" : ""}`.trim()}
-                  >
-                    {modelStatusHint}
-                  </small>
+                  {modelStatusHint ? (
+                    <small className="field-hint create-model-provider-model-status">{modelStatusHint}</small>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -145,6 +145,12 @@
   box-shadow: none;
 }
 
+.create-model-provider-check-block {
+  display: grid;
+  justify-items: start;
+  gap: 6px;
+}
+
 .create-model-provider-check-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Consolidate the add-model-provider check failure message so it only appears below the check button
- Remove the duplicate check error display below the model list
- Adjust the check feedback layout to keep the button and result message visually clear