### PR TITLE
fix(feishu): avoid worker registration overwriting admin

### DIFF
--- a/internal/api/feishu_registration.go
+++ b/internal/api/feishu_registration.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"csgclaw/internal/agent"
 	"csgclaw/internal/config"
 	"csgclaw/internal/participant"
 	"csgclaw/internal/participant/feishubind"
@@ -180,8 +181,14 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	target, err := feishubind.ResolveAgent(h.svc, state.AgentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	userInfo := userInfoFromRegistrationResult(poll)
-	if userInfo.OpenID != "" {
+	if userInfo.OpenID != "" && feishuRegistrationBindsAdmin(target) {
 		adminName := userInfo.Name
 		if adminName == "" {
 			if resolvedName, err := feishuOpenAPIUserDisplayName(r.Context(), appID, appSecret, userInfo.OpenID); err == nil {
@@ -207,6 +214,11 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 	}
 	_ = h.deleteFeishuRegistration(state.RegistrationID)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func feishuRegistrationBindsAdmin(target agent.Agent) bool {
+	return strings.EqualFold(strings.TrimSpace(target.ID), agent.ManagerUserID) ||
+		strings.EqualFold(strings.TrimSpace(target.Role), agent.RoleManager)
 }
 
 func (h *Handler) loadFeishuRegistrationHTTP(w http.ResponseWriter, r *http.Request) (feishuRegistrationState, bool) {

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -122,10 +122,10 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, "admin")
 	if !ok {
-		t.Fatal("feishu:admin participant was not stored")
+		t.Fatal("existing feishu:admin participant was removed")
 	}
-	if admin.Type != participant.TypeHuman || admin.ChannelUserKind != participant.ChannelUserKindOpenID || admin.ChannelUserRef != "ou_admin" {
-		t.Fatalf("admin participant = %+v, want idempotent Feishu human binding to registration open_id", admin)
+	if admin.Type != participant.TypeHuman || admin.ChannelUserKind != participant.ChannelUserKindOpenID || admin.ChannelUserRef != "ou_old_admin" {
+		t.Fatalf("admin participant = %+v, want worker finalize to leave existing Feishu admin unchanged", admin)
 	}
 
 	rec = httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	}
 }
 
-func TestFinalizeFeishuRegistrationUpdatesCanonicalAdminParticipant(t *testing.T) {
+func TestFinalizeFeishuRegistrationDoesNotUpdateCanonicalAdminForWorker(t *testing.T) {
 	accounts := newFakeFeishuAccountsServer(t, map[string]any{
 		"client_id":     "cli_dev",
 		"client_secret": "dev-secret",
@@ -174,10 +174,10 @@ func TestFinalizeFeishuRegistrationUpdatesCanonicalAdminParticipant(t *testing.T
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, participant.BootstrapAdminParticipantID)
 	if !ok {
-		t.Fatal("canonical feishu admin participant was not stored")
+		t.Fatal("existing canonical feishu admin participant was removed")
 	}
-	if admin.ChannelUserRef != "ou_admin" {
-		t.Fatalf("admin channel_user_ref = %q, want registration open_id", admin.ChannelUserRef)
+	if admin.ChannelUserRef != "ou_old_admin" {
+		t.Fatalf("admin channel_user_ref = %q, want worker finalize to leave existing admin unchanged", admin.ChannelUserRef)
 	}
 	if _, ok := participantSvc.Get(participant.ChannelFeishu, "pt-dev"); !ok {
 		t.Fatal("feishu:dev participant was not stored")
@@ -210,8 +210,12 @@ func TestFinalizeFeishuRegistrationResolvesAdminNameFromFeishuOpenAPI(t *testing
 	withFeishuRegistrationAccountsBaseURL(t, accounts.URL)
 	withFeishuOpenAPIBaseURL(t, accounts.URL)
 
-	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{completeWorkerAgent("u-dev", "dev")},
-		agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindPicoClawSandbox}),
+	manager := completeWorkerAgent(agent.ManagerUserID, "manager")
+	manager.Role = agent.RoleManager
+	manager.RuntimeKind = agent.RuntimeKindCodex
+	bridge := &fakeCodexBridgeController{}
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager},
+		agent.WithBindingActivator(bridge),
 	)
 	participantSvc := participant.NewService(participant.NewMemoryStore(nil), participant.WithAgentService(agentSvc))
 	srv := &Handler{
@@ -219,7 +223,7 @@ func TestFinalizeFeishuRegistrationResolvesAdminNameFromFeishuOpenAPI(t *testing
 		participant:                participantSvc,
 		feishuRegistrationStateDir: filepath.Join(t.TempDir(), "registrations"),
 	}
-	registrationID := startFeishuRegistrationForTest(t, srv, "u-dev")
+	registrationID := startFeishuRegistrationForTest(t, srv, agent.ManagerUserID)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/channels/feishu/registrations/"+url.PathEscape(registrationID)+":finalize", nil)


### PR DESCRIPTION
## Summary
- prevent worker Feishu registration finalize from creating or overwriting the global feishu:admin participant
- keep manager registration behavior unchanged, including admin OpenID/name binding
- update finalize tests for worker/admin role boundaries