### PR TITLE
feat(codex): improve runtime lifecycle and output tooling

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -2725,14 +2725,30 @@ func logHydrateUnknownStatus(a Agent, stage string, err error) {
 
 func (s *Service) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	sandboxRuntimes := make(map[string]sandbox.Runtime, len(s.runtimes))
+	for name, rt := range s.runtimes {
+		sandboxRuntimes[name] = rt
+		delete(s.runtimes, name)
+	}
+	registeredRuntimes := make(map[string]io.Closer, len(s.runtimeRegistry))
+	for kind, rt := range s.runtimeRegistry {
+		if closer, ok := rt.(io.Closer); ok {
+			registeredRuntimes[kind] = closer
+		}
+		delete(s.runtimeRegistry, kind)
+	}
+	s.mu.Unlock()
 
 	var closeErr error
-	for name, rt := range s.runtimes {
-		if err := rt.Close(); err != nil && closeErr == nil {
-			closeErr = err
+	for name, rt := range sandboxRuntimes {
+		if err := rt.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close sandbox runtime %q: %w", name, err))
 		}
-		delete(s.runtimes, name)
+	}
+	for kind, rt := range registeredRuntimes {
+		if err := rt.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close agent runtime %q: %w", kind, err))
+		}
 	}
 	return closeErr
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -152,6 +152,18 @@ type fakeAgentRuntime struct {
 	streamLogs   func(context.Context, agentruntime.Handle, agentruntime.LogOptions) error
 }
 
+type fakeClosableAgentRuntime struct {
+	fakeAgentRuntime
+	close func() error
+}
+
+func (f *fakeClosableAgentRuntime) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return nil
+}
+
 type fakeMCPServersListRuntime struct {
 	fakeAgentRuntime
 	list func(context.Context, agentruntime.Handle, agentruntime.MCPServersSnapshot) (agentruntime.MCPServersSnapshot, error)
@@ -10459,6 +10471,32 @@ func TestPicoclawSandboxRuntimeKind(t *testing.T) {
 	}
 	if got, want := rt.Kind(), RuntimeKindPicoClawSandbox; got != want {
 		t.Fatalf("runtime kind = %q, want %q", got, want)
+	}
+}
+
+func TestServiceCloseClosesRegisteredAgentRuntimes(t *testing.T) {
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	closeCalls := 0
+	rt := &fakeClosableAgentRuntime{
+		fakeAgentRuntime: fakeAgentRuntime{kind: RuntimeKindCodex},
+		close: func() error {
+			closeCalls++
+			return nil
+		},
+	}
+	if err := WithRuntime(rt)(svc); err != nil {
+		t.Fatalf("WithRuntime() error = %v", err)
+	}
+
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("registered runtime Close() calls = %d, want 1", closeCalls)
 	}
 }
 

