### PR TITLE
fix(feishu): activate codex manager bindings without rebuild

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -567,6 +567,7 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 	}
 	if svc != nil {
 		svc.SetLifecycleObserver(codexBridgeMgr)
+		svc.SetBindingActivator(codexBridgeMgr)
 	}
 	if codexBridgeMgr != nil {
 		defer codexBridgeMgr.Close()

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -2092,10 +2092,11 @@ func (b *notifyingBuffer) String() string {
 }
 
 type fakeCodexBridgeManager struct {
-	start  func(context.Context) error
-	ensure func(context.Context, agent.Agent) error
-	stop   func(string)
-	close  func()
+	start   func(context.Context) error
+	ensure  func(context.Context, agent.Agent) error
+	stop    func(string)
+	refresh func(context.Context, agent.Agent, string) error
+	close   func()
 }
 
 func (m *fakeCodexBridgeManager) Start(ctx context.Context) error {
@@ -2116,6 +2117,13 @@ func (m *fakeCodexBridgeManager) StopAgent(agentID string) {
 	if m != nil && m.stop != nil {
 		m.stop(agentID)
 	}
+}
+
+func (m *fakeCodexBridgeManager) RefreshAgentChannel(ctx context.Context, a agent.Agent, channel string) error {
+	if m != nil && m.refresh != nil {
+		return m.refresh(ctx, a, channel)
+	}
+	return nil
 }
 
 func (m *fakeCodexBridgeManager) Close() {

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	agentruntime "csgclaw/internal/runtime"
@@ -11,6 +12,13 @@ type LifecycleObserver interface {
 	EnsureAgent(context.Context, Agent) error
 	StopAgent(string)
 }
+
+type ExternalBindingActivation string
+
+const (
+	ExternalBindingActivationLifecycleReconciled ExternalBindingActivation = "lifecycle_reconciled"
+	ExternalBindingActivationRuntimeRecreated    ExternalBindingActivation = "runtime_recreated"
+)
 
 func (s *Service) lifecycleObserver() LifecycleObserver {
 	if s == nil {
@@ -31,6 +39,57 @@ func (s *Service) syncLifecycleForAgent(ctx context.Context, a Agent) error {
 	}
 	observer.StopAgent(a.ID)
 	return nil
+}
+
+// ReconcileLifecycle reapplies lifecycle integrations for an agent without
+// changing its runtime instance. This is used when an external binding, such
+// as a channel participant, changes after the runtime is already running.
+func (s *Service) ReconcileLifecycle(ctx context.Context, id string) (Agent, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Agent{}, fmt.Errorf("agent id is required")
+	}
+	got, ok := s.Agent(id)
+	if !ok {
+		return Agent{}, fmt.Errorf("agent %q not found", id)
+	}
+	return s.reconcileLifecycle(ctx, got)
+}
+
+// ApplyExternalBinding activates an updated external binding using the
+// lifecycle required by the agent's runtime.
+func (s *Service) ApplyExternalBinding(ctx context.Context, id string) (Agent, ExternalBindingActivation, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Agent{}, "", fmt.Errorf("agent id is required")
+	}
+	got, ok := s.Agent(id)
+	if !ok {
+		return Agent{}, "", fmt.Errorf("agent %q not found", id)
+	}
+	if strings.EqualFold(strings.TrimSpace(got.RuntimeKind), RuntimeKindCodex) {
+		reconciled, err := s.reconcileLifecycle(ctx, got)
+		return reconciled, ExternalBindingActivationLifecycleReconciled, err
+	}
+	recreated, err := s.Recreate(ctx, got.ID)
+	return recreated, ExternalBindingActivationRuntimeRecreated, err
+}
+
+func (s *Service) reconcileLifecycle(ctx context.Context, got Agent) (Agent, error) {
+	if !strings.EqualFold(strings.TrimSpace(got.RuntimeKind), RuntimeKindCodex) {
+		return Agent{}, fmt.Errorf("agent %q runtime %q does not support lifecycle reconciliation", got.ID, got.RuntimeKind)
+	}
+	if !shouldEnsureLifecycle(got) {
+		return Agent{}, fmt.Errorf("agent %q must be running with a complete profile to reconcile external bindings", got.ID)
+	}
+	observer := s.lifecycleObserver()
+	if observer == nil {
+		return Agent{}, fmt.Errorf("agent lifecycle observer is not configured")
+	}
+	if err := observer.EnsureAgent(ctx, got); err != nil {
+		return Agent{}, err
+	}
+	return got, nil
 }
 
 func (s *Service) stopLifecycleAgent(agentID string) {

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -13,11 +13,15 @@ type LifecycleObserver interface {
 	StopAgent(string)
 }
 
+type BindingActivator interface {
+	RefreshAgentChannel(context.Context, Agent, string) error
+}
+
 type ExternalBindingActivation string
 
 const (
-	ExternalBindingActivationLifecycleReconciled ExternalBindingActivation = "lifecycle_reconciled"
-	ExternalBindingActivationRuntimeRecreated    ExternalBindingActivation = "runtime_recreated"
+	ExternalBindingActivationChannelRefreshed ExternalBindingActivation = "channel_refreshed"
+	ExternalBindingActivationRuntimeRecreated ExternalBindingActivation = "runtime_recreated"
 )
 
 func (s *Service) lifecycleObserver() LifecycleObserver {
@@ -27,6 +31,15 @@ func (s *Service) lifecycleObserver() LifecycleObserver {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.lifecycle
+}
+
+func (s *Service) bindingActivator() BindingActivator {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.bindingActivation
 }
 
 func (s *Service) syncLifecycleForAgent(ctx context.Context, a Agent) error {
@@ -41,55 +54,36 @@ func (s *Service) syncLifecycleForAgent(ctx context.Context, a Agent) error {
 	return nil
 }
 
-// ReconcileLifecycle reapplies lifecycle integrations for an agent without
-// changing its runtime instance. This is used when an external binding, such
-// as a channel participant, changes after the runtime is already running.
-func (s *Service) ReconcileLifecycle(ctx context.Context, id string) (Agent, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return Agent{}, fmt.Errorf("agent id is required")
-	}
-	got, ok := s.Agent(id)
-	if !ok {
-		return Agent{}, fmt.Errorf("agent %q not found", id)
-	}
-	return s.reconcileLifecycle(ctx, got)
-}
-
 // ApplyExternalBinding activates an updated external binding using the
 // lifecycle required by the agent's runtime.
-func (s *Service) ApplyExternalBinding(ctx context.Context, id string) (Agent, ExternalBindingActivation, error) {
+func (s *Service) ApplyExternalBinding(ctx context.Context, id, channel string) (Agent, ExternalBindingActivation, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return Agent{}, "", fmt.Errorf("agent id is required")
+	}
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	if channel == "" {
+		return Agent{}, "", fmt.Errorf("channel is required")
 	}
 	got, ok := s.Agent(id)
 	if !ok {
 		return Agent{}, "", fmt.Errorf("agent %q not found", id)
 	}
 	if strings.EqualFold(strings.TrimSpace(got.RuntimeKind), RuntimeKindCodex) {
-		reconciled, err := s.reconcileLifecycle(ctx, got)
-		return reconciled, ExternalBindingActivationLifecycleReconciled, err
+		if !shouldEnsureLifecycle(got) {
+			return Agent{}, "", fmt.Errorf("agent %q must be running with a complete profile to refresh external bindings", got.ID)
+		}
+		activator := s.bindingActivator()
+		if activator == nil {
+			return Agent{}, "", fmt.Errorf("agent binding activator is not configured")
+		}
+		if err := activator.RefreshAgentChannel(ctx, got, channel); err != nil {
+			return Agent{}, "", err
+		}
+		return got, ExternalBindingActivationChannelRefreshed, nil
 	}
 	recreated, err := s.Recreate(ctx, got.ID)
 	return recreated, ExternalBindingActivationRuntimeRecreated, err
-}
-
-func (s *Service) reconcileLifecycle(ctx context.Context, got Agent) (Agent, error) {
-	if !strings.EqualFold(strings.TrimSpace(got.RuntimeKind), RuntimeKindCodex) {
-		return Agent{}, fmt.Errorf("agent %q runtime %q does not support lifecycle reconciliation", got.ID, got.RuntimeKind)
-	}
-	if !shouldEnsureLifecycle(got) {
-		return Agent{}, fmt.Errorf("agent %q must be running with a complete profile to reconcile external bindings", got.ID)
-	}
-	observer := s.lifecycleObserver()
-	if observer == nil {
-		return Agent{}, fmt.Errorf("agent lifecycle observer is not configured")
-	}
-	if err := observer.EnsureAgent(ctx, got); err != nil {
-		return Agent{}, err
-	}
-	return got, nil
 }
 
 func (s *Service) stopLifecycleAgent(agentID string) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -187,6 +187,7 @@ type Service struct {
 	runtimeRecords          map[string]RuntimeRecord
 	runtimeRegistry         map[string]agentruntime.Runtime
 	lifecycle               LifecycleObserver
+	bindingActivation       BindingActivator
 	agentLifecycleMu        sync.Mutex
 	agentLifecycleGates     map[string]*agentLifecycleGate
 	profileDefaults         AgentProfile
@@ -304,6 +305,16 @@ func WithLifecycleObserver(observer LifecycleObserver) ServiceOption {
 			return fmt.Errorf("agent service is required")
 		}
 		s.lifecycle = observer
+		return nil
+	}
+}
+
+func WithBindingActivator(activator BindingActivator) ServiceOption {
+	return func(s *Service) error {
+		if s == nil {
+			return fmt.Errorf("agent service is required")
+		}
+		s.bindingActivation = activator
 		return nil
 	}
 }
@@ -449,6 +460,15 @@ func (s *Service) SetLifecycleObserver(observer LifecycleObserver) {
 	}
 	s.mu.Lock()
 	s.lifecycle = observer
+	s.mu.Unlock()
+}
+
+func (s *Service) SetBindingActivator(activator BindingActivator) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.bindingActivation = activator
 	s.mu.Unlock()
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -440,6 +440,21 @@ func (f *fakeLifecycleObserver) StopAgent(agentID string) {
 	f.events = append(f.events, "stop:"+agentID)
 }
 
+type fakeBindingActivator struct {
+	refreshCalls []bindingRefreshCall
+	refreshErr   error
+}
+
+type bindingRefreshCall struct {
+	agent   Agent
+	channel string
+}
+
+func (f *fakeBindingActivator) RefreshAgentChannel(_ context.Context, a Agent, channel string) error {
+	f.refreshCalls = append(f.refreshCalls, bindingRefreshCall{agent: a, channel: channel})
+	return f.refreshErr
+}
+
 type cancelOnWrite struct {
 	writer io.Writer
 	cancel context.CancelFunc
@@ -6700,13 +6715,15 @@ func TestStartTriggersLifecycleObserver(t *testing.T) {
 	}
 }
 
-func TestApplyExternalBindingReconcilesCodexWithoutStartingRuntime(t *testing.T) {
+func TestApplyExternalBindingRefreshesCodexChannelWithoutStartingRuntime(t *testing.T) {
 	observer := &fakeLifecycleObserver{}
+	activator := &fakeBindingActivator{}
 	runtimeStartCalls := 0
 	svc, err := NewService(
 		config.ModelConfig{},
 		config.ServerConfig{}, "manager-image:test", "",
 		WithLifecycleObserver(observer),
+		WithBindingActivator(activator),
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
 			start: func(context.Context, agentruntime.Handle) (agentruntime.State, error) {
@@ -6729,30 +6746,33 @@ func TestApplyExternalBindingReconcilesCodexWithoutStartingRuntime(t *testing.T)
 		ProfileComplete: true,
 	}
 
-	reconciled, activation, err := svc.ApplyExternalBinding(context.Background(), ManagerUserID)
+	reconciled, activation, err := svc.ApplyExternalBinding(context.Background(), ManagerUserID, "feishu")
 	if err != nil {
 		t.Fatalf("ApplyExternalBinding() error = %v", err)
 	}
 	if reconciled.ID != ManagerUserID {
 		t.Fatalf("ApplyExternalBinding() agent = %q, want %q", reconciled.ID, ManagerUserID)
 	}
-	if activation != ExternalBindingActivationLifecycleReconciled {
-		t.Fatalf("activation = %q, want %q", activation, ExternalBindingActivationLifecycleReconciled)
+	if activation != ExternalBindingActivationChannelRefreshed {
+		t.Fatalf("activation = %q, want %q", activation, ExternalBindingActivationChannelRefreshed)
 	}
 	if runtimeStartCalls != 0 {
 		t.Fatalf("runtime Start() calls = %d, want 0", runtimeStartCalls)
 	}
-	if len(observer.ensureCalls) != 1 || observer.ensureCalls[0].ID != ManagerUserID {
-		t.Fatalf("EnsureAgent() calls = %+v, want manager once", observer.ensureCalls)
+	if len(observer.ensureCalls) != 0 {
+		t.Fatalf("EnsureAgent() calls = %+v, want none", observer.ensureCalls)
+	}
+	if len(activator.refreshCalls) != 1 || activator.refreshCalls[0].agent.ID != ManagerUserID || activator.refreshCalls[0].channel != "feishu" {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want manager feishu once", activator.refreshCalls)
 	}
 }
 
-func TestReconcileLifecycleRejectsStoppedAgent(t *testing.T) {
-	observer := &fakeLifecycleObserver{}
+func TestApplyExternalBindingRejectsStoppedCodexAgent(t *testing.T) {
+	activator := &fakeBindingActivator{}
 	svc, err := NewService(
 		config.ModelConfig{},
 		config.ServerConfig{}, "manager-image:test", "",
-		WithLifecycleObserver(observer),
+		WithBindingActivator(activator),
 		WithRuntime(fakeAgentRuntime{
 			kind: RuntimeKindCodex,
 			info: func(_ context.Context, h agentruntime.Handle) (agentruntime.Info, error) {
@@ -6774,11 +6794,11 @@ func TestReconcileLifecycleRejectsStoppedAgent(t *testing.T) {
 		ProfileComplete: true,
 	}
 
-	if _, err := svc.ReconcileLifecycle(context.Background(), ManagerUserID); err == nil {
-		t.Fatal("ReconcileLifecycle() error = nil, want stopped agent rejection")
+	if _, _, err := svc.ApplyExternalBinding(context.Background(), ManagerUserID, "feishu"); err == nil {
+		t.Fatal("ApplyExternalBinding() error = nil, want stopped agent rejection")
 	}
-	if len(observer.ensureCalls) != 0 || len(observer.stopCalls) != 0 {
-		t.Fatalf("lifecycle calls = ensure=%+v stop=%+v, want none", observer.ensureCalls, observer.stopCalls)
+	if len(activator.refreshCalls) != 0 {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want none", activator.refreshCalls)
 	}
 }
 

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -6700,6 +6700,88 @@ func TestStartTriggersLifecycleObserver(t *testing.T) {
 	}
 }
 
+func TestApplyExternalBindingReconcilesCodexWithoutStartingRuntime(t *testing.T) {
+	observer := &fakeLifecycleObserver{}
+	runtimeStartCalls := 0
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{}, "manager-image:test", "",
+		WithLifecycleObserver(observer),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			start: func(context.Context, agentruntime.Handle) (agentruntime.State, error) {
+				runtimeStartCalls++
+				return agentruntime.StateRunning, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents[ManagerUserID] = Agent{
+		ID:              ManagerUserID,
+		Name:            ManagerName,
+		Role:            RoleManager,
+		RuntimeID:       "rt-manager",
+		RuntimeKind:     RuntimeKindCodex,
+		Status:          string(agentruntime.StateRunning),
+		AgentProfile:    AgentProfile{Name: ManagerName, Provider: ProviderCodex, ModelID: "gpt-5.4", ProfileComplete: true},
+		ProfileComplete: true,
+	}
+
+	reconciled, activation, err := svc.ApplyExternalBinding(context.Background(), ManagerUserID)
+	if err != nil {
+		t.Fatalf("ApplyExternalBinding() error = %v", err)
+	}
+	if reconciled.ID != ManagerUserID {
+		t.Fatalf("ApplyExternalBinding() agent = %q, want %q", reconciled.ID, ManagerUserID)
+	}
+	if activation != ExternalBindingActivationLifecycleReconciled {
+		t.Fatalf("activation = %q, want %q", activation, ExternalBindingActivationLifecycleReconciled)
+	}
+	if runtimeStartCalls != 0 {
+		t.Fatalf("runtime Start() calls = %d, want 0", runtimeStartCalls)
+	}
+	if len(observer.ensureCalls) != 1 || observer.ensureCalls[0].ID != ManagerUserID {
+		t.Fatalf("EnsureAgent() calls = %+v, want manager once", observer.ensureCalls)
+	}
+}
+
+func TestReconcileLifecycleRejectsStoppedAgent(t *testing.T) {
+	observer := &fakeLifecycleObserver{}
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{}, "manager-image:test", "",
+		WithLifecycleObserver(observer),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			info: func(_ context.Context, h agentruntime.Handle) (agentruntime.Info, error) {
+				return agentruntime.Info{HandleID: h.HandleID, State: agentruntime.StateStopped}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents[ManagerUserID] = Agent{
+		ID:              ManagerUserID,
+		Name:            ManagerName,
+		Role:            RoleManager,
+		RuntimeID:       "rt-manager",
+		RuntimeKind:     RuntimeKindCodex,
+		Status:          string(agentruntime.StateStopped),
+		AgentProfile:    AgentProfile{Name: ManagerName, Provider: ProviderCodex, ModelID: "gpt-5.4", ProfileComplete: true},
+		ProfileComplete: true,
+	}
+
+	if _, err := svc.ReconcileLifecycle(context.Background(), ManagerUserID); err == nil {
+		t.Fatal("ReconcileLifecycle() error = nil, want stopped agent rejection")
+	}
+	if len(observer.ensureCalls) != 0 || len(observer.stopCalls) != 0 {
+		t.Fatalf("lifecycle calls = ensure=%+v stop=%+v, want none", observer.ensureCalls, observer.stopCalls)
+	}
+}
+
 func TestStartProvisionsRuntimeBeforeStart(t *testing.T) {
 	var callOrder []string
 	svc, err := NewService(

--- a/internal/api/feishu_registration.go
+++ b/internal/api/feishu_registration.go
@@ -198,7 +198,7 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if _, activation, err := h.svc.ApplyExternalBinding(r.Context(), state.AgentID); err != nil {
+	if _, activation, err := h.svc.ApplyExternalBinding(r.Context(), state.AgentID, participant.ChannelFeishu); err != nil {
 		result.Status = "partial"
 		result.ActivationStatus = "activation_failed"
 		result.ActivationError = err.Error()

--- a/internal/api/feishu_registration.go
+++ b/internal/api/feishu_registration.go
@@ -193,10 +193,17 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	}
-	result, err := feishubind.BindBot(r.Context(), h.svc, h.participant, state.AgentID, appID, appSecret, true)
+	result, err := feishubind.BindBot(r.Context(), h.svc, h.participant, state.AgentID, appID, appSecret, false)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if _, activation, err := h.svc.ApplyExternalBinding(r.Context(), state.AgentID); err != nil {
+		result.Status = "partial"
+		result.ActivationStatus = "activation_failed"
+		result.ActivationError = err.Error()
+	} else {
+		result.ActivationStatus = string(activation)
 	}
 	_ = h.deleteFeishuRegistration(state.RegistrationID)
 	writeJSON(w, http.StatusOK, result)

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -107,8 +107,8 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if result["participant_id"] != "pt-dev" || result["config_saved"] != true || result["restart_status"] != "worker_recreated" {
-		t.Fatalf("finalize result = %#v, want saved dev config and worker recreate", result)
+	if result["participant_id"] != "pt-dev" || result["config_saved"] != true || result["restart_status"] != "restart_skipped" || result["activation_status"] != "runtime_recreated" {
+		t.Fatalf("finalize result = %#v, want saved dev config and activated worker runtime", result)
 	}
 	stored, ok := participantSvc.Get(participant.ChannelFeishu, "pt-dev")
 	if !ok {
@@ -351,8 +351,10 @@ func TestFinalizeFeishuRegistrationBindsManagerAdminHuman(t *testing.T) {
 
 	manager := completeWorkerAgent(agent.ManagerUserID, "manager")
 	manager.Role = agent.RoleManager
+	manager.RuntimeKind = agent.RuntimeKindCodex
+	bridge := &fakeCodexBridgeController{}
 	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager},
-		agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindPicoClawSandbox}),
+		agent.WithLifecycleObserver(bridge),
 	)
 	participantSvc := participant.NewService(participant.NewMemoryStore(nil), participant.WithAgentService(agentSvc))
 	srv := &Handler{
@@ -373,8 +375,11 @@ func TestFinalizeFeishuRegistrationBindsManagerAdminHuman(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if result["restart_status"] != "manager_recreated" || result["participant_id"] != "pt-manager" {
-		t.Fatalf("finalize result = %#v, want manager recreated for manager participant", result)
+	if result["restart_status"] != "restart_skipped" || result["activation_status"] != "lifecycle_reconciled" || result["participant_id"] != "pt-manager" {
+		t.Fatalf("finalize result = %#v, want manager lifecycle reconciliation", result)
+	}
+	if len(bridge.ensureCalls) != 1 || bridge.ensureCalls[0].ID != agent.ManagerUserID {
+		t.Fatalf("EnsureAgent() calls = %+v, want manager once", bridge.ensureCalls)
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, "admin")
 	if !ok {

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -355,6 +355,7 @@ func TestFinalizeFeishuRegistrationBindsManagerAdminHuman(t *testing.T) {
 	bridge := &fakeCodexBridgeController{}
 	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager},
 		agent.WithLifecycleObserver(bridge),
+		agent.WithBindingActivator(bridge),
 	)
 	participantSvc := participant.NewService(participant.NewMemoryStore(nil), participant.WithAgentService(agentSvc))
 	srv := &Handler{
@@ -375,11 +376,14 @@ func TestFinalizeFeishuRegistrationBindsManagerAdminHuman(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if result["restart_status"] != "restart_skipped" || result["activation_status"] != "lifecycle_reconciled" || result["participant_id"] != "pt-manager" {
-		t.Fatalf("finalize result = %#v, want manager lifecycle reconciliation", result)
+	if result["restart_status"] != "restart_skipped" || result["activation_status"] != "channel_refreshed" || result["participant_id"] != "pt-manager" {
+		t.Fatalf("finalize result = %#v, want manager Feishu channel refresh", result)
 	}
-	if len(bridge.ensureCalls) != 1 || bridge.ensureCalls[0].ID != agent.ManagerUserID {
-		t.Fatalf("EnsureAgent() calls = %+v, want manager once", bridge.ensureCalls)
+	if len(bridge.ensureCalls) != 0 {
+		t.Fatalf("EnsureAgent() calls = %+v, want none", bridge.ensureCalls)
+	}
+	if len(bridge.refreshCalls) != 1 || bridge.refreshCalls[0].agent.ID != agent.ManagerUserID || bridge.refreshCalls[0].channel != participant.ChannelFeishu {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want manager Feishu once", bridge.refreshCalls)
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, "admin")
 	if !ok {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1241,6 +1241,40 @@ func (h *Handler) handleAgentStopByID(w http.ResponseWriter, r *http.Request) {
 	h.handleAgentStop(w, r, id)
 }
 
+func (h *Handler) handleAgentApplyBindings(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.svc == nil {
+		http.Error(w, "agent service is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if err := h.svc.Reload(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	activated, _, err := h.svc.ApplyExternalBinding(r.Context(), id)
+	if err != nil {
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	writeJSON(w, http.StatusOK, presentAgent(activated))
+}
+
+func (h *Handler) handleAgentApplyBindingsByID(w http.ResponseWriter, r *http.Request) {
+	id := pathValue(r, "id")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	h.handleAgentApplyBindings(w, r, id)
+}
+
 func (h *Handler) handleAgentLogs(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1250,11 +1250,20 @@ func (h *Handler) handleAgentApplyBindings(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "agent service is not configured", http.StatusServiceUnavailable)
 		return
 	}
+	channel, err := applyBindingsChannel(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if channel == "" {
+		http.Error(w, "channel is required", http.StatusBadRequest)
+		return
+	}
 	if err := h.svc.Reload(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	activated, _, err := h.svc.ApplyExternalBinding(r.Context(), id)
+	activated, _, err := h.svc.ApplyExternalBinding(r.Context(), id, channel)
 	if err != nil {
 		status := http.StatusBadRequest
 		if strings.Contains(err.Error(), "not found") {
@@ -1264,6 +1273,31 @@ func (h *Handler) handleAgentApplyBindings(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	writeJSON(w, http.StatusOK, presentAgent(activated))
+}
+
+type applyAgentBindingsRequest struct {
+	Channel string `json:"channel"`
+}
+
+func applyBindingsChannel(r *http.Request) (string, error) {
+	if r == nil {
+		return "", nil
+	}
+	channel := strings.TrimSpace(r.URL.Query().Get("channel"))
+	if channel != "" {
+		return channel, nil
+	}
+	if r.Body == nil {
+		return "", nil
+	}
+	var req applyAgentBindingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			return "", nil
+		}
+		return "", fmt.Errorf("decode apply bindings request: %w", err)
+	}
+	return strings.TrimSpace(req.Channel), nil
 }
 
 func (h *Handler) handleAgentApplyBindingsByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1255,10 +1255,6 @@ func (h *Handler) handleAgentApplyBindings(w http.ResponseWriter, r *http.Reques
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if channel == "" {
-		http.Error(w, "channel is required", http.StatusBadRequest)
-		return
-	}
 	if err := h.svc.Reload(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1288,16 +1284,21 @@ func applyBindingsChannel(r *http.Request) (string, error) {
 		return channel, nil
 	}
 	if r.Body == nil {
-		return "", nil
+		return feishu.ChannelID, nil
 	}
 	var req applyAgentBindingsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		if errors.Is(err, io.EOF) {
-			return "", nil
+			return feishu.ChannelID, nil
 		}
 		return "", fmt.Errorf("decode apply bindings request: %w", err)
 	}
-	return strings.TrimSpace(req.Channel), nil
+	channel = strings.TrimSpace(req.Channel)
+	if channel == "" {
+		// Legacy Feishu skills called this endpoint before channel was explicit.
+		return feishu.ChannelID, nil
+	}
+	return channel, nil
 }
 
 func (h *Handler) handleAgentApplyBindingsByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -231,14 +231,26 @@ func (apiFakeCodexManager) Prompt(context.Context, codexruntime.SessionHandle, c
 }
 
 type fakeCodexBridgeController struct {
-	ensureCalls []agent.Agent
-	stopCalls   []string
-	ensureErr   error
+	ensureCalls  []agent.Agent
+	refreshCalls []agentBindingRefreshCall
+	stopCalls    []string
+	ensureErr    error
+	refreshErr   error
+}
+
+type agentBindingRefreshCall struct {
+	agent   agent.Agent
+	channel string
 }
 
 func (f *fakeCodexBridgeController) EnsureAgent(_ context.Context, a agent.Agent) error {
 	f.ensureCalls = append(f.ensureCalls, a)
 	return f.ensureErr
+}
+
+func (f *fakeCodexBridgeController) RefreshAgentChannel(_ context.Context, a agent.Agent, channel string) error {
+	f.refreshCalls = append(f.refreshCalls, agentBindingRefreshCall{agent: a, channel: channel})
+	return f.refreshErr
 }
 
 func (f *fakeCodexBridgeController) StopAgent(agentID string) {
@@ -1966,15 +1978,15 @@ func TestHandleAgentStartEnsuresCodexBridge(t *testing.T) {
 	}
 }
 
-func TestHandleAgentApplyBindingsEnsuresCodexBridgeWithoutRuntimeStart(t *testing.T) {
+func TestHandleAgentApplyBindingsRefreshesRequestedChannelWithoutLifecycleEnsure(t *testing.T) {
 	manager := completeWorkerAgent(agent.ManagerUserID, agent.ManagerName)
 	manager.Role = agent.RoleManager
 	manager.RuntimeKind = agent.RuntimeKindCodex
 	manager.RuntimeID = "rt-manager"
 	bridge := &fakeCodexBridgeController{}
-	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager}, agent.WithLifecycleObserver(bridge))
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager}, agent.WithBindingActivator(bridge))
 	srv := &Handler{svc: agentSvc}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ManagerUserID+"/bindings:apply", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ManagerUserID+"/bindings:apply?channel=feishu", nil)
 	rec := httptest.NewRecorder()
 
 	srv.Routes().ServeHTTP(rec, req)
@@ -1982,8 +1994,32 @@ func TestHandleAgentApplyBindingsEnsuresCodexBridgeWithoutRuntimeStart(t *testin
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if len(bridge.ensureCalls) != 1 || bridge.ensureCalls[0].ID != agent.ManagerUserID {
-		t.Fatalf("EnsureAgent() calls = %+v, want manager once", bridge.ensureCalls)
+	if len(bridge.ensureCalls) != 0 {
+		t.Fatalf("EnsureAgent() calls = %+v, want none", bridge.ensureCalls)
+	}
+	if len(bridge.refreshCalls) != 1 || bridge.refreshCalls[0].agent.ID != agent.ManagerUserID || bridge.refreshCalls[0].channel != "feishu" {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want manager feishu once", bridge.refreshCalls)
+	}
+}
+
+func TestHandleAgentApplyBindingsRequiresChannel(t *testing.T) {
+	manager := completeWorkerAgent(agent.ManagerUserID, agent.ManagerName)
+	manager.Role = agent.RoleManager
+	manager.RuntimeKind = agent.RuntimeKindCodex
+	manager.RuntimeID = "rt-manager"
+	bridge := &fakeCodexBridgeController{}
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager}, agent.WithBindingActivator(bridge))
+	srv := &Handler{svc: agentSvc}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ManagerUserID+"/bindings:apply", nil)
+	rec := httptest.NewRecorder()
+
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if len(bridge.refreshCalls) != 0 {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want none", bridge.refreshCalls)
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1966,6 +1966,27 @@ func TestHandleAgentStartEnsuresCodexBridge(t *testing.T) {
 	}
 }
 
+func TestHandleAgentApplyBindingsEnsuresCodexBridgeWithoutRuntimeStart(t *testing.T) {
+	manager := completeWorkerAgent(agent.ManagerUserID, agent.ManagerName)
+	manager.Role = agent.RoleManager
+	manager.RuntimeKind = agent.RuntimeKindCodex
+	manager.RuntimeID = "rt-manager"
+	bridge := &fakeCodexBridgeController{}
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager}, agent.WithLifecycleObserver(bridge))
+	srv := &Handler{svc: agentSvc}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ManagerUserID+"/bindings:apply", nil)
+	rec := httptest.NewRecorder()
+
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(bridge.ensureCalls) != 1 || bridge.ensureCalls[0].ID != agent.ManagerUserID {
+		t.Fatalf("EnsureAgent() calls = %+v, want manager once", bridge.ensureCalls)
+	}
+}
+
 func TestHandleAgentStopStopsExistingBox(t *testing.T) {
 	t.Cleanup(agent.TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2002,7 +2002,7 @@ func TestHandleAgentApplyBindingsRefreshesRequestedChannelWithoutLifecycleEnsure
 	}
 }
 
-func TestHandleAgentApplyBindingsRequiresChannel(t *testing.T) {
+func TestHandleAgentApplyBindingsDefaultsLegacyRequestToFeishu(t *testing.T) {
 	manager := completeWorkerAgent(agent.ManagerUserID, agent.ManagerName)
 	manager.Role = agent.RoleManager
 	manager.RuntimeKind = agent.RuntimeKindCodex
@@ -2015,11 +2015,14 @@ func TestHandleAgentApplyBindingsRequiresChannel(t *testing.T) {
 
 	srv.Routes().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if len(bridge.refreshCalls) != 0 {
-		t.Fatalf("RefreshAgentChannel() calls = %+v, want none", bridge.refreshCalls)
+	if len(bridge.ensureCalls) != 0 {
+		t.Fatalf("EnsureAgent() calls = %+v, want none", bridge.ensureCalls)
+	}
+	if len(bridge.refreshCalls) != 1 || bridge.refreshCalls[0].agent.ID != agent.ManagerUserID || bridge.refreshCalls[0].channel != feishu.ChannelID {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want manager feishu once", bridge.refreshCalls)
 	}
 }
 

--- a/internal/api/rest_handlers.go
+++ b/internal/api/rest_handlers.go
@@ -27,13 +27,16 @@ func (h *Handler) createParticipantMessage(w http.ResponseWriter, r *http.Reques
 func (h *Handler) createParticipantNotification(w http.ResponseWriter, r *http.Request) {
 	h.pushNotificationParticipant(w, r)
 }
-func (h *Handler) listAgents(w http.ResponseWriter, r *http.Request)   { h.handleAgents(w, r) }
-func (h *Handler) createAgent(w http.ResponseWriter, r *http.Request)  { h.handleAgents(w, r) }
-func (h *Handler) getAgent(w http.ResponseWriter, r *http.Request)     { h.handleAgentByID(w, r) }
-func (h *Handler) updateAgent(w http.ResponseWriter, r *http.Request)  { h.handleAgentByID(w, r) }
-func (h *Handler) deleteAgent(w http.ResponseWriter, r *http.Request)  { h.handleAgentByID(w, r) }
-func (h *Handler) startAgent(w http.ResponseWriter, r *http.Request)   { h.handleAgentStartByID(w, r) }
-func (h *Handler) stopAgent(w http.ResponseWriter, r *http.Request)    { h.handleAgentStopByID(w, r) }
+func (h *Handler) listAgents(w http.ResponseWriter, r *http.Request)  { h.handleAgents(w, r) }
+func (h *Handler) createAgent(w http.ResponseWriter, r *http.Request) { h.handleAgents(w, r) }
+func (h *Handler) getAgent(w http.ResponseWriter, r *http.Request)    { h.handleAgentByID(w, r) }
+func (h *Handler) updateAgent(w http.ResponseWriter, r *http.Request) { h.handleAgentByID(w, r) }
+func (h *Handler) deleteAgent(w http.ResponseWriter, r *http.Request) { h.handleAgentByID(w, r) }
+func (h *Handler) startAgent(w http.ResponseWriter, r *http.Request)  { h.handleAgentStartByID(w, r) }
+func (h *Handler) stopAgent(w http.ResponseWriter, r *http.Request)   { h.handleAgentStopByID(w, r) }
+func (h *Handler) applyAgentBindings(w http.ResponseWriter, r *http.Request) {
+	h.handleAgentApplyBindingsByID(w, r)
+}
 func (h *Handler) getAgentLogs(w http.ResponseWriter, r *http.Request) { h.handleAgentLogsByID(w, r) }
 func (h *Handler) getAgentProfile(w http.ResponseWriter, r *http.Request) {
 	h.handleAgentProfileByID(w, r)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,6 +30,7 @@ func (h *Handler) registerCoreRoutes(router chi.Router) {
 				r.Delete("/", h.deleteAgent)
 				r.Post("/start", h.startAgent)
 				r.Post("/stop", h.stopAgent)
+				r.Post("/bindings:apply", h.applyAgentBindings)
 				r.Get("/logs", h.getAgentLogs)
 				r.Get("/workspace", h.handleAgentWorkspace)
 				r.Get("/workspace/file", h.handleAgentWorkspaceFile)

--- a/internal/channel/feishu/constants.go
+++ b/internal/channel/feishu/constants.go
@@ -1,0 +1,3 @@
+package feishu
+
+const ChannelID = "feishu"

--- a/internal/channelbridge/codexmanager/manager.go
+++ b/internal/channelbridge/codexmanager/manager.go
@@ -246,16 +246,20 @@ func (m *csgclawManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
 	if !m.ensuring.begin(a.ID) {
 		return nil
 	}
-	defer m.ensuring.finish(a.ID)
-	session, err := currentSession(m.runtime, a)
-	if err != nil {
+	for {
+		session, err := currentSession(m.runtime, a)
+		if err == nil {
+			// Force a fresh bot-event subscription even when the binding is unchanged.
+			// This repairs cases where the bridge worker exists but missed its initial
+			// subscription window and would otherwise be treated as a no-op restart.
+			m.stopAgentBridge(a)
+			err = m.bridge.StartBot(ctx, bindingForAgent(a, session.SessionID))
+		}
+		if m.ensuring.finish(a.ID) {
+			continue
+		}
 		return err
 	}
-	// Force a fresh bot-event subscription even when the binding is unchanged.
-	// This repairs cases where the bridge worker exists but missed its initial
-	// subscription window and would otherwise be treated as a no-op restart.
-	m.stopAgentBridge(a)
-	return m.bridge.StartBot(ctx, bindingForAgent(a, session.SessionID))
 }
 
 func (m *csgclawManager) StopAgent(agentID string) {
@@ -349,29 +353,37 @@ func (m *feishuManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
 	if m == nil || m.runtime == nil || m.bridge == nil {
 		return nil
 	}
-	participantID := strings.TrimSpace(m.participantIDForAgent(a))
-	if !shouldStartCodexBridge(a) || participantID == "" {
+	if !shouldStartCodexBridge(a) {
 		m.StopAgent(a.ID)
 		return nil
 	}
 	if !m.ensuring.begin(a.ID) {
 		return nil
 	}
-	defer m.ensuring.finish(a.ID)
-
-	m.stopStaleBridgeForAgent(a.ID, participantID)
-	session, err := currentSession(m.runtime, a)
-	if err != nil {
+	for {
+		participantID := strings.TrimSpace(m.participantIDForAgent(a))
+		var err error
+		if participantID == "" {
+			m.StopAgent(a.ID)
+		} else {
+			m.stopStaleBridgeForAgent(a.ID, participantID)
+			var session *runtimecodex.Session
+			session, err = currentSession(m.runtime, a)
+			if err == nil {
+				m.stopAgentBridgeForAgent(a.ID, participantID, a)
+				binding := bindingForAgent(a, session.SessionID)
+				binding.BotID = participantID
+				err = m.bridge.StartBot(ctx, binding)
+				if err == nil {
+					m.rememberParticipant(a.ID, participantID)
+				}
+			}
+		}
+		if m.ensuring.finish(a.ID) {
+			continue
+		}
 		return err
 	}
-	m.stopAgentBridgeForAgent(a.ID, participantID, a)
-	binding := bindingForAgent(a, session.SessionID)
-	binding.BotID = participantID
-	if err := m.bridge.StartBot(ctx, binding); err != nil {
-		return err
-	}
-	m.rememberParticipant(a.ID, participantID)
-	return nil
 }
 
 func (m *feishuManager) shouldStartForAgent(a agent.Agent) bool {
@@ -530,12 +542,13 @@ func isCodexBridgeRole(role string) bool {
 }
 
 type ensureGate struct {
-	mu     sync.Mutex
-	active map[string]bool
+	mu      sync.Mutex
+	active  map[string]bool
+	pending map[string]bool
 }
 
 func newEnsureGate() ensureGate {
-	return ensureGate{active: make(map[string]bool)}
+	return ensureGate{active: make(map[string]bool), pending: make(map[string]bool)}
 }
 
 func (g *ensureGate) begin(agentID string) bool {
@@ -549,20 +562,29 @@ func (g *ensureGate) begin(agentID string) bool {
 		g.active = make(map[string]bool)
 	}
 	if g.active[agentID] {
+		if g.pending == nil {
+			g.pending = make(map[string]bool)
+		}
+		g.pending[agentID] = true
 		return false
 	}
 	g.active[agentID] = true
 	return true
 }
 
-func (g *ensureGate) finish(agentID string) {
+func (g *ensureGate) finish(agentID string) bool {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
-		return
+		return false
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	if g.pending[agentID] {
+		delete(g.pending, agentID)
+		return true
+	}
 	delete(g.active, agentID)
+	return false
 }
 
 func stopBotIDs(bridge *codexbridge.Service, ids ...string) {

--- a/internal/channelbridge/codexmanager/manager.go
+++ b/internal/channelbridge/codexmanager/manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"csgclaw/internal/agent"
+	csgclawchannel "csgclaw/internal/channel/csgclaw"
 	"csgclaw/internal/channel/feishu"
 	"csgclaw/internal/channelbridge/codexbridge"
 	agentruntime "csgclaw/internal/runtime"
@@ -18,6 +19,7 @@ type Manager interface {
 	Start(context.Context) error
 	EnsureAgent(context.Context, agent.Agent) error
 	StopAgent(string)
+	RefreshAgentChannel(context.Context, agent.Agent, string) error
 	Close()
 }
 
@@ -27,6 +29,11 @@ type AgentLister interface {
 
 type RuntimeProvider interface {
 	Runtime(kind string) (agentruntime.Runtime, error)
+}
+
+type channelManager interface {
+	Manager
+	supportsAgentChannel(string) bool
 }
 
 type Options struct {
@@ -138,6 +145,32 @@ func (m *multiManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
 		if err := manager.EnsureAgent(ctx, a); err != nil {
 			outErr = errors.Join(outErr, err)
 		}
+	}
+	return outErr
+}
+
+func (m *multiManager) RefreshAgentChannel(ctx context.Context, a agent.Agent, channel string) error {
+	channel = normalizeAgentChannel(channel)
+	if channel == "" {
+		return fmt.Errorf("channel is required")
+	}
+	if m == nil {
+		return nil
+	}
+	var outErr error
+	handled := false
+	for _, manager := range m.managers {
+		target, ok := manager.(channelManager)
+		if !ok || !target.supportsAgentChannel(channel) {
+			continue
+		}
+		handled = true
+		if err := target.RefreshAgentChannel(ctx, a, channel); err != nil {
+			outErr = errors.Join(outErr, err)
+		}
+	}
+	if !handled {
+		return fmt.Errorf("channel %q bridge manager is not configured", channel)
 	}
 	return outErr
 }
@@ -262,6 +295,18 @@ func (m *csgclawManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
 	}
 }
 
+func (m *csgclawManager) RefreshAgentChannel(ctx context.Context, a agent.Agent, channel string) error {
+	channel = normalizeAgentChannel(channel)
+	if !m.supportsAgentChannel(channel) {
+		return unsupportedAgentChannelError(channel)
+	}
+	return m.EnsureAgent(ctx, a)
+}
+
+func (m *csgclawManager) supportsAgentChannel(channel string) bool {
+	return normalizeAgentChannel(channel) == csgclawchannel.ChannelID
+}
+
 func (m *csgclawManager) StopAgent(agentID string) {
 	if m == nil || m.bridge == nil {
 		return
@@ -384,6 +429,18 @@ func (m *feishuManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
 		}
 		return err
 	}
+}
+
+func (m *feishuManager) RefreshAgentChannel(ctx context.Context, a agent.Agent, channel string) error {
+	channel = normalizeAgentChannel(channel)
+	if !m.supportsAgentChannel(channel) {
+		return unsupportedAgentChannelError(channel)
+	}
+	return m.EnsureAgent(ctx, a)
+}
+
+func (m *feishuManager) supportsAgentChannel(channel string) bool {
+	return normalizeAgentChannel(channel) == feishu.ChannelID
 }
 
 func (m *feishuManager) shouldStartForAgent(a agent.Agent) bool {
@@ -539,6 +596,18 @@ func shouldRestoreCodexBridgeOnStartup(a agent.Agent) bool {
 func isCodexBridgeRole(role string) bool {
 	role = strings.TrimSpace(role)
 	return strings.EqualFold(role, agent.RoleWorker) || strings.EqualFold(role, agent.RoleManager)
+}
+
+func normalizeAgentChannel(channel string) string {
+	return strings.ToLower(strings.TrimSpace(channel))
+}
+
+func unsupportedAgentChannelError(channel string) error {
+	channel = normalizeAgentChannel(channel)
+	if channel == "" {
+		return fmt.Errorf("channel is required")
+	}
+	return fmt.Errorf("channel %q is not supported by this codex bridge manager", channel)
 }
 
 type ensureGate struct {

--- a/internal/channelbridge/codexmanager/manager_test.go
+++ b/internal/channelbridge/codexmanager/manager_test.go
@@ -81,6 +81,28 @@ func TestShouldStartCodexBridge(t *testing.T) {
 	}
 }
 
+func TestEnsureGateCoalescesOverlappingEnsures(t *testing.T) {
+	gate := newEnsureGate()
+	if !gate.begin("u-manager") {
+		t.Fatal("first begin() = false, want true")
+	}
+	if gate.begin("u-manager") {
+		t.Fatal("overlapping begin() = true, want false")
+	}
+	if !gate.finish("u-manager") {
+		t.Fatal("first finish() = false, want a coalesced rerun")
+	}
+	if gate.finish("u-manager") {
+		t.Fatal("second finish() = true, want no further rerun")
+	}
+	if !gate.begin("u-manager") {
+		t.Fatal("begin() after finish = false, want true")
+	}
+	if gate.finish("u-manager") {
+		t.Fatal("finish() without overlap = true, want false")
+	}
+}
+
 func TestShouldRestoreCodexBridgeOnStartup(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/channelbridge/codexmanager/manager_test.go
+++ b/internal/channelbridge/codexmanager/manager_test.go
@@ -249,6 +249,50 @@ func TestCSGClawManagerStartupOnlyAttachesToLiveSession(t *testing.T) {
 	}
 }
 
+func TestMultiManagerRefreshFeishuChannelDoesNotRefreshCSGClawBridge(t *testing.T) {
+	sessions := &trackingSessionManager{
+		live: &runtimecodex.Session{
+			RuntimeID: "rt-agent-manager",
+			SessionID: "sess-manager",
+		},
+	}
+	runtime := runtimecodex.New(runtimecodex.Dependencies{Manager: sessions})
+	csgclawClient := newRecordingBotClient()
+	feishuClient := newRecordingBotClient()
+	manager := &multiManager{managers: []Manager{
+		newCSGClawManager(managerDeps{
+			runtime: runtime,
+			client:  csgclawClient,
+		}),
+		newFeishuManager(managerDeps{
+			runtime:  runtime,
+			client:   feishuClient,
+			provider: testCredentialProvider{agent.ManagerUserID: agent.ManagerParticipantID},
+		}),
+	}}
+	a := agent.Agent{
+		ID:              agent.ManagerUserID,
+		Name:            agent.ManagerName,
+		Role:            agent.RoleManager,
+		RuntimeKind:     agent.RuntimeKindCodex,
+		RuntimeID:       "rt-agent-manager",
+		Status:          string(agentruntime.StateRunning),
+		ProfileComplete: true,
+	}
+
+	if err := manager.RefreshAgentChannel(context.Background(), a, "feishu"); err != nil {
+		t.Fatalf("RefreshAgentChannel() error = %v", err)
+	}
+
+	feishuClient.waitStarted(t, agent.ManagerParticipantID)
+	if got := csgclawClient.totalStartedSignals(); got != 0 {
+		t.Fatalf("CSGClaw bridge starts = %d, want 0", got)
+	}
+	if got := csgclawClient.totalStoppedSignals(); got != 0 {
+		t.Fatalf("CSGClaw bridge stops = %d, want 0", got)
+	}
+}
+
 func TestFeishuManagerStopAgentStopsRememberedParticipant(t *testing.T) {
 	client := newRecordingBotClient()
 	bridge := codexbridge.NewService(client, noopPrompter{}, runtimecodex.NewEventSink())
@@ -440,6 +484,24 @@ func (c *recordingBotClient) waitStarted(t *testing.T, botID string) {
 func (c *recordingBotClient) waitStopped(t *testing.T, botID string) {
 	t.Helper()
 	c.wait(t, c.stopped, botID, "stop")
+}
+
+func (c *recordingBotClient) totalStartedSignals() int {
+	return c.totalSignals(c.started)
+}
+
+func (c *recordingBotClient) totalStoppedSignals() int {
+	return c.totalSignals(c.stopped)
+}
+
+func (c *recordingBotClient) totalSignals(signals map[string]chan struct{}) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	total := 0
+	for _, ch := range signals {
+		total += len(ch)
+	}
+	return total
 }
 
 func (c *recordingBotClient) wait(t *testing.T, signals map[string]chan struct{}, botID string, action string) {

--- a/internal/participant/feishubind/bind.go
+++ b/internal/participant/feishubind/bind.go
@@ -10,15 +10,17 @@ import (
 )
 
 type Result struct {
-	Status          string   `json:"status"`
-	Channel         string   `json:"channel"`
-	ParticipantType string   `json:"participant_type"`
-	ParticipantID   string   `json:"participant_id"`
-	AgentID         string   `json:"agent_id,omitempty"`
-	ConfigSaved     bool     `json:"config_saved"`
-	RestartStatus   string   `json:"restart_status,omitempty"`
-	RestartError    string   `json:"restart_error,omitempty"`
-	Warnings        []string `json:"warnings,omitempty"`
+	Status           string   `json:"status"`
+	Channel          string   `json:"channel"`
+	ParticipantType  string   `json:"participant_type"`
+	ParticipantID    string   `json:"participant_id"`
+	AgentID          string   `json:"agent_id,omitempty"`
+	ConfigSaved      bool     `json:"config_saved"`
+	RestartStatus    string   `json:"restart_status,omitempty"`
+	RestartError     string   `json:"restart_error,omitempty"`
+	ActivationStatus string   `json:"activation_status,omitempty"`
+	ActivationError  string   `json:"activation_error,omitempty"`
+	Warnings         []string `json:"warnings,omitempty"`
 }
 
 func BindAdminHuman(ctx context.Context, participantSvc *participant.Service, openID, name string) (Result, error) {

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/SKILL.md
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/SKILL.md
@@ -234,7 +234,7 @@ printf '%s' '[REDACTED]' | csgclaw-cli participant bind \
   --restart
 ```
 
-For manager setup, use the wrapper so the final chat response is a browser action card:
+For manager setup, use the wrapper so the binding and Feishu bridge activation complete automatically:
 
 ```bash
 printf '%s' '[REDACTED]' | python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" bind-manager \
@@ -249,7 +249,7 @@ Return the printed JSON object exactly as the chat response. Do not summarize it
 
 The script writes Feishu config through `csgclaw-cli participant bind` because skills should not edit host files directly.
 
-For `u-manager`, `bind-manager` binds `feishu:admin` when `--open-id` is provided, binds `feishu:manager` without direct restart from inside the manager runtime, then prints a top-level action card:
+For `u-manager`, `bind-manager` binds `feishu:admin` when `--open-id` is provided, binds `feishu:manager` without restarting the Codex runtime, then calls the Agent binding activation API to refresh the Feishu bridge against the existing Codex session:
 
 ```bash
 printf '%s' '[REDACTED]' | python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" bind-manager --open-id ou_xxx --app-id cli_xxx --app-secret-stdin
@@ -259,23 +259,20 @@ Expected wrapper response shape:
 
 ```json
 {
-  "type": "csgclaw.action_card",
-  "status": "manager_recreate_pending",
+  "status": "configured",
   "agent_id": "u-manager",
   "bot_id": "u-manager",
-  "setup_status": "configured",
+  "binding_activated": true,
   "config": {
     "bot_bind": {
       "participant_id": "manager",
       "restart_status": "restart_skipped"
+    },
+    "binding_activation": {
+      "id": "u-manager",
+      "status": "running"
     }
-  },
-  "actions": [
-    {
-      "id": "rebuild-manager",
-      "method": "manager-bootstrap-replace"
-    }
-  ]
+  }
 }
 ```
 
@@ -287,7 +284,7 @@ printf '%s' '[REDACTED]' | csgclaw-cli participant bind --channel feishu --feish
 
 ## CLI Workflow for Manual Control
 
-Use `participant bind` for channel config. Use the helper script for manager rebuild because the manager must not recreate itself from the same manager-hosted run.
+Use `participant bind` for channel config. The manager wrapper automatically activates its Feishu bridge without recreating the manager runtime.
 
 ```bash
 printf '%s' '[REDACTED]' | csgclaw-cli participant bind --channel feishu --feishu-kind bot --agent u-dev --app-id cli_xxx --app-secret-stdin --restart
@@ -330,11 +327,11 @@ python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" start --agent u-ma
 python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" finalize --registration-id <id>
 ```
 
-4. Return the `finalize` JSON object exactly as the chat response. Do not summarize it, translate it, add a Markdown table, or wrap it in a code fence. The object contains `type: csgclaw.action_card` and action metadata so the Web frontend can render the button.
+4. Return the `finalize` JSON object exactly as the chat response. Do not summarize it, translate it, add a Markdown table, or wrap it in a code fence. The object reports the completed binding activation.
 
-5. Do not call a manager recreate API or host command from this skill. The Manager rebuild must be completed by the rendered Web action-card button.
+5. Do not call a manager recreate API or host command from this skill. The script activates the updated Feishu binding through CSGClaw without rebuilding the Manager.
 
-Do not use the generic manager recreate endpoint or any terminal/host-side manager rebuild fallback. The Web action card uses `POST /api/v1/agents` with `{"id":"u-manager","replace":true}` from the browser after the user clicks the window button.
+Do not use the generic manager recreate endpoint or any terminal/host-side manager rebuild fallback.
 
 ## Common Pitfalls
 
@@ -342,9 +339,9 @@ Do not use the generic manager recreate endpoint or any terminal/host-side manag
 2. Running host-only commands from inside manager: manager usually only has `csgclaw-cli`; use this script/API from manager, and ask the host operator to clean stale runtime state if needed.
 3. If you see older workflow docs mentioning alternate Feishu config commands, ignore them and use `csgclaw-cli participant bind ...` to write config.
 4. Binding the wrong target: pass the CSGClaw agent ID such as `u-dev` or `u-manager`; the bind command writes the canonical Feishu participant ID.
-5. Expecting bind alone to update an already-running worker: worker recreate or manager rebuild is still required.
-6. Calling manager recreate from inside this manager-hosted skill: return the action card so the current window renders the rebuild button.
-7. Checking host runtime status after manager recreate and treating transient status as failure: the browser-owned manager bootstrap replace is the success boundary for this skill.
+5. Expecting bind alone to update an already-running worker: worker recreate is still required; the manager wrapper activates its binding automatically.
+6. Calling manager recreate from inside this manager-hosted skill: use the binding activation result instead; it preserves the current Codex session.
+7. Treating a binding activation API failure as configured: the participant may be saved, but the activation must succeed before the Skill reports completion.
 8. Printing secrets in summaries or logs: always mask as `[REDACTED]` or `present`.
 9. Calling CSGClaw SSE endpoint a Feishu webhook: it is an internal CSGClaw-to-runtime bridge.
 10. If Feishu changes the accounts registration endpoint or tenant policy blocks PersonalAgent creation, fall back to manual App ID/App Secret setup.
@@ -358,6 +355,6 @@ Do not use the generic manager recreate endpoint or any terminal/host-side manag
 - [ ] CSGClaw participant exists with `channel=feishu`.
 - [ ] Worker bind reported `restart_status` such as `worker_recreated` or `restart_skipped`.
 - [ ] New worker finalize was run with a tool timeout of at least 600 seconds.
-- [ ] Manager finalize returned a raw `csgclaw.action_card` JSON object with `rebuild-manager` action metadata for the web button.
+- [ ] Manager finalize reports a successful `config.binding_activation` result and no `rebuild-manager` action.
 - [ ] No manager-hosted command called the generic manager recreate endpoint or any host-side manager rebuild command.
 - [ ] No public Feishu webhook endpoint was added or required.

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/SKILL.md
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/SKILL.md
@@ -23,7 +23,7 @@ If `start`/`poll` returns a machine-mode `next` command, prefer that absolute co
 - `scripts/feishu_register.py`: User-facing CLI entrypoint. Supports `start`, `poll`, `finalize`, `status`, `recreate-agent`, `bind-manager`.
 - `scripts/feishu_setup/commands.py`: Parses CLI arguments and maps them to handler functions.
 - `scripts/feishu_setup/registration.py`: Implements registration flow and device-code polling state transitions.
-- `scripts/feishu_setup/csgclaw.py`: Applies config to CSGClaw through `participant bind` and returns the manager action card when needed.
+- `scripts/feishu_setup/csgclaw.py`: Applies config to CSGClaw through `participant bind` and activates manager Feishu bindings without rebuilding the manager runtime.
 - `scripts/feishu_setup/state.py`: Stores and migrates registration state files.
 - `scripts/feishu_setup/config.py`: Defines constants, env-key names, and default path constants.
 - `scripts/tests/`: tests and fixtures for script behavior.
@@ -48,7 +48,7 @@ Use this skill when the user asks to:
 - generate a Feishu/Lark bot creation URL or QR code
 - get Feishu AK/SK, App ID/App Secret, or client_id/client_secret for a CSGClaw-managed agent
 - bind Feishu participant config after setting Feishu credentials
-- recreate a worker or manager after Feishu credentials are configured
+- recreate a worker after Feishu credentials are configured, or activate a manager binding without recreating the manager
 - debug why Feishu messages do not reach a CSGClaw worker
 
 Do not use this skill for generic Feishu webhook integrations or non-CSGClaw Feishu app development.
@@ -120,7 +120,7 @@ If the user does not specify an agent in the request, ask: "请明确要对接�
 Resolve target:
 1. If input is `manager` or `u-manager`, treat as manager flow.
 2. Otherwise, treat input as worker flow, set the target agent ID to the input if it already starts with `u-`, otherwise prefix `u-`.
-3. If only role was inferred as manager, stop using recreate path and force action-card flow.
+3. If only role was inferred as manager, stop using recreate path and force the manager binding activation flow.
 
 Example normalization:
 - `dev` -> worker agent `u-dev`, participant `dev`
@@ -175,7 +175,7 @@ By default, `finalize` will:
 4. bind the Feishu bot participant through `csgclaw-cli participant bind --feishu-kind bot`
 5. for worker targets, recreate the worker from the bind command so the new Feishu config takes effect
    - if the runtime reports a name conflict while CSGClaw reports `agent "<id>" not found`, stop and tell the user the host has a stale partial worker runtime; do not keep trying random API paths or host-only commands from inside manager
-6. for manager targets, print a `csgclaw.action_card` JSON payload with a whitelisted `rebuild-manager` action; the CSGClaw Web chat message should render the button to complete the window-triggered manager bootstrap replace flow.
+6. for manager targets, call the Agent binding activation API so the existing Codex runtime refreshes its Feishu bridge without rebuilding the manager
 7. print JSON with `app_secret: present`, never the real secret
 
 For a worker, default finalize is usually enough:
@@ -187,12 +187,11 @@ python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" finalize --registr
 Use an exec/tool timeout of at least 600 seconds for this command. The bind command should report `restart_status`; do not create a second worker or change the target agent ID.
 Worker finalize must not bind or overwrite `feishu:admin`, even when Feishu returns a registration `open_id`; `feishu:admin` belongs to the manager Feishu app scope.
 
-For manager, default finalize binds `feishu:admin` when Feishu returns `open_id`, binds `feishu:manager`, then prints a structured action card. Return the JSON object exactly as the chat message content: no leading sentence, no Markdown table, no bullet list, no ```json fence, and no explanatory wrapper. The CSGClaw Web frontend will render a "重建 Manager" button.
-The click is handled by the browser and calls the manager bootstrap replace surface (`POST /api/v1/agents` with `{"id":"u-manager","replace":true}`), not the hazardous generic recreate route.
+For manager, default finalize binds `feishu:admin` when Feishu returns `open_id`, binds `feishu:manager`, calls the binding activation API, then prints a structured JSON object. Return the JSON object exactly as the chat message content: no leading sentence, no Markdown table, no bullet list, no ```json fence, and no explanatory wrapper. A successful manager finalize includes `config.binding_activation` / `activation` and no `rebuild-manager` action.
 
-Do not run `python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" recreate-agent --agent u-manager` as a terminal self-recreate step. The manager-rebuild action must be completed by clicking the rendered Web window button, which calls `POST /api/v1/agents` with `{"id":"u-manager","replace":true}`.
+Do not run `python "$CODEX_HOME/skills/feishu/scripts/feishu_register.py" recreate-agent --agent u-manager` as a terminal self-recreate step. A normal manager finalize should not produce or require a manager rebuild action.
 
-For manager only, do not use host runtime status as the post-recreate success check in this skill. The manager rebuild is a browser-owned bootstrap replace flow; after returning the action card, wait for the user to click it instead of trying another manager-hosted rebuild.
+For manager only, do not use host runtime status as a post-recreate success check in this skill. The manager path is complete when the binding activation result succeeds.
 
 ### 3. Optional status/poll commands
 
@@ -312,7 +311,7 @@ Run the command with exec `timeout` at least `600`.
 
 ## Manager One-Shot Recipe
 
-Run this recipe from the normal flow and render the manager rebuild action card in the web window.
+Run this recipe from the normal flow and use the returned binding activation result as the success signal.
 
 1. Start registration:
 

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/commands.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/commands.py
@@ -156,7 +156,7 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         *secret_args,
     ]
     config["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=input_text)
-    config["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply")
+    config["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply?channel=feishu")
     output = {
         "status": "configured",
         "agent_id": agent_id,

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/commands.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/commands.py
@@ -156,6 +156,7 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         *secret_args,
     ]
     config["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=input_text)
+    config["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply")
     output = {
         "status": "configured",
         "agent_id": agent_id,
@@ -167,6 +168,7 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         "admin_open_id": open_id,
         "config": public_result(config),
         "bot_ensured": True,
+        "binding_activated": True,
     }
     add_manager_group_permission_info(
         args,
@@ -174,11 +176,6 @@ def cmd_bind_manager(args: argparse.Namespace) -> int:
         {"app_id": app_id, "domain": args.domain, "open_id": open_id},
         output,
     )
-    setup_status = output["status"]
-    recreated = manager_recreate_action_card(agent_id)
-    output.update(recreated)
-    output["setup_status"] = setup_status
-    output["recreate"] = public_result(recreated)
     print(json.dumps(output, ensure_ascii=False, indent=2))
     return 0
 
@@ -270,9 +267,6 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     role = resolve_role(args, state)
     worker_existed_before_ensure = None
     ensured = (configured or {}).get("bot_bind") if isinstance(configured, dict) else None
-    recreated = None
-    if role == "manager" and configured is not None and args.recreate != "none":
-        recreated = manager_recreate_action_card(state["agent_id"])
     if not args.keep_state:
         delete_state(args, state["registration_id"])
     if configured is not None:
@@ -302,14 +296,9 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         "bot_ensured": ensured is not None,
         "worker_existed_before_ensure": worker_existed_before_ensure,
         "worker_recreate_policy": worker_recreate_policy,
-        "recreate": public_result(recreated or {}),
+        "activation": public_result((configured or {}).get("binding_activation") or {}),
     }
     add_manager_group_permission_info(args, state, result, output)
-    if isinstance(recreated, dict) and recreated.get("type") == "csgclaw.action_card":
-        setup_status = output["status"]
-        output.update(recreated)
-        output["setup_status"] = setup_status
-        output["recreate"] = public_result(recreated)
     print(json.dumps(output, ensure_ascii=False, indent=2))
     return 0
 

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
@@ -138,7 +138,7 @@ def configure_csgclaw(args, state: dict, result: dict) -> dict:
         bot_bind_args.append("--restart")
     response["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=result["app_secret"])
     if role == "manager":
-        response["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply")
+        response["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply?channel=feishu")
     if role == "manager" and candidate_admin_open_id:
         response["admin_open_id"] = candidate_admin_open_id
         response["admin_open_id_source"] = "registration"

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/feishu_setup/csgclaw.py
@@ -137,6 +137,8 @@ def configure_csgclaw(args, state: dict, result: dict) -> dict:
     if role == "worker" and args.recreate in ("auto", "worker"):
         bot_bind_args.append("--restart")
     response["bot_bind"] = csgclaw_cli_json(args, bot_bind_args, input_text=result["app_secret"])
+    if role == "manager":
+        response["binding_activation"] = api_json(args, "POST", f"/api/v1/agents/{path_id(agent_id)}/bindings:apply")
     if role == "manager" and candidate_admin_open_id:
         response["admin_open_id"] = candidate_admin_open_id
         response["admin_open_id_source"] = "registration"

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
@@ -79,7 +79,7 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertIn("/app/cli_example/auth", payload["manager_group_permission_url"])
         self.assertIn("im:chat.members:write_only", payload["manager_group_permission_url"])
         self.assertFalse(any("--restart" in call[0] for call in calls))
-        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply", None)])
+        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply?channel=feishu", None)])
         self.assertTrue(any("--app-secret-env" in call[0] for call in calls))
 
     def test_configure_worker_skips_admin_from_registration_open_id(self):
@@ -147,7 +147,7 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertEqual(admin_bind[admin_bind.index("--name") + 1], "龙韵")
         self.assertEqual(response["admin_bind"]["participant_id"], "admin")
         self.assertEqual(response["binding_activation"]["status"], "running")
-        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply", None)])
+        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply?channel=feishu", None)])
         self.assertEqual(response["admin_open_id"], "ou_admin")
         self.assertEqual(response["admin_open_id_source"], "registration")
 

--- a/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
+++ b/internal/template/embed/manager/codex/workspace/skills/feishu/scripts/tests/test_manager_action_card.py
@@ -25,9 +25,11 @@ class ManagerActionCardTest(unittest.TestCase):
         self.assertNotIn("fallback", result)
         self.assertNotIn("non_web_instruction", result)
 
-    def test_bind_manager_wraps_bind_result_as_action_card(self):
+    def test_bind_manager_reconciles_bridge_without_action_card(self):
         calls = []
+        api_calls = []
         original_csgclaw_cli_json = commands.csgclaw_cli_json
+        original_api_json = commands.api_json
 
         def fake_csgclaw_cli_json(args, cli_args, input_text=None):
             calls.append((cli_args, input_text))
@@ -39,7 +41,12 @@ class ManagerActionCardTest(unittest.TestCase):
                 "restart_status": "restart_skipped",
             }
 
+        def fake_api_json(args, method, path, body=None):
+            api_calls.append((method, path, body))
+            return {"id": "u-manager", "status": "running"}
+
         commands.csgclaw_cli_json = fake_csgclaw_cli_json
+        commands.api_json = fake_api_json
         try:
             args = Namespace(
                 agent="u-manager",
@@ -56,20 +63,23 @@ class ManagerActionCardTest(unittest.TestCase):
                 exit_code = commands.cmd_bind_manager(args)
         finally:
             commands.csgclaw_cli_json = original_csgclaw_cli_json
+            commands.api_json = original_api_json
 
         self.assertEqual(exit_code, 0)
         payload = json.loads(stdout.getvalue())
-        self.assertEqual(payload["type"], "csgclaw.action_card")
-        self.assertEqual(payload["status"], "manager_recreate_pending")
-        self.assertEqual(payload["setup_status"], "configured")
+        self.assertEqual(payload["status"], "configured")
         self.assertEqual(payload["agent_id"], "u-manager")
         self.assertEqual(payload["bot_id"], "u-manager")
         self.assertEqual(payload["config"]["bot_bind"]["restart_status"], "restart_skipped")
-        self.assertEqual(payload["actions"][0]["id"], "rebuild-manager")
+        self.assertEqual(payload["config"]["binding_activation"]["status"], "running")
+        self.assertTrue(payload["binding_activated"])
+        self.assertNotIn("type", payload)
+        self.assertNotIn("actions", payload)
         self.assertEqual(payload["manager_group_permission_app_id"], "cli_example")
         self.assertIn("/app/cli_example/auth", payload["manager_group_permission_url"])
         self.assertIn("im:chat.members:write_only", payload["manager_group_permission_url"])
         self.assertFalse(any("--restart" in call[0] for call in calls))
+        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply", None)])
         self.assertTrue(any("--app-secret-env" in call[0] for call in calls))
 
     def test_configure_worker_skips_admin_from_registration_open_id(self):
@@ -102,7 +112,9 @@ class ManagerActionCardTest(unittest.TestCase):
 
     def test_configure_manager_passes_admin_name_from_registration(self):
         calls = []
+        api_calls = []
         original_csgclaw_cli_json = csgclaw.csgclaw_cli_json
+        original_api_json = csgclaw.api_json
 
         def fake_csgclaw_cli_json(args, cli_args, input_text=None):
             calls.append((cli_args, input_text))
@@ -114,7 +126,12 @@ class ManagerActionCardTest(unittest.TestCase):
                 "restart_status": "restart_skipped",
             }
 
+        def fake_api_json(args, method, path, body=None):
+            api_calls.append((method, path, body))
+            return {"id": "u-manager", "status": "running"}
+
         csgclaw.csgclaw_cli_json = fake_csgclaw_cli_json
+        csgclaw.api_json = fake_api_json
         try:
             response = csgclaw.configure_csgclaw(
                 Namespace(role="manager", recreate="auto"),
@@ -123,15 +140,18 @@ class ManagerActionCardTest(unittest.TestCase):
             )
         finally:
             csgclaw.csgclaw_cli_json = original_csgclaw_cli_json
+            csgclaw.api_json = original_api_json
 
         admin_bind = next(call[0] for call in calls if "--feishu-kind" in call[0] and "human" in call[0])
         self.assertIn("--name", admin_bind)
         self.assertEqual(admin_bind[admin_bind.index("--name") + 1], "龙韵")
         self.assertEqual(response["admin_bind"]["participant_id"], "admin")
+        self.assertEqual(response["binding_activation"]["status"], "running")
+        self.assertEqual(api_calls, [("POST", "/api/v1/agents/u-manager/bindings:apply", None)])
         self.assertEqual(response["admin_open_id"], "ou_admin")
         self.assertEqual(response["admin_open_id_source"], "registration")
 
-    def test_manager_finalize_promotes_action_card_to_top_level(self):
+    def test_manager_finalize_returns_reconciled_binding_without_action_card(self):
         originals = {
             "load_state": commands.load_state,
             "poll_until_success": commands.poll_until_success,
@@ -157,6 +177,7 @@ class ManagerActionCardTest(unittest.TestCase):
                 "agent_id": "u-manager",
                 "restart_status": "restart_skipped",
             },
+            "binding_activation": {"id": "u-manager", "status": "running"},
         }
         commands.delete_state = lambda args, registration_id: None
         try:
@@ -179,11 +200,12 @@ class ManagerActionCardTest(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         payload = json.loads(stdout.getvalue())
-        self.assertEqual(payload["type"], "csgclaw.action_card")
-        self.assertEqual(payload["status"], "manager_recreate_pending")
-        self.assertEqual(payload["setup_status"], "configured")
-        self.assertEqual(payload["bot_id"], "u-manager")
-        self.assertEqual(payload["actions"][0]["id"], "rebuild-manager")
+        self.assertEqual(payload["status"], "configured")
+        self.assertEqual(payload["agent_id"], "u-manager")
+        self.assertEqual(payload["config"]["bot_bind"]["participant_id"], "manager")
+        self.assertEqual(payload["activation"]["status"], "running")
+        self.assertNotIn("type", payload)
+        self.assertNotIn("actions", payload)
         self.assertEqual(payload["app_secret"], "present")
         self.assertEqual(payload["manager_group_permission_app_id"], "cli_example")
         self.assertIn("/app/cli_example/auth", payload["manager_group_permission_url"])


### PR DESCRIPTION
## Summary
- activate updated Feishu bindings through the agent binding apply flow without rebuilding the Codex manager
- align the bundled Feishu skill docs with the manager binding activation flow

## Validation
- `git diff --check`
- `env GOCACHE=/tmp/gocache go test ./internal/agent ./internal/api ./internal/channelbridge/codexmanager`
- `python3 -m unittest discover -s internal/template/embed/manager/codex/workspace/skills/feishu/scripts/tests`
