### PR TITLE
fix(agent): restrict CSGHub workers to Codex

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -118,6 +118,7 @@ type imEventResponse struct {
 type bootstrapConfigResponse struct {
 	DefaultManagerTemplate string                                        `json:"default_manager_template"`
 	DefaultWorkerTemplate  string                                        `json:"default_worker_template"`
+	SandboxProvider        string                                        `json:"sandbox_provider"`
 	RuntimeKind            string                                        `json:"runtime_kind"`
 	ManagerRuntime         managerRuntimeResponse                        `json:"manager_runtime"`
 	ShowUpgrade            bool                                          `json:"show_upgrade"`
@@ -497,6 +498,7 @@ func bootstrapConfigView(ctx context.Context, cfg config.Config, hubSvc *hub.Ser
 	resp := bootstrapConfigResponse{
 		DefaultManagerTemplate: cfg.Bootstrap.ResolvedDefaultManagerTemplate(),
 		DefaultWorkerTemplate:  cfg.Bootstrap.ResolvedDefaultWorkerTemplate(),
+		SandboxProvider:        strings.TrimSpace(cfg.Sandbox.Provider),
 		ShowUpgrade:            cfg.Server.ShowUpgrade,
 		AdvertiseBaseURL:       config.ResolveAdvertiseBaseURL(cfg.Server),
 		ManagerRuntime:         managerRuntimeReadiness(),
@@ -590,6 +592,9 @@ func workerRuntimeChoices(cfg config.Config) []workerRuntimeChoiceResponse {
 	if _, err := locateCodexCLI(); err != nil {
 		choices[0].Installed = false
 		choices[0].Message = "Codex CLI not installed"
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Sandbox.Provider), config.CSGHubProvider) {
+		return choices[:1]
 	}
 	return choices
 }
@@ -1388,6 +1393,11 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
+		items, err = h.filterHubTemplatesForConfiguredProvider(items)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		writeJSON(w, http.StatusOK, presentHubTemplates(items))
 	case http.MethodPost:
 		hubSvc, err := h.hubServiceForRequest(r)
@@ -1423,6 +1433,28 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func (h *Handler) filterHubTemplatesForConfiguredProvider(items []hub.Template) ([]hub.Template, error) {
+	if strings.TrimSpace(h.configPath) == "" {
+		return items, nil
+	}
+	cfg, _, err := h.loadBootstrapConfig()
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.Sandbox.Provider), config.CSGHubProvider) {
+		return items, nil
+	}
+
+	filtered := make([]hub.Template, 0, len(items))
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item.Role), hub.TemplateRoleWorker) &&
+			bootstrapRuntimeKind(item.RuntimeKind) == agent.RuntimeKindCodex {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered, nil
 }
 
 func (h *Handler) handleHubTemplateByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3103,6 +3103,63 @@ func TestHandleHubTemplatesListsAggregatedTemplates(t *testing.T) {
 	}
 }
 
