### PR TITLE
build(web): use npmmirror for frontend dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE=golang:1.26.2-alpine
 ARG NODE_IMAGE=node:22.13.0-alpine
 ARG PNPM_VERSION=11.1.3
+ARG NPM_REGISTRY=https://registry.npmmirror.com
 ARG RUNTIME_IMAGE=alpine:3.23
 
 FROM ${NODE_IMAGE} AS web
@@ -8,10 +9,11 @@ FROM ${NODE_IMAGE} AS web
 WORKDIR /src/web/app
 
 ARG PNPM_VERSION
-RUN npm install -g pnpm@${PNPM_VERSION}
+ARG NPM_REGISTRY
+RUN npm config set registry ${NPM_REGISTRY} && npm install -g pnpm@${PNPM_VERSION}
 
 COPY web/app/package.json web/app/pnpm-lock.yaml web/app/.npmrc ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm config set registry ${NPM_REGISTRY} && pnpm install --frozen-lockfile
 
 COPY web/app ./
 RUN pnpm build && test -f ../static-dist/index.html


### PR DESCRIPTION
## Summary
- Configure npm and pnpm to use npmmirror while building the embedded Web UI.
- Keep the registry configurable through NPM_REGISTRY.

## Validation
- docker build --target web --build-arg NPM_REGISTRY=https://registry.npmmirror.com -t csgclaw-web-npmmirror-test .