### PR TITLE
fix(web): keep select overlays in app root

### DIFF
--- a/web/app/src/components/ui/Select/Select.tsx
+++ b/web/app/src/components/ui/Select/Select.tsx
@@ -83,10 +83,19 @@ export type SelectContentProps = ComponentPropsWithoutRef<typeof RadixSelect.Con
   portalContainer?: ComponentPropsWithoutRef<typeof RadixSelect.Portal>["container"];
 };
 
+function defaultSelectPortalContainer() {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+  return document.getElementById("root") ?? undefined;
+}
+
 export const SelectContent = forwardRef<ComponentRef<typeof RadixSelect.Content>, SelectContentProps>(
   function SelectContent({ children, className, portalContainer, position = "popper", sideOffset = 6, ...props }, ref) {
+    const resolvedPortalContainer = portalContainer ?? defaultSelectPortalContainer();
+
     return (
-      <RadixSelect.Portal container={portalContainer}>
+      <RadixSelect.Portal container={resolvedPortalContainer}>
         <RadixSelect.Content
           ref={ref}
           className={classNames("csg-select-content overflow-hidden", className)}

--- a/web/app/tests/components/Select.test.tsx
+++ b/web/app/tests/components/Select.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { Select } from "@/components/ui";
+
+describe("Select", () => {
+  it("renders default portal content inside the app root", () => {
+    const appRoot = document.createElement("div");
+    appRoot.id = "root";
+    document.body.appendChild(appRoot);
+
+    try {
+      render(
+        <Select
+          open
+          value="remote"
+          options={[
+            { value: "remote", label: "remote" },
+            { value: "codex", label: "Codex" },
+          ]}
+        />,
+        { container: appRoot },
+      );
+
+      const content = document.querySelector(".csg-select-content");
+      expect(content).toBeInTheDocument();
+      expect(appRoot).toContainElement(content as HTMLElement);
+      expect(screen.getByText("Codex")).toBeInTheDocument();
+    } finally {
+      appRoot.remove();
+    }
+  });
+
+  it("allows callers to override the portal container", () => {
+    const appRoot = document.createElement("div");
+    appRoot.id = "root";
+    const portalContainer = document.createElement("div");
+    portalContainer.id = "select-portal";
+    document.body.append(appRoot, portalContainer);
+
+    try {
+      render(
+        <Select
+          open
+          value="remote"
+          contentProps={{ portalContainer }}
+          options={[
+            { value: "remote", label: "remote" },
+            { value: "codex", label: "Codex" },
+          ]}
+        />,
+        { container: appRoot },
+      );
+
+      const content = document.querySelector(".csg-select-content");
+      expect(content).toBeInTheDocument();
+      expect(portalContainer).toContainElement(content as HTMLElement);
+    } finally {
+      appRoot.remove();
+      portalContainer.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Render select overlay portals inside the app root by default to keep embedded sandbox coordinates aligned
- Add Select portal container regression coverage