### PR TITLE
fix(build): prevent Windows CLI binary conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 APP ?= csgclaw
 BIN_DIR ?= bin
-BIN ?= $(BIN_DIR)/$(APP)
 DIST_DIR ?= dist
 GOCACHE ?= $(CURDIR)/.gocache
 VERSION ?= $(shell sh $(CURDIR)/scripts/version.sh)
@@ -21,6 +20,10 @@ WEB_STATIC_DIST_DIR ?= web/static-dist
 WEB_PNPM ?= $(CURDIR)/scripts/web-pnpm.sh
 TARGET_OS ?= $(shell $(GO) env GOOS)
 TARGET_ARCH ?= $(shell $(GO) env GOARCH)
+HOST_BINARY_SUFFIX := $(if $(filter windows,$(TARGET_OS)),.exe,)
+SERVER_BIN ?= $(BIN_DIR)/$(APP)$(HOST_BINARY_SUFFIX)
+HOST_CLI_BIN ?= $(BIN_DIR)/csgclaw-cli$(HOST_BINARY_SUFFIX)
+BIN ?= $(SERVER_BIN)
 SANDBOX_BUNDLE_TOOLS_DIR ?= $(BIN_DIR)/sandbox-tools
 SANDBOX_CLI_BIN ?= $(SANDBOX_BUNDLE_TOOLS_DIR)/csgclaw-cli
 
@@ -106,9 +109,15 @@ build-all: build
 
 build-server-bin:
 	mkdir -p $(BIN_DIR)
-	env GOCACHE=$(GOCACHE) $(GO) build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/csgclaw ./cmd/csgclaw
+	@if [ "$(TARGET_OS)" = "windows" ]; then \
+		rm -f "$(BIN_DIR)/csgclaw" "$(BIN_DIR)/csgclaw-cli"; \
+	else \
+		rm -f "$(BIN_DIR)/csgclaw.exe" "$(BIN_DIR)/csgclaw-cli.exe"; \
+	fi
 	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) \
-		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o $(BIN_DIR)/csgclaw-cli ./cmd/csgclaw-cli
+		$(GO) build -ldflags "$(LDFLAGS)" -o "$(SERVER_BIN)" ./cmd/csgclaw
+	env GOCACHE=$(GOCACHE) CGO_ENABLED=$(CGO_ENABLED) GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) \
+		$(GO) build -ldflags "$(CLI_LDFLAGS)" -o "$(HOST_CLI_BIN)" ./cmd/csgclaw-cli
 
 build-server: build-server-bin build-sandbox-cli
 

--- a/internal/upgrade/install.go
+++ b/internal/upgrade/install.go
@@ -181,6 +181,19 @@ func refreshCompanionLauncher(installRoot string) error {
 	if err != nil || source == "" {
 		return err
 	}
+	if strings.EqualFold(filepath.Ext(source), ".exe") {
+		stale := filepath.Join(launcherDir, "csgclaw-cli")
+		if info, statErr := os.Lstat(stale); statErr == nil {
+			if !info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 {
+				return fmt.Errorf("stale companion launcher %s is not a regular file", stale)
+			}
+			if removeErr := os.Remove(stale); removeErr != nil {
+				return fmt.Errorf("remove stale companion launcher: %w", removeErr)
+			}
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("stat stale companion launcher: %w", statErr)
+		}
+	}
 	target := filepath.Join(launcherDir, filepath.Base(source))
 	if info, err := os.Lstat(target); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -736,6 +736,10 @@ func TestClientInstallPreparedResolvesWindowsLauncherLayout(t *testing.T) {
 	if err := os.WriteFile(launcherPath, []byte("launcher"), 0o755); err != nil {
 		t.Fatalf("WriteFile(%q) error = %v", launcherPath, err)
 	}
+	staleCLIPath := filepath.Join(launcherDir, "csgclaw-cli")
+	if err := os.WriteFile(staleCLIPath, []byte("stale linux companion"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", staleCLIPath, err)
+	}
 	if err := os.WriteFile(bundleMarkerPath(appHome), []byte(`{"app":"csgclaw","layout":"official-bundle"}`), 0o755); err != nil {
 		t.Fatalf("WriteFile(%q) error = %v", bundleMarkerPath(appHome), err)
 	}
@@ -760,6 +764,9 @@ func TestClientInstallPreparedResolvesWindowsLauncherLayout(t *testing.T) {
 	}
 	assertFileContent(t, filepath.Join(installRoot, "README.md"), "new")
 	assertFileContent(t, filepath.Join(launcherDir, "csgclaw-cli.exe"), "new companion")
+	if _, err := os.Lstat(staleCLIPath); !os.IsNotExist(err) {
+		t.Fatalf("stale extensionless companion still exists, stat error = %v", err)
+	}
 
 	updatedRoot := writeBundleFiles(t, t.TempDir(), map[string]string{
 		filepath.Join("csgclaw", "bin", "csgclaw.exe"):     "@echo off\r\nREM newer\r\n",

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -182,6 +182,26 @@ function Get-BinaryName {
     return $BaseName
 }
 
+function Remove-StaleHostBinaries {
+    param(
+        [Parameter(Mandatory = $true)][string]$Directory,
+        [Parameter(Mandatory = $true)][string]$Goos
+    )
+
+    $staleNames = if ($Goos -eq "windows") {
+        @("csgclaw", "csgclaw-cli")
+    }
+    else {
+        @("csgclaw.exe", "csgclaw-cli.exe")
+    }
+    foreach ($name in $staleNames) {
+        $path = Join-Path $Directory $name
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            Remove-Item -LiteralPath $path -Force
+        }
+    }
+}
+
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
     if (-not (Test-Path -LiteralPath $Path)) {
@@ -369,6 +389,7 @@ function Invoke-GoBuild {
 
 function Invoke-TargetBuildServerBin {
     Ensure-Directory -Path $script:BinDir
+    Remove-StaleHostBinaries -Directory $script:BinDir -Goos $script:TargetOs
 
     $serverBinary = Join-Path $script:BinDir (Get-BinaryName -BaseName "csgclaw" -Goos $script:TargetOs)
     $cliBinary = Join-Path $script:BinDir (Get-BinaryName -BaseName "csgclaw-cli" -Goos $script:TargetOs)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -131,12 +131,16 @@ function Install-Launcher {
 
     $launcherExePath = Join-Path $InstallDir "${Name}.exe"
     $launcherCmdPath = Join-Path $InstallDir "${Name}.cmd"
+    $extensionlessLauncherPath = Join-Path $InstallDir $Name
 
     if (Test-Path -LiteralPath $launcherExePath) {
         Remove-Item -LiteralPath $launcherExePath -Force
     }
     if (Test-Path -LiteralPath $launcherCmdPath) {
         Remove-Item -LiteralPath $launcherCmdPath -Force
+    }
+    if (Test-Path -LiteralPath $extensionlessLauncherPath -PathType Leaf) {
+        Remove-Item -LiteralPath $extensionlessLauncherPath -Force
     }
 
     try {


### PR DESCRIPTION
## Summary

- Emit host binaries with the correct platform suffix.
- Keep the Linux sandbox CLI under `sandbox-tools`.
- Remove stale extensionless Windows launchers during build, installation, and upgrade.

## Root cause

Windows packages could retain extensionless host launchers alongside `.exe` binaries, causing conflicting CLI resolution.

## Impact

Windows builds, installations, and upgrades consistently use platform-correct CLI binaries.

## Validation

- `go test ./internal/upgrade -run '^TestClientInstallPreparedResolvesWindowsLauncherLayout$'`

## Notes

No breaking configuration changes.
