### PR TITLE
feat(web): hide floating chat in conversations

### DIFF
--- a/web/app/src/models/routing.ts
+++ b/web/app/src/models/routing.ts
@@ -254,6 +254,10 @@ export function workspaceHasContextSidebar(pane: WorkspacePane | null | undefine
   return pane?.type !== WorkspacePaneTypes.task && pane?.type !== WorkspacePaneTypes.settings;
 }
 
+export function workspaceShowsFloatingChat(pane: WorkspacePane | null | undefined): boolean {
+  return pane?.type !== WorkspacePaneTypes.conversation || !pane.id;
+}
+
 export function readCollapsedWorkspaceGroups(): CollapsedWorkspaceGroups {
   try {
     const parsed = JSON.parse(window.localStorage.getItem(WORKSPACE_GROUPS_COLLAPSED_STORAGE_KEY) || "{}");

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceOverlays/WorkspaceOverlays.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceOverlays/WorkspaceOverlays.tsx
@@ -1,4 +1,5 @@
 import { useWorkspaceControllerContext } from "@/hooks/workspace";
+import { workspaceShowsFloatingChat } from "@/models/routing";
 import { AuthLoginNotice } from "../AuthLoginNotice";
 import { FloatingChat } from "../FloatingChat";
 import { ProfilePreviewPopover } from "../ProfilePreviewPopover";
@@ -15,6 +16,7 @@ import {
 export function WorkspaceOverlays() {
   const controller = useWorkspaceControllerContext();
   const closeLabel = controller.sidebarProps?.t?.("close") || "Close";
+  const showFloatingChat = workspaceShowsFloatingChat(controller.activePane);
 
   return (
     <>
@@ -23,7 +25,7 @@ export function WorkspaceOverlays() {
         closeLabel={closeLabel}
         onDismiss={controller.onDismissAuthNotice}
       />
-      {controller.floatingChatProps ? <FloatingChat {...controller.floatingChatProps} /> : null}
+      {showFloatingChat && controller.floatingChatProps ? <FloatingChat {...controller.floatingChatProps} /> : null}
       {controller.profilePreviewProps ? <ProfilePreviewPopover {...controller.profilePreviewProps} /> : null}
       {controller.createRoomModalProps ? <CreateRoomModal {...controller.createRoomModalProps} /> : null}
       {controller.createModelProviderModalProps ? (

--- a/web/app/tests/models/routing.test.ts
+++ b/web/app/tests/models/routing.test.ts
@@ -5,6 +5,7 @@ import {
   paneFromLocation,
   pathForPane,
   workspaceHasContextSidebar,
+  workspaceShowsFloatingChat,
   workspaceTabForPane,
 } from "@/models/routing";
 
@@ -97,5 +98,11 @@ describe("task routing", () => {
     expect(workspaceHasContextSidebar({ type: WorkspacePaneTypes.conversation, id: "" })).toBe(true);
     expect(workspaceHasContextSidebar({ type: WorkspacePaneTypes.task, id: "" })).toBe(false);
     expect(workspaceHasContextSidebar({ type: WorkspacePaneTypes.settings, id: "" })).toBe(false);
+  });
+
+  it("hides floating chat while a conversation is open", () => {
+    expect(workspaceShowsFloatingChat({ type: WorkspacePaneTypes.conversation, id: "room-1" })).toBe(false);
+    expect(workspaceShowsFloatingChat({ type: WorkspacePaneTypes.conversation, id: "" })).toBe(true);
+    expect(workspaceShowsFloatingChat({ type: WorkspacePaneTypes.agent, id: "agent-1" })).toBe(true);
   });
 });


### PR DESCRIPTION
- Hide the floating manager chat entry while a direct message, room, channel, or conversation is open, while keeping it available elsewhere.
