### PR TITLE
fix: support hosted login and agent detail DMs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,8 @@ English | [中文](config.zh.md)
 
 Use `advertise_base_url` when the automatically inferred address is not reachable from BoxLite boxes, such as when you need a LAN address, a tunnel URL, or a host alias.
 
+When it is set, the Web UI login flow also uses it as the trusted public base for the auth callback and post-login return URL. Reverse proxies and sandbox gateways must route `<advertise_base_url>/api/v1/auth/callback` back to the CSGClaw server.
+
 When the sandbox provider is `docker` on Docker Desktop, an empty `advertise_base_url` resolves to `http://host.docker.internal:<port>` for generated manager and worker runtime config. Set `advertise_base_url` explicitly when you need a different Docker callback URL.
 
 `access_token` protects authenticated API routes, including the PicoClaw participant bridge routes. When authentication is enabled, clients must send `Authorization: Bearer <access_token>`.

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -12,6 +12,8 @@
 
 当自动推断出的地址无法从 BoxLite box 内访问时，可以设置 `advertise_base_url`，例如使用局域网地址、隧道地址或 host alias。
 
+设置该值后，Web UI 登录流程也会将它作为受信任的公开地址，用于认证回调和登录后的返回地址。反向代理或 sandbox gateway 必须将 `<advertise_base_url>/api/v1/auth/callback` 路由回 CSGClaw server。
+
 当 sandbox provider 是 Docker Desktop 上的 `docker` 时，空的 `advertise_base_url` 会在生成 manager 和 worker 运行时配置时解析为 `http://host.docker.internal:<port>`。如果 Docker 需要使用其它回连地址，请显式设置 `advertise_base_url`。
 
 `access_token` 用来保护需要认证的 API 路由，包括 PicoClaw participant bridge 路由。启用鉴权时，客户端必须发送 `Authorization: Bearer <access_token>`。

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -21,6 +21,7 @@ type authLoginRequest struct {
 	CSGHubBaseURL    string `json:"csghub_base_url,omitempty"`
 	AIGatewayBaseURL string `json:"ai_gateway_base_url,omitempty"`
 	CallbackURL      string `json:"-"`
+	AdvertiseBaseURL string `json:"-"`
 }
 
 var appAuthStatus = func(r *http.Request) (auth.Status, error) {
@@ -31,6 +32,7 @@ var appAuthLogin = func(r *http.Request, req authLoginRequest) (auth.LoginRespon
 	return auth.Default().Login(r.Context(), auth.LoginOptions{
 		ReturnURL:        req.ReturnURL,
 		CallbackURL:      req.CallbackURL,
+		AdvertiseBaseURL: req.AdvertiseBaseURL,
 		OpenCSGBaseURL:   req.OpenCSGBaseURL,
 		CSGHubBaseURL:    req.CSGHubBaseURL,
 		AIGatewayBaseURL: req.AIGatewayBaseURL,
@@ -41,7 +43,7 @@ var appAuthLogout = func(r *http.Request) (auth.Status, error) {
 	return auth.Default().Logout(r.Context())
 }
 
-var appAuthCallback = func(r *http.Request) (string, error) {
+var appAuthCallback = func(r *http.Request, advertiseBaseURL string) (string, error) {
 	values := r.URL.Query()
 	if values.Get("jwt_token") == "" {
 		if token := bearerToken(r.Header.Get("Authorization")); token != "" {
@@ -49,7 +51,9 @@ var appAuthCallback = func(r *http.Request) (string, error) {
 			values.Set("jwt_token", token)
 		}
 	}
-	return auth.Default().CompleteCallback(r.Context(), values)
+	return auth.Default().CompleteCallback(r.Context(), values, auth.CallbackOptions{
+		AdvertiseBaseURL: advertiseBaseURL,
+	})
 }
 
 func (h *Handler) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +74,7 @@ func (h *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	redirectURL, err := appAuthCallback(r)
+	redirectURL, err := appAuthCallback(r, h.authAdvertiseBaseURL())
 	if err != nil {
 		status := http.StatusBadRequest
 		if !auth.IsCallbackValidationError(err) {
@@ -99,8 +103,12 @@ func (h *Handler) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	if req.ReturnURL == "" {
 		req.ReturnURL = r.Referer()
 	}
+	req.AdvertiseBaseURL = h.authAdvertiseBaseURL()
 	if req.CallbackURL == "" {
-		req.CallbackURL = authLocalCallbackURL(r)
+		req.CallbackURL = authAdvertisedCallbackURL(req.AdvertiseBaseURL)
+		if req.CallbackURL == "" {
+			req.CallbackURL = authLocalCallbackURL(r)
+		}
 	}
 	resp, err := appAuthLogin(r, req)
 	if err != nil {
@@ -108,6 +116,34 @@ func (h *Handler) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) authAdvertiseBaseURL() string {
+	if h == nil || strings.TrimSpace(h.configPath) == "" {
+		return ""
+	}
+	cfg, _, err := h.loadBootstrapConfig()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(cfg.Server.AdvertiseBaseURL), "/")
+}
+
+func authAdvertisedCallbackURL(advertiseBaseURL string) string {
+	u, err := url.Parse(strings.TrimRight(strings.TrimSpace(advertiseBaseURL), "/"))
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return ""
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + authCallbackPath
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
 }
 
 func (h *Handler) handleAuthLogout(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -89,9 +91,47 @@ func TestHandleAuthLogin(t *testing.T) {
 	}
 }
 
+func TestHandleAuthLoginUsesAdvertiseBaseURL(t *testing.T) {
+	const advertiseBaseURL = "https://aigateway.opencsg-stg.com/v1/sandboxes/jared-1784118727"
+	t.Setenv("CSGCLAW_ADVERTISE_BASE_URL", advertiseBaseURL)
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	content := `[server]
+listen_addr = "0.0.0.0:18080"
+advertise_base_url = "${CSGCLAW_ADVERTISE_BASE_URL}"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+
+	var got authLoginRequest
+	restore := stubAuthLogin(func(_ *http.Request, req authLoginRequest) (auth.LoginResponse, error) {
+		got = req
+		return auth.LoginResponse{LoginURL: "https://opencsg-stg.com/sso/login"}, nil
+	})
+	defer restore()
+
+	handler := &Handler{}
+	handler.SetConfigPath(configPath)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{
+		"return_url":"https://aigateway.opencsg-stg.com/v1/sandboxes/jared-1784118727/#/workspace"
+	}`))
+	req.Host = "csgclaw.internal:18080"
+	handler.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got.AdvertiseBaseURL != advertiseBaseURL {
+		t.Fatalf("advertise_base_url = %q, want %q", got.AdvertiseBaseURL, advertiseBaseURL)
+	}
+	if want := advertiseBaseURL + authCallbackPath; got.CallbackURL != want {
+		t.Fatalf("callback_url = %q, want %q", got.CallbackURL, want)
+	}
+}
+
 func TestHandleAuthCallback(t *testing.T) {
 	var gotToken string
-	restore := stubAuthCallback(func(r *http.Request) (string, error) {
+	restore := stubAuthCallback(func(r *http.Request, _ string) (string, error) {
 		gotToken = r.URL.Query().Get("jwt_token")
 		return "http://127.0.0.1:18080/#/workspace", nil
 	})
@@ -143,7 +183,7 @@ func stubAuthLogin(fn func(*http.Request, authLoginRequest) (auth.LoginResponse,
 	return func() { appAuthLogin = previous }
 }
 
-func stubAuthCallback(fn func(*http.Request) (string, error)) func() {
+func stubAuthCallback(fn func(*http.Request, string) (string, error)) func() {
 	previous := appAuthCallback
 	appAuthCallback = fn
 	return func() { appAuthCallback = previous }

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -28,9 +28,14 @@ type LoginResponse struct {
 type LoginOptions struct {
 	ReturnURL        string
 	CallbackURL      string
+	AdvertiseBaseURL string
 	OpenCSGBaseURL   string
 	CSGHubBaseURL    string
 	AIGatewayBaseURL string
+}
+
+type CallbackOptions struct {
+	AdvertiseBaseURL string
 }
 
 type Service struct {
@@ -95,8 +100,8 @@ func (s *Service) Login(_ context.Context, opts ...LoginOptions) (LoginResponse,
 		CSGHubBaseURL:  s.csghubBaseURL(),
 	}
 	if len(opts) > 0 {
-		returnURL = sanitizeReturnURL(opts[0].ReturnURL)
-		callbackURL = sanitizeCallbackURL(opts[0].CallbackURL)
+		returnURL = sanitizeReturnURL(opts[0].ReturnURL, opts[0].AdvertiseBaseURL)
+		callbackURL = sanitizeCallbackURL(opts[0].CallbackURL, opts[0].AdvertiseBaseURL)
 		var err error
 		env, err = s.loginEnvironment(opts[0])
 		if err != nil {
@@ -121,11 +126,19 @@ func (s *Service) Logout(context.Context) (Status, error) {
 	return Status{}, nil
 }
 
-func (s *Service) CompleteCallback(ctx context.Context, values url.Values) (string, error) {
-	return s.completeCallback(ctx, values)
+func (s *Service) CompleteCallback(ctx context.Context, values url.Values, opts ...CallbackOptions) (string, error) {
+	advertiseBaseURL := ""
+	if len(opts) > 0 {
+		advertiseBaseURL = opts[0].AdvertiseBaseURL
+	}
+	return s.completeCallbackWithAdvertiseBaseURL(ctx, values, advertiseBaseURL)
 }
 
 func (s *Service) completeCallback(ctx context.Context, values url.Values) (string, error) {
+	return s.completeCallbackWithAdvertiseBaseURL(ctx, values, "")
+}
+
+func (s *Service) completeCallbackWithAdvertiseBaseURL(ctx context.Context, values url.Values, advertiseBaseURL string) (string, error) {
 	values = callbackValuesWithAuthState(values)
 	jwtToken := strings.TrimSpace(values.Get("jwt_token"))
 	if jwtToken == "" {
@@ -198,7 +211,7 @@ func (s *Service) completeCallback(ctx context.Context, values url.Values) (stri
 		}
 	}
 
-	if returnURL := callbackReturnURL(values); returnURL != "" {
+	if returnURL := callbackReturnURL(values, advertiseBaseURL); returnURL != "" {
 		return returnURL, nil
 	}
 	if portalURL == "" {
@@ -526,7 +539,7 @@ func joinAPIPath(baseURL, apiPath string) (*url.URL, error) {
 	return base.ResolveReference(ref), nil
 }
 
-func sanitizeReturnURL(raw string) string {
+func sanitizeReturnURL(raw, advertiseBaseURL string) string {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return ""
@@ -538,10 +551,13 @@ func sanitizeReturnURL(raw string) string {
 	if isLocalHostname(u.Hostname()) {
 		return u.String()
 	}
+	if urlWithinBase(u, advertiseBaseURL) {
+		return u.String()
+	}
 	return ""
 }
 
-func sanitizeCallbackURL(raw string) string {
+func sanitizeCallbackURL(raw, advertiseBaseURL string) string {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return ""
@@ -550,10 +566,33 @@ func sanitizeCallbackURL(raw string) string {
 	if scheme != "http" && scheme != "https" {
 		return ""
 	}
-	if !isLocalHostname(u.Hostname()) {
-		return ""
+	if isLocalHostname(u.Hostname()) {
+		return u.String()
 	}
-	return u.String()
+	if urlWithinBase(u, advertiseBaseURL) {
+		return u.String()
+	}
+	return ""
+}
+
+func urlWithinBase(candidate *url.URL, rawBaseURL string) bool {
+	if candidate == nil || candidate.User != nil {
+		return false
+	}
+	base, err := url.Parse(strings.TrimRight(strings.TrimSpace(rawBaseURL), "/"))
+	if err != nil || base.Scheme == "" || base.Host == "" || base.User != nil {
+		return false
+	}
+	baseScheme := strings.ToLower(base.Scheme)
+	if baseScheme != "http" && baseScheme != "https" {
+		return false
+	}
+	if !strings.EqualFold(candidate.Scheme, base.Scheme) || !strings.EqualFold(candidate.Host, base.Host) {
+		return false
+	}
+	basePath := strings.TrimRight(base.Path, "/")
+	candidatePath := strings.TrimRight(candidate.Path, "/")
+	return basePath == "" || candidatePath == basePath || strings.HasPrefix(candidatePath, basePath+"/")
 }
 
 func callbackURLWithAuthState(callbackURL string, env authEnvironment, returnURL string) string {
@@ -610,9 +649,9 @@ func cloneURLValues(values url.Values) url.Values {
 	return cloned
 }
 
-func callbackReturnURL(values url.Values) string {
+func callbackReturnURL(values url.Values, advertiseBaseURL string) string {
 	for _, key := range []string{"return_url", "url"} {
-		if returnURL := sanitizeReturnURL(values.Get(key)); returnURL != "" {
+		if returnURL := sanitizeReturnURL(values.Get(key), advertiseBaseURL); returnURL != "" {
 			return returnURL
 		}
 	}

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -262,6 +262,37 @@ func TestLoginUsesOpenCSGSSOCallbackURL(t *testing.T) {
 	}
 }
 
+func TestLoginUsesAdvertisedCallbackAndReturnURLs(t *testing.T) {
+	service := &Service{}
+	advertiseBaseURL := "https://aigateway.opencsg-stg.com/v1/sandboxes/jared-1784118727"
+	returnURL := advertiseBaseURL + "/#/workspace"
+	callbackURL := advertiseBaseURL + "/api/v1/auth/callback"
+
+	login, err := service.Login(context.Background(), LoginOptions{
+		ReturnURL:        returnURL,
+		CallbackURL:      callbackURL,
+		AdvertiseBaseURL: advertiseBaseURL,
+		OpenCSGBaseURL:   "https://opencsg-stg.com",
+	})
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+	parsedLogin, err := url.Parse(login.LoginURL)
+	if err != nil {
+		t.Fatalf("parse LoginURL: %v", err)
+	}
+	parsedCallback, err := url.Parse(parsedLogin.Query().Get("redirect_url"))
+	if err != nil {
+		t.Fatalf("parse redirect_url: %v", err)
+	}
+	if got := parsedCallback.Scheme + "://" + parsedCallback.Host + parsedCallback.Path; got != callbackURL {
+		t.Fatalf("redirect callback = %q, want %q", got, callbackURL)
+	}
+	if got := loginCallbackStateQuery(t, parsedCallback).Get("return_url"); got != returnURL {
+		t.Fatalf("return_url = %q, want %q", got, returnURL)
+	}
+}
+
 func TestCallbackReadsPackedAuthState(t *testing.T) {
 	returnURL := "http://127.0.0.1:18080/#/dms/room-1783408363036922000"
 	callbackURL := callbackURLWithAuthState("http://127.0.0.1:18080/api/v1/auth/callback", authEnvironment{
@@ -277,7 +308,7 @@ func TestCallbackReadsPackedAuthState(t *testing.T) {
 	values.Set("jwt_token", testJWT("alice", "user-1"))
 	values = callbackValuesWithAuthState(values)
 
-	if got := callbackReturnURL(values); got != returnURL {
+	if got := callbackReturnURL(values, ""); got != returnURL {
 		t.Fatalf("callbackReturnURL() = %q, want %q", got, returnURL)
 	}
 	env, err := (&Service{}).callbackEnvironment(values)
@@ -436,7 +467,7 @@ func TestCallbackReturnURLAcceptsLangflowURLParam(t *testing.T) {
 	returnURL := "http://127.0.0.1:18080/#/workspace"
 	got := callbackReturnURL(url.Values{
 		"url": []string{returnURL},
-	})
+	}, "")
 	if got != returnURL {
 		t.Fatalf("callbackReturnURL() = %q, want %q", got, returnURL)
 	}
@@ -446,9 +477,21 @@ func TestCallbackReturnURLRejectsExternalURLs(t *testing.T) {
 	got := callbackReturnURL(url.Values{
 		"return_url": []string{"https://evil.example.test/callback"},
 		"url":        []string{"https://also-evil.example.test/callback"},
-	})
+	}, "")
 	if got != "" {
 		t.Fatalf("callbackReturnURL() = %q, want empty for external URLs", got)
+	}
+}
+
+func TestCallbackReturnURLAcceptsAdvertisedPathOnly(t *testing.T) {
+	advertiseBaseURL := "https://aigateway.opencsg-stg.com/v1/sandboxes/jared-1784118727"
+	want := advertiseBaseURL + "/#/workspace"
+	if got := callbackReturnURL(url.Values{"return_url": []string{want}}, advertiseBaseURL); got != want {
+		t.Fatalf("callbackReturnURL() = %q, want %q", got, want)
+	}
+	otherSandbox := "https://aigateway.opencsg-stg.com/v1/sandboxes/other/#/workspace"
+	if got := callbackReturnURL(url.Values{"return_url": []string{otherSandbox}}, advertiseBaseURL); got != "" {
+		t.Fatalf("callbackReturnURL() = %q, want empty for another sandbox", got)
 	}
 }
 

--- a/web/app/src/hooks/workspace/types.ts
+++ b/web/app/src/hooks/workspace/types.ts
@@ -271,5 +271,5 @@ export type UseAgentControllerArgs = {
 };
 
 export type AgentDetailSidePanelProps = AgentDetailPaneProps & {
-  onClose: () => void;
+  onClose: (restoreFocus?: boolean) => boolean | void;
 };

--- a/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
+++ b/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
@@ -12,7 +12,17 @@ import { normalizeAuthProviderName } from "@/models/agents";
 import { getConversationDescription, isDirectConversation } from "@/models/conversations";
 import type { AgentDetailSidePanelProps } from "@/hooks/workspace/types";
 
-function AgentDetailSidePanel({ onClose, ...props }: AgentDetailSidePanelProps) {
+function AgentDetailSidePanel({ onClose, onOpenDM, ...props }: AgentDetailSidePanelProps) {
+  const handleOpenDM = useCallback(
+    async (...args: Parameters<typeof onOpenDM>) => {
+      if (onClose(false) === false) {
+        return;
+      }
+      await onOpenDM(...args);
+    },
+    [onClose, onOpenDM],
+  );
+
   return (
     <DialogRoot open onOpenChange={(open) => (!open ? onClose() : undefined)}>
       <DialogContent
@@ -30,7 +40,7 @@ function AgentDetailSidePanel({ onClose, ...props }: AgentDetailSidePanelProps) 
           <DialogTitle className="agent-detail-side-panel-title">{props.t("agentDetailPanel")}</DialogTitle>
         </div>
         <div className="agent-detail-side-panel-body">
-          <AgentView {...props} />
+          <AgentView {...props} onOpenDM={handleOpenDM} />
         </div>
       </DialogContent>
     </DialogRoot>

--- a/web/app/tests/components/ConversationPane.test.tsx
+++ b/web/app/tests/components/ConversationPane.test.tsx
@@ -380,6 +380,7 @@ describe("ConversationPane", () => {
   it("renders agent details as a modal drawer with keyboard dismissal", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
+    const onOpenDM = vi.fn();
     const { container } = renderThreadPane({
       agentDetailPanelProps: {
         item: {
@@ -391,7 +392,7 @@ describe("ConversationPane", () => {
         onClose,
         onDelete: vi.fn(),
         onInvite: vi.fn(),
-        onOpenDM: vi.fn(),
+        onOpenDM,
         onRecreate: vi.fn(),
         onStart: vi.fn(),
         onStop: vi.fn(),
@@ -414,6 +415,41 @@ describe("ConversationPane", () => {
     onClose.mockClear();
     await user.keyboard("{Escape}");
     expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    await user.click(within(dialog).getByRole("button", { name: "openDM" }));
+    expect(onClose).toHaveBeenCalledWith(false);
+    expect(onOpenDM).toHaveBeenCalledWith(expect.objectContaining({ id: "u-manager" }));
+  });
+
+  it("keeps agent details open when unsaved changes block direct-message navigation", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn(() => false);
+    const onOpenDM = vi.fn();
+    renderThreadPane({
+      agentDetailPanelProps: {
+        item: {
+          id: "u-manager",
+          name: "manager",
+          role: "worker",
+        },
+        t,
+        onClose,
+        onDelete: vi.fn(),
+        onInvite: vi.fn(),
+        onOpenDM,
+        onRecreate: vi.fn(),
+        onStart: vi.fn(),
+        onStop: vi.fn(),
+      },
+    });
+
+    await user.click(
+      within(screen.getByRole("dialog", { name: "agentDetailPanel" })).getByRole("button", { name: "openDM" }),
+    );
+
+    expect(onClose).toHaveBeenCalledWith(false);
+    expect(onOpenDM).not.toHaveBeenCalled();
   });
 
   it("keeps the caret at the end after slash text is tokenized in the main composer", async () => {


### PR DESCRIPTION
- Use `advertise_base_url` as the trusted OpenCSG login callback and return base for hosted sandbox deployments.
- Close the conversation agent detail drawer before navigating to the selected agent's direct message.
- Preserve local callback protections and unsaved-change confirmation behavior.