--- a/internal/agent/skills.go
+++ b/internal/agent/skills.go
@@ -160,7 +160,7 @@ func (s *Service) installDefaultSystemSkills(agentID, runtimeKind string) error 
 }
 
 func defaultSystemSkillNames() ([]string, error) {
-	names, err := skillsystem.Names()
+	names, err := skillsystem.DefaultNames()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/skills_system_test.go
+++ b/internal/agent/skills_system_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDefaultSystemSkillNamesExcludeManagerOnlyDemo(t *testing.T) {
+	names, err := defaultSystemSkillNames()
+	if err != nil {
+		t.Fatalf("defaultSystemSkillNames() error = %v", err)
+	}
+	if slices.Contains(names, "csgclaw-interactive-output-demo") {
+		t.Fatalf("defaultSystemSkillNames() = %#v, want Manager-only demo excluded", names)
+	}
+	for _, name := range []string{"skill-creator", "skill-installer"} {
+		if !slices.Contains(names, name) {
+			t.Fatalf("defaultSystemSkillNames() = %#v, want %s", names, name)
+		}
+	}
+}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3924,8 +3924,8 @@ func TestHandleSkillsListsGlobalSkillsAndBrowsesFiles(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&skills); err != nil {
 		t.Fatalf("decode skills response: %v", err)
 	}
-	if len(skills) != 4 {
-		t.Fatalf("len(skills) = %d, want 4", len(skills))
+	if len(skills) != 5 {
+		t.Fatalf("len(skills) = %d, want 5", len(skills))
 	}
 	skillsByName := map[string]skillsystem.SkillSummary{}
 	for _, item := range skills {
@@ -3943,6 +3943,9 @@ func TestHandleSkillsListsGlobalSkillsAndBrowsesFiles(t *testing.T) {
 	if got := skillsByName["skill-creator"]; got.Name != "skill-creator" || got.Source != skillsystem.SkillSourceSystem || !got.Readonly {
 		t.Fatalf("skill-creator = %+v, want read-only system skill", got)
 	}
+	if got := skillsByName["csgclaw-interactive-output-demo"]; got.Name != "csgclaw-interactive-output-demo" || got.Source != skillsystem.SkillSourceSystem || !got.Readonly {
+		t.Fatalf("interactive output demo = %+v, want read-only system skill", got)
+	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/skills/tree", nil)
 	rec = httptest.NewRecorder()
@@ -3959,7 +3962,7 @@ func TestHandleSkillsListsGlobalSkillsAndBrowsesFiles(t *testing.T) {
 	for _, entry := range listing.Entries {
 		paths = append(paths, entry.Path)
 	}
-	if !slices.Contains(paths, "alpha/SKILL.md") || !slices.Contains(paths, "skill-installer/SKILL.md") {
+	if !slices.Contains(paths, "alpha/SKILL.md") || !slices.Contains(paths, "skill-installer/SKILL.md") || !slices.Contains(paths, "csgclaw-interactive-output-demo/SKILL.md") {
 		t.Fatalf("root tree paths = %#v, want local and system skill files", paths)
 	}
 
@@ -3976,7 +3979,7 @@ func TestHandleSkillsListsGlobalSkillsAndBrowsesFiles(t *testing.T) {
 	for _, entry := range listing.Entries {
 		paths = append(paths, entry.Path)
 	}
-	if !slices.Contains(paths, "alpha/SKILL.md") || !slices.Contains(paths, "skill-installer/SKILL.md") {
+	if !slices.Contains(paths, "alpha/SKILL.md") || !slices.Contains(paths, "skill-installer/SKILL.md") || !slices.Contains(paths, "csgclaw-interactive-output-demo/SKILL.md") {
 		t.Fatalf("dot root tree paths = %#v, want local and system skill files", paths)
 	}
 
@@ -4045,6 +4048,36 @@ func TestHandleSkillsListsGlobalSkillsAndBrowsesFiles(t *testing.T) {
 	if !strings.Contains(file.Content, "registry skill search") {
 		t.Fatalf("system skill content = %q, want skill-installer instructions", file.Content)
 	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/skills/tree?path=csgclaw-interactive-output-demo", nil)
+	rec = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("demo tree status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode demo tree response: %v", err)
+	}
+	paths = paths[:0]
+	for _, entry := range listing.Entries {
+		paths = append(paths, entry.Path)
+	}
+	if !slices.Contains(paths, "csgclaw-interactive-output-demo/SKILL.md") || !slices.Contains(paths, "csgclaw-interactive-output-demo/scripts/emit_demo.py") {
+		t.Fatalf("demo tree paths = %#v, want skill and emitter files", paths)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/skills/file?path=csgclaw-interactive-output-demo/scripts/emit_demo.py", nil)
+	rec = httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("demo file status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&file); err != nil {
+		t.Fatalf("decode demo file response: %v", err)
+	}
+	if !strings.Contains(file.Content, "::csgclaw-output::") {
+		t.Fatalf("demo emitter content = %q, want structured output record", file.Content)
+	}
 }
 
 func TestHandleSkillsMissingRootUsesEmptyOrNotFound(t *testing.T) {
@@ -4067,7 +4100,7 @@ func TestHandleSkillsMissingRootUsesEmptyOrNotFound(t *testing.T) {
 	for _, item := range skills {
 		skillsByName[item.Name] = item
 	}
-	for _, name := range []string{"skill-installer", "skill-creator"} {
+	for _, name := range []string{"skill-installer", "skill-creator", "csgclaw-interactive-output-demo"} {
 		if got := skillsByName[name]; got.Name != name || got.Source != skillsystem.SkillSourceSystem || !got.Readonly {
 			t.Fatalf("skills = %+v, want read-only system skill %s", skills, name)
 		}
@@ -4087,7 +4120,7 @@ func TestHandleSkillsMissingRootUsesEmptyOrNotFound(t *testing.T) {
 	for _, entry := range listing.Entries {
 		paths = append(paths, entry.Path)
 	}
-	if !slices.Contains(paths, "skill-installer/SKILL.md") {
+	if !slices.Contains(paths, "skill-installer/SKILL.md") || !slices.Contains(paths, "csgclaw-interactive-output-demo/SKILL.md") {
 		t.Fatalf("root tree paths = %#v, want system skill file", paths)
 	}
 
@@ -4129,7 +4162,7 @@ func TestHandleSkillsBrowsesSystemSkillWhenLocalSystemSkillIsMalformed(t *testin
 	for _, item := range skills {
 		skillsByName[item.Name] = item
 	}
-	for _, name := range []string{"skill-installer", "skill-creator"} {
+	for _, name := range []string{"skill-installer", "skill-creator", "csgclaw-interactive-output-demo"} {
 		if got := skillsByName[name]; got.Name != name || got.Source != skillsystem.SkillSourceSystem || !got.Readonly {
 			t.Fatalf("skills = %+v, want read-only system skill %s", skills, name)
 		}

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -46,6 +46,35 @@ func newAppServerManager(deps managerDeps) *appServerManager {
 	}
 }
 
+func (m *appServerManager) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	runtimeIDs := make([]string, 0, len(m.sessions))
+	for runtimeID := range m.sessions {
+		runtimeIDs = append(runtimeIDs, runtimeID)
+	}
+	m.mu.RUnlock()
+
+	var closeErr error
+	for _, runtimeID := range runtimeIDs {
+		if err := m.Stop(context.Background(), SessionHandle{RuntimeID: runtimeID}); err != nil && !errors.Is(err, os.ErrNotExist) {
+			closeErr = errors.Join(closeErr, fmt.Errorf("stop codex app-server runtime %q: %w", runtimeID, err))
+		}
+	}
+	return closeErr
+}
+
+func (m *appServerManager) hasSession(runtimeID string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sessions[strings.TrimSpace(runtimeID)] != nil
+}
+
 func (m *appServerManager) Start(ctx context.Context, spec SessionSpec) (*Session, error) {
 	spec.RuntimeID = strings.TrimSpace(spec.RuntimeID)
 	if spec.RuntimeID == "" {
@@ -1144,25 +1173,33 @@ func (m *appServerManager) waitAppServerSession(runtimeID string, live *liveSess
 	if live.appClient != nil {
 		live.appClient.closeAllPending(fmt.Errorf("codex app-server exited with code %d", exitCode))
 	}
+	isCurrent := m.detachSession(runtimeID, live)
 	if live.session != nil {
 		live.session.ProcessID = 0
-		if m.deps.OnExit != nil {
+		if isCurrent && m.deps.OnExit != nil {
 			m.deps.OnExit(live.session, exitCode)
 		}
 	}
-	if m.deps.Permission != nil {
+	if isCurrent && m.deps.Permission != nil {
 		m.deps.Permission.CancelSession(runtimeID, "")
 	}
-	if m.deps.UserInput != nil {
+	if isCurrent && m.deps.UserInput != nil {
 		m.deps.UserInput.CancelSession(runtimeID, "")
 	}
 	if live.stderr != nil {
 		_ = live.stderr.Close()
 	}
-	m.mu.Lock()
-	delete(m.sessions, runtimeID)
-	m.mu.Unlock()
 	close(live.done)
+}
+
+func (m *appServerManager) detachSession(runtimeID string, live *liveSession) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sessions[runtimeID] != live {
+		return false
+	}
+	delete(m.sessions, runtimeID)
+	return true
 }
 
 func (m *appServerManager) wrapStartupError(spec SessionSpec, action string, err error) error {

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -159,6 +159,56 @@ func TestAppServerManagerStopClosesPendingRequests(t *testing.T) {
 	}
 }
 
+func TestAppServerManagerStaleExitDoesNotDetachReplacement(t *testing.T) {
+	manager := newAppServerManager(testAppServerManagerDeps())
+	stale := &liveSession{}
+	replacement := &liveSession{}
+	manager.sessions["runtime-1"] = replacement
+
+	if manager.detachSession("runtime-1", stale) {
+		t.Fatal("detachSession() = true for stale session, want false")
+	}
+	if got := manager.sessions["runtime-1"]; got != replacement {
+		t.Fatalf("sessions[runtime-1] = %p, want replacement %p", got, replacement)
+	}
+	if !manager.detachSession("runtime-1", replacement) {
+		t.Fatal("detachSession() = false for current session, want true")
+	}
+	if _, ok := manager.sessions["runtime-1"]; ok {
+		t.Fatal("current session still registered after detach")
+	}
+}
+
+func TestAppServerManagerCloseStopsAllSessions(t *testing.T) {
+	withAppServerHelperCommand(t, "pending")
+	manager := newAppServerManager(testAppServerManagerDeps())
+	var pids []int
+	for _, runtimeID := range []string{"runtime-1", "runtime-2"} {
+		spec := testAppServerSessionSpec(filepath.Join(t.TempDir(), runtimeID))
+		spec.RuntimeID = runtimeID
+		session, err := manager.Start(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("Start(%s) error = %v", runtimeID, err)
+		}
+		pids = append(pids, session.ProcessID)
+	}
+
+	if err := manager.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	manager.mu.RLock()
+	remaining := len(manager.sessions)
+	manager.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("live sessions after Close() = %d, want 0", remaining)
+	}
+	for _, pid := range pids {
+		if processAlive(pid) {
+			t.Fatalf("codex app-server process %d is still alive after Close()", pid)
+		}
+	}
+}
+
 func TestAppServerManagerPromptCompletesTurn(t *testing.T) {
 	withAppServerHelperCommand(t, "prompt-complete")
 	dir := t.TempDir()

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -142,6 +143,8 @@ type Dependencies struct {
 	Stat      func(string) (os.FileInfo, error)
 	RemoveAll func(string) error
 	OpenFile  func(string, int, os.FileMode) (*os.File, error)
+
+	StopRuntimeProcesses func(string) ([]int, error)
 }
 
 type Runtime struct {
@@ -158,6 +161,7 @@ var (
 	_ agentruntime.MCPServersController        = (*Runtime)(nil)
 	_ agentruntime.MCPServersReconciler        = (*Runtime)(nil)
 	_ agentruntime.MCPServersListController    = (*Runtime)(nil)
+	_ io.Closer                                = (*Runtime)(nil)
 )
 
 func New(deps Dependencies) *Runtime {
@@ -166,6 +170,17 @@ func New(deps Dependencies) *Runtime {
 
 func (r *Runtime) Kind() string {
 	return agentruntime.KindCodex
+}
+
+func (r *Runtime) Close() error {
+	if r == nil || r.deps.Manager == nil {
+		return nil
+	}
+	closer, ok := r.deps.Manager.(io.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
 }
 
 func workspaceRoot(agentHome string) string {
@@ -371,6 +386,9 @@ func (r *Runtime) Delete(ctx context.Context, h agentruntime.Handle) error {
 	if err != nil {
 		return err
 	}
+	if err := r.stopUntrackedRuntimeProcesses(ctx, runtimeID, dir); err != nil {
+		return err
+	}
 	if err := r.removeRuntimeDir(ctx, runtimeID, dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -513,6 +531,13 @@ func (r *Runtime) ensureSession(ctx context.Context, spec SessionSpec) (*Session
 	spec.HomeDir = r.hostSessionHomeDir(dirs.Home)
 	spec.CodexHomeDir = dirs.CodexHome
 	spec.StderrPath = dirs.StderrLog
+	manager := r.sessionManager()
+	tracker, tracksSessions := manager.(interface{ hasSession(string) bool })
+	if !tracksSessions || !tracker.hasSession(runtimeID) {
+		if err := r.stopUntrackedRuntimeProcesses(ctx, runtimeID, spec.RuntimeDir); err != nil {
+			return nil, err
+		}
+	}
 	if err := r.mkdirAll(spec.WorkspaceDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create codex workspace dir %s: %w", spec.WorkspaceDir, err)
 	}
@@ -544,7 +569,7 @@ func (r *Runtime) ensureSession(ctx context.Context, spec SessionSpec) (*Session
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	session, err := r.sessionManager().Start(context.WithoutCancel(ctx), spec)
+	session, err := manager.Start(context.WithoutCancel(ctx), spec)
 	if err != nil {
 		return nil, err
 	}
@@ -1315,6 +1340,28 @@ func (r *Runtime) removeAll(path string) error {
 		return r.deps.RemoveAll(path)
 	}
 	return os.RemoveAll(path)
+}
+
+func (r *Runtime) stopUntrackedRuntimeProcesses(ctx context.Context, runtimeID, runtimeDir string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stop := stopRuntimeProcessesUsingDir
+	if r != nil && r.deps.StopRuntimeProcesses != nil {
+		stop = r.deps.StopRuntimeProcesses
+	}
+	pids, err := stop(runtimeDir)
+	if err != nil {
+		return fmt.Errorf("stop untracked codex processes for runtime %q: %w", runtimeID, err)
+	}
+	if len(pids) > 0 {
+		slog.InfoContext(ctx, "stopped untracked codex runtime processes",
+			"runtime_id", runtimeID,
+			"runtime_dir", runtimeDir,
+			"process_ids", pids,
+		)
+	}
+	return nil
 }
 
 func (r *Runtime) removeRuntimeDir(ctx context.Context, runtimeID, path string) error {

--- a/internal/runtime/codex/runtime_processes.go
+++ b/internal/runtime/codex/runtime_processes.go
@@ -1,0 +1,50 @@
+package codex
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+func splitNullTerminated(data []byte) []string {
+	parts := bytes.Split(data, []byte{0})
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) > 0 {
+			values = append(values, string(part))
+		}
+	}
+	return values
+}
+
+func isCodexAppServerCommand(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	binary := filepath.Base(strings.TrimSpace(args[0]))
+	if binary != "codex" && !strings.HasPrefix(binary, "codex-") {
+		return false
+	}
+	return strings.TrimSpace(args[1]) == "app-server"
+}
+
+func pathWithinRuntimeDir(runtimeDir, candidate string) bool {
+	runtimeDir = strings.TrimSpace(runtimeDir)
+	candidate = strings.TrimSpace(candidate)
+	if runtimeDir == "" || candidate == "" {
+		return false
+	}
+	runtimeDir, err := filepath.Abs(runtimeDir)
+	if err != nil {
+		return false
+	}
+	candidate, err = filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(filepath.Clean(runtimeDir), filepath.Clean(candidate))
+	if err != nil {
+		return false
+	}
+	return relative == "." || relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/internal/runtime/codex/runtime_processes_linux.go
+++ b/internal/runtime/codex/runtime_processes_linux.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package codex
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func stopRuntimeProcessesUsingDir(runtimeDir string) ([]int, error) {
+	runtimeDir = strings.TrimSpace(runtimeDir)
+	if runtimeDir == "" {
+		return nil, fmt.Errorf("runtime directory is required")
+	}
+	runtimeDir, err := filepath.Abs(runtimeDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtime directory: %w", err)
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("read process table: %w", err)
+	}
+
+	pids := make([]int, 0)
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 || pid == os.Getpid() {
+			continue
+		}
+		matches, err := processUsesCodexRuntime(pid, runtimeDir)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+				continue
+			}
+			return nil, err
+		}
+		if matches {
+			pids = append(pids, pid)
+		}
+	}
+	sort.Ints(pids)
+
+	var stopErr error
+	stopped := make([]int, 0, len(pids))
+	for _, pid := range pids {
+		if err := stopProcess(pid); err != nil && !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+			stopErr = errors.Join(stopErr, fmt.Errorf("stop process %d: %w", pid, err))
+			continue
+		}
+		stopped = append(stopped, pid)
+	}
+	return stopped, stopErr
+}
+
+func processUsesCodexRuntime(pid int, runtimeDir string) (bool, error) {
+	procDir := filepath.Join("/proc", strconv.Itoa(pid))
+	info, err := os.Stat(procDir)
+	if err != nil {
+		return false, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Geteuid() {
+		return false, nil
+	}
+
+	cmdline, err := os.ReadFile(filepath.Join(procDir, "cmdline"))
+	if err != nil {
+		return false, err
+	}
+	args := splitNullTerminated(cmdline)
+	if !isCodexAppServerCommand(args) {
+		return false, nil
+	}
+
+	environ, err := os.ReadFile(filepath.Join(procDir, "environ"))
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range splitNullTerminated(environ) {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && key == "CODEX_HOME" {
+			return pathWithinRuntimeDir(runtimeDir, value), nil
+		}
+	}
+	return false, nil
+}

--- a/internal/runtime/codex/runtime_processes_other.go
+++ b/internal/runtime/codex/runtime_processes_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package codex
+
+func stopRuntimeProcessesUsingDir(string) ([]int, error) {
+	return nil, nil
+}

--- a/internal/runtime/codex/runtime_processes_test.go
+++ b/internal/runtime/codex/runtime_processes_test.go
@@ -1,0 +1,51 @@
+package codex
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestIsCodexAppServerCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "codex app server", args: []string{"/usr/local/bin/codex", "app-server", "--listen", "stdio://"}, want: true},
+		{name: "versioned codex app server", args: []string{"/opt/codex/codex-x86_64-linux", "app-server"}, want: true},
+		{name: "other codex command", args: []string{"codex", "exec"}, want: false},
+		{name: "app server argument to other command", args: []string{"codex", "exec", "app-server"}, want: false},
+		{name: "unrelated app server", args: []string{"node", "codex", "app-server"}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCodexAppServerCommand(tc.args); got != tc.want {
+				t.Fatalf("isCodexAppServerCommand(%q) = %t, want %t", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPathWithinRuntimeDir(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "agent-manager", ".codex")
+	if pathWithinRuntimeDir("", filepath.Join(runtimeDir, "home")) {
+		t.Fatal("empty runtime directory must not match")
+	}
+	if !pathWithinRuntimeDir(runtimeDir, filepath.Join(runtimeDir, "home")) {
+		t.Fatal("runtime home should be within runtime directory")
+	}
+	if pathWithinRuntimeDir(runtimeDir, runtimeDir+"-other/home") {
+		t.Fatal("sibling runtime must not match runtime directory")
+	}
+	if pathWithinRuntimeDir(runtimeDir, filepath.Join(runtimeDir, "..", "worker", ".codex", "home")) {
+		t.Fatal("worker runtime must not match manager runtime directory")
+	}
+}
+
+func TestSplitNullTerminated(t *testing.T) {
+	got := splitNullTerminated([]byte("codex\x00app-server\x00\x00"))
+	want := []string{"codex", "app-server"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("splitNullTerminated() = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -42,6 +42,18 @@ type fakeManager struct {
 	prompt func(context.Context, SessionHandle, PromptRequest) (PromptResponse, error)
 }
 
+type fakeClosableManager struct {
+	fakeManager
+	close func() error
+}
+
+func (f *fakeClosableManager) Close() error {
+	if f.close != nil {
+		return f.close()
+	}
+	return nil
+}
+
 func (f fakeManager) LiveSession(handle SessionHandle) (*Session, error) {
 	if f.live != nil {
 		return f.live(handle)
@@ -222,6 +234,82 @@ func TestRuntimeCreateStartAndInfo(t *testing.T) {
 	}
 	if !strings.Contains(agentsText, "Use concise Go comments.") {
 		t.Fatalf("codex home AGENTS.md missing agent instructions:\n%s", agentsText)
+	}
+}
+
+func TestRuntimeCloseClosesSessionManager(t *testing.T) {
+	closeCalls := 0
+	manager := &fakeClosableManager{
+		fakeManager: fakeManager{
+			start: func(context.Context, SessionSpec) (*Session, error) {
+				return nil, nil
+			},
+		},
+		close: func() error {
+			closeCalls++
+			return nil
+		},
+	}
+	rt := New(Dependencies{Manager: manager})
+
+	if err := rt.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("session manager Close() calls = %d, want 1", closeCalls)
+	}
+}
+
+func TestRuntimeNewStopsUntrackedProcessesBeforeStartingSession(t *testing.T) {
+	root := t.TempDir()
+	var steps []string
+	rt := New(Dependencies{
+		BinaryProvider: fakeBinaryProvider{path: "/tmp/codex"},
+		AgentHome: func(string) (string, error) {
+			return filepath.Join(root, "agent-manager"), nil
+		},
+		ResolveAgent: func(h agentruntime.Handle) (AgentRef, error) {
+			return AgentRef{
+				ID:        agent.ManagerUserID,
+				Name:      agent.ManagerName,
+				RuntimeID: h.RuntimeID,
+			}, nil
+		},
+		Manager: fakeManager{
+			start: func(_ context.Context, spec SessionSpec) (*Session, error) {
+				steps = append(steps, "start")
+				return &Session{
+					RuntimeID:    spec.RuntimeID,
+					AgentID:      spec.AgentID,
+					AgentName:    spec.AgentName,
+					SessionID:    "manager-thread",
+					RuntimeDir:   spec.RuntimeDir,
+					WorkspaceDir: spec.WorkspaceDir,
+					HomeDir:      spec.HomeDir,
+					CodexHomeDir: spec.CodexHomeDir,
+					StderrPath:   spec.StderrPath,
+				}, nil
+			},
+		},
+		StopRuntimeProcesses: func(path string) ([]int, error) {
+			steps = append(steps, "stop-untracked")
+			want := filepath.Join(root, "agent-manager", ".codex")
+			if path != want {
+				t.Fatalf("StopRuntimeProcesses() path = %q, want %q", path, want)
+			}
+			return []int{123}, nil
+		},
+	})
+
+	if _, err := rt.New(context.Background(), agentruntime.Spec{
+		RuntimeID: "rt-agent-manager",
+		AgentID:   agent.ManagerUserID,
+		AgentName: agent.ManagerName,
+	}); err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if got, want := steps, []string{"stop-untracked", "start"}; !slices.Equal(got, want) {
+		t.Fatalf("New() steps = %q, want %q", got, want)
 	}
 }
 
@@ -908,6 +996,52 @@ func TestDeleteStopsLiveSessionWhenRuntimeMetadataIsMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("runtime dir stat error = %v, want not exist", err)
+	}
+}
+
+func TestDeleteStopsUntrackedRuntimeProcessesBeforeRemoval(t *testing.T) {
+	root := t.TempDir()
+	runtimeDir := filepath.Join(root, "agent-manager", ".codex")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(runtime dir) error = %v", err)
+	}
+
+	var steps []string
+	rt := New(Dependencies{
+		AgentHome: func(string) (string, error) {
+			return filepath.Join(root, "agent-manager"), nil
+		},
+		ResolveAgent: func(h agentruntime.Handle) (AgentRef, error) {
+			return AgentRef{
+				ID:        agent.ManagerUserID,
+				Name:      agent.ManagerName,
+				RuntimeID: h.RuntimeID,
+			}, nil
+		},
+		Manager: fakeManager{
+			stop: func(context.Context, SessionHandle) error {
+				steps = append(steps, "stop-session")
+				return os.ErrNotExist
+			},
+		},
+		StopRuntimeProcesses: func(path string) ([]int, error) {
+			steps = append(steps, "stop-untracked")
+			if path != runtimeDir {
+				t.Fatalf("StopRuntimeProcesses() path = %q, want %q", path, runtimeDir)
+			}
+			return []int{123}, nil
+		},
+		RemoveAll: func(path string) error {
+			steps = append(steps, "remove")
+			return os.RemoveAll(path)
+		},
+	})
+
+	if err := rt.Delete(context.Background(), agentruntime.Handle{RuntimeID: "rt-agent-manager"}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if got, want := steps, []string{"stop-session", "stop-untracked", "remove"}; !slices.Equal(got, want) {
+		t.Fatalf("Delete() steps = %q, want %q", got, want)
 	}
 }
 

--- a/internal/skill/system/embed.go
+++ b/internal/skill/system/embed.go
@@ -1,8 +1,97 @@
 package system
 
-import "embed"
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	pathpkg "path"
+	"slices"
+	"strings"
 
-const skillsRoot = "embed"
+	templateembed "csgclaw/internal/template/embed"
+)
+
+const (
+	skillsRoot                        = "embed"
+	interactiveOutputDemoName         = "csgclaw-interactive-output-demo"
+	interactiveOutputDemoTemplateRoot = templateembed.CodexManagerRoot + "/" + templateembed.SkillsDirName + "/" + interactiveOutputDemoName
+)
 
 //go:embed embed
-var skillsFS embed.FS
+var defaultSkillsFS embed.FS
+
+type registeredSkillSource struct {
+	name string
+	fs   fs.FS
+	root string
+}
+
+var additionalSkillSources = []registeredSkillSource{
+	{
+		name: interactiveOutputDemoName,
+		fs:   templateembed.FS(),
+		root: interactiveOutputDemoTemplateRoot,
+	},
+}
+
+var skillsFS fs.FS = combinedSkillsFS{}
+
+type combinedSkillsFS struct{}
+
+func (combinedSkillsFS) Open(name string) (fs.File, error) {
+	source, sourcePath := systemSkillFSPath(name)
+	return source.Open(sourcePath)
+}
+
+func (combinedSkillsFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == skillsRoot {
+		entries, err := fs.ReadDir(defaultSkillsFS, name)
+		if err != nil {
+			return nil, err
+		}
+		seen := make(map[string]struct{}, len(entries)+len(additionalSkillSources))
+		for _, entry := range entries {
+			seen[entry.Name()] = struct{}{}
+		}
+		for _, source := range additionalSkillSources {
+			if _, exists := seen[source.name]; exists {
+				return nil, fmt.Errorf("duplicate system skill %q", source.name)
+			}
+			info, err := fs.Stat(source.fs, source.root)
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, fs.FileInfoToDirEntry(info))
+			seen[source.name] = struct{}{}
+		}
+		slices.SortFunc(entries, func(left, right fs.DirEntry) int {
+			return strings.Compare(left.Name(), right.Name())
+		})
+		return entries, nil
+	}
+	source, sourcePath := systemSkillFSPath(name)
+	return fs.ReadDir(source, sourcePath)
+}
+
+func (combinedSkillsFS) ReadFile(name string) ([]byte, error) {
+	source, sourcePath := systemSkillFSPath(name)
+	return fs.ReadFile(source, sourcePath)
+}
+
+func (combinedSkillsFS) Stat(name string) (fs.FileInfo, error) {
+	source, sourcePath := systemSkillFSPath(name)
+	return fs.Stat(source, sourcePath)
+}
+
+func systemSkillFSPath(name string) (fs.FS, string) {
+	for _, source := range additionalSkillSources {
+		prefix := pathpkg.Join(skillsRoot, source.name)
+		if name == prefix {
+			return source.fs, source.root
+		}
+		if suffix, ok := strings.CutPrefix(name, prefix+"/"); ok {
+			return source.fs, pathpkg.Join(source.root, suffix)
+		}
+	}
+	return defaultSkillsFS, name
+}

--- a/internal/skill/system/skill.go
+++ b/internal/skill/system/skill.go
@@ -84,6 +84,19 @@ func Names() ([]string, error) {
 	return names, nil
 }
 
+// DefaultNames returns the system skills installed automatically into agent runtimes.
+func DefaultNames() ([]string, error) {
+	items, err := listFS(defaultSkillsFS, skillsRoot)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names, nil
+}
+
 func RootSource() SkillSource {
 	return SkillSource{
 		Source:   SkillSourceSystem,

--- a/internal/skill/system/skill_test.go
+++ b/internal/skill/system/skill_test.go
@@ -18,6 +18,24 @@ func TestNamesReadsEmbeddedDirectory(t *testing.T) {
 	if !slicesContains(got, "skill-creator") {
 		t.Fatalf("Names() = %#v, want embedded skill-creator", got)
 	}
+	if !slicesContains(got, "csgclaw-interactive-output-demo") {
+		t.Fatalf("Names() = %#v, want embedded interactive output demo", got)
+	}
+}
+
+func TestDefaultNamesExcludeManagerOnlyDemo(t *testing.T) {
+	got, err := DefaultNames()
+	if err != nil {
+		t.Fatalf("DefaultNames() error = %v", err)
+	}
+	if slicesContains(got, "csgclaw-interactive-output-demo") {
+		t.Fatalf("DefaultNames() = %#v, want Manager-only demo excluded", got)
+	}
+	for _, name := range []string{"skill-creator", "skill-installer"} {
+		if !slicesContains(got, name) {
+			t.Fatalf("DefaultNames() = %#v, want %s", got, name)
+		}
+	}
 }
 
 func TestResolveSource(t *testing.T) {
@@ -56,6 +74,25 @@ func TestSkillCreatorUsesRuntimeNeutralDefaultPath(t *testing.T) {
 	content := buf.String()
 	if !strings.Contains(content, "~/.openclaw/workspace/skills") || !strings.Contains(content, "~/.picoclaw/workspace/skills") {
 		t.Fatalf("skill-creator content = %q, want runtime-neutral workspace skills paths", content)
+	}
+}
+
+func TestResolveInteractiveOutputDemoUsesManagerTemplate(t *testing.T) {
+	source, err := ResolveSource("csgclaw-interactive-output-demo")
+	if err != nil {
+		t.Fatalf("ResolveSource(csgclaw-interactive-output-demo) error = %v", err)
+	}
+	data, err := source.FS.Open(source.RootPath + "/scripts/emit_demo.py")
+	if err != nil {
+		t.Fatalf("Open(emit_demo.py) error = %v", err)
+	}
+	defer data.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(data); err != nil {
+		t.Fatalf("ReadFrom(emit_demo.py) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "::csgclaw-output::") {
+		t.Fatalf("emit_demo.py content = %q, want structured output emitter", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- close all managed Codex app-server sessions and terminate stale per-runtime processes before deleting an agent runtime
- prevent stale session exits from detaching replacement sessions, and close registered runtimes during service shutdown
- add a browsable interactive-output demo system skill without installing it for workers by default

## Root cause and impact

The sandbox failure was caused by a leftover Codex app-server process whose `CODEX_HOME` was inside the manager runtime. On NFS, its open files became `.nfs*` placeholders during deletion, so runtime removal ended with `EBUSY`. Manager hit this more often because session recovery and replacement could overlap across goroutines while lifecycle ownership was incomplete. The fix closes tracked sessions and adds a Linux process-scoped fallback for matching untracked app-server processes. It does not restart CSGClaw or interrupt other agents.

Recreation can take longer only on the failure path because runtime deletion keeps the existing bounded NFS retry window while waiting for open handles to disappear before rebuilding.