+func TestFilterHubTemplatesForConfiguredProvider(t *testing.T) {
+	items := []hub.Template{
+		{ID: "codex-worker", Role: hub.TemplateRoleWorker, RuntimeKind: agent.RuntimeKindCodex},
+		{ID: "codex-manager", Role: hub.TemplateRoleManager, RuntimeKind: agent.RuntimeKindCodex},
+		{ID: "openclaw-worker", Role: hub.TemplateRoleWorker, RuntimeKind: "openclaw"},
+	}
+	tests := []struct {
+		name     string
+		provider string
+		wantIDs  []string
+	}{
+		{name: "csghub only returns codex workers", provider: config.CSGHubProvider, wantIDs: []string{"codex-worker"}},
+		{name: "other providers are unchanged", provider: config.DockerProvider, wantIDs: []string{"codex-worker", "codex-manager", "openclaw-worker"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.toml")
+			content := "[sandbox]\nprovider = \"" + tt.provider + "\"\n"
+			if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+				t.Fatalf("WriteFile(config) error = %v", err)
+			}
+			srv := &Handler{}
+			srv.SetConfigPath(configPath)
+
+			got, err := srv.filterHubTemplatesForConfiguredProvider(items)
+			if err != nil {
+				t.Fatalf("filterHubTemplatesForConfiguredProvider() error = %v", err)
+			}
+			gotIDs := make([]string, 0, len(got))
+			for _, item := range got {
+				gotIDs = append(gotIDs, item.ID)
+			}
+			if !slices.Equal(gotIDs, tt.wantIDs) {
+				t.Fatalf("template ids = %#v, want %#v", gotIDs, tt.wantIDs)
+			}
+		})
+	}
+}
+
+func TestBootstrapConfigViewRestrictsCSGHubToCodexRuntime(t *testing.T) {
+	got := bootstrapConfigView(context.Background(), config.Config{
+		Sandbox: config.SandboxConfig{Provider: config.CSGHubProvider},
+	}, nil, nil)
+
+	if got.SandboxProvider != config.CSGHubProvider {
+		t.Fatalf("sandbox provider = %q, want %q", got.SandboxProvider, config.CSGHubProvider)
+	}
+	if len(got.WorkerRuntimeChoices) != 1 {
+		t.Fatalf("worker runtime choices = %#v, want only Codex", got.WorkerRuntimeChoices)
+	}
+	choice := got.WorkerRuntimeChoices[0]
+	if choice.Name != agent.RuntimeNameCodex || choice.SandboxEnabled {
+		t.Fatalf("worker runtime choice = %#v, want non-sandbox Codex", choice)
+	}
+}
+
 func TestHandleHubTemplateByIDReturnsTemplate(t *testing.T) {
 	hubSvc := mustNewLocalTemplateHubService(t, "review-bot", hub.Template{
 		ID:          "review-bot",

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -1135,6 +1135,10 @@ export function useAgentController({
     const codexAvailable = runtimeChoices.some(
       (item) => !item?.sandbox_enabled && normalizeRuntimeName(item?.name) === "codex" && item?.installed !== false,
     );
+    const isCSGHubSandboxProvider =
+      String(bootstrapConfig?.sandbox_provider || "")
+        .trim()
+        .toLowerCase() === "csghub";
     const createWorkerTemplates = workerSelectableTemplates(hubTemplates).filter(
       (item) => normalizeRuntimeKind(item.runtime_kind) !== "picoclaw_sandbox",
     );
@@ -1144,7 +1148,9 @@ export function useAgentController({
       ) || normalizeRuntimeName(runtimeChoices.find((item) => item?.sandbox_enabled)?.name || "openclaw");
     let preferredRuntimeKind =
       normalizeRuntimeKind(composeLegacyRuntimeKind(preferredSandboxRuntimeName, true)) || "openclaw_sandbox";
-    if (!runtimeChoices.length && !codexAvailable) {
+    if (isCSGHubSandboxProvider) {
+      preferredRuntimeKind = "codex";
+    } else if (!runtimeChoices.length && !codexAvailable) {
       preferredRuntimeKind = "openclaw_sandbox";
     }
     const selectedTemplate =

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -410,6 +410,7 @@ export type RuntimeBootstrapConfig = {
   default_worker_template?: string | null;
   effective_manager_image?: string | null;
   manager_runtime?: ManagerRuntimeLike | null;
+  sandbox_provider?: string | null;
   runtime_default_images?: unknown;
   runtime_kind?: string | null;
   worker_runtime_choices?: RuntimeChoiceLike[] | null;

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/AgentProfileModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/AgentProfileModal.tsx
@@ -154,7 +154,11 @@ export function AgentProfileModal({
     [hubTemplates],
   );
   const selectedWorkerTemplate = workerTemplates.find((item) => item.id === agentDraft.from_template) ?? null;
-  const sandboxEnabled = Boolean(agentDraft.sandbox_enabled);
+  const isCSGHubSandboxProvider =
+    String(bootstrapConfig?.sandbox_provider || "")
+      .trim()
+      .toLowerCase() === "csghub";
+  const sandboxEnabled = !isCSGHubSandboxProvider && Boolean(agentDraft.sandbox_enabled);
   const runtimeChoices = Array.isArray(bootstrapConfig?.worker_runtime_choices)
     ? bootstrapConfig.worker_runtime_choices
     : [];
@@ -186,7 +190,7 @@ export function AgentProfileModal({
     : "";
 
   function defaultCustomWorkerDraft(baseDraft: AgentDraft): AgentDraft {
-    const codexAvailable = codexChoice?.installed !== false;
+    const codexAvailable = isCSGHubSandboxProvider || codexChoice?.installed !== false;
     const runtimeName = codexAvailable ? "codex" : defaultSandboxRuntimeName;
     const nextSandboxEnabled = !codexAvailable;
     const runtimeKind = composeLegacyRuntimeKind(runtimeName, nextSandboxEnabled) || DEFAULT_RUNTIME_KIND;
@@ -467,7 +471,7 @@ export function AgentProfileModal({
               </div>
               <div className="agent-section-form">
                 <div className="profile-grid profile-grid-compact agent-basics-grid">
-                  {isWorkerCreate ? (
+                  {isWorkerCreate && !isCSGHubSandboxProvider ? (
                     <div className="field span-2 agent-fast-mode-field agent-sandbox-field">
                       <div className="field-label-with-help">
                         <span>{t("profileSandboxEnabled")}</span>

--- a/web/app/tests/components/AgentProfileModal.test.tsx
+++ b/web/app/tests/components/AgentProfileModal.test.tsx
@@ -990,6 +990,48 @@ describe("AgentProfileModal", () => {
     expect(screen.queryByRole("option", { name: "Codex CLI" })).not.toBeInTheDocument();
   });
 
+  it("hides sandbox controls and only exposes Codex for CSGHub custom creation", async () => {
+    render(
+      <AgentProfileModal
+        t={t}
+        agentModalMode="create"
+        editingAgent={null}
+        agentDraft={{
+          ...agentToDraft(worker),
+          sandbox_enabled: true,
+          runtime_name: "openclaw",
+          runtime_kind: "openclaw_sandbox",
+        }}
+        onAgentDraftChange={vi.fn()}
+        onAgentModelsReset={vi.fn()}
+        hubTemplates={[]}
+        bootstrapConfig={{
+          sandbox_provider: "csghub",
+          worker_runtime_choices: [{ name: "codex", sandbox_enabled: false, installed: true, label: "Codex CLI" }],
+        }}
+        managerAgent={null}
+        agentModels={[]}
+        agentModelBusy={false}
+        locale="en"
+        authStatuses={{}}
+        authBusyProvider=""
+        agentCreateBotKind="worker"
+        agentCreateMode="custom"
+        onAgentCreateBotKindChange={vi.fn()}
+        notifierWebhookPublicOrigin="http://127.0.0.1:18080"
+        onProviderLogin={vi.fn()}
+        agentError=""
+        agentProgress={null}
+        agentBusy={false}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("checkbox", { name: "Sandbox" })).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Runtime" })).toHaveTextContent("Codex CLI");
+  });
+
   it("uses the matching worker template image when switching blank drafts to OpenClaw", async () => {
     const user = userEvent.setup();
     const onAgentDraftChange = vi.fn();


### PR DESCRIPTION
- When the sandbox provider is CSGHub, the template API returns only Codex worker templates.
- The agent creation UI hides the sandbox toggle and restricts runtime selection to Codex CLI.