### PR TITLE
fix(agent): recreate manager after MCP changes

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -723,7 +723,7 @@ func (s *Service) newCodexManagerAgent(name, description, instructions, avatar s
 	}
 }
 
-func (s *Service) persistManagerAgent(ctx context.Context, manager Agent, syncLifecycle bool) (Agent, error) {
+func (s *Service) persistManagerAgent(ctx context.Context, manager Agent, runtimeApplied bool) (Agent, error) {
 	if s == nil {
 		return Agent{}, fmt.Errorf("agent service is required")
 	}
@@ -750,11 +750,19 @@ func (s *Service) persistManagerAgent(ctx context.Context, manager Agent, syncLi
 
 	s.mu.Lock()
 	if existing, ok := s.agents[ManagerUserID]; ok {
+		// A successful runtime start clears requirements already applied to that
+		// runtime, but a concurrent config change must keep its recreate signal.
+		runtimeInputsChangedAfterApply := runtimeApplied && (!reflect.DeepEqual(manager.MCPServers, existing.MCPServers) ||
+			!reflect.DeepEqual(
+				runtimeConfigSnapshotForAgent(manager.AgentProfile, manager.RuntimeOptions),
+				runtimeConfigSnapshotForAgent(existing.AgentProfile, existing.RuntimeOptions),
+			) ||
+			!profilesEqualEnv(manager.AgentProfile, existing.AgentProfile))
 		manager.MCPServers = cloneMCPServers(existing.MCPServers)
-		if existing.AgentProfile.EnvRestartRequired {
+		if existing.AgentProfile.EnvRestartRequired && (!runtimeApplied || runtimeInputsChangedAfterApply) {
 			manager.AgentProfile.EnvRestartRequired = true
 		}
-		if existing.AgentProfile.ImageUpgradeRequired {
+		if existing.AgentProfile.ImageUpgradeRequired && !runtimeApplied {
 			manager.AgentProfile.ImageUpgradeRequired = true
 		}
 	}
@@ -778,7 +786,7 @@ func (s *Service) persistManagerAgent(ctx context.Context, manager Agent, syncLi
 	if !ok {
 		return Agent{}, fmt.Errorf("manager agent not found after save")
 	}
-	if syncLifecycle {
+	if runtimeApplied {
 		if err := s.syncLifecycleForAgent(ctx, created); err != nil {
 			return Agent{}, err
 		}

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -508,6 +508,9 @@ func (s *Service) update(ctx context.Context, id string, req UpdateRequest) (Age
 	if !ok {
 		return Agent{}, fmt.Errorf("agent %q not found", id)
 	}
+	if mcpServersUpdated && restartRequired && runtimeRunning && isManagerAgent(updated) {
+		return s.Recreate(ctx, id)
+	}
 	if runtimeAffectingUpdate {
 		normalized := normalizeProfileForAgentRuntime(updated.AgentProfile, updated.RuntimeOptions, updated.Name, updated.Description, updated.RuntimeKind, nil)
 		if err := s.syncGatewayAfterProfileChange(ctx, id, previous, normalized, restartRequired); err != nil {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -2040,6 +2040,84 @@ func TestAddMCPServersSerializesWithDirectMCPServersUpdate(t *testing.T) {
 	}
 }
 
+func TestAddMCPServersFromHubRecreatesRunningCodexManager(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	origLocateCodexCLI := locateCodexCLI
+	locateCodexCLI = func() (string, error) { return "/usr/local/bin/codex", nil }
+	t.Cleanup(func() {
+		locateCodexCLI = origLocateCodexCLI
+	})
+
+	deleteCalls := 0
+	newCalls := 0
+	var provisionedMCPServers map[string]any
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{ListenAddr: ":18080", AccessToken: "server-token"},
+		"",
+		filepath.Join(t.TempDir(), "agents.json"),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			del: func(context.Context, agentruntime.Handle) error {
+				deleteCalls++
+				return nil
+			},
+			provision: func(_ context.Context, req agentruntime.ProvisionRequest) error {
+				provisionedMCPServers = cloneMCPServers(req.MCPServers)
+				return nil
+			},
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				newCalls++
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-manager-session-new"}, nil
+			},
+			info: func(_ context.Context, h agentruntime.Handle) (agentruntime.Info, error) {
+				return agentruntime.Info{HandleID: h.HandleID, State: agentruntime.StateRunning}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	profile := AgentProfile{
+		Name:            ManagerName,
+		Provider:        ProviderCodex,
+		ModelID:         "gpt-5.5",
+		ProfileComplete: true,
+	}
+	svc.agents[ManagerUserID] = Agent{
+		ID:              ManagerUserID,
+		Name:            ManagerName,
+		RuntimeID:       runtimeIDForAgentID(ManagerUserID),
+		RuntimeKind:     RuntimeKindCodex,
+		RuntimeName:     RuntimeNameCodex,
+		BoxID:           "codex-manager-session-old",
+		Role:            RoleManager,
+		Status:          string(agentruntime.StateRunning),
+		Profile:         profileSelector(profile),
+		AgentProfile:    profile,
+		ProfileComplete: true,
+		CreatedAt:       time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC),
+	}
+
+	updated, err := svc.AddMCPServersFromHub(context.Background(), ManagerUserID, []string{"context7"}, map[string]any{
+		"context7": map[string]any{"command": "uvx", "args": []any{"context7-mcp"}},
+	})
+	if err != nil {
+		t.Fatalf("AddMCPServersFromHub() error = %v", err)
+	}
+	if deleteCalls != 1 || newCalls != 1 {
+		t.Fatalf("manager recreate calls = delete %d/new %d, want 1/1", deleteCalls, newCalls)
+	}
+	assertMCPServersHasServer(t, provisionedMCPServers, "context7")
+	assertMCPServersHasServer(t, updated.MCPServers, "context7")
+	if updated.AgentProfile.EnvRestartRequired {
+		t.Fatal("AddMCPServersFromHub().AgentProfile.EnvRestartRequired = true, want false after successful manager recreate")
+	}
+	if got, want := updated.BoxID, "codex-manager-session-new"; got != want {
+		t.Fatalf("AddMCPServersFromHub().BoxID = %q, want %q", got, want)
+	}
+}
+
 func TestUpdateMCPServersRecreatesOpenClawAndProvisionsLatestConfig(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 


### PR DESCRIPTION
## Summary

- Recreate the running Codex manager automatically after MCP server changes.
- Clear applied recreate state while preserving concurrent configuration updates.