### PR TITLE
fix(web): make tooltip usage explicit

### DIFF
--- a/web/app/src/bootstrap/AppProviders.tsx
+++ b/web/app/src/bootstrap/AppProviders.tsx
@@ -1,13 +1,16 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { GlobalScrollbarController } from "@/bootstrap/GlobalScrollbarController";
+import { TooltipProvider } from "@/components/ui";
 import { queryClient } from "@/bootstrap/queryClient";
 
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
-      <GlobalScrollbarController />
-      {children}
+      <TooltipProvider>
+        <GlobalScrollbarController />
+        {children}
+      </TooltipProvider>
     </QueryClientProvider>
   );
 }

--- a/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
@@ -54,17 +54,18 @@ function AttachmentDraftItem({
         <span className="attachment-name truncate">{draft.name}</span>
         <span className="attachment-size">{formatAttachmentSize(draft.sizeBytes)}</span>
       </span>
-      <Button
-        aria-label={t("removeAttachment")}
-        className="attachment-remove-button"
-        iconOnly
-        size="sm"
-        title={t("removeAttachment")}
-        variant="tertiaryGray"
-        onClick={() => onRemove(draft.id)}
-      >
-        <X aria-hidden="true" size={14} />
-      </Button>
+      <Tooltip content={t("removeAttachment")}>
+        <Button
+          aria-label={t("removeAttachment")}
+          className="attachment-remove-button"
+          iconOnly
+          size="sm"
+          variant="tertiaryGray"
+          onClick={() => onRemove(draft.id)}
+        >
+          <X aria-hidden="true" size={14} />
+        </Button>
+      </Tooltip>
     </div>
   );
 }

--- a/web/app/src/components/business/ConversationPane/ConversationComposer.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationComposer.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useRef } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, RefObject } from "react";
 import { ArrowUp, Paperclip, Plus } from "lucide-react";
 import { CLIProxyAuthControl } from "@/components/business/ProfileControls";
-import { Button, PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger } from "@/components/ui";
+import { Button, PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger, Tooltip } from "@/components/ui";
 import { IconImage } from "@/components/ui/Icons";
 import type { CLIProxyAuthStatusMap } from "@/hooks/workspace/useCLIProxyAuthStatuses";
 import type { AgentProfileLike } from "@/models/agents";
