### PR TITLE
fix(codex): retry transient runtime cleanup failures

### DIFF
--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	pathpkg "path"
 	"path/filepath"
@@ -42,6 +43,8 @@ var (
 	runtimeDirRemoveMaxDelay     = 1 * time.Second
 	runtimeDirRemoveTries        = 15
 )
+
+const runtimeDirRemovalEntryLimit = 32
 
 type AgentRef struct {
 	ID             string
@@ -322,7 +325,7 @@ func (r *Runtime) Delete(ctx context.Context, h agentruntime.Handle) error {
 	if err != nil {
 		return err
 	}
-	if err := r.removeRuntimeDir(ctx, dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := r.removeRuntimeDir(ctx, runtimeID, dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil
@@ -1182,39 +1185,181 @@ func (r *Runtime) removeAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-func (r *Runtime) removeRuntimeDir(ctx context.Context, path string) error {
-	var err error
-	for attempt := 0; attempt < runtimeDirRemoveTries; attempt++ {
-		err = r.removeAll(path)
-		if err == nil || errors.Is(err, os.ErrNotExist) || !isTransientRuntimeDirRemoveError(err) {
-			return err
+func (r *Runtime) removeRuntimeDir(ctx context.Context, runtimeID, path string) error {
+	startedAt := time.Now()
+	for attempt := 1; attempt <= runtimeDirRemoveTries; attempt++ {
+		err := r.removeAll(path)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			if attempt > 1 {
+				slog.InfoContext(ctx, "codex runtime directory removal recovered after retry",
+					"runtime_id", runtimeID,
+					"runtime_dir", path,
+					"attempts", attempt,
+					"elapsed", time.Since(startedAt).Round(time.Millisecond),
+				)
+			}
+			return nil
 		}
-		if attempt == runtimeDirRemoveTries-1 {
-			break
+		if !isTransientRuntimeDirRemoveError(err) || attempt == runtimeDirRemoveTries {
+			return runtimeDirRemovalFailure(ctx, runtimeID, path, attempt, startedAt, err)
 		}
-		delay := runtimeDirRemoveInitialDelay << attempt
+
+		delay := runtimeDirRemoveInitialDelay << (attempt - 1)
 		if delay > runtimeDirRemoveMaxDelay {
 			delay = runtimeDirRemoveMaxDelay
+		}
+		if attempt == 1 {
+			logRuntimeDirRemovalBlocked(ctx, runtimeID, path, attempt, delay, err)
 		}
 		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ctx.Err()
+			return runtimeDirRemovalFailure(ctx, runtimeID, path, attempt, startedAt, errors.Join(ctx.Err(), err))
 		case <-timer.C:
 		}
 	}
-	return err
+	return nil
 }
 
 func isTransientRuntimeDirRemoveError(err error) bool {
-	if errors.Is(err, syscall.EBUSY) {
+	if errors.Is(err, syscall.EBUSY) || errors.Is(err, syscall.ENOTEMPTY) {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "being used by another process") ||
 		strings.Contains(msg, "the process cannot access the file") ||
 		strings.Contains(msg, "access is denied")
+}
+
+type runtimeDirRemovalDiagnostics struct {
+	FilesystemType            string
+	FilesystemInspectionError string
+	RemainingEntries          []string
+	RemainingEntriesTruncated bool
+	DirectoryInspectionError  string
+}
+
+type runtimeDirRemovalErrorDetails struct {
+	Operation string
+	Path      string
+	Errno     string
+	ErrnoCode int64
+}
+
+func logRuntimeDirRemovalBlocked(ctx context.Context, runtimeID, path string, attempt int, retryDelay time.Duration, err error) {
+	diagnostics := inspectRuntimeDirRemoval(path)
+	details := inspectRuntimeDirRemovalError(err)
+	slog.LogAttrs(ctx, slog.LevelWarn, "codex runtime directory removal blocked; retrying",
+		slog.String("runtime_id", runtimeID),
+		slog.String("runtime_dir", path),
+		slog.Int("attempt", attempt),
+		slog.Int("max_attempts", runtimeDirRemoveTries),
+		slog.Duration("retry_delay", retryDelay),
+		slog.Any("error", err),
+		slog.String("error_operation", details.Operation),
+		slog.String("error_path", details.Path),
+		slog.String("errno", details.Errno),
+		slog.Int64("errno_code", details.ErrnoCode),
+		slog.String("filesystem_type", diagnostics.FilesystemType),
+		slog.String("filesystem_inspection_error", diagnostics.FilesystemInspectionError),
+		slog.Any("remaining_entries", diagnostics.RemainingEntries),
+		slog.Bool("remaining_entries_truncated", diagnostics.RemainingEntriesTruncated),
+		slog.String("directory_inspection_error", diagnostics.DirectoryInspectionError),
+	)
+}
+
+func runtimeDirRemovalFailure(ctx context.Context, runtimeID, path string, attempts int, startedAt time.Time, err error) error {
+	diagnostics := inspectRuntimeDirRemoval(path)
+	details := inspectRuntimeDirRemovalError(err)
+	elapsed := time.Since(startedAt).Round(time.Millisecond)
+	slog.LogAttrs(ctx, slog.LevelError, "codex runtime directory removal failed",
+		slog.String("runtime_id", runtimeID),
+		slog.String("runtime_dir", path),
+		slog.Int("attempts", attempts),
+		slog.Duration("elapsed", elapsed),
+		slog.Any("error", err),
+		slog.String("error_operation", details.Operation),
+		slog.String("error_path", details.Path),
+		slog.String("errno", details.Errno),
+		slog.Int64("errno_code", details.ErrnoCode),
+		slog.String("filesystem_type", diagnostics.FilesystemType),
+		slog.String("filesystem_inspection_error", diagnostics.FilesystemInspectionError),
+		slog.Any("remaining_entries", diagnostics.RemainingEntries),
+		slog.Bool("remaining_entries_truncated", diagnostics.RemainingEntriesTruncated),
+		slog.String("directory_inspection_error", diagnostics.DirectoryInspectionError),
+	)
+	return fmt.Errorf(
+		"remove codex runtime directory %q after %d attempts over %s: %w; diagnostics: filesystem_type=%q errno=%q error_path=%q remaining_entries=%q remaining_entries_truncated=%t filesystem_inspection_error=%q directory_inspection_error=%q",
+		path,
+		attempts,
+		elapsed,
+		err,
+		diagnostics.FilesystemType,
+		details.Errno,
+		details.Path,
+		diagnostics.RemainingEntries,
+		diagnostics.RemainingEntriesTruncated,
+		diagnostics.FilesystemInspectionError,
+		diagnostics.DirectoryInspectionError,
+	)
+}
+
+func inspectRuntimeDirRemoval(path string) runtimeDirRemovalDiagnostics {
+	diagnostics := runtimeDirRemovalDiagnostics{}
+	diagnostics.FilesystemType, diagnostics.FilesystemInspectionError = runtimeDirFilesystemType(path)
+	walkErr := filepath.WalkDir(path, func(entryPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entryPath == path {
+			return nil
+		}
+		relative, err := filepath.Rel(path, entryPath)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if entry.IsDir() {
+			relative += "/"
+		}
+		diagnostics.RemainingEntries = append(diagnostics.RemainingEntries, relative)
+		if len(diagnostics.RemainingEntries) >= runtimeDirRemovalEntryLimit {
+			diagnostics.RemainingEntriesTruncated = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, os.ErrNotExist) {
+		diagnostics.DirectoryInspectionError = walkErr.Error()
+	}
+	return diagnostics
+}
+
+func inspectRuntimeDirRemovalError(err error) runtimeDirRemovalErrorDetails {
+	details := runtimeDirRemovalErrorDetails{}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		details.Operation = pathErr.Op
+		details.Path = pathErr.Path
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		details.ErrnoCode = int64(errno)
+		switch errno {
+		case syscall.ENOTEMPTY:
+			details.Errno = "ENOTEMPTY"
+		case syscall.EBUSY:
+			details.Errno = "EBUSY"
+		case syscall.EACCES:
+			details.Errno = "EACCES"
+		case syscall.EPERM:
+			details.Errno = "EPERM"
+		default:
+			details.Errno = errno.Error()
+		}
+	}
+	return details
 }
 
 func (r *Runtime) openFile(path string, flag int, mode os.FileMode) (*os.File, error) {

--- a/internal/runtime/codex/runtime_dir_filesystem_linux.go
+++ b/internal/runtime/codex/runtime_dir_filesystem_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package codex
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"syscall"
+)
+
+func runtimeDirFilesystemType(path string) (string, string) {
+	probe := filepath.Clean(path)
+	for {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(probe, &stat); err == nil {
+			return linuxFilesystemType(stat.Type), ""
+		} else if !errors.Is(err, syscall.ENOENT) {
+			return "unknown", err.Error()
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "unknown", syscall.ENOENT.Error()
+		}
+		probe = parent
+	}
+}
+
+func linuxFilesystemType(magic int64) string {
+	switch magic {
+	case 0x6969:
+		return "nfs"
+	case 0xff534d42:
+		return "cifs"
+	case 0xfe534d42:
+		return "smb2"
+	case 0x65735546:
+		return "fuse"
+	case 0x794c7630:
+		return "overlayfs"
+	case 0x01021994:
+		return "tmpfs"
+	case 0xef53:
+		return "ext2/3/4"
+	case 0x58465342:
+		return "xfs"
+	case 0x9123683e:
+		return "btrfs"
+	case 0x2fc12fc1:
+		return "zfs"
+	default:
+		return fmt.Sprintf("unknown(0x%x)", uint64(magic))
+	}
+}

--- a/internal/runtime/codex/runtime_dir_filesystem_other.go
+++ b/internal/runtime/codex/runtime_dir_filesystem_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package codex
+
+func runtimeDirFilesystemType(string) (string, string) {
+	return "unavailable", ""
+}

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -1,9 +1,11 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -845,7 +847,7 @@ func TestRemoveRuntimeDirRetriesLockedPluginCloneFetchHead(t *testing.T) {
 		},
 	})
 
-	if err := rt.removeRuntimeDir(context.Background(), runtimeDir); err != nil {
+	if err := rt.removeRuntimeDir(context.Background(), "rt-u-alice", runtimeDir); err != nil {
 		t.Fatalf("removeRuntimeDir() error = %v", err)
 	}
 	if removeCalls != 4 {
@@ -853,6 +855,118 @@ func TestRemoveRuntimeDirRetriesLockedPluginCloneFetchHead(t *testing.T) {
 	}
 	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("runtime dir stat error = %v, want not exist", err)
+	}
+}
+
+func TestRemoveRuntimeDirRetriesNonEmptyDirectory(t *testing.T) {
+	root := t.TempDir()
+	runtimeDir := filepath.Join(root, "agent-manager", ".codex")
+	blockedDir := filepath.Join(runtimeDir, "home", "tmp", "arg0", "codex-arg0zMf3j5")
+	if err := os.MkdirAll(blockedDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(blocked runtime dir) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedDir, "pending"), []byte("pending"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(pending) error = %v", err)
+	}
+
+	origInitialDelay := runtimeDirRemoveInitialDelay
+	origMaxDelay := runtimeDirRemoveMaxDelay
+	origTries := runtimeDirRemoveTries
+	runtimeDirRemoveInitialDelay = time.Millisecond
+	runtimeDirRemoveMaxDelay = time.Millisecond
+	runtimeDirRemoveTries = 4
+	t.Cleanup(func() {
+		runtimeDirRemoveInitialDelay = origInitialDelay
+		runtimeDirRemoveMaxDelay = origMaxDelay
+		runtimeDirRemoveTries = origTries
+	})
+
+	var removeCalls int
+	rt := New(Dependencies{
+		RemoveAll: func(path string) error {
+			removeCalls++
+			if path == runtimeDir && removeCalls < 3 {
+				return &os.PathError{Op: "unlinkat", Path: blockedDir, Err: syscall.ENOTEMPTY}
+			}
+			return os.RemoveAll(path)
+		},
+	})
+
+	if err := rt.removeRuntimeDir(context.Background(), "rt-agent-manager", runtimeDir); err != nil {
+		t.Fatalf("removeRuntimeDir() error = %v", err)
+	}
+	if removeCalls != 3 {
+		t.Fatalf("RemoveAll() calls = %d, want 3", removeCalls)
+	}
+}
+
+func TestRemoveRuntimeDirFailureReportsDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	runtimeDir := filepath.Join(root, "agent-manager", ".codex")
+	blockedDir := filepath.Join(runtimeDir, "home", "tmp", "arg0", "codex-arg0zMf3j5")
+	if err := os.MkdirAll(blockedDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(blocked runtime dir) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedDir, ".nfs0000000000000001"), []byte("pending"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(.nfs file) error = %v", err)
+	}
+
+	origInitialDelay := runtimeDirRemoveInitialDelay
+	origMaxDelay := runtimeDirRemoveMaxDelay
+	origTries := runtimeDirRemoveTries
+	runtimeDirRemoveInitialDelay = time.Millisecond
+	runtimeDirRemoveMaxDelay = time.Millisecond
+	runtimeDirRemoveTries = 2
+	t.Cleanup(func() {
+		runtimeDirRemoveInitialDelay = origInitialDelay
+		runtimeDirRemoveMaxDelay = origMaxDelay
+		runtimeDirRemoveTries = origTries
+	})
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	var removeCalls int
+	rt := New(Dependencies{
+		RemoveAll: func(string) error {
+			removeCalls++
+			return &os.PathError{Op: "unlinkat", Path: blockedDir, Err: syscall.ENOTEMPTY}
+		},
+	})
+
+	err := rt.removeRuntimeDir(context.Background(), "rt-agent-manager", runtimeDir)
+	if err == nil {
+		t.Fatal("removeRuntimeDir() error = nil, want diagnostics")
+	}
+	for _, want := range []string{
+		"after 2 attempts",
+		`errno="ENOTEMPTY"`,
+		`error_path="` + blockedDir + `"`,
+		"home/tmp/arg0/codex-arg0zMf3j5/.nfs0000000000000001",
+		"filesystem_type=",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("removeRuntimeDir() error = %q, want %q", err, want)
+		}
+	}
+	if removeCalls != 2 {
+		t.Fatalf("RemoveAll() calls = %d, want 2", removeCalls)
+	}
+	for _, want := range []string{
+		"codex runtime directory removal blocked; retrying",
+		"codex runtime directory removal failed",
+		"runtime_id=rt-agent-manager",
+		"errno=ENOTEMPTY",
+		"remaining_entries=",
+		".nfs0000000000000001",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("runtime removal logs = %q, want %q", logs.String(), want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- retry transient non-empty Codex runtime cleanup failures
- log bounded filesystem and remaining-entry diagnostics when cleanup is blocked