### PR TITLE
fix(web): clear agent profile errors on agent switch

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -946,6 +946,8 @@ export function useAgentController({
   useEffect(() => {
     setAgentSkillAddError("");
     setAgentSkillDeleteError("");
+    setAgentMCPAddError("");
+    setAgentMCPDeleteError("");
   }, [agentDetailAgentID]);
 
   useEffect(() => {
@@ -959,6 +961,7 @@ export function useAgentController({
       return;
     }
     if (agentPageHasUnsavedChanges) {
+      setAgentPageError('');
       return;
     }
     const loadSeq = agentPageDraftLoadSeqRef.current + 1;


### PR DESCRIPTION
## Summary

- Clear `agentMCPAddError` and `agentMCPDeleteError` when switching agents (via `agentDetailAgentID` useEffect), matching existing behavior for skill add/delete errors
- Clear `agentPageError` (saveError) when switching agents even when there are unsaved changes, preventing stale error messages from persisting on the new agent's profile page