### PR TITLE
fix(web): polish resource dialog and empty states

### DIFF
--- a/web/app/src/components/ui/Dialog/Dialog.tsx
+++ b/web/app/src/components/ui/Dialog/Dialog.tsx
@@ -6,6 +6,16 @@ import { Button } from "@/components/ui/Button";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { classNames } from "@/shared/lib/classNames";
 
+const dialogFocusableSelector = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 export type DialogRootProps = ComponentPropsWithoutRef<typeof RadixDialog.Root>;
 
 export function DialogRoot(props: DialogRootProps) {
@@ -40,11 +50,32 @@ export type DialogContentProps = ComponentPropsWithoutRef<typeof RadixDialog.Con
 };
 
 export const DialogContent = forwardRef<ComponentRef<typeof RadixDialog.Content>, DialogContentProps>(
-  function DialogContent({ children, className, overlayClassName, portalContainer, ...props }, ref) {
+  function DialogContent(
+    { children, className, onOpenAutoFocus, overlayClassName, portalContainer, tabIndex = -1, ...props },
+    ref,
+  ) {
     return (
       <DialogPortal container={portalContainer}>
         <DialogOverlay className={overlayClassName} />
-        <RadixDialog.Content ref={ref} className={classNames("csg-dialog-content", className)} {...props}>
+        <RadixDialog.Content
+          ref={ref}
+          className={classNames("csg-dialog-content", className)}
+          tabIndex={tabIndex}
+          onOpenAutoFocus={(event) => {
+            onOpenAutoFocus?.(event);
+            if (event.defaultPrevented) {
+              return;
+            }
+            const content = event.currentTarget as HTMLElement | null;
+            const firstFocusable = content?.querySelector<HTMLElement>(dialogFocusableSelector);
+            if (!firstFocusable?.hasAttribute("data-csg-tooltip-trigger")) {
+              return;
+            }
+            event.preventDefault();
+            content?.focus();
+          }}
+          {...props}
+        >
           {children}
         </RadixDialog.Content>
       </DialogPortal>

--- a/web/app/src/components/ui/Tooltip/Tooltip.tsx
+++ b/web/app/src/components/ui/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ export type TooltipTriggerProps = ComponentPropsWithoutRef<typeof RadixTooltip.T
 
 export const TooltipTrigger = forwardRef<ComponentRef<typeof RadixTooltip.Trigger>, TooltipTriggerProps>(
   function TooltipTrigger(props, ref) {
-    return <RadixTooltip.Trigger ref={ref} {...props} />;
+    return <RadixTooltip.Trigger ref={ref} data-csg-tooltip-trigger="" {...props} />;
   },
 );
 

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
@@ -1530,6 +1530,59 @@
   border-radius: 8px;
 }
 
+:root[data-theme="dark"] .csg-dialog-overlay.agent-skill-delete-backdrop {
+  background: color-mix(in srgb, var(--gray-950) 78%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+:root[data-theme="dark"] .csg-dialog-content.agent-skill-delete-dialog {
+  border: 1px solid color-mix(in oklab, var(--line) 78%, var(--gray-700) 22%);
+  background: color-mix(in oklab, var(--panel) 92%, var(--gray-800) 8%);
+  color: var(--text);
+  box-shadow:
+    0 24px 48px color-mix(in srgb, var(--gray-950) 42%, transparent),
+    inset 0 1px 0 color-mix(in oklab, var(--gray-25) 6%, transparent);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .csg-dialog-title {
+  color: var(--text);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .csg-dialog-description {
+  color: color-mix(in oklab, var(--muted) 86%, var(--text) 14%);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .csg-dialog-close {
+  color: var(--gray-400);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .csg-dialog-close:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--gray-700) 30%, transparent);
+  color: var(--text);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .agent-skills-dialog-actions .btn-secondary-gray {
+  border-color: color-mix(in oklab, var(--line) 80%, var(--gray-700) 20%);
+  background: color-mix(in oklab, var(--field) 78%, var(--gray-950) 22%);
+  color: var(--text);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .agent-skills-dialog-actions .btn-secondary-gray:hover:not(:disabled) {
+  border-color: color-mix(in oklab, var(--brand-300) 24%, var(--line));
+  background: color-mix(in oklab, var(--field) 84%, var(--brand-300) 8%);
+  color: var(--text);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .agent-skills-dialog-actions .btn-danger {
+  border-color: color-mix(in oklab, var(--error-500) 92%, var(--error-300) 8%);
+  background: color-mix(in oklab, var(--error-600) 84%, var(--error-400) 16%);
+}
+
+:root[data-theme="dark"] .agent-skill-delete-dialog .agent-skills-dialog-actions .btn-danger:hover:not(:disabled) {
+  border-color: var(--error-400);
+  background: color-mix(in oklab, var(--error-600) 76%, var(--error-300) 24%);
+}
+
 .agent-detail-pane .agent-status-dot {
   width: 8px;
   height: 8px;

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
@@ -255,18 +255,58 @@
 }
 
 .hub-json-editor-shell {
+  --hub-json-editor-bg: color-mix(in oklab, var(--gray-50) 76%, var(--surface));
+  --hub-json-editor-border: var(--line);
+  --hub-json-editor-text: var(--text);
+  --hub-json-editor-caret: var(--text);
+  --hub-json-editor-gutter-bg: transparent;
+  --hub-json-editor-gutter-border: color-mix(in oklab, var(--line) 70%, transparent);
+  --hub-json-editor-gutter-text: var(--gray-500);
+  --hub-json-editor-gutter-active-bg: color-mix(in oklab, var(--brand-600) 7%, transparent);
+  --hub-json-editor-gutter-active-text: var(--gray-700);
+  --hub-json-editor-active-line: color-mix(in oklab, var(--brand-600) 7%, transparent);
+  --hub-json-editor-selection: color-mix(in oklab, var(--brand-600) 24%, transparent);
+  --hub-json-editor-tooltip-bg: var(--surface);
+  --hub-json-editor-tooltip-border: var(--line);
+  --hub-json-editor-property: var(--brand-700);
+  --hub-json-editor-string: var(--success-700);
+  --hub-json-editor-number: var(--warning-700);
+  --hub-json-editor-literal: var(--error-600);
+  --hub-json-editor-punctuation: var(--gray-500);
+
   width: 100%;
   min-height: 220px;
   overflow: auto;
   resize: vertical;
-  border: 1px solid var(--line);
+  border: 1px solid var(--hub-json-editor-border);
   border-radius: var(--radius-lg);
-  background: color-mix(in oklab, var(--gray-50) 76%, var(--surface));
+  background: var(--hub-json-editor-bg);
+}
+
+:root[data-theme="dark"] .hub-json-editor-shell {
+  --hub-json-editor-bg: color-mix(in oklab, var(--gray-950) 82%, var(--gray-900) 18%);
+  --hub-json-editor-border: color-mix(in oklab, var(--brand-300) 18%, var(--line));
+  --hub-json-editor-text: color-mix(in oklab, var(--gray-25) 90%, var(--muted) 10%);
+  --hub-json-editor-caret: color-mix(in oklab, var(--gray-25) 92%, var(--brand-300) 8%);
+  --hub-json-editor-gutter-bg: color-mix(in oklab, var(--gray-950) 70%, var(--gray-900) 30%);
+  --hub-json-editor-gutter-border: color-mix(in oklab, var(--brand-300) 12%, var(--line));
+  --hub-json-editor-gutter-text: color-mix(in oklab, var(--muted) 80%, var(--gray-400) 20%);
+  --hub-json-editor-gutter-active-bg: color-mix(in oklab, var(--brand-300) 10%, transparent);
+  --hub-json-editor-gutter-active-text: color-mix(in oklab, var(--brand-300) 78%, var(--text) 22%);
+  --hub-json-editor-active-line: color-mix(in oklab, var(--brand-300) 8%, transparent);
+  --hub-json-editor-selection: color-mix(in oklab, var(--brand-300) 28%, transparent);
+  --hub-json-editor-tooltip-bg: var(--panel);
+  --hub-json-editor-tooltip-border: color-mix(in oklab, var(--brand-300) 18%, var(--line));
+  --hub-json-editor-property: var(--brand-300);
+  --hub-json-editor-string: var(--success-300);
+  --hub-json-editor-number: var(--warning-300);
+  --hub-json-editor-literal: var(--error-300);
+  --hub-json-editor-punctuation: var(--gray-400);
 }
 
 .hub-json-editor-shell:focus-within {
-  border-color: color-mix(in oklab, var(--success-600) 55%, var(--line));
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--success-600) 16%, transparent);
+  border-color: color-mix(in oklab, var(--success-500) 54%, var(--hub-json-editor-border));
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--success-500) 16%, transparent);
 }
 
 .hub-json-editor.is-invalid .hub-json-editor-shell {

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -135,7 +135,7 @@ const DEFAULT_MCP_SERVER_DOCUMENT =
 const jsonEditorTheme = EditorView.theme({
   "&": {
     backgroundColor: "transparent",
-    color: "var(--text)",
+    color: "var(--hub-json-editor-text, var(--text))",
     fontFamily: "var(--font-mono)",
     fontSize: "12px",
   },
@@ -148,36 +148,36 @@ const jsonEditorTheme = EditorView.theme({
     minHeight: "var(--hub-json-editor-min-height, 220px)",
   },
   ".cm-content": {
-    caretColor: "var(--text)",
+    caretColor: "var(--hub-json-editor-caret)",
     padding: "14px 0",
   },
   ".cm-line": {
     padding: "0 14px",
   },
   ".cm-gutters": {
-    backgroundColor: "transparent",
-    borderRight: "1px solid color-mix(in oklab, var(--line) 70%, transparent)",
-    color: "var(--gray-500)",
+    backgroundColor: "var(--hub-json-editor-gutter-bg)",
+    borderRight: "1px solid var(--hub-json-editor-gutter-border)",
+    color: "var(--hub-json-editor-gutter-text)",
     paddingLeft: "4px",
   },
   ".cm-activeLine": {
-    backgroundColor: "color-mix(in oklab, var(--brand-600) 7%, transparent)",
+    backgroundColor: "var(--hub-json-editor-active-line)",
   },
   ".cm-activeLineGutter": {
-    backgroundColor: "color-mix(in oklab, var(--brand-600) 7%, transparent)",
-    color: "var(--gray-700)",
+    backgroundColor: "var(--hub-json-editor-gutter-active-bg)",
+    color: "var(--hub-json-editor-gutter-active-text)",
   },
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-    backgroundColor: "color-mix(in oklab, var(--brand-600) 24%, transparent)",
+    backgroundColor: "var(--hub-json-editor-selection)",
   },
   ".cm-lintRange-error": {
     textDecoration: "underline wavy var(--error-600)",
     textDecorationSkipInk: "none",
   },
   ".cm-tooltip": {
-    border: "1px solid var(--line)",
+    border: "1px solid var(--hub-json-editor-tooltip-border)",
     borderRadius: "var(--radius-md)",
-    backgroundColor: "var(--surface)",
+    backgroundColor: "var(--hub-json-editor-tooltip-bg)",
     color: "var(--text)",
     boxShadow: "var(--shadow-lg)",
     fontFamily: "var(--font-sans)",
@@ -186,12 +186,12 @@ const jsonEditorTheme = EditorView.theme({
 });
 
 const jsonHighlightStyle = HighlightStyle.define([
-  { tag: tags.propertyName, color: "var(--brand-700)" },
-  { tag: tags.string, color: "var(--success-700)" },
-  { tag: tags.number, color: "var(--warning-700)" },
-  { tag: tags.bool, color: "var(--error-600)" },
-  { tag: tags.null, color: "var(--error-600)" },
-  { tag: tags.punctuation, color: "var(--gray-500)" },
+  { tag: tags.propertyName, color: "var(--hub-json-editor-property)" },
+  { tag: tags.string, color: "var(--hub-json-editor-string)" },
+  { tag: tags.number, color: "var(--hub-json-editor-number)" },
+  { tag: tags.bool, color: "var(--hub-json-editor-literal)" },
+  { tag: tags.null, color: "var(--hub-json-editor-literal)" },
+  { tag: tags.punctuation, color: "var(--hub-json-editor-punctuation)" },
 ]);
 
 function jsonSyntaxLinter(view: EditorView): Diagnostic[] {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -1854,8 +1854,8 @@
 }
 
 .rich-empty-mark {
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   display: inline-grid;
   place-items: center;
   border: 1px solid oklch(0.77 0.16 164 / 0.42);
@@ -1868,7 +1868,9 @@
 }
 
 .shell-empty-state {
-  gap: 12px;
+  gap: 8px;
+  align-content: center;
+  justify-items: center;
   background:
     linear-gradient(90deg, oklch(1 0 0 / 0.02) 1px, transparent 1px),
     linear-gradient(0deg, oklch(1 0 0 / 0.018) 1px, transparent 1px);

--- a/web/app/src/shared/styles/globals.css
+++ b/web/app/src/shared/styles/globals.css
@@ -97,7 +97,9 @@ body {
 .empty-state {
   height: 100%;
   display: grid;
-  place-items: center;
+  align-content: center;
+  justify-items: center;
+  gap: 10px;
   padding: 40px;
   text-align: center;
   color: var(--muted);

--- a/web/app/tests/components/Dialog.test.tsx
+++ b/web/app/tests/components/Dialog.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+  TooltipProvider,
+} from "@/components/ui";
+
+describe("Dialog", () => {
+  it("does not show a close-button tooltip when the dialog opens", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <DialogRoot open>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Example dialog</DialogTitle>
+              <DialogCloseButton label="Close" />
+            </DialogHeader>
+          </DialogContent>
+        </DialogRoot>
+      </TooltipProvider>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => expect(dialog).toHaveFocus());
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    await waitFor(() => expect(screen.getByRole("tooltip", { name: "Close" })).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent dialog close-button tooltips from appearing immediately on open
- Improve MCP JSON editor dark-mode colors
- Tighten shared empty-state icon and text spacing