@@ -225,18 +225,21 @@ export const ConversationComposer = memo(function ConversationComposer({
               event.currentTarget.value = "";
             }}
           />
-          <Button
-            variant="primary"
-            className="composer-send-button"
-            aria-label={t("send")}
-            title={t("send")}
-            disabled={sendDisabled}
-            iconOnly
-            size="lg"
-            onClick={onSendMessage}
-          >
-            <ArrowUp aria-hidden="true" size={22} strokeWidth={2.25} />
-          </Button>
+          <Tooltip content={t("send")}>
+            <span>
+              <Button
+                variant="primary"
+                className="composer-send-button"
+                aria-label={t("send")}
+                disabled={sendDisabled}
+                iconOnly
+                size="lg"
+                onClick={onSendMessage}
+              >
+                <ArrowUp aria-hidden="true" size={22} strokeWidth={2.25} />
+              </Button>
+            </span>
+          </Tooltip>
         </div>
       </div>
       {composerError ? <div className="form-error composer-error">{composerError}</div> : null}
@@ -315,20 +318,23 @@ function ComposerAddMenu({
 
   return (
     <PopoverRoot>
-      <PopoverTrigger asChild>
-        <Button
-          aria-haspopup="dialog"
-          aria-label={t("composerAdd")}
-          className="composer-add-button"
-          disabled={disabled}
-          iconOnly
-          size="lg"
-          title={t("composerAdd")}
-          variant="tertiaryGray"
-        >
-          <Plus aria-hidden="true" size={24} strokeWidth={1.8} />
-        </Button>
-      </PopoverTrigger>
+      <Tooltip content={t("composerAdd")}>
+        <PopoverTrigger asChild>
+          <span>
+            <Button
+              aria-haspopup="dialog"
+              aria-label={t("composerAdd")}
+              className="composer-add-button"
+              disabled={disabled}
+              iconOnly
+              size="lg"
+              variant="tertiaryGray"
+            >
+              <Plus aria-hidden="true" size={24} strokeWidth={1.8} />
+            </Button>
+          </span>
+        </PopoverTrigger>
+      </Tooltip>
       <PopoverContent aria-label={t("composerAdd")} className="composer-add-popover" role="dialog" side="top">
         <section className="composer-add-section" aria-label={t("composerAdd")}>
           <div className="composer-add-section-label">{t("composerAdd")}</div>

--- a/web/app/src/components/business/ConversationPane/ConversationDialogs.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationDialogs.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogRoot,
   DialogTitle,
+  Tooltip,
 } from "@/components/ui";
 import type { TranslateFn } from "@/models/conversations";
 import type { VoidOrPromise } from "./types";
@@ -103,18 +104,21 @@ export function ConversationAgentLogsDialog({
             <DialogDescription>{agentName}</DialogDescription>
           </div>
           <div className="agent-logs-header-actions">
-            <Button
-              className="icon-button agent-logs-refresh"
-              aria-label={t("refreshLogs")}
-              title={t("refreshLogs")}
-              loading={loading}
-              loadingLabel={t("agentLogsLoading")}
-              onClick={onRefresh}
-            >
-              <span className="icon-button-mark" aria-hidden="true">
-                <RefreshCw size={18} strokeWidth={2} />
+            <Tooltip content={t("refreshLogs")}>
+              <span>
+                <Button
+                  className="icon-button agent-logs-refresh"
+                  aria-label={t("refreshLogs")}
+                  loading={loading}
+                  loadingLabel={t("agentLogsLoading")}
+                  onClick={onRefresh}
+                >
+                  <span className="icon-button-mark" aria-hidden="true">
+                    <RefreshCw size={18} strokeWidth={2} />
+                  </span>
+                </Button>
               </span>
-            </Button>
+            </Tooltip>
             <DialogCloseButton className="icon-button" label={t("close")} />
           </div>
         </DialogHeader>

--- a/web/app/src/components/business/ConversationPane/ConversationHeader.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationHeader.tsx
@@ -84,22 +84,23 @@ export const ConversationHeader = memo(function ConversationHeader({
               <div className="chat-title truncate">{conversation.title}</div>
               {showMemberListAction ? (
                 <div ref={memberMenuRef} className="header-menu">
-                  <Button
-                    className="member-badge-button"
-                    active={showMemberList}
-                    aria-label={t("membersTitle")}
-                    aria-pressed={showMemberList}
-                    title={t("membersTitle")}
-                    onClick={() => {
-                      onToggleMemberList?.((value) => !value);
-                      onToggleChannelTools(false);
-                    }}
-                  >
-                    <span className="icon-button-mark" aria-hidden="true">
-                      <UsersIcon />
-                    </span>
-                    <span className="member-badge-count">{conversationMembers.length}</span>
-                  </Button>
+                  <Tooltip content={t("membersTitle")}>
+                    <Button
+                      className="member-badge-button"
+                      active={showMemberList}
+                      aria-label={t("membersTitle")}
+                      aria-pressed={showMemberList}
+                      onClick={() => {
+                        onToggleMemberList?.((value) => !value);
+                        onToggleChannelTools(false);
+                      }}
+                    >
+                      <span className="icon-button-mark" aria-hidden="true">
+                        <UsersIcon />
+                      </span>
+                      <span className="member-badge-count">{conversationMembers.length}</span>
+                    </Button>
+                  </Tooltip>
                   {showMemberList ? (
                     <div className="header-popover members-popover">
                       <div className="header-popover-title">{t("membersTitle")}</div>

--- a/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Paperclip, X } from "lucide-react";
 import { AgentAvatarContent } from "@/components/business/AgentAvatar";
 import { MessageContent, MessagePreviewText } from "@/components/business/MessageContent";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 import { IconImage } from "@/components/ui/Icons";
 import { resolveAgentAvatarFallback, type AgentLike } from "@/models/agents";
 import type { AttachmentDraft } from "@/models/attachments";
@@ -272,11 +272,13 @@ export function ConversationThreadPanel({
             )}
           </div>
         </div>
-        <Button className="icon-button" aria-label={t("close")} title={t("close")} onClick={onClose}>
-          <span className="icon-button-mark" aria-hidden="true">
-            <X size={18} strokeWidth={2} />
-          </span>
-        </Button>
+        <Tooltip content={t("close")}>
+          <Button className="icon-button" aria-label={t("close")} onClick={onClose}>
+            <span className="icon-button-mark" aria-hidden="true">
+              <X size={18} strokeWidth={2} />
+            </span>
+          </Button>
+        </Tooltip>
       </div>
       <div ref={threadBodyRef} className="thread-panel-body">
         {loading && !root ? <div className="thread-empty">{t("loading")}</div> : null}
@@ -476,17 +478,20 @@ export function ConversationThreadPanel({
             event.currentTarget.value = "";
           }}
         />
-        <Button
-          className="thread-attach-button"
-          aria-label={t("addAttachment")}
-          title={t("addAttachment")}
-          disabled={disabled}
-          iconOnly
-          variant="tertiaryGray"
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Paperclip aria-hidden="true" size={18} />
-        </Button>
+        <Tooltip content={t("addAttachment")}>
+          <span>
+            <Button
+              className="thread-attach-button"
+              aria-label={t("addAttachment")}
+              disabled={disabled}
+              iconOnly
+              variant="tertiaryGray"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Paperclip aria-hidden="true" size={18} />
+            </Button>
+          </span>
+        </Tooltip>
         <Button
           variant="primary"
           className="thread-send-button"

--- a/web/app/src/components/business/ProfileControls/EnvKeyValueEditor.tsx
+++ b/web/app/src/components/business/ProfileControls/EnvKeyValueEditor.tsx
@@ -1,4 +1,4 @@
-import { Button, TextInput } from "@/components/ui";
+import { Button, TextInput, Tooltip } from "@/components/ui";
 import { classNames } from "@/shared/lib/classNames";
 import type { EnvKeyValueRow, Translator } from "./types";
 
@@ -42,16 +42,19 @@ export function EnvKeyValueEditor({ rows = [], t, onChange }: EnvKeyValueEditorP
             aria-required={row.required ? "true" : undefined}
             onInput={(event) => update(index, { value: event.currentTarget.value })}
           />
-          <Button
-            variant="ghost"
-            className="env-remove-button"
-            aria-label={t("profileEnvRemove")}
-            title={t("profileEnvRemove")}
-            disabled={row.required}
-            onClick={() => remove(index)}
-          >
-            ×
-          </Button>
+          <Tooltip content={t("profileEnvRemove")}>
+            <span>
+              <Button
+                variant="ghost"
+                className="env-remove-button"
+                aria-label={t("profileEnvRemove")}
+                disabled={row.required}
+                onClick={() => remove(index)}
+              >
+                ×
+              </Button>
+            </span>
+          </Tooltip>
         </div>
       ))}
       <Button className="secondary-button env-add-button" onClick={() => onChange([...items, { key: "", value: "" }])}>

--- a/web/app/src/components/business/WorkspaceFileTree/WorkspaceFilePreview.tsx
+++ b/web/app/src/components/business/WorkspaceFileTree/WorkspaceFilePreview.tsx
@@ -86,17 +86,18 @@ export function WorkspaceFilePreview({
             <div className="workspace-preview-file-actions">
               <span className="workspace-preview-file-meta">{fileMeta}</span>
               {!file.binary ? (
-                <Button
-                  iconOnly
-                  aria-label={previewText}
-                  title={previewText}
-                  className="workspace-preview-open-button"
-                  size="sm"
-                  variant="tertiaryGray"
-                  onClick={() => setDialogOpen(true)}
-                >
-                  <FileSearch size={16} strokeWidth={2} aria-hidden="true" />
-                </Button>
+                <Tooltip content={previewText}>
+                  <Button
+                    iconOnly
+                    aria-label={previewText}
+                    className="workspace-preview-open-button"
+                    size="sm"
+                    variant="tertiaryGray"
+                    onClick={() => setDialogOpen(true)}
+                  >
+                    <FileSearch size={16} strokeWidth={2} aria-hidden="true" />
+                  </Button>
+                </Tooltip>
               ) : null}
             </div>
           </div>
@@ -118,30 +119,32 @@ export function WorkspaceFilePreview({
                   <div className="workspace-preview-dialog-actions">
                     {markdownFile ? (
                       <div className="workspace-preview-mode-switch" role="tablist" aria-label={viewToggleLabel}>
-                        <Button
-                          role="tab"
-                          aria-selected={activeDialogMode === "preview"}
-                          active={activeDialogMode === "preview"}
-                          className="workspace-preview-mode-button"
-                          size="sm"
-                          title={previewText}
-                          variant="tertiaryGray"
-                          onClick={() => setDialogMode("preview")}
-                        >
-                          {previewText}
-                        </Button>
-                        <Button
-                          role="tab"
-                          aria-selected={activeDialogMode === "code"}
-                          active={activeDialogMode === "code"}
-                          className="workspace-preview-mode-button"
-                          size="sm"
-                          title={codeText}
-                          variant="tertiaryGray"
-                          onClick={() => setDialogMode("code")}
-                        >
-                          {codeText}
-                        </Button>
+                        <Tooltip content={previewText}>
+                          <Button
+                            role="tab"
+                            aria-selected={activeDialogMode === "preview"}
+                            active={activeDialogMode === "preview"}
+                            className="workspace-preview-mode-button"
+                            size="sm"
+                            variant="tertiaryGray"
+                            onClick={() => setDialogMode("preview")}
+                          >
+                            {previewText}
+                          </Button>
+                        </Tooltip>
+                        <Tooltip content={codeText}>
+                          <Button
+                            role="tab"
+                            aria-selected={activeDialogMode === "code"}
+                            active={activeDialogMode === "code"}
+                            className="workspace-preview-mode-button"
+                            size="sm"
+                            variant="tertiaryGray"
+                            onClick={() => setDialogMode("code")}
+                          >
+                            {codeText}
+                          </Button>
+                        </Tooltip>
                       </div>
                     ) : null}
                     <Tooltip content={closeText}>

--- a/web/app/src/components/ui/Button/Button.tsx
+++ b/web/app/src/components/ui/Button/Button.tsx
@@ -1,7 +1,6 @@
 import { forwardRef } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { classNames } from "@/shared/lib/classNames";
-import { Tooltip } from "../Tooltip";
 
 export type ButtonVariant =
   | "primary"
@@ -62,7 +61,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     loading = false,
     loadingLabel,
     size = "md",
-    title,
     type = "button",
     variant = "secondaryGray",
     "aria-busy": ariaBusy,
@@ -75,7 +73,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const childAccessibleLabel =
     typeof children === "string" || typeof children === "number" ? String(children) : undefined;
 
-  const button = (
+  return (
     <button
       ref={ref}
       type={type}
@@ -101,8 +99,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       ) : null}
     </button>
   );
-
-  return title ? <Tooltip content={title}>{button}</Tooltip> : button;
 });
 
 export type IconButtonProps = Omit<ButtonProps, "aria-label" | "children" | "iconOnly"> & {
@@ -112,11 +108,11 @@ export type IconButtonProps = Omit<ButtonProps, "aria-label" | "children" | "ico
 };
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
-  { icon, label, markClassName, title = label, ...props },
+  { icon, label, markClassName, ...props },
   ref,
 ) {
   return (
-    <Button ref={ref} iconOnly aria-label={label} title={title} {...props}>
+    <Button ref={ref} iconOnly aria-label={label} {...props}>
       <span className={markClassName} aria-hidden="true">
         {icon}
       </span>

--- a/web/app/src/components/ui/Dialog/Dialog.tsx
+++ b/web/app/src/components/ui/Dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 import { forwardRef } from "react";
 import type { ComponentPropsWithoutRef, ComponentRef, HTMLAttributes } from "react";
 import { Button } from "@/components/ui/Button";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { classNames } from "@/shared/lib/classNames";
 
 export type DialogRootProps = ComponentPropsWithoutRef<typeof RadixDialog.Root>;
@@ -108,22 +109,18 @@ export type DialogCloseButtonProps = Omit<ComponentPropsWithoutRef<typeof Button
 };
 
 export const DialogCloseButton = forwardRef<HTMLButtonElement, DialogCloseButtonProps>(function DialogCloseButton(
-  { className, label, title = label, ...props },
+  { className, label, title, ...props },
   ref,
 ) {
-  return (
+  const button = (
     <DialogClose asChild>
-      <Button
-        ref={ref}
-        className={classNames("csg-dialog-close", className)}
-        aria-label={label}
-        title={title}
-        {...props}
-      >
+      <Button ref={ref} className={classNames("csg-dialog-close", className)} aria-label={label} {...props}>
         <span className="icon-button-mark" aria-hidden="true">
           <X size={18} strokeWidth={2} />
         </span>
       </Button>
     </DialogClose>
   );
+
+  return <Tooltip content={title ?? label}>{button}</Tooltip>;
 });

--- a/web/app/src/components/ui/Tooltip/Tooltip.tsx
+++ b/web/app/src/components/ui/Tooltip/Tooltip.tsx
@@ -5,12 +5,14 @@ import { classNames } from "@/shared/lib/classNames";
 
 export type TooltipRootProps = ComponentPropsWithoutRef<typeof RadixTooltip.Root>;
 
-export function TooltipRoot({ delayDuration = 250, ...props }: TooltipRootProps) {
-  return (
-    <RadixTooltip.Provider delayDuration={delayDuration}>
-      <RadixTooltip.Root {...props} />
-    </RadixTooltip.Provider>
-  );
+export type TooltipProviderProps = ComponentPropsWithoutRef<typeof RadixTooltip.Provider>;
+
+export function TooltipProvider({ delayDuration = 250, ...props }: TooltipProviderProps) {
+  return <RadixTooltip.Provider delayDuration={delayDuration} {...props} />;
+}
+
+export function TooltipRoot(props: TooltipRootProps) {
+  return <RadixTooltip.Root {...props} />;
 }
 
 export type TooltipTriggerProps = ComponentPropsWithoutRef<typeof RadixTooltip.Trigger>;

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentActivityPanel.tsx
@@ -1037,17 +1037,20 @@ function AgentActivityToolbar({
             ) : null}
           </DropdownMenuContent>
         </DropdownMenuRoot>
-        <Button
-          className="agent-activity-toolbar-refresh"
-          variant="secondaryGray"
-          size="sm"
-          disabled={refreshDisabled}
-          aria-label={t("agentActivityRefresh")}
-          title={t("agentActivityRefresh")}
-          onClick={onRefresh}
-        >
-          <RefreshCw aria-hidden="true" size={15} strokeWidth={2} />
-        </Button>
+        <Tooltip content={t("agentActivityRefresh")}>
+          <span>
+            <Button
+              className="agent-activity-toolbar-refresh"
+              variant="secondaryGray"
+              size="sm"
+              disabled={refreshDisabled}
+              aria-label={t("agentActivityRefresh")}
+              onClick={onRefresh}
+            >
+              <RefreshCw aria-hidden="true" size={15} strokeWidth={2} />
+            </Button>
+          </span>
+        </Tooltip>
       </div>
       {selectedFilterOptions.length ? (
         <div className="agent-activity-selected-filters" aria-label={t("agentActivitySelectedFiltersLabel")}>

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -78,6 +78,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Select,
+  Tooltip,
 } from "@/components/ui";
 import { AgentActivityPanel } from "./AgentActivityPanel";
 
@@ -1123,17 +1124,20 @@ function AgentMCPPanel({
               <span>{t("profileMCPServers")}</span>
               <small className="agent-section-count-badge">{servers.length}</small>
             </div>
-            <Button
-              className="agent-skill-add-button"
-              variant="secondaryGray"
-              size="sm"
-              aria-label={t("agentMCPAdd")}
-              title={t("agentMCPAdd")}
-              disabled={addBusy}
-              onClick={onOpenAddMCP}
-            >
-              <Plus aria-hidden="true" size={16} strokeWidth={2.2} />
-            </Button>
+            <Tooltip content={t("agentMCPAdd")}>
+              <span>
+                <Button
+                  className="agent-skill-add-button"
+                  variant="secondaryGray"
+                  size="sm"
+                  aria-label={t("agentMCPAdd")}
+                  disabled={addBusy}
+                  onClick={onOpenAddMCP}
+                >
+                  <Plus aria-hidden="true" size={16} strokeWidth={2.2} />
+                </Button>
+              </span>
+            </Tooltip>
           </div>
           {addError ? <div className="form-error">{addError}</div> : null}
           {deleteError ? <div className="form-error">{deleteError}</div> : null}
@@ -1147,17 +1151,20 @@ function AgentMCPPanel({
                       <Server aria-hidden="true" size={14} strokeWidth={2} />
                       <span>{server.name}</span>
                     </div>
-                    <Button
-                      className="agent-skill-icon-button"
-                      variant="outlineDanger"
-                      size="sm"
-                      aria-label={t("agentDeleteMCP")}
-                      title={t("agentDeleteMCP")}
-                      disabled={deleteBusy}
-                      onClick={() => onRequestDeleteMCP(server)}
-                    >
-                      <Trash2 aria-hidden="true" size={16} strokeWidth={1.9} />
-                    </Button>
+                    <Tooltip content={t("agentDeleteMCP")}>
+                      <span>
+                        <Button
+                          className="agent-skill-icon-button"
+                          variant="outlineDanger"
+                          size="sm"
+                          aria-label={t("agentDeleteMCP")}
+                          disabled={deleteBusy}
+                          onClick={() => onRequestDeleteMCP(server)}
+                        >
+                          <Trash2 aria-hidden="true" size={16} strokeWidth={1.9} />
+                        </Button>
+                      </span>
+                    </Tooltip>
                   </div>
                   <p className="agent-skill-description">{server.description || "-"}</p>
                 </article>
@@ -1403,17 +1410,20 @@ function AgentSkillsPanel({
               <span>{t("agentSkillsTitle")}</span>
               <small className="agent-section-count-badge">{skills.length}</small>
             </div>
-            <Button
-              className="agent-skill-add-button"
-              variant="secondaryGray"
-              size="sm"
-              aria-label={t("agentSkillAdd")}
-              title={t("agentSkillAdd")}
-              disabled={skillCandidatesLoading || skillAddBusy}
-              onClick={onOpenAddSkills}
-            >
-              <Plus aria-hidden="true" size={16} strokeWidth={2.2} />
-            </Button>
+            <Tooltip content={t("agentSkillAdd")}>
+              <span>
+                <Button
+                  className="agent-skill-add-button"
+                  variant="secondaryGray"
+                  size="sm"
+                  aria-label={t("agentSkillAdd")}
+                  disabled={skillCandidatesLoading || skillAddBusy}
+                  onClick={onOpenAddSkills}
+                >
+                  <Plus aria-hidden="true" size={16} strokeWidth={2.2} />
+                </Button>
+              </span>
+            </Tooltip>
           </div>
           {skillsError ? <div className="form-error">{skillsError}</div> : null}
           {skillAddError ? <div className="form-error">{skillAddError}</div> : null}
@@ -1426,17 +1436,20 @@ function AgentSkillsPanel({
                 <article key={skill.name} className="agent-skill-card">
                   <div className="agent-skill-card-header">
                     <div className="agent-skill-name">{skill.name}</div>
-                    <Button
-                      className="agent-skill-icon-button"
-                      variant="outlineDanger"
-                      size="sm"
-                      aria-label={t("agentDeleteSkill")}
-                      title={t("agentDeleteSkill")}
-                      disabled={skillDeleteBusy}
-                      onClick={() => onRequestDeleteSkill(skill)}
-                    >
-                      <Trash2 aria-hidden="true" size={16} strokeWidth={1.9} />
-                    </Button>
+                    <Tooltip content={t("agentDeleteSkill")}>
+                      <span>
+                        <Button
+                          className="agent-skill-icon-button"
+                          variant="outlineDanger"
+                          size="sm"
+                          aria-label={t("agentDeleteSkill")}
+                          disabled={skillDeleteBusy}
+                          onClick={() => onRequestDeleteSkill(skill)}
+                        >
+                          <Trash2 aria-hidden="true" size={16} strokeWidth={1.9} />
+                        </Button>
+                      </span>
+                    </Tooltip>
                   </div>
                   <p className="agent-skill-description">{skill.description || "-"}</p>
                 </article>

--- a/web/app/src/pages/AgentPage/components/AgentList/AgentList.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentList/AgentList.tsx
@@ -12,7 +12,7 @@ import {
   isNotificationBotAgent,
 } from "@/models/agents";
 import { AgentIcon, PlayIcon, StopIcon, TrashIcon, WrenchIcon } from "@/components/ui/Icons";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 import { AgentAvatarContent } from "@/components/business/AgentAvatar";
 import { avatarFallbackText } from "@/shared/avatar";
 import { providerNameForProviderID } from "@/models/modelProviders";
@@ -66,11 +66,13 @@ export function AgentSection({
             {title} {items.length}
           </div>
         </div>
-        <Button className="agent-add-button" aria-label={t("createAgent")} title={t("createAgent")} onClick={onCreate}>
-          <span aria-hidden="true">
-            <AgentIcon />
-          </span>
-        </Button>
+        <Tooltip content={t("createAgent")}>
+          <Button className="agent-add-button" aria-label={t("createAgent")} onClick={onCreate}>
+            <span aria-hidden="true">
+              <AgentIcon />
+            </span>
+          </Button>
+        </Tooltip>
       </div>
       <div className="agent-list">
         {items.length ? (
@@ -159,27 +161,27 @@ export function AgentRow({
         </div>
       </div>
       <div className="agent-actions">
-        <Button
-          className="agent-icon-button"
-          aria-label={t("editProfile")}
-          title={t("editProfile")}
-          onClick={() => onEdit(item)}
-        >
-          <span aria-hidden="true">
-            <WrenchIcon />
-          </span>
-        </Button>
+        <Tooltip content={t("editProfile")}>
+          <Button className="agent-icon-button" aria-label={t("editProfile")} onClick={() => onEdit(item)}>
+            <span aria-hidden="true">
+              <WrenchIcon />
+            </span>
+          </Button>
+        </Tooltip>
         {SHOW_AGENT_LIFECYCLE_ACTIONS ? (
           <>
-            <Button
-              className="agent-icon-button"
-              aria-label={running ? t("agentStop") : t("agentStart")}
-              title={running ? t("agentStop") : t("agentStart")}
-              disabled={busyKey.startsWith(busyPrefix) || incomplete}
-              onClick={() => (running ? onStop(item) : onStart(item))}
-            >
-              <span aria-hidden="true">{running ? <StopIcon /> : <PlayIcon />}</span>
-            </Button>
+            <Tooltip content={running ? t("agentStop") : t("agentStart")}>
+              <span>
+                <Button
+                  className="agent-icon-button"
+                  aria-label={running ? t("agentStop") : t("agentStart")}
+                  disabled={busyKey.startsWith(busyPrefix) || incomplete}
+                  onClick={() => (running ? onStop(item) : onStart(item))}
+                >
+                  <span aria-hidden="true">{running ? <StopIcon /> : <PlayIcon />}</span>
+                </Button>
+              </span>
+            </Tooltip>
           </>
         ) : null}
         {!isNotification ? (
@@ -213,18 +215,21 @@ export function AgentRow({
           </Button>
         ) : null}
         {!isManager ? (
-          <Button
-            variant="outlineDanger"
-            className="agent-icon-button danger"
-            aria-label={t("agentDelete")}
-            title={t("agentDelete")}
-            disabled={busyKey.startsWith(busyPrefix)}
-            onClick={() => onDelete(item)}
-          >
-            <span aria-hidden="true">
-              <TrashIcon />
+          <Tooltip content={t("agentDelete")}>
+            <span>
+              <Button
+                variant="outlineDanger"
+                className="agent-icon-button danger"
+                aria-label={t("agentDelete")}
+                disabled={busyKey.startsWith(busyPrefix)}
+                onClick={() => onDelete(item)}
+              >
+                <span aria-hidden="true">
+                  <TrashIcon />
+                </span>
+              </Button>
             </span>
-          </Button>
+          </Tooltip>
         ) : null}
       </div>
     </div>

--- a/web/app/src/pages/ModelProviderPage/ModelProviderPage.tsx
+++ b/web/app/src/pages/ModelProviderPage/ModelProviderPage.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, CheckCircle2, LogIn, RefreshCw, Save, Trash2 } from "lucid
 import { errorMessage } from "@/api/client";
 import { checkModelProvider, deleteModelProvider, updateModelProvider } from "@/api/modelProviders";
 import { APIKeyField, ModelProviderModelList } from "@/components/business/ProfileControls";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 import { useWorkspaceControllerContext } from "@/hooks/workspace";
 import { isAuthenticated } from "@/models/auth";
 import {
@@ -277,15 +277,18 @@ export function ModelProviderPage() {
             </Button>
           ) : null}
           {!provider.builtin ? (
-            <Button
-              variant="outlineDanger"
-              aria-label={t("agentDelete")}
-              title={t("agentDelete")}
-              onClick={removeProvider}
-              disabled={Boolean(busy)}
-            >
-              <Trash2 size={16} aria-hidden="true" />
-            </Button>
+            <Tooltip content={t("agentDelete")}>
+              <span>
+                <Button
+                  variant="outlineDanger"
+                  aria-label={t("agentDelete")}
+                  onClick={removeProvider}
+                  disabled={Boolean(busy)}
+                >
+                  <Trash2 size={16} aria-hidden="true" />
+                </Button>
+              </span>
+            </Tooltip>
           ) : null}
         </div>
       </header>

--- a/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
+++ b/web/app/src/pages/TasksPage/components/TasksView/TasksView.tsx
@@ -1124,16 +1124,22 @@ type TaskToolbarButtonProps = {
 
 function TaskToolbarButton({ label, title = label, variant = "secondaryGray", ...props }: TaskToolbarButtonProps) {
   return (
-    <Button
-      className={classNames(styles.taskToolbarButton, variant === "secondaryGray" && styles.taskToolbarButtonSecondary)}
-      aria-label={title}
-      title={title}
-      size="sm"
-      variant={variant}
-      {...props}
-    >
-      {label}
-    </Button>
+    <Tooltip content={title}>
+      <span>
+        <Button
+          className={classNames(
+            styles.taskToolbarButton,
+            variant === "secondaryGray" && styles.taskToolbarButtonSecondary,
+          )}
+          aria-label={title}
+          size="sm"
+          variant={variant}
+          {...props}
+        >
+          {label}
+        </Button>
+      </span>
+    </Tooltip>
   );
 }
 

--- a/web/app/src/pages/WorkspacePage/components/FloatingChat/FloatingChat.tsx
+++ b/web/app/src/pages/WorkspacePage/components/FloatingChat/FloatingChat.tsx
@@ -417,16 +417,17 @@ export function FloatingChat({
   }
 
   const headerAccessory = (
-    <Button
-      className={classNames("icon-button", styles.collapseButton)}
-      aria-label={t("floatingChatCollapse")}
-      title={t("floatingChatCollapse")}
-      onClick={() => onOpenChange(false)}
-    >
-      <span className="icon-button-mark" aria-hidden="true">
-        <Minus size={17} strokeWidth={2.2} />
-      </span>
-    </Button>
+    <Tooltip content={t("floatingChatCollapse")}>
+      <Button
+        className={classNames("icon-button", styles.collapseButton)}
+        aria-label={t("floatingChatCollapse")}
+        onClick={() => onOpenChange(false)}
+      >
+        <span className="icon-button-mark" aria-hidden="true">
+          <Minus size={17} strokeWidth={2.2} />
+        </span>
+      </Button>
+    </Tooltip>
   );
 
   return (

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceTabBar.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceTabBar.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 import { HubIcon, RoomsIcon, TaskIcon, UsersIcon } from "@/components/ui/Icons";
 import { WorkspaceTabs } from "@/models/routing";
 import type { WorkspaceSidebarProps } from "./types";
@@ -30,84 +30,88 @@ export function WorkspaceTabBar({
       aria-label="Workspace sections"
       aria-orientation={rail ? "vertical" : undefined}
     >
-      <Button
-        className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
-        active={workspaceTab === WorkspaceTabs.messages}
-        role="tab"
-        aria-selected={workspaceTab === WorkspaceTabs.messages}
-        aria-label={t("messagesTab")}
-        title={t("messagesTab")}
-        onClick={() => onWorkspaceTabChange(WorkspaceTabs.messages)}
-      >
-        <span className="workspace-tab-icon" aria-hidden="true">
-          <RoomsIcon />
-        </span>
-        {!rail ? (
-          <span className="workspace-tab-copy">
-            <strong>{t("messagesTab")}</strong>
-            <small>{roomCount}</small>
+      <Tooltip content={t("messagesTab")}>
+        <Button
+          className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
+          active={workspaceTab === WorkspaceTabs.messages}
+          role="tab"
+          aria-selected={workspaceTab === WorkspaceTabs.messages}
+          aria-label={t("messagesTab")}
+          onClick={() => onWorkspaceTabChange(WorkspaceTabs.messages)}
+        >
+          <span className="workspace-tab-icon" aria-hidden="true">
+            <RoomsIcon />
           </span>
-        ) : null}
-      </Button>
-      <Button
-        className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
-        active={workspaceTab === WorkspaceTabs.agents}
-        role="tab"
-        aria-selected={workspaceTab === WorkspaceTabs.agents}
-        aria-label={t("agentsTab")}
-        title={t("agentsTab")}
-        onClick={() => onWorkspaceTabChange(WorkspaceTabs.agents)}
-      >
-        <span className="workspace-tab-icon" aria-hidden="true">
-          <UsersIcon />
-        </span>
-        {!rail ? (
-          <span className="workspace-tab-copy">
-            <strong>{t("agentsTab")}</strong>
-            <small>{agentCount}</small>
+          {!rail ? (
+            <span className="workspace-tab-copy">
+              <strong>{t("messagesTab")}</strong>
+              <small>{roomCount}</small>
+            </span>
+          ) : null}
+        </Button>
+      </Tooltip>
+      <Tooltip content={t("agentsTab")}>
+        <Button
+          className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
+          active={workspaceTab === WorkspaceTabs.agents}
+          role="tab"
+          aria-selected={workspaceTab === WorkspaceTabs.agents}
+          aria-label={t("agentsTab")}
+          onClick={() => onWorkspaceTabChange(WorkspaceTabs.agents)}
+        >
+          <span className="workspace-tab-icon" aria-hidden="true">
+            <UsersIcon />
           </span>
-        ) : null}
-      </Button>
-      <Button
-        className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
-        active={workspaceTab === WorkspaceTabs.tasks}
-        role="tab"
-        aria-selected={workspaceTab === WorkspaceTabs.tasks}
-        aria-label={t("tasksTab")}
-        title={t("tasksTab")}
-        onClick={() => onWorkspaceTabChange(WorkspaceTabs.tasks)}
-      >
-        <span className="workspace-tab-icon" aria-hidden="true">
-          <TaskIcon />
-        </span>
-        {!rail ? (
-          <span className="workspace-tab-copy">
-            <strong>{t("tasksTab")}</strong>
-            <small>{taskCount}</small>
+          {!rail ? (
+            <span className="workspace-tab-copy">
+              <strong>{t("agentsTab")}</strong>
+              <small>{agentCount}</small>
+            </span>
+          ) : null}
+        </Button>
+      </Tooltip>
+      <Tooltip content={t("tasksTab")}>
+        <Button
+          className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
+          active={workspaceTab === WorkspaceTabs.tasks}
+          role="tab"
+          aria-selected={workspaceTab === WorkspaceTabs.tasks}
+          aria-label={t("tasksTab")}
+          onClick={() => onWorkspaceTabChange(WorkspaceTabs.tasks)}
+        >
+          <span className="workspace-tab-icon" aria-hidden="true">
+            <TaskIcon />
           </span>
-        ) : null}
-      </Button>
-      <Button
-        className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
-        active={workspaceTab === WorkspaceTabs.hub}
-        role="tab"
-        aria-selected={workspaceTab === WorkspaceTabs.hub}
-        aria-label={t("resourcesTab")}
-        title={t("resourcesTab")}
-        onClick={() => onSelectHub()}
-      >
-        <span className="workspace-tab-icon" aria-hidden="true">
-          <HubIcon />
-        </span>
-        {rail && showHubNewBadge ? (
-          <span className="workspace-tab-rail-new" aria-hidden="true"></span>
-        ) : !rail ? (
-          <span className="workspace-tab-copy">
-            <strong>{t("resourcesTab")}</strong>
-            {showHubNewBadge ? <span className="workspace-tab-badge">{t("newBadge")}</span> : null}
+          {!rail ? (
+            <span className="workspace-tab-copy">
+              <strong>{t("tasksTab")}</strong>
+              <small>{taskCount}</small>
+            </span>
+          ) : null}
+        </Button>
+      </Tooltip>
+      <Tooltip content={t("resourcesTab")}>
+        <Button
+          className={`workspace-tab ${rail ? "workspace-tab-rail" : ""}`}
+          active={workspaceTab === WorkspaceTabs.hub}
+          role="tab"
+          aria-selected={workspaceTab === WorkspaceTabs.hub}
+          aria-label={t("resourcesTab")}
+          onClick={() => onSelectHub()}
+        >
+          <span className="workspace-tab-icon" aria-hidden="true">
+            <HubIcon />
           </span>
-        ) : null}
-      </Button>
+          {rail && showHubNewBadge ? (
+            <span className="workspace-tab-rail-new" aria-hidden="true"></span>
+          ) : !rail ? (
+            <span className="workspace-tab-copy">
+              <strong>{t("resourcesTab")}</strong>
+              {showHubNewBadge ? <span className="workspace-tab-badge">{t("newBadge")}</span> : null}
+            </span>
+          ) : null}
+        </Button>
+      </Tooltip>
     </div>
   );
 }

--- a/web/app/tests/testing-library-react-dist.d.ts
+++ b/web/app/tests/testing-library-react-dist.d.ts
@@ -1,0 +1,3 @@
+declare module "@testing-library/react/dist/index.js" {
+  export * from "@testing-library/react";
+}

--- a/web/app/tests/testing-library-react.tsx
+++ b/web/app/tests/testing-library-react.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable react-refresh/only-export-components */
+import { TooltipProvider } from "@/components/ui";
+import type { ReactElement, ReactNode } from "react";
+import {
+  render as baseRender,
+  renderHook as baseRenderHook,
+  type RenderHookOptions,
+  type RenderHookResult,
+  type RenderOptions,
+} from "@testing-library/react/dist/index.js";
+export * from "@testing-library/react/dist/index.js";
+
+function TooltipTestProvider({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+export function render(ui: ReactElement, options: RenderOptions = {}) {
+  const ProvidedWrapper = options.wrapper;
+  const wrapper = ProvidedWrapper
+    ? function Wrapper({ children }: { children: ReactNode }) {
+        return (
+          <TooltipTestProvider>
+            <ProvidedWrapper>{children}</ProvidedWrapper>
+          </TooltipTestProvider>
+        );
+      }
+    : TooltipTestProvider;
+
+  return baseRender(ui, { ...options, wrapper });
+}
+
+export function renderHook<Result, Props>(
+  renderCallback: (initialProps: Props) => Result,
+  options: RenderHookOptions<Props> = {},
+): RenderHookResult<Result, Props> {
+  const ProvidedWrapper = options.wrapper;
+  const wrapper = ProvidedWrapper
+    ? function Wrapper({ children }: { children: ReactNode }) {
+        return (
+          <TooltipTestProvider>
+            <ProvidedWrapper>{children}</ProvidedWrapper>
+          </TooltipTestProvider>
+        );
+      }
+    : TooltipTestProvider;
+
+  return baseRenderHook(renderCallback, { ...options, wrapper });
+}

--- a/web/app/vitest.config.ts
+++ b/web/app/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "./vite.config";
+import path from "node:path";
 
 const resolvedViteConfig =
   typeof viteConfig === "function" ? viteConfig({ command: "build", mode: "test" }) : viteConfig;
@@ -7,6 +8,14 @@ const resolvedViteConfig =
 export default mergeConfig(
   resolvedViteConfig,
   defineConfig({
+    resolve: {
+      alias: [
+        {
+          find: /^@testing-library\/react$/,
+          replacement: path.resolve(__dirname, "tests/testing-library-react.tsx"),
+        },
+      ],
+    },
     test: {
       environment: "jsdom",
       globals: true,


### PR DESCRIPTION
## Summary

- Keep Button as a pure button primitive
- Compose tooltips explicitly at call sites
- Share tooltip provider across the app and tests