### PR TITLE
fix(web): preserve agent drawer metadata edits

### DIFF
--- a/web/app/src/hooks/workspace/types.ts
+++ b/web/app/src/hooks/workspace/types.ts
@@ -271,5 +271,5 @@ export type UseAgentControllerArgs = {
 };
 
 export type AgentDetailSidePanelProps = AgentDetailPaneProps & {
-  onClose: (restoreFocus?: boolean) => boolean | void;
+  onClose: (restoreFocus?: boolean, options?: { skipUnsavedCheck?: boolean }) => boolean | void;
 };

--- a/web/app/src/hooks/workspace/useWorkspaceController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceController.ts
@@ -296,11 +296,15 @@ export function useWorkspaceController() {
     t,
   });
   const closeConversationAgentDetail = useCallback(
-    (restoreFocus = true) => {
+    (restoreFocus = true, options: { skipUnsavedCheck?: boolean } = {}) => {
       if (!conversationProfileDetailAgentID) {
         return true;
       }
-      if (agent.agentViewProps.hasUnsavedChanges && !window.confirm(t("agentUnsavedChangesWarning"))) {
+      if (
+        !options.skipUnsavedCheck &&
+        agent.agentViewProps.hasUnsavedChanges &&
+        !window.confirm(t("agentUnsavedChangesWarning"))
+      ) {
         return false;
       }
       const trigger = conversationProfileDetailTriggerRef.current;

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import type { Ref } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentDraft, AgentLike } from "@/models/agents";
+import type { TranslateFn } from "@/models/conversations";
+import { AgentDetailPane } from "./AgentDetailPane";
+import type { AgentDetailPaneHandle, AgentDetailPaneProps } from "./AgentDetailPane";
+
+const t: TranslateFn = (key) => key;
+
+const agent: AgentLike = {
+  id: "agent-1",
+  name: "Saved agent",
+  description: "Saved description",
+  role: "assistant",
+  runtime_kind: "codex",
+  runtime: {
+    kind: "codex",
+    name: "codex",
+    state: "running",
+  },
+  agent_profile: {
+    model_id: "gpt-4.1-mini",
+    model_provider_id: "csghub_lite",
+    provider: "csghub_lite",
+    profile_complete: true,
+    reasoning_effort: "medium",
+  },
+};
+
+const savedDraft: AgentDraft = {
+  agent_id: "agent-1",
+  api_key: "",
+  api_key_preview: "",
+  api_key_set: false,
+  avatar: "",
+  base_url: "",
+  description: "Saved description",
+  enable_fast_mode: false,
+  envRows: [],
+  from_template: "",
+  headersText: "{}",
+  image: "",
+  instructions: "",
+  mcpServers: {},
+  model_id: "gpt-4.1-mini",
+  model_provider_id: "csghub_lite",
+  name: "Saved agent",
+  provider: "csghub_lite",
+  reasoning_effort: "medium",
+  requestOptionsText: "{}",
+  role: "assistant",
+  runtime_kind: "codex",
+  runtime_options: {},
+  sandbox_enabled: false,
+};
+
+type HarnessProps = Partial<AgentDetailPaneProps>;
+
+function Harness({
+  detailPaneRef,
+  onMetadataSave = vi.fn(),
+  ...props
+}: HarnessProps & { detailPaneRef?: Ref<AgentDetailPaneHandle> }) {
+  const [draft, setDraft] = useState(savedDraft);
+  return (
+    <AgentDetailPane
+      ref={detailPaneRef}
+      item={agent}
+      t={t}
+      draft={draft}
+      savedDraft={savedDraft}
+      onDraftChange={setDraft}
+      onMetadataSave={onMetadataSave}
+      onDelete={vi.fn()}
+      onInvite={vi.fn()}
+      onOpenDM={vi.fn()}
+      onRecreate={vi.fn()}
+      onStart={vi.fn()}
+      onStop={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe("AgentDetailPane metadata editing", () => {
+  it("reverts name edits on Escape without saving on blur", async () => {
+    const user = userEvent.setup();
+    const onMetadataSave = vi.fn();
+    const onOuterKeyDown = vi.fn();
+    render(
+      <div onKeyDown={onOuterKeyDown}>
+        <Harness onMetadataSave={onMetadataSave} />
+      </div>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "editAgentName" }));
+    const input = screen.getByDisplayValue("Saved agent");
+    await user.clear(input);
+    await user.type(input, "Draft agent");
+    onOuterKeyDown.mockClear();
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("button", { name: "editAgentName" })).toHaveTextContent("Saved agent");
+    expect(onOuterKeyDown).not.toHaveBeenCalled();
+    await waitFor(() => expect(onMetadataSave).not.toHaveBeenCalled());
+  });
+
+  it("reverts description edits on Escape without saving on blur", async () => {
+    const user = userEvent.setup();
+    const onMetadataSave = vi.fn();
+    const onOuterKeyDown = vi.fn();
+    render(
+      <div onKeyDown={onOuterKeyDown}>
+        <Harness onMetadataSave={onMetadataSave} />
+      </div>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "editDescription" }));
+    const textarea = screen.getByDisplayValue("Saved description");
+    await user.clear(textarea);
+    await user.type(textarea, "Draft description");
+    onOuterKeyDown.mockClear();
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("button", { name: "editDescription" })).toHaveTextContent("Saved description");
+    expect(onOuterKeyDown).not.toHaveBeenCalled();
+    await waitFor(() => expect(onMetadataSave).not.toHaveBeenCalled());
+  });
+
+  it("commits active name edits through the imperative close hook", async () => {
+    const user = userEvent.setup();
+    const detailPaneRef = createRef<AgentDetailPaneHandle>();
+    const onMetadataSave = vi.fn();
+    render(<Harness detailPaneRef={detailPaneRef} onMetadataSave={onMetadataSave} />);
+
+    await user.click(screen.getByRole("button", { name: "editAgentName" }));
+    const input = screen.getByDisplayValue("Saved agent");
+    await user.clear(input);
+    await user.type(input, "Backdrop saved agent");
+
+    expect(detailPaneRef.current?.commitActiveMetadataEdit()).toEqual(["name"]);
+    expect(onMetadataSave).toHaveBeenCalledWith({ name: "Backdrop saved agent" });
+  });
+
+  it("cancels active name edits through the imperative escape hook", async () => {
+    const user = userEvent.setup();
+    const detailPaneRef = createRef<AgentDetailPaneHandle>();
+    const onMetadataSave = vi.fn();
+    render(<Harness detailPaneRef={detailPaneRef} onMetadataSave={onMetadataSave} />);
+
+    await user.click(screen.getByRole("button", { name: "editAgentName" }));
+    const input = screen.getByDisplayValue("Saved agent");
+    await user.clear(input);
+    await user.type(input, "Esc canceled agent");
+
+    let canceledFields: ReturnType<AgentDetailPaneHandle["cancelActiveMetadataEdit"]> = [];
+    act(() => {
+      canceledFields = detailPaneRef.current?.cancelActiveMetadataEdit() ?? [];
+    });
+
+    expect(canceledFields).toEqual(["name"]);
+    expect(screen.getByRole("button", { name: "editAgentName" })).toHaveTextContent("Saved agent");
+    await waitFor(() => expect(onMetadataSave).not.toHaveBeenCalled());
+  });
+});

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -12,7 +12,7 @@ import {
   Trash2,
   Unlink2,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { errorMessage } from "@/api/client";
 import { REASONING_EFFORTS, SHOW_AGENT_LIFECYCLE_ACTIONS } from "@/shared/constants/agents";
 import { AGENT_PROFILE_ACTIVE_TAB_STORAGE_KEY } from "@/shared/storage/keys";
@@ -170,7 +170,12 @@ export type AgentDetailPaneProps = {
   onRetryMCPServers?: () => void | Promise<unknown>;
 };
 
-export function AgentDetailPane({
+export type AgentDetailPaneHandle = {
+  cancelActiveMetadataEdit: () => (keyof AgentMetadataSavePatch)[];
+  commitActiveMetadataEdit: () => (keyof AgentMetadataSavePatch)[];
+};
+
+export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPaneProps>(function AgentDetailPane({
   item,
   t,
   activeRoom = null,
@@ -232,7 +237,7 @@ export function AgentDetailPane({
   onInstallMCPServers,
   onDeleteMCPServer,
   onRetryMCPServers,
-}: AgentDetailPaneProps) {
+}, ref) {
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState<AgentProfileTabID>(() => readAgentProfileActiveTab());
@@ -247,7 +252,7 @@ export function AgentDetailPane({
   const [isProfileScrolling, setIsProfileScrolling] = useState(false);
   const descriptionInputRef = useRef<HTMLTextAreaElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
-  const skipMetadataAutosaveRef = useRef(false);
+  const skipMetadataAutosaveRef = useRef<Partial<Record<keyof AgentMetadataSavePatch, boolean>>>({});
   const profileScrollTimerRef = useRef<number | null>(null);
   const isManager = isManagerAgent(item);
   const canEditAgentName = Boolean(draft && !isManager);
@@ -265,26 +270,64 @@ export function AgentDetailPane({
     hasUnsavedChangesProp ?? Boolean(draft && savedDraft && JSON.stringify(draft) !== JSON.stringify(savedDraft));
   const saveDisabled = agentProfilePageSaveDisabled(draft, item, { saving, savedDraft });
   const updateDraft = (patch: Partial<AgentDraft>) => onDraftChange?.({ ...(draft || agentToDraft(item)), ...patch });
-  const saveMetadataPatch = (patch: AgentMetadataSavePatch) => {
-    if (skipMetadataAutosaveRef.current) {
-      skipMetadataAutosaveRef.current = false;
-      return;
+  const saveMetadataField = <K extends keyof AgentMetadataSavePatch>(
+    field: K,
+    value: AgentMetadataSavePatch[K],
+  ): boolean => {
+    if (skipMetadataAutosaveRef.current[field]) {
+      skipMetadataAutosaveRef.current = { ...skipMetadataAutosaveRef.current, [field]: false };
+      return false;
     }
     if (!onMetadataSave || saving) {
-      return;
+      return false;
     }
-    void onMetadataSave(patch);
+    void onMetadataSave({ [field]: value } as Pick<AgentMetadataSavePatch, K>);
+    return true;
   };
   const cancelNameEdit = () => {
-    skipMetadataAutosaveRef.current = true;
+    skipMetadataAutosaveRef.current = { ...skipMetadataAutosaveRef.current, name: true };
     updateDraft({ name: savedDraft?.name ?? item.name ?? "" });
     setIsEditingName(false);
   };
   const cancelDescriptionEdit = () => {
-    skipMetadataAutosaveRef.current = true;
+    skipMetadataAutosaveRef.current = { ...skipMetadataAutosaveRef.current, description: true };
     updateDraft({ description: savedDraft?.description ?? item.description ?? "" });
     setIsEditingDescription(false);
   };
+  useImperativeHandle(
+    ref,
+    () => ({
+      cancelActiveMetadataEdit: () => {
+        const canceledFields: (keyof AgentMetadataSavePatch)[] = [];
+        if (isEditingName) {
+          cancelNameEdit();
+          canceledFields.push("name");
+        }
+        if (isEditingDescription) {
+          cancelDescriptionEdit();
+          canceledFields.push("description");
+        }
+        return canceledFields;
+      },
+      commitActiveMetadataEdit: () => {
+        const committedFields: (keyof AgentMetadataSavePatch)[] = [];
+        if (isEditingName) {
+          setIsEditingName(false);
+          if (saveMetadataField("name", nameInputRef.current?.value ?? draft?.name ?? "")) {
+            committedFields.push("name");
+          }
+        }
+        if (isEditingDescription) {
+          setIsEditingDescription(false);
+          if (saveMetadataField("description", descriptionInputRef.current?.value ?? draft?.description ?? "")) {
+            committedFields.push("description");
+          }
+        }
+        return committedFields;
+      },
+    }),
+    [draft?.description, draft?.name, isEditingDescription, isEditingName, saveMetadataField],
+  );
   const runtimeOptionSchemas = runtimeOptionSchemasForAgent(draft?.runtime_kind || runtimeKind, item);
   const fallbackProviderID = String(draft?.model_provider_id || "").trim();
   const fallbackModelOptions =
@@ -480,12 +523,14 @@ export function AgentDetailPane({
                       aria-required="true"
                       onBlur={(event) => {
                         setIsEditingName(false);
-                        saveMetadataPatch({ name: event.currentTarget.value });
+                        saveMetadataField("name", event.currentTarget.value);
                       }}
                       onInput={(event) => updateDraft({ name: event.currentTarget.value })}
                       onKeyDown={(event) => {
                         if (event.key === "Escape") {
                           event.preventDefault();
+                          event.stopPropagation();
+                          event.nativeEvent.stopImmediatePropagation();
                           cancelNameEdit();
                           event.currentTarget.blur();
                         } else if (event.key === "Enter") {
@@ -538,12 +583,14 @@ export function AgentDetailPane({
                     value={draft.description}
                     onBlur={(event) => {
                       setIsEditingDescription(false);
-                      saveMetadataPatch({ description: event.currentTarget.value });
+                      saveMetadataField("description", event.currentTarget.value);
                     }}
                     onInput={(event) => updateDraft({ description: event.currentTarget.value })}
                     onKeyDown={(event) => {
                       if (event.key === "Escape") {
                         event.preventDefault();
+                        event.stopPropagation();
+                        event.nativeEvent.stopImmediatePropagation();
                         cancelDescriptionEdit();
                         event.currentTarget.blur();
                       }
@@ -1029,7 +1076,7 @@ export function AgentDetailPane({
       </DialogRoot>
     </section>
   );
-}
+});
 
 function readAgentProfileActiveTab(): AgentProfileTabID {
   if (typeof window === "undefined") {

--- a/web/app/src/pages/AgentPage/components/AgentView/AgentView.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentView/AgentView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import {
   Button,
   DialogCloseButton,
@@ -11,10 +11,10 @@ import {
 import { isNotificationBotAgent, agentDeleteConfirmationMessage } from "@/models/agents";
 import type { AgentLike } from "@/models/agents";
 import { AgentDetailPane } from "../AgentDetailPane";
-import type { AgentDetailPaneProps } from "../AgentDetailPane";
+import type { AgentDetailPaneHandle, AgentDetailPaneProps } from "../AgentDetailPane";
 import { NotificationParticipantDetailPane } from "../NotificationParticipantDetailPane";
 
-export function AgentView(props: AgentDetailPaneProps) {
+export const AgentView = forwardRef<AgentDetailPaneHandle, AgentDetailPaneProps>(function AgentView(props, ref) {
   const [deletePendingAgent, setDeletePendingAgent] = useState<AgentLike | null>(null);
   const deleteConfirmMessage = deletePendingAgent ? agentDeleteConfirmationMessage(deletePendingAgent, props.t) : "";
 
@@ -45,7 +45,7 @@ export function AgentView(props: AgentDetailPaneProps) {
       {isNotificationBotAgent(props.item) ? (
         <NotificationParticipantDetailPane {...sharedProps} />
       ) : (
-        <AgentDetailPane {...sharedProps} />
+        <AgentDetailPane ref={ref} {...sharedProps} />
       )}
       <DialogRoot
         open={Boolean(deletePendingAgent)}
@@ -84,4 +84,4 @@ export function AgentView(props: AgentDetailPaneProps) {
       </DialogRoot>
     </>
   );
-}
+});

--- a/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
+++ b/web/app/src/pages/ConversationPage/components/ConversationPane/ConversationPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchAgentLogsRequest } from "@/api/agents";
 import { errorMessage } from "@/api/client";
 import {
@@ -8,7 +8,7 @@ import {
   useQuestionAnswerMode,
   useConversationDraftEditorSync,
 } from "@/components/business/ConversationPane";
-import { AgentView } from "@/pages/AgentPage/components";
+import { AgentView, type AgentDetailPaneHandle } from "@/pages/AgentPage/components";
 import { Button, DialogCloseButton, DialogContent, DialogRoot, DialogTitle } from "@/components/ui";
 import { normalizeAuthProviderName } from "@/models/agents";
 import { getConversationDescription, isDirectConversation } from "@/models/conversations";
@@ -38,25 +38,57 @@ function writeConversationActivityActionSeen() {
   }
 }
 
+function hasBlockingAgentDetailChangesAfterMetadataCommit(
+  props: Pick<AgentDetailSidePanelProps, "draft" | "hasUnsavedChanges" | "savedDraft">,
+  committedFields: Array<"description" | "name">,
+): boolean {
+  if (!props.hasUnsavedChanges) {
+    return false;
+  }
+  if (!committedFields.length || !props.draft || !props.savedDraft) {
+    return true;
+  }
+  const normalizedDraft = { ...props.draft };
+  committedFields.forEach((field) => {
+    normalizedDraft[field] = props.savedDraft?.[field] ?? "";
+  });
+  return JSON.stringify(normalizedDraft) !== JSON.stringify(props.savedDraft);
+}
+
 function AgentDetailSidePanel({ onClose, onOpenDM, ...props }: AgentDetailSidePanelProps) {
   const [dialogPortalContainer, setDialogPortalContainer] = useState<HTMLDivElement | null>(null);
+  const detailPaneRef = useRef<AgentDetailPaneHandle | null>(null);
+  const requestClose = useCallback(
+    (restoreFocus = true) => {
+      const committedFields = detailPaneRef.current?.commitActiveMetadataEdit() ?? [];
+      const skipUnsavedCheck = !hasBlockingAgentDetailChangesAfterMetadataCommit(props, committedFields);
+      return onClose(restoreFocus, { skipUnsavedCheck });
+    },
+    [onClose, props],
+  );
   const handleOpenDM = useCallback(
     async (...args: Parameters<typeof onOpenDM>) => {
-      if (onClose(false) === false) {
+      if (requestClose(false) === false) {
         return;
       }
       await onOpenDM(...args);
     },
-    [onClose, onOpenDM],
+    [onOpenDM, requestClose],
   );
 
   return (
-    <DialogRoot open onOpenChange={(open) => (!open ? onClose() : undefined)}>
+    <DialogRoot open onOpenChange={(open) => (!open ? requestClose() : undefined)}>
       <DialogContent
         ref={setDialogPortalContainer}
         aria-describedby={undefined}
         aria-modal="true"
         className="agent-detail-side-panel"
+        onEscapeKeyDown={(event) => {
+          const canceledFields = detailPaneRef.current?.cancelActiveMetadataEdit() ?? [];
+          if (canceledFields.length) {
+            event.preventDefault();
+          }
+        }}
         overlayClassName="agent-detail-drawer-backdrop"
       >
         <div className="agent-detail-side-panel-bar">
@@ -69,7 +101,12 @@ function AgentDetailSidePanel({ onClose, onOpenDM, ...props }: AgentDetailSidePa
           <DialogTitle className="agent-detail-side-panel-title">{props.t("agentDetailPanel")}</DialogTitle>
         </div>
         <div className="agent-detail-side-panel-body">
-          <AgentView {...props} dialogPortalContainer={dialogPortalContainer} onOpenDM={handleOpenDM} />
+          <AgentView
+            ref={detailPaneRef}
+            {...props}
+            dialogPortalContainer={dialogPortalContainer}
+            onOpenDM={handleOpenDM}
+          />
         </div>
       </DialogContent>
     </DialogRoot>


### PR DESCRIPTION
## Summary
- Preserve blur-save behavior when closing the agent detail drawer from an active name or description edit
- Restore saved metadata without autosaving when Escape cancels an active drawer edit
- Add AgentDetailPane tests for drawer metadata commit and cancel behavior