### PR TITLE
fix(web): delete notification agents via participant endpoint

### DIFF
--- a/web/app/src/api/agents.test.ts
+++ b/web/app/src/api/agents.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteAgentLikeRequest } from "./agents";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("deleteAgentLikeRequest", () => {
+  it("deletes notification participants through the channel participant endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteAgentLikeRequest({
+      id: "notification-1",
+      name: "Notification",
+      type: "notification",
+      bot_type: "notification",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "api/v1/channels/csgclaw/participants/notification-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("keeps regular agents on the agent endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteAgentLikeRequest({
+      id: "agent-1",
+      name: "Agent",
+      type: "agent",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("api/v1/agents/agent-1", expect.objectContaining({ method: "DELETE" }));
+  });
+});

--- a/web/app/src/api/agents.ts
+++ b/web/app/src/api/agents.ts
@@ -1,6 +1,7 @@
 import { del, get, patch, post, put, requestText, type ApiError } from "@/api/client";
 import { BOT_TYPE_NOTIFICATION, MANAGER_AGENT_ID } from "@/shared/constants/agents";
 import {
+  isNotificationBotAgent,
   resolveRuntimeSelection,
   type AgentLike,
   type AgentProfileLike,
@@ -350,6 +351,14 @@ export function deleteBotRequest(botID: string, options: DeleteBotOptions = {}):
   }
   const query = params.toString();
   return del(`api/v1/channels/csgclaw/participants/${encodeURIComponent(botID)}${query ? `?${query}` : ""}`);
+}
+
+export function deleteAgentLikeRequest(item: AgentLike): Promise<void> {
+  const id = String(item.id ?? "").trim();
+  if (!id) {
+    return Promise.reject(new Error("agent id is required"));
+  }
+  return isNotificationBotAgent(item) ? deleteBotRequest(id) : deleteAgentRequest(id);
 }
 
 export function deleteFeishuParticipantRequest(participantID: string): Promise<void> {

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -10,7 +10,7 @@ import {
   createBotRequest,
   createManagerAgentRequest,
   createNotificationBotRequest,
-  deleteAgentRequest,
+  deleteAgentLikeRequest,
   deleteAgentSkillRequest,
   deleteBotRequest,
   deleteFeishuParticipantRequest,
@@ -1829,13 +1829,14 @@ export function useAgentController({
     }
     try {
       let updatedAgent: AgentLike | null = null;
+      const deletingNotificationBot = action === "delete" && isNotificationBotAgent(item);
       if (action === "delete") {
-        await deleteAgentRequest(item.id);
+        await deleteAgentLikeRequest(item);
       } else {
         updatedAgent = await runAgentActionRequest(item.id, action);
       }
       await refreshAgentsWithUpdatedAgent(updatedAgent);
-      if (action === "delete") {
+      if (action === "delete" && !deletingNotificationBot) {
         await refreshAgentSkills(item.id);
       }
       if (item.id === MANAGER_AGENT_ID) {


### PR DESCRIPTION
## Summary

- Delete notification agents through the channel participant endpoint.
- Preserve the existing agent endpoint for regular agent deletion.
- Skip agent skill refresh after deleting participant-backed notification agents.
- Add regression coverage for both deletion paths.

## Root cause

Notification agents are participant-backed, but the shared delete flow sent their participant IDs to the regular agent endpoint.

## Impact

Fixes the `agent not found` error when deleting notification agents. Regular agent deletion remains unchanged.

## Validation

- `pnpm vitest run src/api/agents.test.ts`
- `pnpm typecheck`

## Notes

No breaking API or configuration changes.
