### PR TITLE
fix(feishu): preserve admin and codex sessions

### DIFF
--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -86,6 +86,35 @@ func (s *Service) ApplyExternalBinding(ctx context.Context, id, channel string) 
 	return recreated, ExternalBindingActivationRuntimeRecreated, err
 }
 
+// DeactivateExternalBinding refreshes runtime-side channel state after an
+// external participant binding has been removed.
+func (s *Service) DeactivateExternalBinding(ctx context.Context, id, channel string) (Agent, ExternalBindingActivation, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Agent{}, "", fmt.Errorf("agent id is required")
+	}
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	if channel == "" {
+		return Agent{}, "", fmt.Errorf("channel is required")
+	}
+	got, ok := s.Agent(id)
+	if !ok {
+		return Agent{}, "", fmt.Errorf("agent %q not found", id)
+	}
+	if strings.EqualFold(strings.TrimSpace(got.RuntimeKind), RuntimeKindCodex) {
+		activator := s.bindingActivator()
+		if activator == nil {
+			return Agent{}, "", fmt.Errorf("agent binding activator is not configured")
+		}
+		if err := activator.RefreshAgentChannel(ctx, got, channel); err != nil {
+			return Agent{}, "", err
+		}
+		return got, ExternalBindingActivationChannelRefreshed, nil
+	}
+	recreated, err := s.Recreate(ctx, got.ID)
+	return recreated, ExternalBindingActivationRuntimeRecreated, err
+}
+
 func (s *Service) stopLifecycleAgent(agentID string) {
 	observer := s.lifecycleObserver()
 	if observer == nil {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -6802,6 +6802,53 @@ func TestApplyExternalBindingRejectsStoppedCodexAgent(t *testing.T) {
 	}
 }
 
+func TestDeactivateExternalBindingRefreshesStoppedCodexChannelWithoutRecreate(t *testing.T) {
+	activator := &fakeBindingActivator{}
+	runtimeCreates := 0
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{}, "manager-image:test", "",
+		WithBindingActivator(activator),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindCodex,
+			new: func(context.Context, agentruntime.Spec) (agentruntime.Handle, error) {
+				runtimeCreates++
+				return agentruntime.Handle{}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents[ManagerUserID] = Agent{
+		ID:              ManagerUserID,
+		Name:            ManagerName,
+		Role:            RoleManager,
+		RuntimeID:       "rt-manager",
+		RuntimeKind:     RuntimeKindCodex,
+		Status:          string(agentruntime.StateStopped),
+		AgentProfile:    AgentProfile{Name: ManagerName, Provider: ProviderCodex, ModelID: "gpt-5.4", ProfileComplete: true},
+		ProfileComplete: true,
+	}
+
+	reconciled, activation, err := svc.DeactivateExternalBinding(context.Background(), ManagerUserID, "feishu")
+	if err != nil {
+		t.Fatalf("DeactivateExternalBinding() error = %v", err)
+	}
+	if reconciled.ID != ManagerUserID {
+		t.Fatalf("DeactivateExternalBinding() agent = %q, want %q", reconciled.ID, ManagerUserID)
+	}
+	if activation != ExternalBindingActivationChannelRefreshed {
+		t.Fatalf("activation = %q, want %q", activation, ExternalBindingActivationChannelRefreshed)
+	}
+	if runtimeCreates != 0 {
+		t.Fatalf("runtime New() calls = %d, want 0", runtimeCreates)
+	}
+	if len(activator.refreshCalls) != 1 || activator.refreshCalls[0].agent.ID != ManagerUserID || activator.refreshCalls[0].channel != "feishu" {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want manager feishu once", activator.refreshCalls)
+	}
+}
+
 func TestStartProvisionsRuntimeBeforeStart(t *testing.T) {
 	var callOrder []string
 	svc, err := NewService(

--- a/internal/api/feishu_registration.go
+++ b/internal/api/feishu_registration.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"csgclaw/internal/agent"
 	"csgclaw/internal/config"
 	"csgclaw/internal/participant"
 	"csgclaw/internal/participant/feishubind"
@@ -180,8 +181,14 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	target, err := feishubind.ResolveAgent(h.svc, state.AgentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	userInfo := userInfoFromRegistrationResult(poll)
-	if userInfo.OpenID != "" {
+	if userInfo.OpenID != "" && feishuRegistrationBindsAdmin(target) {
 		adminName := userInfo.Name
 		if adminName == "" {
 			if resolvedName, err := feishuOpenAPIUserDisplayName(r.Context(), appID, appSecret, userInfo.OpenID); err == nil {
@@ -207,6 +214,11 @@ func (h *Handler) finalizeFeishuRegistration(w http.ResponseWriter, r *http.Requ
 	}
 	_ = h.deleteFeishuRegistration(state.RegistrationID)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func feishuRegistrationBindsAdmin(target agent.Agent) bool {
+	return strings.EqualFold(strings.TrimSpace(target.ID), agent.ManagerUserID) ||
+		strings.EqualFold(strings.TrimSpace(target.Role), agent.RoleManager)
 }
 
 func (h *Handler) loadFeishuRegistrationHTTP(w http.ResponseWriter, r *http.Request) (feishuRegistrationState, bool) {

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -122,10 +122,10 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, "admin")
 	if !ok {
-		t.Fatal("feishu:admin participant was not stored")
+		t.Fatal("existing feishu:admin participant was removed")
 	}
-	if admin.Type != participant.TypeHuman || admin.ChannelUserKind != participant.ChannelUserKindOpenID || admin.ChannelUserRef != "ou_admin" {
-		t.Fatalf("admin participant = %+v, want idempotent Feishu human binding to registration open_id", admin)
+	if admin.Type != participant.TypeHuman || admin.ChannelUserKind != participant.ChannelUserKindOpenID || admin.ChannelUserRef != "ou_old_admin" {
+		t.Fatalf("admin participant = %+v, want worker finalize to leave existing Feishu admin unchanged", admin)
 	}
 
 	rec = httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestFinalizeFeishuRegistrationBindsWorkerParticipant(t *testing.T) {
 	}
 }
 
-func TestFinalizeFeishuRegistrationUpdatesCanonicalAdminParticipant(t *testing.T) {
+func TestFinalizeFeishuRegistrationDoesNotUpdateCanonicalAdminForWorker(t *testing.T) {
 	accounts := newFakeFeishuAccountsServer(t, map[string]any{
 		"client_id":     "cli_dev",
 		"client_secret": "dev-secret",
@@ -174,10 +174,10 @@ func TestFinalizeFeishuRegistrationUpdatesCanonicalAdminParticipant(t *testing.T
 	}
 	admin, ok := participantSvc.Get(participant.ChannelFeishu, participant.BootstrapAdminParticipantID)
 	if !ok {
-		t.Fatal("canonical feishu admin participant was not stored")
+		t.Fatal("existing canonical feishu admin participant was removed")
 	}
-	if admin.ChannelUserRef != "ou_admin" {
-		t.Fatalf("admin channel_user_ref = %q, want registration open_id", admin.ChannelUserRef)
+	if admin.ChannelUserRef != "ou_old_admin" {
+		t.Fatalf("admin channel_user_ref = %q, want worker finalize to leave existing admin unchanged", admin.ChannelUserRef)
 	}
 	if _, ok := participantSvc.Get(participant.ChannelFeishu, "pt-dev"); !ok {
 		t.Fatal("feishu:dev participant was not stored")
@@ -210,8 +210,12 @@ func TestFinalizeFeishuRegistrationResolvesAdminNameFromFeishuOpenAPI(t *testing
 	withFeishuRegistrationAccountsBaseURL(t, accounts.URL)
 	withFeishuOpenAPIBaseURL(t, accounts.URL)
 
-	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{completeWorkerAgent("u-dev", "dev")},
-		agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindPicoClawSandbox}),
+	manager := completeWorkerAgent(agent.ManagerUserID, "manager")
+	manager.Role = agent.RoleManager
+	manager.RuntimeKind = agent.RuntimeKindCodex
+	bridge := &fakeCodexBridgeController{}
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{manager},
+		agent.WithBindingActivator(bridge),
 	)
 	participantSvc := participant.NewService(participant.NewMemoryStore(nil), participant.WithAgentService(agentSvc))
 	srv := &Handler{
@@ -219,7 +223,7 @@ func TestFinalizeFeishuRegistrationResolvesAdminNameFromFeishuOpenAPI(t *testing
 		participant:                participantSvc,
 		feishuRegistrationStateDir: filepath.Join(t.TempDir(), "registrations"),
 	}
-	registrationID := startFeishuRegistrationForTest(t, srv, "u-dev")
+	registrationID := startFeishuRegistrationForTest(t, srv, agent.ManagerUserID)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/channels/feishu/registrations/"+url.PathEscape(registrationID)+":finalize", nil)

--- a/internal/api/participant.go
+++ b/internal/api/participant.go
@@ -113,7 +113,7 @@ func (h *Handler) handleParticipantByIDPath(w http.ResponseWriter, r *http.Reque
 			http.NotFound(w, r)
 			return
 		}
-		if err := h.recreateFeishuAgentAfterDisconnect(r.Context(), deleted, r.URL.Query().Get("delete_agent")); err != nil {
+		if err := h.deactivateFeishuAgentAfterDisconnect(r.Context(), deleted, r.URL.Query().Get("delete_agent")); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -124,7 +124,7 @@ func (h *Handler) handleParticipantByIDPath(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-func (h *Handler) recreateFeishuAgentAfterDisconnect(ctx context.Context, deleted apitypes.Participant, deleteAgentMode string) error {
+func (h *Handler) deactivateFeishuAgentAfterDisconnect(ctx context.Context, deleted apitypes.Participant, deleteAgentMode string) error {
 	if !strings.EqualFold(strings.TrimSpace(deleted.Channel), participant.ChannelFeishu) {
 		return nil
 	}
@@ -158,8 +158,8 @@ func (h *Handler) recreateFeishuAgentAfterDisconnect(ctx context.Context, delete
 			}
 		}
 	}
-	if _, err := h.svc.Recreate(ctx, agentID); err != nil {
-		return fmt.Errorf("recreate agent %q after disconnecting feishu participant %q: %w", agentID, deleted.ID, err)
+	if _, _, err := h.svc.DeactivateExternalBinding(ctx, agentID, participant.ChannelFeishu); err != nil {
+		return fmt.Errorf("deactivate feishu binding for agent %q after disconnecting participant %q: %w", agentID, deleted.ID, err)
 	}
 	return nil
 }

--- a/internal/api/participant_test.go
+++ b/internal/api/participant_test.go
@@ -494,6 +494,91 @@ func TestDeleteFeishuAgentParticipantRemovesSameAgentFeishuBotsBeforeRecreate(t 
 	}
 }
 
+func TestDeleteFeishuCodexAgentParticipantRefreshesBridgeWithoutRecreate(t *testing.T) {
+	var runtimeCreates int
+	target := completeWorkerAgent("u-dev", "dev")
+	target.RuntimeKind = agent.RuntimeKindCodex
+	target.RuntimeID = "rt-dev"
+	target.BoxID = "codex-session-dev"
+	target.AgentProfile = agent.AgentProfile{
+		Name:            "dev",
+		Provider:        agent.ProviderCodex,
+		ModelID:         "gpt-5.4",
+		ProfileComplete: true,
+	}
+	target.ProfileComplete = true
+	bridge := &fakeCodexBridgeController{}
+	agentSvc, _ := mustNewSeededServiceWithPathAndOptions(t, []agent.Agent{target},
+		agent.WithBindingActivator(bridge),
+		agent.WithRuntime(fakeCompatRuntime{
+			kind: agent.RuntimeKindCodex,
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				runtimeCreates++
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "codex-session-new"}, nil
+			},
+		}),
+	)
+	participantSvc := participant.NewService(
+		participant.NewMemoryStore([]apitypes.Participant{
+			{
+				ID:              "dev",
+				Channel:         participant.ChannelFeishu,
+				Type:            participant.TypeAgent,
+				Name:            "dev",
+				ChannelUserKind: participant.ChannelUserKindAppID,
+				ChannelAppConfig: map[string]any{
+					"app_id":     "cli_dev",
+					"app_secret": "dev-secret",
+				},
+				AgentID:         "u-dev",
+				LifecycleStatus: participant.LifecycleStatusActive,
+				Mentionable:     true,
+			},
+			{
+				ID:              "legacy-dev",
+				Channel:         participant.ChannelFeishu,
+				Type:            participant.TypeAgent,
+				Name:            "legacy dev",
+				ChannelUserKind: participant.ChannelUserKindAppID,
+				ChannelAppConfig: map[string]any{
+					"app_id":     "cli_legacy_dev",
+					"app_secret": "legacy-dev-secret",
+				},
+				AgentID:         "u-dev",
+				LifecycleStatus: participant.LifecycleStatusActive,
+				Mentionable:     true,
+			},
+		}),
+		participant.WithAgentService(agentSvc),
+	)
+	srv := &Handler{
+		svc:         agentSvc,
+		participant: participantSvc,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/channels/feishu/participants/dev", nil)
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	for _, id := range []string{"dev", "legacy-dev"} {
+		if _, ok := participantSvc.Get(participant.ChannelFeishu, id); ok {
+			t.Fatalf("participant feishu:%s still exists after disconnect", id)
+		}
+	}
+	if runtimeCreates != 0 {
+		t.Fatalf("runtime New() calls = %d, want 0", runtimeCreates)
+	}
+	if len(bridge.refreshCalls) != 1 {
+		t.Fatalf("RefreshAgentChannel() calls = %+v, want one call", bridge.refreshCalls)
+	}
+	if bridge.refreshCalls[0].agent.ID != "agent-dev" || bridge.refreshCalls[0].channel != participant.ChannelFeishu {
+		t.Fatalf("RefreshAgentChannel() call = %+v, want agent-dev feishu", bridge.refreshCalls[0])
+	}
+}
+
 func TestCreateFeishuHumanParticipantViaAPI(t *testing.T) {
 	participantSvc := participant.NewService(participant.NewMemoryStore(nil))
 	srv := &Handler{participant: participantSvc}


### PR DESCRIPTION
## Summary

- Prevent worker Feishu registration from overwriting the administrator participant.
- Refresh the Codex Feishu bridge on disconnect instead of recreating the Codex runtime.
- Preserve recreation behavior for non-Codex runtimes.

## Validation

- `go test ./...`

## Impact

Codex sessions survive Feishu disconnects; API routes and persisted participant data remain compatible.