### PR TITLE
fix(web): prevent task form input crashes

### DIFF
--- a/web/app/src/pages/TasksPage/components/TasksView/ScheduledTaskFormFields.tsx
+++ b/web/app/src/pages/TasksPage/components/TasksView/ScheduledTaskFormFields.tsx
@@ -34,7 +34,8 @@ export function ScheduledTaskFormFields({
           maxLength={TASK_TITLE_MAX_LENGTH}
           placeholder={t("taskTitlePlaceholder")}
           onInput={(event) => {
-            onChange((current) => ({ ...current, title: event.currentTarget.value }));
+            const value = event.currentTarget.value;
+            onChange((current) => ({ ...current, title: value }));
             onClearError("title");
           }}
         />
@@ -63,7 +64,8 @@ export function ScheduledTaskFormFields({
           value={draft.prompt}
           placeholder={t("scheduledTaskPromptPlaceholder")}
           onInput={(event) => {
-            onChange((current) => ({ ...current, prompt: event.currentTarget.value }));
+            const value = event.currentTarget.value;
+            onChange((current) => ({ ...current, prompt: value }));
             onClearError("prompt");
           }}
         />
@@ -91,7 +93,8 @@ export function ScheduledTaskFormFields({
           type="date"
           value={draft.date}
           onInput={(event) => {
-            onChange((current) => ({ ...current, date: event.currentTarget.value }));
+            const value = event.currentTarget.value;
+            onChange((current) => ({ ...current, date: value }));
             onClearError("date");
           }}
         />
@@ -103,7 +106,8 @@ export function ScheduledTaskFormFields({
           type="time"
           value={draft.time}
           onInput={(event) => {
-            onChange((current) => ({ ...current, time: event.currentTarget.value }));
+            const value = event.currentTarget.value;
+            onChange((current) => ({ ...current, time: value }));
             onClearError("time");
           }}
         />
@@ -114,7 +118,10 @@ export function ScheduledTaskFormFields({
         <input
           type="date"
           value={draft.expiresDate}
-          onInput={(event) => onChange((current) => ({ ...current, expiresDate: event.currentTarget.value }))}
+          onInput={(event) => {
+            const value = event.currentTarget.value;
+            onChange((current) => ({ ...current, expiresDate: value }));
+          }}
         />
       </label>
     </div>

--- a/web/app/src/pages/TasksPage/components/TasksView/TaskCreateDialog.tsx
+++ b/web/app/src/pages/TasksPage/components/TasksView/TaskCreateDialog.tsx
@@ -68,7 +68,8 @@ export function TaskCreateDialog({
                 aria-describedby={errors.title ? "task-create-title-error" : undefined}
                 aria-invalid={errors.title ? true : undefined}
                 onInput={(event) => {
-                  onChange((current) => ({ ...current, title: event.currentTarget.value }));
+                  const value = event.currentTarget.value;
+                  onChange((current) => ({ ...current, title: value }));
                   onClearError("title");
                 }}
                 placeholder={t("taskTitlePlaceholder")}
@@ -85,7 +86,8 @@ export function TaskCreateDialog({
                 value={draft.description}
                 aria-label={t("taskDescriptionLabel")}
                 onInput={(event) => {
-                  onChange((current) => ({ ...current, description: event.currentTarget.value }));
+                  const value = event.currentTarget.value;
+                  onChange((current) => ({ ...current, description: value }));
                 }}
                 placeholder={t("taskDescriptionPlaceholder")}
               />

--- a/web/app/tests/components/TasksView.test.tsx
+++ b/web/app/tests/components/TasksView.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SetStateAction } from "react";
 import { vi } from "vitest";
 import { TasksView } from "@/pages/TasksPage/components";
+import { ScheduledTaskFormFields } from "@/pages/TasksPage/components/TasksView/ScheduledTaskFormFields";
+import { TaskCreateDialog } from "@/pages/TasksPage/components/TasksView/TaskCreateDialog";
+import type { ScheduledTaskFormDraft, TaskCreateDraft } from "@/pages/TasksPage/components/TasksView/taskDialogTypes";
 import type { AgentLike } from "@/models/agents";
 import type { TranslateFn } from "@/models/conversations";
 import type { WorkspaceScheduledTask, WorkspaceScheduledTaskRun } from "@/models/scheduledTasks";
@@ -139,6 +144,10 @@ const t: TranslateFn = (key, params = {}) => {
   }
   return labels[key] ?? key;
 };
+
+function applyStateAction<Value>(action: SetStateAction<Value>, current: Value): Value {
+  return typeof action === "function" ? (action as (value: Value) => Value)(current) : action;
+}
 
 function task(overrides: Partial<WorkspaceTask>): WorkspaceTask {
   return {
@@ -515,6 +524,107 @@ describe("TasksView", () => {
     expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Schedule" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+  });
+
+  it("accepts consecutive characters in the task create text fields", async () => {
+    const user = userEvent.setup();
+
+    render(<TasksView showCreateTaskModal agents={[agent()]} teams={[team()]} t={t} />);
+
+    await user.type(screen.getByLabelText("Title"), "AB");
+    await user.type(screen.getByLabelText("Description"), "CD");
+
+    expect(screen.getByLabelText("Title")).toHaveValue("AB");
+    expect(screen.getByLabelText("Description")).toHaveValue("CD");
+  });
+
+  it("accepts consecutive changes in every scheduled-task input field", async () => {
+    const user = userEvent.setup();
+
+    render(<TasksView showCreateScheduledTaskModal agents={[agent()]} teams={[team()]} t={t} />);
+
+    await user.type(screen.getByLabelText("Title"), "AB");
+    await user.type(screen.getByLabelText("Prompt"), "CD");
+
+    const date = screen.getByLabelText("Date");
+    fireEvent.input(date, { target: { value: "2026-07-25" } });
+    fireEvent.input(date, { target: { value: "2026-07-26" } });
+
+    const time = screen.getByLabelText("Time");
+    fireEvent.input(time, { target: { value: "09:30" } });
+    fireEvent.input(time, { target: { value: "10:45" } });
+
+    const expiresDate = screen.getByLabelText("End date (optional)");
+    fireEvent.input(expiresDate, { target: { value: "2026-08-01" } });
+    fireEvent.input(expiresDate, { target: { value: "2026-08-02" } });
+
+    expect(screen.getByLabelText("Title")).toHaveValue("AB");
+    expect(screen.getByLabelText("Prompt")).toHaveValue("CD");
+    expect(date).toHaveValue("2026-07-26");
+    expect(time).toHaveValue("10:45");
+    expect(expiresDate).toHaveValue("2026-08-02");
+  });
+
+  it("captures task form values before passing deferred state updaters", () => {
+    const draft: TaskCreateDraft = { assignee: "", description: "", title: "" };
+    const updates: Array<SetStateAction<TaskCreateDraft>> = [];
+
+    render(
+      <TaskCreateDialog
+        assignmentOptions={[]}
+        busy={false}
+        draft={draft}
+        error=""
+        errors={{}}
+        onChange={(update) => updates.push(update)}
+        onClearError={vi.fn()}
+        onSubmit={vi.fn()}
+        open
+        t={t}
+      />,
+    );
+
+    fireEvent.input(screen.getByLabelText("Title"), { target: { value: "Task title" } });
+    fireEvent.input(screen.getByLabelText("Description"), { target: { value: "Task description" } });
+
+    expect(applyStateAction(updates[0], draft)).toEqual({ ...draft, title: "Task title" });
+    expect(applyStateAction(updates[1], draft)).toEqual({ ...draft, description: "Task description" });
+  });
+
+  it("captures scheduled-task values before passing deferred state updaters", () => {
+    const draft: ScheduledTaskFormDraft = {
+      agentID: "",
+      date: "",
+      expiresDate: "",
+      prompt: "",
+      recurrence: "once",
+      time: "",
+      title: "",
+    };
+    const updates: Array<SetStateAction<ScheduledTaskFormDraft>> = [];
+
+    render(
+      <ScheduledTaskFormFields
+        draft={draft}
+        errors={{}}
+        onChange={(update) => updates.push(update)}
+        onClearError={vi.fn()}
+        scheduledAgentOptions={[]}
+        t={t}
+      />,
+    );
+
+    fireEvent.input(screen.getByLabelText("Title"), { target: { value: "Scheduled title" } });
+    fireEvent.input(screen.getByLabelText("Prompt"), { target: { value: "Scheduled prompt" } });
+    fireEvent.input(screen.getByLabelText("Date"), { target: { value: "2026-07-25" } });
+    fireEvent.input(screen.getByLabelText("Time"), { target: { value: "09:30" } });
+    fireEvent.input(screen.getByLabelText("End date (optional)"), { target: { value: "2026-08-01" } });
+
+    expect(applyStateAction(updates[0], draft)).toEqual({ ...draft, title: "Scheduled title" });
+    expect(applyStateAction(updates[1], draft)).toEqual({ ...draft, prompt: "Scheduled prompt" });
+    expect(applyStateAction(updates[2], draft)).toEqual({ ...draft, date: "2026-07-25" });
+    expect(applyStateAction(updates[3], draft)).toEqual({ ...draft, time: "09:30" });
+    expect(applyStateAction(updates[4], draft)).toEqual({ ...draft, expiresDate: "2026-08-01" });
   });
 
   it("does not show planner as the current worker after a parent task is completed", () => {


### PR DESCRIPTION
- Prevent task and scheduled-task forms from retaining React event objects in deferred state updaters.
- Add regression coverage for consecutive input events across all affected task form fields.
