### PR TITLE
fix(api): refresh hub context after site changes

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agentruntime "csgclaw/internal/runtime"
+	hub "csgclaw/internal/template"
 	"csgclaw/internal/utils"
 )
 
@@ -568,9 +569,10 @@ func normalizeCompactUpdateFieldMask(fieldMask []string, profileField string, ha
 }
 
 type CreateRequest struct {
-	Spec      CreateAgentSpec
-	Replace   bool
-	FieldMask []string
+	Spec       CreateAgentSpec
+	Replace    bool
+	FieldMask  []string
+	HubService *hub.Service
 }
 
 func normalizeRole(role string) string {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -275,6 +275,17 @@ func WithHubService(svc *hub.Service) ServiceOption {
 	}
 }
 
+// SetHubService replaces the default template service used by operations that
+// do not carry an HTTP request-scoped Hub.
+func (s *Service) SetHubService(hubSvc *hub.Service) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.hub = hubSvc
+	s.mu.Unlock()
+}
+
 func WithBootstrapDefaultTemplates(cfg config.BootstrapConfig) ServiceOption {
 	return func(s *Service) error {
 		if s == nil {
@@ -1023,7 +1034,17 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Agent, error) 
 	if shouldResolveTemplateCreateSpec(req.Spec) {
 		var cleanup func()
 		var err error
-		req.Spec, cleanup, err = s.resolveTemplateCreateSpec(ctx, req.Spec)
+		var hubSvc templateService
+		s.mu.RLock()
+		defaultHubSvc := s.hub
+		s.mu.RUnlock()
+		if defaultHubSvc != nil {
+			hubSvc = defaultHubSvc
+		}
+		if req.HubService != nil {
+			hubSvc = req.HubService
+		}
+		req.Spec, cleanup, err = s.resolveTemplateCreateSpecWithService(ctx, req.Spec, hubSvc)
 		if err != nil {
 			return Agent{}, err
 		}
@@ -1035,6 +1056,17 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Agent, error) 
 }
 
 func (s *Service) resolveTemplateCreateSpec(ctx context.Context, spec CreateAgentSpec) (CreateAgentSpec, func(), error) {
+	s.mu.RLock()
+	hubSvc := s.hub
+	s.mu.RUnlock()
+	return s.resolveTemplateCreateSpecWithService(ctx, spec, hubSvc)
+}
+
+func (s *Service) resolveTemplateCreateSpecWithService(
+	ctx context.Context,
+	spec CreateAgentSpec,
+	hubSvc templateService,
+) (CreateAgentSpec, func(), error) {
 	if s == nil {
 		return CreateAgentSpec{}, nil, fmt.Errorf("agent service is required")
 	}
@@ -1042,14 +1074,14 @@ func (s *Service) resolveTemplateCreateSpec(ctx context.Context, spec CreateAgen
 	if templateRef == "" {
 		return spec, nil, nil
 	}
-	if s.hub == nil {
+	if hubSvc == nil {
 		if usedDefault {
 			return CreateAgentSpec{}, nil, fmt.Errorf("default %s template %q requires hub service, but hub service is not configured", expectedRole, templateRef)
 		}
 		return CreateAgentSpec{}, nil, fmt.Errorf("hub service is not configured")
 	}
 
-	item, err := s.hub.Get(ctx, templateRef)
+	item, err := hubSvc.Get(ctx, templateRef)
 	if err != nil {
 		if usedDefault {
 			return CreateAgentSpec{}, nil, fmt.Errorf("resolve default %s template %q: %w", expectedRole, templateRef, err)
@@ -1064,7 +1096,7 @@ func (s *Service) resolveTemplateCreateSpec(ctx context.Context, spec CreateAgen
 			return CreateAgentSpec{}, nil, err
 		}
 	}
-	workspace, err := s.hub.FetchWorkspace(ctx, templateRef)
+	workspace, err := hubSvc.FetchWorkspace(ctx, templateRef)
 	if err != nil {
 		if usedDefault {
 			return CreateAgentSpec{}, nil, fmt.Errorf("fetch default %s template workspace %q: %w", expectedRole, templateRef, err)
@@ -2778,6 +2810,30 @@ func (s *Service) Close() error {
 	for kind, rt := range registeredRuntimes {
 		if err := rt.Close(); err != nil {
 			closeErr = errors.Join(closeErr, fmt.Errorf("close agent runtime %q: %w", kind, err))
+		}
+	}
+	return closeErr
+}
+
+// ResetSandboxRuntimes drops cached sandbox clients so the next operation
+// reloads environment-sensitive credentials, such as the active CSGHub site
+// and access token.
+func (s *Service) ResetSandboxRuntimes() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	sandboxRuntimes := make(map[string]sandbox.Runtime, len(s.runtimes))
+	for name, rt := range s.runtimes {
+		sandboxRuntimes[name] = rt
+		delete(s.runtimes, name)
+	}
+	s.mu.Unlock()
+
+	var closeErr error
+	for name, rt := range sandboxRuntimes {
+		if err := rt.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close sandbox runtime %q: %w", name, err))
 		}
 	}
 	return closeErr

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -72,7 +72,9 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-type fakeRuntime struct{}
+type fakeRuntime struct {
+	close func() error
+}
 
 type fakeProvider struct {
 	open func(context.Context, string) (sandbox.Runtime, error)
@@ -106,6 +108,9 @@ func (f *fakeRuntime) Remove(context.Context, string, sandbox.RemoveOptions) err
 }
 
 func (f *fakeRuntime) Close() error {
+	if f != nil && f.close != nil {
+		return f.close()
+	}
 	return nil
 }
 
@@ -7399,6 +7404,48 @@ func TestApplyTemplateEnvDefaults(t *testing.T) {
 	}
 }
 
+func TestCreateFromTemplateUsesRequestHubService(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
+
+	requestHub := mustNewLocalTemplateHubService(t, "request-worker", hub.Template{
+		ID:          "request-worker",
+		Name:        "request-worker",
+		Description: "request-scoped template",
+		Role:        hub.TemplateRoleWorker,
+		RuntimeKind: RuntimeNamePicoClaw,
+		Image:       "worker-image:request",
+	})
+	startupHub, err := hub.NewService(config.HubConfig{}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
+	}
+	svc, err := NewService(
+		testModelConfig(),
+		config.ServerConfig{},
+		"manager-image:1",
+		"",
+		WithHubService(startupHub),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	got, err := svc.Create(context.Background(), CreateRequest{
+		Spec: CreateAgentSpec{
+			Name:         "alice",
+			FromTemplate: "local.request-worker",
+		},
+		HubService: requestHub,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if got.Description != "request-scoped template" || got.Image != "worker-image:request" {
+		t.Fatalf("created agent = %+v, want request-scoped template defaults", got)
+	}
+}
+
 func TestCreateWorkerFromTemplateAppliesImageEnvToSandbox(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -10567,6 +10614,28 @@ func TestServiceCloseClosesRegisteredAgentRuntimes(t *testing.T) {
 	}
 	if closeCalls != 1 {
 		t.Fatalf("registered runtime Close() calls = %d, want 1", closeCalls)
+	}
+}
+
+func TestResetSandboxRuntimesClosesAndDropsCachedClients(t *testing.T) {
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	closeCalls := 0
+	svc.runtimes["agent-home"] = &fakeRuntime{close: func() error {
+		closeCalls++
+		return nil
+	}}
+
+	if err := svc.ResetSandboxRuntimes(); err != nil {
+		t.Fatalf("ResetSandboxRuntimes() error = %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("sandbox runtime Close() calls = %d, want 1", closeCalls)
+	}
+	if len(svc.runtimes) != 0 {
+		t.Fatalf("cached runtimes = %d, want 0", len(svc.runtimes))
 	}
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -68,6 +68,7 @@ func (h *Handler) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	h.syncAgentHubService(r)
 	writeJSON(w, http.StatusOK, status)
 }
 
@@ -88,6 +89,8 @@ func (h *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	if err := h.refreshOpenCSGModelProvider(r.Context()); err != nil {
 		slog.Warn("refresh OpenCSG models after login failed", "error", err)
 	}
+	h.syncAgentHubService(r)
+	h.resetEnvironmentSensitiveRuntimes()
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
@@ -156,6 +159,7 @@ func (h *Handler) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	h.resetEnvironmentSensitiveRuntimes()
 	status, err := appAuthLogout(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -164,7 +168,29 @@ func (h *Handler) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	if err := h.clearOpenCSGModelProviderCache(); err != nil {
 		slog.Warn("clear OpenCSG models after logout failed", "error", err)
 	}
+	h.syncAgentHubService(r)
 	writeJSON(w, http.StatusOK, status)
+}
+
+func (h *Handler) syncAgentHubService(r *http.Request) {
+	if h == nil || h.svc == nil {
+		return
+	}
+	hubSvc, err := h.hubServiceForRequest(r)
+	if err != nil {
+		slog.Warn("sync agent Hub service after OpenCSG environment change failed", "error", err)
+		return
+	}
+	h.svc.SetHubService(hubSvc)
+}
+
+func (h *Handler) resetEnvironmentSensitiveRuntimes() {
+	if h == nil || h.svc == nil {
+		return
+	}
+	if err := h.svc.ResetSandboxRuntimes(); err != nil {
+		slog.Warn("reset sandbox runtimes after OpenCSG environment change failed", "error", err)
+	}
 }
 
 func (h *Handler) clearOpenCSGModelProviderCache() error {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -159,12 +159,12 @@ func (h *Handler) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	h.resetEnvironmentSensitiveRuntimes()
 	status, err := appAuthLogout(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	h.resetEnvironmentSensitiveRuntimes()
 	if err := h.clearOpenCSGModelProviderCache(); err != nil {
 		slog.Warn("clear OpenCSG models after logout failed", "error", err)
 	}
@@ -185,10 +185,17 @@ func (h *Handler) syncAgentHubService(r *http.Request) {
 }
 
 func (h *Handler) resetEnvironmentSensitiveRuntimes() {
-	if h == nil || h.svc == nil {
+	if h == nil {
 		return
 	}
-	if err := h.svc.ResetSandboxRuntimes(); err != nil {
+	reset := h.environmentRuntimeReset
+	if reset == nil && h.svc != nil {
+		reset = h.svc.ResetSandboxRuntimes
+	}
+	if reset == nil {
+		return
+	}
+	if err := reset(); err != nil {
 		slog.Warn("reset sandbox runtimes after OpenCSG environment change failed", "error", err)
 	}
 }

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -280,6 +280,32 @@ func TestHandleAuthLogout(t *testing.T) {
 	}
 }
 
+func TestHandleAuthLogoutResetsRuntimeAfterCredentialsAreDeleted(t *testing.T) {
+	logoutComplete := false
+	restore := stubAuthLogout(func(*http.Request) (auth.Status, error) {
+		logoutComplete = true
+		return auth.Status{}, nil
+	})
+	defer restore()
+	resetCalls := 0
+	handler := &Handler{environmentRuntimeReset: func() error {
+		if !logoutComplete {
+			t.Fatal("runtime reset before credentials were deleted")
+		}
+		resetCalls++
+		return nil
+	}}
+
+	rec := httptest.NewRecorder()
+	handler.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if resetCalls != 1 {
+		t.Fatalf("runtime reset calls = %d, want 1", resetCalls)
+	}
+}
+
 func TestHandleAuthLogoutClearsCachedOpenCSGModels(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	writeCachedOpenCSGModelsConfig(t, configPath)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1417,7 +1417,14 @@ func (h *Handler) handleCreateAgentWorker(w http.ResponseWriter, r *http.Request
 		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
 		return
 	}
-	created, err := h.svc.Create(r.Context(), agentCreateRequestFromAPI(req))
+	hubSvc, err := h.hubServiceForRequest(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("resolve hub service: %v", err), http.StatusInternalServerError)
+		return
+	}
+	createReq := agentCreateRequestFromAPI(req)
+	createReq.HubService = hubSvc
+	created, err := h.svc.Create(r.Context(), createReq)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -2099,6 +2106,11 @@ func (h *Handler) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.participant != nil && h.svc != nil && shouldCreateWorkerForUser(id, role) {
+		hubSvc, err := h.hubServiceForRequest(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("resolve hub service: %v", err), http.StatusInternalServerError)
+			return
+		}
 		participantID := workerParticipantIDFromUserID(id)
 		workerAgentID := workerAgentIDFromUserID(id)
 		if existing, ok := h.participant.Get(participant.ChannelCSGClaw, participantID); ok && strings.TrimSpace(existing.Type) == participant.TypeAgent {
@@ -2126,10 +2138,11 @@ func (h *Handler) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		created, err := h.participant.Create(r.Context(), participant.CreateRequest{
-			ID:      participantID,
-			Channel: participant.ChannelCSGClaw,
-			Type:    participant.TypeAgent,
-			Name:    name,
+			ID:              participantID,
+			Channel:         participant.ChannelCSGClaw,
+			Type:            participant.TypeAgent,
+			Name:            name,
+			AgentHubService: hubSvc,
 			ChannelUser: participant.ChannelUserSpec{
 				Ref:  id,
 				Kind: participant.ChannelUserKindLocalUserID,

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -73,6 +73,7 @@ type Handler struct {
 	upgradeApply               func(upgrade.ApplyHelperOptions) error
 	serverRestartApply         func(upgrade.RestartHelperOptions) error
 	localRuntimeImages         func(context.Context, config.Config) ([]string, error)
+	environmentRuntimeReset    func() error
 	notificationDeliver        notification.Fanouter
 	activityDecider            ActivityDecider
 	userInputResponder         UserInputResponder

--- a/internal/api/participant.go
+++ b/internal/api/participant.go
@@ -50,6 +50,12 @@ func (h *Handler) handleParticipants(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		req.Channel = channelName
+		hubSvc, err := h.hubServiceForRequest(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("resolve hub service: %v", err), http.StatusInternalServerError)
+			return
+		}
+		req.AgentHubService = hubSvc
 		created, err := h.participant.Create(r.Context(), req)
 		if err != nil {
 			http.Error(w, err.Error(), participantCreateStatus(err))

--- a/internal/api/participant_test.go
+++ b/internal/api/participant_test.go
@@ -17,6 +17,7 @@ import (
 	"csgclaw/internal/im"
 	"csgclaw/internal/participant"
 	agentruntime "csgclaw/internal/runtime"
+	hub "csgclaw/internal/template"
 )
 
 func TestCreateCSGClawAgentParticipantViaAPI(t *testing.T) {
@@ -85,6 +86,59 @@ func TestCreateCSGClawAgentParticipantViaAPI(t *testing.T) {
 		t.Fatalf("channel user = %+v, ok=%v; want u-qa display user", user, ok)
 	} else if user.Avatar == "" {
 		t.Fatalf("channel user avatar is empty, want user-owned default")
+	}
+}
+
+func TestCreateCSGClawAgentParticipantViaAPIUsesRequestHub(t *testing.T) {
+	agentSvc, _ := mustNewSeededServiceWithPath(t, nil)
+	requestHub := mustNewLocalTemplateHubService(t, "request-worker", hub.Template{
+		ID:          "request-worker",
+		Name:        "request-worker",
+		Description: "request-scoped template",
+		Role:        hub.TemplateRoleWorker,
+		RuntimeKind: agent.RuntimeNamePicoClaw,
+		Image:       "agent-image:request",
+	})
+	imSvc := im.NewService()
+	participantSvc := participant.NewService(
+		participant.NewMemoryStore(nil),
+		participant.WithAgentService(agentSvc),
+		participant.WithIMService(imSvc),
+	)
+	srv := &Handler{
+		svc:         agentSvc,
+		hub:         requestHub,
+		im:          imSvc,
+		participant: participantSvc,
+	}
+	body := `{
+		"id": "request-worker",
+		"type": "agent",
+		"name": "request-worker",
+		"channel_user": {"ref": "u-request-worker", "kind": "local_user_id"},
+		"agent_binding": {
+			"mode": "create",
+			"agent": {
+				"name": "request-worker",
+				"role": "worker",
+				"from_template": "local.request-worker"
+			}
+		}
+	}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/channels/csgclaw/participants", strings.NewReader(body))
+
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	created, ok := agentSvc.Agent("agent-request-worker")
+	if !ok {
+		t.Fatal("request-scoped template agent was not created")
+	}
+	if created.Description != "request-scoped template" || created.Image != "agent-image:request" {
+		t.Fatalf("created agent = %+v, want request-scoped template defaults", created)
 	}
 }
 

--- a/internal/participant/model.go
+++ b/internal/participant/model.go
@@ -3,6 +3,7 @@ package participant
 import (
 	"csgclaw/internal/agent"
 	"csgclaw/internal/apitypes"
+	hub "csgclaw/internal/template"
 )
 
 const (
@@ -43,6 +44,7 @@ type CreateRequest struct {
 	Type             string           `json:"type"`
 	Name             string           `json:"name"`
 	Avatar           string           `json:"-"`
+	AgentHubService  *hub.Service     `json:"-"`
 	ChannelAppRef    string           `json:"channel_app_ref,omitempty"`
 	ChannelAppConfig map[string]any   `json:"channel_app_config,omitempty"`
 	ChannelUser      ChannelUserSpec  `json:"channel_user,omitempty"`

--- a/internal/participant/service.go
+++ b/internal/participant/service.go
@@ -12,6 +12,7 @@ import (
 	"csgclaw/internal/agent"
 	"csgclaw/internal/apitypes"
 	"csgclaw/internal/im"
+	hub "csgclaw/internal/template"
 )
 
 type Service struct {
@@ -621,6 +622,7 @@ type normalizedCreateRequest struct {
 	ChannelAppConfig map[string]any
 	ChannelUser      ChannelUserSpec
 	AgentBinding     AgentBindingSpec
+	AgentHubService  *hub.Service
 	AgentID          string
 	Metadata         map[string]any
 }
@@ -713,6 +715,7 @@ func (s *Service) normalizeCreateRequest(req CreateRequest) (normalizedCreateReq
 		ChannelAppConfig: cloneMap(req.ChannelAppConfig),
 		ChannelUser:      channelUser,
 		AgentBinding:     binding,
+		AgentHubService:  req.AgentHubService,
 		Metadata:         cloneMetadata(req.Metadata),
 	}, nil
 }
@@ -881,7 +884,10 @@ func (s *Service) ensureAgentBinding(ctx context.Context, req normalizedCreateRe
 		if strings.TrimSpace(spec.Role) == "" {
 			spec.Role = agent.RoleWorker
 		}
-		created, err := s.agents.Create(ctx, agent.CreateRequest{Spec: spec})
+		created, err := s.agents.Create(ctx, agent.CreateRequest{
+			Spec:       spec,
+			HubService: req.AgentHubService,
+		})
 		if err != nil {
 			return "", err
 		}

--- a/internal/sandbox/csghub/provider.go
+++ b/internal/sandbox/csghub/provider.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"csgclaw/internal/auth"
@@ -113,6 +114,7 @@ var _ sandbox.Provider = Provider{}
 
 // Runtime adapts the csghub lifecycle API to sandbox.Runtime.
 type Runtime struct {
+	mu     sync.RWMutex
 	cfg    runtimeConfig
 	client *csghubsdk.Client
 }
@@ -130,7 +132,12 @@ func (runtimeLogger) Errorf(format string, args ...any) {
 var _ sandbox.Runtime = (*Runtime)(nil)
 
 func (r *Runtime) Create(ctx context.Context, spec sandbox.CreateSpec) (sandbox.Instance, error) {
-	if r == nil || r.client == nil {
+	if r == nil {
+		return nil, fmt.Errorf("invalid csghub runtime")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.client == nil {
 		return nil, fmt.Errorf("invalid csghub runtime")
 	}
 	req, err := r.createRequest(spec)
@@ -166,7 +173,12 @@ func (r *Runtime) Create(ctx context.Context, spec sandbox.CreateSpec) (sandbox.
 }
 
 func (r *Runtime) Get(ctx context.Context, idOrName string) (sandbox.Instance, error) {
-	if r == nil || r.client == nil {
+	if r == nil {
+		return nil, fmt.Errorf("invalid csghub runtime")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.client == nil {
 		return nil, fmt.Errorf("invalid csghub runtime")
 	}
 	name, err := r.sandboxName(idOrName)
@@ -183,7 +195,12 @@ func (r *Runtime) Get(ctx context.Context, idOrName string) (sandbox.Instance, e
 }
 
 func (r *Runtime) Remove(ctx context.Context, idOrName string, _ sandbox.RemoveOptions) error {
-	if r == nil || r.client == nil {
+	if r == nil {
+		return fmt.Errorf("invalid csghub runtime")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.client == nil {
 		return fmt.Errorf("invalid csghub runtime")
 	}
 	name, err := r.sandboxName(idOrName)
@@ -197,10 +214,13 @@ func (r *Runtime) Remove(ctx context.Context, idOrName string, _ sandbox.RemoveO
 }
 
 func (r *Runtime) Close() error {
-	if r != nil {
-		r.client = nil
-		r.cfg = runtimeConfig{}
+	if r == nil {
+		return nil
 	}
+	r.mu.Lock()
+	r.client = nil
+	r.cfg = runtimeConfig{}
+	r.mu.Unlock()
 	return nil
 }
 
@@ -448,51 +468,57 @@ type Instance struct {
 var _ sandbox.Instance = (*Instance)(nil)
 
 func (i *Instance) Start(ctx context.Context) error {
-	if err := i.valid(); err != nil {
-		return err
-	}
-	name, err := i.runtime.sandboxName(i.name)
+	runtime, err := i.lockRuntime()
 	if err != nil {
 		return err
 	}
-	if _, err := i.runtime.startSandboxIdempotent(ctx, name); err != nil {
+	defer runtime.mu.RUnlock()
+	name, err := runtime.sandboxName(i.name)
+	if err != nil {
 		return err
 	}
-	if _, err := i.runtime.waitForRunning(ctx, name); err != nil {
+	if _, err := runtime.startSandboxIdempotent(ctx, name); err != nil {
 		return err
 	}
-	return i.runtime.waitForRuntimeHealth(ctx, name)
+	if _, err := runtime.waitForRunning(ctx, name); err != nil {
+		return err
+	}
+	return runtime.waitForRuntimeHealth(ctx, name)
 }
 
 func (i *Instance) Stop(ctx context.Context, opts sandbox.StopOptions) error {
-	if err := i.valid(); err != nil {
+	runtime, err := i.lockRuntime()
+	if err != nil {
 		return err
 	}
+	defer runtime.mu.RUnlock()
 	if opts.Force {
 		return fmt.Errorf("unsupported sandbox option: force stop")
 	}
 	if opts.Timeout != 0 {
 		return fmt.Errorf("unsupported sandbox option: stop timeout")
 	}
-	name, err := i.runtime.sandboxName(i.name)
+	name, err := runtime.sandboxName(i.name)
 	if err != nil {
 		return err
 	}
-	if err := i.runtime.client.Stop(ctx, name); err != nil {
+	if err := runtime.client.Stop(ctx, name); err != nil {
 		return wrapError("stop csghub sandbox", err)
 	}
-	return i.runtime.waitForStopped(ctx, name)
+	return runtime.waitForStopped(ctx, name)
 }
 
 func (i *Instance) Info(ctx context.Context) (sandbox.Info, error) {
-	if err := i.valid(); err != nil {
-		return sandbox.Info{}, err
-	}
-	name, err := i.runtime.sandboxName(i.name)
+	runtime, err := i.lockRuntime()
 	if err != nil {
 		return sandbox.Info{}, err
 	}
-	resp, err := i.runtime.client.Get(ctx, name)
+	defer runtime.mu.RUnlock()
+	name, err := runtime.sandboxName(i.name)
+	if err != nil {
+		return sandbox.Info{}, err
+	}
+	resp, err := runtime.client.Get(ctx, name)
 	if err != nil {
 		return sandbox.Info{}, wrapError("read csghub sandbox info", err)
 	}
@@ -500,9 +526,11 @@ func (i *Instance) Info(ctx context.Context) (sandbox.Info, error) {
 }
 
 func (i *Instance) Run(ctx context.Context, spec sandbox.CommandSpec) (sandbox.CommandResult, error) {
-	if err := i.valid(); err != nil {
+	runtime, err := i.lockRuntime()
+	if err != nil {
 		return sandbox.CommandResult{}, err
 	}
+	defer runtime.mu.RUnlock()
 	name := strings.TrimSpace(spec.Name)
 	if name == "" {
 		return sandbox.CommandResult{}, fmt.Errorf("invalid sandbox command: name is required")
@@ -522,11 +550,11 @@ func (i *Instance) Run(ctx context.Context, spec sandbox.CommandSpec) (sandbox.C
 		}
 		return nil
 	}
-	name, err := i.runtime.sandboxName(i.name)
+	name, err = runtime.sandboxName(i.name)
 	if err != nil {
 		return sandbox.CommandResult{}, err
 	}
-	if err := i.runtime.client.StreamExecute(ctx, name, command, emit); err != nil {
+	if err := runtime.client.StreamExecute(ctx, name, command, emit); err != nil {
 		return sandbox.CommandResult{}, fmt.Errorf("run csghub command: %w", err)
 	}
 	if firstStreamError != "" {
@@ -541,14 +569,21 @@ func (i *Instance) Close() error {
 	return nil
 }
 
-func (i *Instance) valid() error {
-	if i == nil || i.runtime == nil || i.runtime.client == nil {
-		return fmt.Errorf("invalid csghub sandbox")
+func (i *Instance) lockRuntime() (*Runtime, error) {
+	if i == nil || i.runtime == nil {
+		return nil, fmt.Errorf("invalid csghub sandbox")
+	}
+	runtime := i.runtime
+	runtime.mu.RLock()
+	if runtime.client == nil {
+		runtime.mu.RUnlock()
+		return nil, fmt.Errorf("invalid csghub sandbox")
 	}
 	if strings.TrimSpace(i.name) == "" {
-		return fmt.Errorf("csghub sandbox id or name is required")
+		runtime.mu.RUnlock()
+		return nil, fmt.Errorf("csghub sandbox id or name is required")
 	}
-	return nil
+	return runtime, nil
 }
 
 func loadRuntimeConfigFromEnv() (runtimeConfig, error) {

--- a/internal/sandbox/csghub/provider.go
+++ b/internal/sandbox/csghub/provider.go
@@ -197,6 +197,10 @@ func (r *Runtime) Remove(ctx context.Context, idOrName string, _ sandbox.RemoveO
 }
 
 func (r *Runtime) Close() error {
+	if r != nil {
+		r.client = nil
+		r.cfg = runtimeConfig{}
+	}
 	return nil
 }
 

--- a/internal/sandbox/csghub/provider_test.go
+++ b/internal/sandbox/csghub/provider_test.go
@@ -107,6 +107,56 @@ func TestOpenPrefersEnvOverAuthStore(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseWaitsForInFlightOperation(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/sandboxes/worker-1" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		close(requestStarted)
+		<-releaseRequest
+		writeSandboxState(w, "worker-1", "img:1", "running")
+	}))
+	t.Cleanup(server.Close)
+	setRequiredEnv(t, server.URL)
+
+	rtAny, err := NewProvider().Open(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	rt := rtAny.(*Runtime)
+	getDone := make(chan error, 1)
+	go func() {
+		_, getErr := rt.Get(context.Background(), "worker-1")
+		getDone <- getErr
+	}()
+	<-requestStarted
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- rt.Close()
+	}()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close() completed during in-flight Get(), error = %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseRequest)
+	if err := <-getDone; err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if _, err := rt.Get(context.Background(), "worker-1"); err == nil {
+		t.Fatal("Get() after Close() error = nil, want invalid runtime error")
+	}
+}
+
 func TestRuntimeCreateBuildsRequestAndMapsMounts(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/web/app/src/hooks/workspace/useAuthController.ts
+++ b/web/app/src/hooks/workspace/useAuthController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { beginAuthLogin, fetchAuthStatus, logoutAuth } from "@/api/auth";
 import { errorMessage } from "@/api/client";
@@ -20,6 +20,16 @@ import { workspaceQueryKeys } from "./workspaceQueries";
 const AUTH_LOGIN_PENDING_STORAGE_KEY = "csgclaw.auth.loginPending";
 const LOGIN_POLL_INTERVAL_MS = 2000;
 const LOGIN_POLL_TIMEOUT_MS = 120000;
+const ENVIRONMENT_QUERY_NAMES = new Set([
+  "bootstrap-config",
+  "hub-templates",
+  "hub-template",
+  "hub-workspace",
+  "hub-workspace-file",
+  "official-skills",
+  "model-providers",
+  "agent-profile-models",
+]);
 
 export type AuthNotice = {
   id: string;
@@ -51,6 +61,7 @@ export function useAuthController(t: TranslateFn): AuthController {
   const [authNotice, setAuthNotice] = useState<AuthNotice | null>(null);
   const [loginPending, setLoginPending] = useState(false);
   const [selectedEnvironment, setSelectedEnvironment] = useState<AuthEnvironmentDraft>(readStoredAuthEnvironmentDraft);
+  const environmentFingerprintRef = useRef("");
 
   const statusQuery = useQuery({
     queryKey: workspaceQueryKeys.authStatus(),
@@ -74,6 +85,15 @@ export function useAuthController(t: TranslateFn): AuthController {
     },
     [queryClient],
   );
+
+  const resetEnvironmentQueries = useCallback(async () => {
+    await queryClient.resetQueries({
+      predicate: (query) => {
+        const [scope, name] = query.queryKey;
+        return scope === "workspace" && typeof name === "string" && ENVIRONMENT_QUERY_NAMES.has(name);
+      },
+    });
+  }, [queryClient]);
 
   const refreshStatus = useCallback(async () => {
     return queryClient.fetchQuery({
@@ -125,7 +145,7 @@ export function useAuthController(t: TranslateFn): AuthController {
     try {
       const next = normalizeAuthStatus(await logoutAuth());
       setStatus(next);
-      void queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.modelProviders() });
+      await resetEnvironmentQueries();
       clearPendingAuthLogin();
       setAuthNotice({
         id: `auth-logout-complete-${Date.now()}`,
@@ -142,11 +162,29 @@ export function useAuthController(t: TranslateFn): AuthController {
     } finally {
       setBusyAction("");
     }
-  }, [busyAction, queryClient, setStatus, status.user_id, status.user_uuid, status.avatar, t]);
+  }, [busyAction, resetEnvironmentQueries, setStatus, status.user_id, status.user_uuid, status.avatar, t]);
 
   useEffect(() => {
     writeStoredAuthEnvironmentDraft(environment);
   }, [environment]);
+
+  useEffect(() => {
+    if (!statusQuery.isFetched) {
+      return;
+    }
+    const fingerprint = [
+      status.authenticated ? "authenticated" : "anonymous",
+      status.user_uuid || status.user_id || "",
+      status.opencsg_base_url || "",
+      status.base_url || "",
+      status.ai_gateway_base_url || "",
+    ].join("|");
+    if (environmentFingerprintRef.current === fingerprint) {
+      return;
+    }
+    environmentFingerprintRef.current = fingerprint;
+    void resetEnvironmentQueries();
+  }, [resetEnvironmentQueries, status, statusQuery.isFetched]);
 
   useEffect(() => {
     if (!loginPending) {
@@ -191,7 +229,7 @@ export function useAuthController(t: TranslateFn): AuthController {
     }
     const user = status.user_id || status.user_uuid || t("csghubSignedIn");
     const environment = authNoticeEnvironmentLabel(status, t);
-    void queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.modelProviders() });
+    void resetEnvironmentQueries();
     setLoginPending(false);
     setAuthError("");
     setAuthNotice({
@@ -205,7 +243,7 @@ export function useAuthController(t: TranslateFn): AuthController {
       type: "login",
       tone: "success",
     });
-  }, [queryClient, status, t]);
+  }, [resetEnvironmentQueries, status, t]);
 
   return {
     environment,


### PR DESCRIPTION
## Summary

- Resolve template operations with the request-scoped Hub service.
- Reset cached sandbox runtimes after login and logout.
- Clear frontend resource caches when the active site changes.

## Root cause

Hub and sandbox state initialized at startup could remain bound to the previous site after authentication or site changes.

## Impact

Template and sandbox operations now use the active site's credentials and configuration.

## Validation

- `go test ./internal/agent -run 'Test(CreateFromTemplateUsesRequestHubService|ResetSandboxRuntimesClosesAndDropsCachedClients)$'`
- `go test ./internal/api -run '^TestCreateCSGClawAgentParticipantViaAPIUsesRequestHub$'`

## Notes

No breaking API or configuration changes.
