### PR TITLE
feat: add bilingual interactive output demo

### DIFF
--- a/internal/activity/user_input_markdown.go
+++ b/internal/activity/user_input_markdown.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 const userInputMarkdownSeparator = "："
@@ -33,7 +34,7 @@ func UserInputQuestionMarkdown(snapshot UserInputSnapshot) string {
 		return ""
 	}
 	var out strings.Builder
-	out.WriteString("## Questions\n\n")
+	out.WriteString("## " + userInputMarkdownHeading(snapshot, "Questions", "问题") + "\n\n")
 	for _, question := range snapshot.Questions {
 		fmt.Fprintf(&out, "- %s%s%s\n", markdownLine(question.ID), userInputMarkdownSeparator, markdownLine(question.Question))
 		for _, option := range question.Options {
@@ -61,7 +62,7 @@ func UserInputAnswerMarkdown(snapshot UserInputSnapshot) string {
 		return ""
 	}
 	var out strings.Builder
-	out.WriteString("## Answers\n\n")
+	out.WriteString("## " + userInputMarkdownHeading(snapshot, "Answers", "回答") + "\n\n")
 	for _, question := range snapshot.Questions {
 		answer, ok := snapshot.Answers[question.ID]
 		if !ok {
@@ -76,6 +77,22 @@ func UserInputAnswerMarkdown(snapshot UserInputSnapshot) string {
 		)
 	}
 	return strings.TrimSpace(out.String())
+}
+
+func userInputMarkdownHeading(snapshot UserInputSnapshot, english, chinese string) string {
+	for _, question := range snapshot.Questions {
+		prompt := strings.TrimSpace(question.Question)
+		if prompt == "" {
+			continue
+		}
+		for _, char := range prompt {
+			if unicode.Is(unicode.Han, char) {
+				return chinese
+			}
+		}
+		return english
+	}
+	return english
 }
 
 func userInputAnswerLabelAndDescription(question UserInputQuestionSnapshot, answer UserInputAnswerSnapshot) (string, string) {

--- a/internal/activity/user_input_markdown_test.go
+++ b/internal/activity/user_input_markdown_test.go
@@ -44,6 +44,48 @@ func TestUserInputQuestionMarkdown(t *testing.T) {
 	}
 }
 
+func TestUserInputMarkdownUsesChineseHeadingsForChineseQuestions(t *testing.T) {
+	t.Parallel()
+
+	snapshot := UserInputSnapshot{
+		Status: UserInputStatusAnswered,
+		Questions: []UserInputQuestionSnapshot{
+			{
+				ID:       "demo_kind",
+				Question: "演示应该执行哪种工作流？",
+				Options: []UserInputOptionSnapshot{
+					{Label: "修复缺陷（推荐）", Description: "执行聚焦的修复流程。"},
+				},
+			},
+		},
+		Answers: map[string]UserInputAnswerSnapshot{
+			"demo_kind": {Answered: true, OptionIndex: 1, OptionLabel: "修复缺陷（推荐）"},
+		},
+	}
+
+	if got := UserInputQuestionMarkdown(snapshot); !strings.HasPrefix(got, "## 问题\n\n") {
+		t.Fatalf("UserInputQuestionMarkdown() = %q, want Chinese heading", got)
+	}
+	if got := UserInputAnswerMarkdown(snapshot); !strings.HasPrefix(got, "## 回答\n\n") {
+		t.Fatalf("UserInputAnswerMarkdown() = %q, want Chinese heading", got)
+	}
+}
+
+func TestUserInputMarkdownUsesFirstQuestionToDetectLanguage(t *testing.T) {
+	t.Parallel()
+
+	snapshot := UserInputSnapshot{
+		Questions: []UserInputQuestionSnapshot{
+			{ID: "primary", Question: "Choose the primary option."},
+			{ID: "unicode", Question: "Choose 中文 punctuation?"},
+		},
+	}
+
+	if got := UserInputQuestionMarkdown(snapshot); !strings.HasPrefix(got, "## Questions\n\n") {
+		t.Fatalf("UserInputQuestionMarkdown() = %q, want primary question language", got)
+	}
+}
+
 func TestUserInputAnswerMarkdownUsesStrictReadableShape(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/codex/structured_output_test.go
+++ b/internal/runtime/codex/structured_output_test.go
@@ -176,6 +176,33 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 	if !strings.HasSuffix(request.Questions[0].Options[0].Label, " (Recommended)") {
 		t.Fatalf("recommended option = %+v", request.Questions[0].Options[0])
 	}
+	chineseOutput, err := exec.Command("python3", emitterPath, "start", "--language", "zh").Output()
+	if err != nil {
+		t.Fatalf("run Chinese demo emitter: %v", err)
+	}
+	chineseCleaned, chineseArtifact, chineseErrors := decodeStructuredCommandOutput(string(chineseOutput))
+	if len(chineseErrors) != 0 || strings.TrimSpace(chineseCleaned) != "## 交互式输出演示 - 第 1/3 步\n\n请选择工作流分支。" {
+		t.Fatalf("decode Chinese demo emitter: stdout=%q artifact=%+v errors=%v", chineseCleaned, chineseArtifact, chineseErrors)
+	}
+	chineseRequest := chineseArtifact.RequestUserInput
+	if chineseRequest == nil || len(chineseRequest.Questions) != 1 || chineseRequest.Questions[0].Question != "演示应该执行哪种工作流？" {
+		t.Fatalf("Chinese stage 1 request = %+v", chineseRequest)
+	}
+	chineseSnapshot := activity.UserInputSnapshot{
+		Questions: []activity.UserInputQuestionSnapshot{{
+			ID:       chineseRequest.Questions[0].ID,
+			Question: chineseRequest.Questions[0].Question,
+		}},
+		Answers: map[string]activity.UserInputAnswerSnapshot{
+			chineseRequest.Questions[0].ID: {Answered: true, Text: "修复缺陷"},
+		},
+	}
+	if questionMarkdown := activity.UserInputQuestionMarkdown(chineseSnapshot); !strings.HasPrefix(questionMarkdown, "## 问题\n\n") {
+		t.Fatalf("Chinese question transcript = %q", questionMarkdown)
+	}
+	if answerMarkdown := activity.UserInputAnswerMarkdown(chineseSnapshot); !strings.HasPrefix(answerMarkdown, "## 回答\n\n") {
+		t.Fatalf("Chinese answer transcript = %q", answerMarkdown)
+	}
 	contextOutput, err := exec.Command("python3", emitterPath, "context", "--workflow", "bug-fix").Output()
 	if err != nil {
 		t.Fatalf("run demo context stage: %v", err)
@@ -199,6 +226,14 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 		!strings.HasSuffix(contextRequest.Questions[3].Options[0].Label, " (Recommended)") ||
 		!strings.Contains(contextRequest.Questions[3].Options[2].Label, "中文") {
 		t.Fatalf("stage 2 request = %+v, want four mixed questions including Unicode, other, freeform-only, and Recommended", contextRequest)
+	}
+	chineseContextOutput, err := exec.Command("python3", emitterPath, "context", "--workflow", "bug-fix", "--language", "zh").Output()
+	if err != nil {
+		t.Fatalf("run Chinese demo context stage: %v", err)
+	}
+	_, chineseContextArtifact, chineseContextErrors := decodeStructuredCommandOutput(string(chineseContextOutput))
+	if len(chineseContextErrors) != 0 || chineseContextArtifact.RequestUserInput == nil || chineseContextArtifact.RequestUserInput.Questions[0].Question != "验证应该多严格？" {
+		t.Fatalf("decode Chinese context stage: artifact=%+v errors=%v", chineseContextArtifact, chineseContextErrors)
 	}
 
 	confirmOutput, err := exec.Command(
@@ -226,6 +261,21 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 		!strings.Contains(confirmRequest.Questions[1].Question, "never a real credential") {
 		t.Fatalf("stage 3 request = %+v, want final options and freeform secret", confirmRequest)
 	}
+	chineseConfirmOutput, err := exec.Command(
+		"python3", emitterPath, "confirm",
+		"--workflow", "bug-fix",
+		"--destination", "qa-thread",
+		"--verification", "strict",
+		"--presentation", "bilingual",
+		"--language", "zh",
+	).Output()
+	if err != nil {
+		t.Fatalf("run Chinese demo confirmation stage: %v", err)
+	}
+	_, chineseConfirmArtifact, chineseConfirmErrors := decodeStructuredCommandOutput(string(chineseConfirmOutput))
+	if len(chineseConfirmErrors) != 0 || chineseConfirmArtifact.RequestUserInput == nil || chineseConfirmArtifact.RequestUserInput.Questions[0].Question != "演示接下来应该执行什么？" {
+		t.Fatalf("decode Chinese confirmation stage: artifact=%+v errors=%v", chineseConfirmArtifact, chineseConfirmErrors)
+	}
 
 	completeOutput, err := exec.Command(
 		"python3", emitterPath, "complete",
@@ -252,6 +302,21 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 		if !strings.Contains(completion, want) {
 			t.Fatalf("completion output = %q, want %q", completion, want)
 		}
+	}
+	chineseCompleteOutput, err := exec.Command(
+		"python3", emitterPath, "complete",
+		"--workflow", "bug-fix",
+		"--destination", "qa-thread",
+		"--verification", "strict",
+		"--presentation", "bilingual",
+		"--action", "execute",
+		"--language", "zh",
+	).Output()
+	if err != nil {
+		t.Fatalf("run Chinese demo completion stage: %v", err)
+	}
+	if chineseCompletion := string(chineseCompleteOutput); !strings.Contains(chineseCompletion, "## 交互式输出演示完成") || !strings.Contains(chineseCompletion, "- 已执行操作：`execute`") {
+		t.Fatalf("Chinese completion output = %q", chineseCompletion)
 	}
 
 	emitter, err := os.ReadFile(filepath.Join(dir, "scripts", "emit_demo.py"))
@@ -281,8 +346,8 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 		"Each supported protocol field is documented at its first use",
 		"The script deliberately has no response JSON input",
 		"def emit_resource_links()",
-		"def emit_start()",
-		"def emit_context(workflow: str)",
+		"def emit_start(language: str)",
+		"def emit_context(workflow: str, language: str)",
 		"def emit_confirmation(",
 		"def complete(",
 		"Required ResourceLink discriminator",
@@ -308,6 +373,7 @@ func TestEmbeddedInteractiveOutputDemoExercisesEveryPositiveFeature(t *testing.T
 		"complete --workflow <bug-fix|new-feature|code-review|custom> --destination",
 		"Never include received response JSON in a user-visible response.",
 		"Never repeat a secret answer value",
+		"--language <en|zh>",
 	} {
 		if !strings.Contains(string(workflowInstructions), workflowContract) {
 			t.Fatalf("skill instructions are missing multi-stage contract %q:\n%s", workflowContract, workflowInstructions)

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/SKILL.md
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: csgclaw-interactive-output-demo
-description: Run the complete three-stage CSGClaw structured-output demo when the user explicitly invokes $csgclaw-interactive-output-demo. Exercise resource links, Codex-style options, recommended and Unicode labels, freeform alternatives, secret input, and agent-directed automatic continuation.
+description: Run the complete three-stage CSGClaw structured-output demo in English or Chinese when the user explicitly invokes $csgclaw-interactive-output-demo. Exercise resource links, Codex-style options, recommended and Unicode labels, freeform alternatives, secret input, and agent-directed automatic continuation.
 ---
 
 # CSGClaw Interactive Output Demo
@@ -12,7 +12,7 @@ It never receives or parses `RequestUserInputResponse`.
 After each question submission, CSGClaw automatically continues this same Manager session with the wire-compatible response JSON.
 Submitted secret values are replaced with `<redacted>` before that JSON enters the model session.
 The Manager brain reads that JSON and chooses the next allowlisted stage.
-The readable `## Answers` message is persisted separately by CSGClaw as a local-user message and must not be parsed or echoed by this skill.
+The readable `## Answers` message is persisted separately by CSGClaw as a local-user message, using `## 回答` for Chinese questions, and must not be parsed or echoed by this skill.
 
 ## Mandatory one-stage boundary
 
@@ -24,13 +24,16 @@ After the one emitter command returns, do not route again, read another file, or
 
 ## Initial invocation
 
-When the current prompt does not contain an automatic continuation response JSON, execute this command exactly once:
+When the current prompt does not contain an automatic continuation response JSON, detect the language of the user's invocation.
+Use `zh` for Chinese and `en` otherwise, then execute this command exactly once:
 
 ```bash
-python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" start
+python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" start --language <en|zh>
 ```
 
-After the command succeeds, return this exact Markdown and end the turn:
+After the command succeeds, return the matching exact Markdown and end the turn.
+
+English:
 
 ```markdown
 ## Interactive output demo - step 1 of 3
@@ -38,11 +41,20 @@ After the command succeeds, return this exact Markdown and end the turn:
 Choose the workflow branch.
 ```
 
+Chinese:
+
+```markdown
+## 交互式输出演示 - 第 1/3 步
+
+请选择工作流分支。
+```
+
 Do not quote, summarize, or restate emitted control records.
 
 ## Automatic continuation routing
 
 Inspect only the question IDs in the response JSON that was present when this turn began.
+Keep the language selected during the initial invocation for every later stage.
 Read exactly one matching reference completely, follow it, and do not read another reference in this turn:
 
 - If it contains `demo_kind`, read `references/stage-2.md`.

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/agents/openai.yaml
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "CSGClaw Interactive Output Demo"
-  short_description: "Exercise structured links and interactive questions"
-  default_prompt: "Use $csgclaw-interactive-output-demo to run the complete interactive output demo."
+  short_description: "Exercise bilingual structured links and questions"
+  default_prompt: "Use $csgclaw-interactive-output-demo to run the complete interactive output demo in my language."
 policy:
   allow_implicit_invocation: false

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/complete.md
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/complete.md
@@ -4,18 +4,19 @@ Use this reference only when the response JSON present at the beginning of the c
 
 Choose one action argument from the `final_action` answer:
 
-- `Execute demo (Recommended)` becomes `execute`.
-- `Revise context` becomes `revise`.
-- `Stop here` becomes `stop`.
+- `Execute demo (Recommended)` or `执行演示 (Recommended)` becomes `execute`.
+- `Revise context` or `修改上下文` becomes `revise`.
+- `Stop here` or `在此停止` becomes `stop`.
 - A skipped or unrecognized value becomes `skip`.
 
 Preserve the allowlisted workflow, destination, verification, and presentation selectors chosen during the prior stages.
+Keep the initial `en` or `zh` language selection.
 Execute exactly one command using only those selectors and the allowlisted action:
 
 ```bash
-python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" complete --workflow <bug-fix|new-feature|code-review|custom> --destination <current-room|qa-thread|custom|unspecified> --verification <standard|strict|fast|unspecified> --presentation <concise|detailed|bilingual|unspecified> --action <execute|revise|stop|skip>
+python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" complete --workflow <bug-fix|new-feature|code-review|custom> --destination <current-room|qa-thread|custom|unspecified> --verification <standard|strict|fast|unspecified> --presentation <concise|detailed|bilingual|unspecified> --action <execute|revise|stop|skip> --language <en|zh>
 ```
 
-Then return only the Markdown beginning with `## Interactive output demo complete` and end the turn.
+Then return only the Markdown beginning with `## Interactive output demo complete` or `## 交互式输出演示完成` and end the turn.
 Do not quote the preceding `FINAL_RECEIPT_EMITTED` stage-boundary line.
 Never repeat or pass the secret answer value.

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/stage-2.md
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/stage-2.md
@@ -4,23 +4,34 @@ Use this reference only when the response JSON present at the beginning of the c
 
 Choose one workflow argument from the `demo_kind` answer:
 
-- `Bug fix (Recommended)` becomes `bug-fix`.
-- `New feature` becomes `new-feature`.
-- `Code review` becomes `code-review`.
+- `Bug fix (Recommended)` or `修复缺陷 (Recommended)` becomes `bug-fix`.
+- `New feature` or `新功能` becomes `new-feature`.
+- `Code review` or `代码审查` becomes `code-review`.
 - A skipped or unrecognized value becomes `custom`.
 
-Execute exactly one command, substituting only that allowlisted argument:
+Keep the initial `en` or `zh` language selection.
+Execute exactly one command, substituting only those allowlisted arguments:
 
 ```bash
-python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" context --workflow <bug-fix|new-feature|code-review|custom>
+python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" context --workflow <bug-fix|new-feature|code-review|custom> --language <en|zh>
 ```
 
-After the command succeeds, return this exact Markdown and end the turn:
+After the command succeeds, return the matching exact Markdown and end the turn.
+
+English:
 
 ```markdown
 ## Interactive output demo - step 2 of 3
 
 Configure verification, destination, an optional freeform note, and presentation.
+```
+
+Chinese:
+
+```markdown
+## 交互式输出演示 - 第 2/3 步
+
+请配置验证方式、目标位置、可选备注和展示方式。
 ```
 
 Do not read `stage-3.md` or `complete.md` in this turn.

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/stage-3.md
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/references/stage-3.md
@@ -4,38 +4,49 @@ Use this reference only when the response JSON present at the beginning of the c
 
 Choose one destination argument from the `destination` answer:
 
-- `Current room` becomes `current-room`.
-- `Thread: QA / 验收` becomes `qa-thread`.
+- `Current room` or `当前房间` becomes `current-room`.
+- `Thread: QA / 验收` or `线程：QA / 验收` becomes `qa-thread`.
 - A `user_note: ` value becomes `custom`.
 - A skipped or unrecognized value becomes `unspecified`.
 
 Choose one verification argument from the `verification` answer:
 
-- `Standard` becomes `standard`.
-- `Strict + Unicode 中文` becomes `strict`.
-- `Fast, focused` becomes `fast`.
+- `Standard` or `标准` becomes `standard`.
+- `Strict + Unicode 中文` or `严格 + Unicode 中文` becomes `strict`.
+- `Fast, focused` or `快速、聚焦` becomes `fast`.
 - A skipped or unrecognized value becomes `unspecified`.
 
 Choose one presentation argument from the `presentation` answer:
 
-- `Concise (Recommended)` becomes `concise`.
-- `Detailed` becomes `detailed`.
-- `Bilingual 中文 + English` becomes `bilingual`.
+- `Concise (Recommended)` or `简洁 (Recommended)` becomes `concise`.
+- `Detailed` or `详细` becomes `detailed`.
+- `Bilingual 中文 + English` or `双语 中文 + English` becomes `bilingual`.
 - A skipped or unrecognized value becomes `unspecified`.
 
 Preserve the allowlisted workflow chosen during stage 2.
+Keep the initial `en` or `zh` language selection.
 Execute exactly one command using only allowlisted branch selectors:
 
 ```bash
-python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" confirm --workflow <bug-fix|new-feature|code-review|custom> --destination <current-room|qa-thread|custom|unspecified> --verification <standard|strict|fast|unspecified> --presentation <concise|detailed|bilingual|unspecified>
+python3 "$CODEX_HOME/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py" confirm --workflow <bug-fix|new-feature|code-review|custom> --destination <current-room|qa-thread|custom|unspecified> --verification <standard|strict|fast|unspecified> --presentation <concise|detailed|bilingual|unspecified> --language <en|zh>
 ```
 
-After the command succeeds, return this exact Markdown and end the turn:
+After the command succeeds, return the matching exact Markdown and end the turn.
+
+English:
 
 ```markdown
 ## Interactive output demo - step 3 of 3
 
 Choose the final action and optionally enter a disposable secret test value.
+```
+
+Chinese:
+
+```markdown
+## 交互式输出演示 - 第 3/3 步
+
+请选择最终操作，并可选择输入一次性秘密测试值。
 ```
 
 Do not read `complete.md` in this turn.

--- a/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py
+++ b/internal/template/embed/manager/codex/skills/csgclaw-interactive-output-demo/scripts/emit_demo.py
@@ -16,6 +16,13 @@ DESTINATIONS = ("current-room", "qa-thread", "custom", "unspecified")
 VERIFICATIONS = ("standard", "strict", "fast", "unspecified")
 PRESENTATIONS = ("concise", "detailed", "bilingual", "unspecified")
 ACTIONS = ("execute", "revise", "stop", "skip")
+LANGUAGES = ("en", "zh")
+
+
+def localize(language: str, english: str, chinese: str) -> str:
+    """Select one of the demo's two user-facing languages."""
+
+    return chinese if language == "zh" else english
 
 
 def emit(kind: str, payload: dict[str, object]) -> None:
@@ -84,14 +91,20 @@ def emit_resource_links() -> None:
     )
 
 
-def emit_start() -> None:
+def emit_start(language: str) -> None:
     """Emit resource links and option-based questions for stage 1."""
 
     # Ordinary stdout becomes the readable response when CSGClaw closes the
     # turn at the structured question boundary. Control records stay hidden.
-    print("## Interactive output demo - step 1 of 3")
+    print(
+        localize(
+            language,
+            "## Interactive output demo - step 1 of 3",
+            "## 交互式输出演示 - 第 1/3 步",
+        )
+    )
     print()
-    print("Choose the workflow branch.")
+    print(localize(language, "Choose the workflow branch.", "请选择工作流分支。"))
     emit_resource_links()
     emit(
         "request_user_input",
@@ -102,9 +115,13 @@ def emit_start() -> None:
                     # Required unique response-map key.
                     "id": "demo_kind",
                     # Required short activity/history label.
-                    "header": "Demo kind",
+                    "header": localize(language, "Demo kind", "演示类型"),
                     # Required concrete UI title.
-                    "question": "What workflow should the demo execute?",
+                    "question": localize(
+                        language,
+                        "What workflow should the demo execute?",
+                        "演示应该执行哪种工作流？",
+                    ),
                     # Show a freeform alternative when true or options are absent.
                     "isOther": False,
                     # Use password input and redact persisted values when true.
@@ -113,17 +130,33 @@ def emit_start() -> None:
                     "options": [
                         {
                             # Exact submitted value; the suffix adds the badge.
-                            "label": "Bug fix (Recommended)",
+                            "label": localize(
+                                language,
+                                "Bug fix (Recommended)",
+                                "修复缺陷 (Recommended)",
+                            ),
                             # Optional supporting text.
-                            "description": "Follow a focused repair workflow with reproduction and verification.",
+                            "description": localize(
+                                language,
+                                "Follow a focused repair workflow with reproduction and verification.",
+                                "执行包含复现和验证的聚焦修复流程。",
+                            ),
                         },
                         {
-                            "label": "New feature",
-                            "description": "Plan a user-facing capability from goal to test coverage.",
+                            "label": localize(language, "New feature", "新功能"),
+                            "description": localize(
+                                language,
+                                "Plan a user-facing capability from goal to test coverage.",
+                                "规划从目标到测试覆盖的用户功能。",
+                            ),
                         },
                         {
-                            "label": "Code review",
-                            "description": "Inspect changes, concrete risks, and priorities.",
+                            "label": localize(language, "Code review", "代码审查"),
+                            "description": localize(
+                                language,
+                                "Inspect changes, concrete risks, and priorities.",
+                                "检查变更、具体风险和优先级。",
+                            ),
                         },
                     ],
                 },
@@ -135,14 +168,23 @@ def emit_start() -> None:
     )
 
 
-def emit_context(workflow: str) -> None:
+def emit_context(workflow: str, language: str) -> None:
     """Emit option-or-freeform and freeform-only questions for stage 2."""
 
-    print("## Interactive output demo - step 2 of 3")
+    print(
+        localize(
+            language,
+            "## Interactive output demo - step 2 of 3",
+            "## 交互式输出演示 - 第 2/3 步",
+        )
+    )
     print()
     print(
-        "Configure verification, destination, an optional freeform note, "
-        "and presentation."
+        localize(
+            language,
+            "Configure verification, destination, an optional freeform note, and presentation.",
+            "请配置验证方式、目标位置、可选备注和展示方式。",
+        )
     )
     emit_resource_links()
     emit(
@@ -151,68 +193,126 @@ def emit_context(workflow: str) -> None:
             "questions": [
                 {
                     "id": "verification",
-                    "header": "Checks",
-                    "question": "How cautious should verification be?",
+                    "header": localize(language, "Checks", "检查"),
+                    "question": localize(
+                        language,
+                        "How cautious should verification be?",
+                        "验证应该多严格？",
+                    ),
                     "isOther": False,
                     "isSecret": False,
                     "options": [
                         {
-                            "label": "Standard",
-                            "description": "Use targeted checks, normal punctuation, and practical coverage.",
+                            "label": localize(language, "Standard", "标准"),
+                            "description": localize(
+                                language,
+                                "Use targeted checks, normal punctuation, and practical coverage.",
+                                "使用有针对性的检查、正常标点和实用覆盖。",
+                            ),
                         },
                         {
-                            "label": "Strict + Unicode 中文",
-                            "description": "Add broader verification, edge cases, and explicit acceptance criteria.",
+                            "label": localize(
+                                language, "Strict + Unicode 中文", "严格 + Unicode 中文"
+                            ),
+                            "description": localize(
+                                language,
+                                "Add broader verification, edge cases, and explicit acceptance criteria.",
+                                "增加更广泛的验证、边界场景和明确的验收标准。",
+                            ),
                         },
                         {
-                            "label": "Fast, focused",
-                            "description": "Keep validation lightweight and emphasize speed.",
+                            "label": localize(language, "Fast, focused", "快速、聚焦"),
+                            "description": localize(
+                                language,
+                                "Keep validation lightweight and emphasize speed.",
+                                "保持轻量验证并优先考虑速度。",
+                            ),
                         },
                     ],
                 },
                 {
                     "id": "destination",
-                    "header": "Destination",
-                    "question": f"Where should the {workflow} demo result go?",
+                    "header": localize(language, "Destination", "目标位置"),
+                    "question": localize(
+                        language,
+                        f"Where should the {workflow} demo result go?",
+                        "演示结果应该发送到哪里？",
+                    ),
                     "isOther": True,
                     "isSecret": False,
                     "options": [
                         {
-                            "label": "Current room",
-                            "description": "Keep the result in this CSGClaw conversation.",
+                            "label": localize(language, "Current room", "当前房间"),
+                            "description": localize(
+                                language,
+                                "Keep the result in this CSGClaw conversation.",
+                                "将结果保留在当前 CSGClaw 对话中。",
+                            ),
                         },
                         {
-                            "label": "Thread: QA / 验收",
-                            "description": "Use the option as written, including spaces, slash, and Unicode.",
+                            "label": localize(
+                                language, "Thread: QA / 验收", "线程：QA / 验收"
+                            ),
+                            "description": localize(
+                                language,
+                                "Use the option as written, including spaces, slash, and Unicode.",
+                                "按原样使用包含空格、斜杠和 Unicode 的选项。",
+                            ),
                         },
                     ],
                 },
                 {
                     "id": "freeform_note",
-                    "header": "Freeform",
-                    "question": "Add an optional note with spaces, punctuation, or Unicode.",
+                    "header": localize(language, "Freeform", "自由输入"),
+                    "question": localize(
+                        language,
+                        "Add an optional note with spaces, punctuation, or Unicode.",
+                        "添加一条可包含空格、标点或 Unicode 的可选备注。",
+                    ),
                     "isOther": True,
                     "isSecret": False,
                     "options": None,
                 },
                 {
                     "id": "presentation",
-                    "header": "Presentation",
-                    "question": "How should the final execution receipt be presented?",
+                    "header": localize(language, "Presentation", "展示方式"),
+                    "question": localize(
+                        language,
+                        "How should the final execution receipt be presented?",
+                        "最终执行回执应该如何展示？",
+                    ),
                     "isOther": False,
                     "isSecret": False,
                     "options": [
                         {
-                            "label": "Concise (Recommended)",
-                            "description": "Show a short branch and action receipt.",
+                            "label": localize(
+                                language, "Concise (Recommended)", "简洁 (Recommended)"
+                            ),
+                            "description": localize(
+                                language,
+                                "Show a short branch and action receipt.",
+                                "显示简短的分支和操作回执。",
+                            ),
                         },
                         {
-                            "label": "Detailed",
-                            "description": "Show every allowlisted selection in the receipt.",
+                            "label": localize(language, "Detailed", "详细"),
+                            "description": localize(
+                                language,
+                                "Show every allowlisted selection in the receipt.",
+                                "在回执中显示所有白名单选项。",
+                            ),
                         },
                         {
-                            "label": "Bilingual 中文 + English",
-                            "description": "Exercise spaces, punctuation, and Unicode in an ordinary option.",
+                            "label": localize(
+                                language,
+                                "Bilingual 中文 + English",
+                                "双语 中文 + English",
+                            ),
+                            "description": localize(
+                                language,
+                                "Exercise spaces, punctuation, and Unicode in an ordinary option.",
+                                "在普通选项中测试空格、标点和 Unicode。",
+                            ),
                         },
                     ],
                 },
@@ -222,14 +322,28 @@ def emit_context(workflow: str) -> None:
 
 
 def emit_confirmation(
-    workflow: str, destination: str, verification: str, presentation: str
+    workflow: str,
+    destination: str,
+    verification: str,
+    presentation: str,
+    language: str,
 ) -> None:
     """Emit final action options and optional secret input for stage 3."""
 
-    print("## Interactive output demo - step 3 of 3")
+    print(
+        localize(
+            language,
+            "## Interactive output demo - step 3 of 3",
+            "## 交互式输出演示 - 第 3/3 步",
+        )
+    )
     print()
     print(
-        "Choose the final action and optionally enter a disposable secret test value."
+        localize(
+            language,
+            "Choose the final action and optionally enter a disposable secret test value.",
+            "请选择最终操作，并可选择输入一次性秘密测试值。",
+        )
     )
     emit(
         "request_user_input",
@@ -237,29 +351,53 @@ def emit_confirmation(
             "questions": [
                 {
                     "id": "final_action",
-                    "header": "Final action",
-                    "question": "What should the demo execute next?",
+                    "header": localize(language, "Final action", "最终操作"),
+                    "question": localize(
+                        language,
+                        "What should the demo execute next?",
+                        "演示接下来应该执行什么？",
+                    ),
                     "isOther": False,
                     "isSecret": False,
                     "options": [
                         {
-                            "label": "Execute demo (Recommended)",
-                            "description": "Complete the selected branch and show its execution receipt.",
+                            "label": localize(
+                                language,
+                                "Execute demo (Recommended)",
+                                "执行演示 (Recommended)",
+                            ),
+                            "description": localize(
+                                language,
+                                "Complete the selected branch and show its execution receipt.",
+                                "完成所选分支并显示执行回执。",
+                            ),
                         },
                         {
-                            "label": "Revise context",
-                            "description": "Finish with a receipt requesting revised context.",
+                            "label": localize(language, "Revise context", "修改上下文"),
+                            "description": localize(
+                                language,
+                                "Finish with a receipt requesting revised context.",
+                                "通过请求修改上下文的回执结束。",
+                            ),
                         },
                         {
-                            "label": "Stop here",
-                            "description": "Finish without executing the selected demo branch.",
+                            "label": localize(language, "Stop here", "在此停止"),
+                            "description": localize(
+                                language,
+                                "Finish without executing the selected demo branch.",
+                                "结束且不执行所选演示分支。",
+                            ),
                         },
                     ],
                 },
                 {
                     "id": "test_secret",
-                    "header": "Test secret",
-                    "question": "Optionally enter a disposable test value only - never a real credential.",
+                    "header": localize(language, "Test secret", "秘密测试值"),
+                    "question": localize(
+                        language,
+                        "Optionally enter a disposable test value only - never a real credential.",
+                        "可选择输入一次性测试值，但绝不能输入真实凭据。",
+                    ),
                     "isOther": True,
                     "isSecret": True,
                     "options": None,
@@ -275,6 +413,7 @@ def complete(
     verification: str,
     presentation: str,
     action: str,
+    language: str,
 ) -> None:
     """Print a safe final receipt selected by the agent, never by parsed JSON."""
 
@@ -282,14 +421,50 @@ def complete(
         "FINAL_RECEIPT_EMITTED. STOP CURRENT TURN. Return only the Markdown below "
         "and do not execute another command."
     )
-    print("## Interactive output demo complete")
+    print(
+        localize(
+            language, "## Interactive output demo complete", "## 交互式输出演示完成"
+        )
+    )
     print()
-    print(f"- Workflow branch: `{workflow}`")
-    print(f"- Destination branch: `{destination}`")
-    print(f"- Verification branch: `{verification}`")
-    print(f"- Presentation branch: `{presentation}`")
-    print(f"- Executed action: `{action}`")
-    print("- Secret handling: no secret value was passed to this script")
+    print(
+        localize(
+            language, f"- Workflow branch: `{workflow}`", f"- 工作流分支：`{workflow}`"
+        )
+    )
+    print(
+        localize(
+            language,
+            f"- Destination branch: `{destination}`",
+            f"- 目标分支：`{destination}`",
+        )
+    )
+    print(
+        localize(
+            language,
+            f"- Verification branch: `{verification}`",
+            f"- 验证分支：`{verification}`",
+        )
+    )
+    print(
+        localize(
+            language,
+            f"- Presentation branch: `{presentation}`",
+            f"- 展示分支：`{presentation}`",
+        )
+    )
+    print(
+        localize(
+            language, f"- Executed action: `{action}`", f"- 已执行操作：`{action}`"
+        )
+    )
+    print(
+        localize(
+            language,
+            "- Secret handling: no secret value was passed to this script",
+            "- 秘密值处理：未向此脚本传递任何秘密值",
+        )
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -297,16 +472,19 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="stage", required=True)
-    subparsers.add_parser("start")
+    start = subparsers.add_parser("start")
+    start.add_argument("--language", choices=LANGUAGES, default="en")
 
     context = subparsers.add_parser("context")
     context.add_argument("--workflow", required=True, choices=WORKFLOWS)
+    context.add_argument("--language", choices=LANGUAGES, default="en")
 
     confirm = subparsers.add_parser("confirm")
     confirm.add_argument("--workflow", required=True, choices=WORKFLOWS)
     confirm.add_argument("--destination", required=True, choices=DESTINATIONS)
     confirm.add_argument("--verification", required=True, choices=VERIFICATIONS)
     confirm.add_argument("--presentation", required=True, choices=PRESENTATIONS)
+    confirm.add_argument("--language", choices=LANGUAGES, default="en")
 
     finish = subparsers.add_parser("complete")
     finish.add_argument("--workflow", required=True, choices=WORKFLOWS)
@@ -314,6 +492,7 @@ def parse_args() -> argparse.Namespace:
     finish.add_argument("--verification", required=True, choices=VERIFICATIONS)
     finish.add_argument("--presentation", required=True, choices=PRESENTATIONS)
     finish.add_argument("--action", required=True, choices=ACTIONS)
+    finish.add_argument("--language", choices=LANGUAGES, default="en")
     return parser.parse_args()
 
 
@@ -322,12 +501,16 @@ def main() -> None:
 
     args = parse_args()
     if args.stage == "start":
-        emit_start()
+        emit_start(args.language)
     elif args.stage == "context":
-        emit_context(args.workflow)
+        emit_context(args.workflow, args.language)
     elif args.stage == "confirm":
         emit_confirmation(
-            args.workflow, args.destination, args.verification, args.presentation
+            args.workflow,
+            args.destination,
+            args.verification,
+            args.presentation,
+            args.language,
         )
     else:
         complete(
@@ -336,6 +519,7 @@ def main() -> None:
             args.verification,
             args.presentation,
             args.action,
+            args.language,
         )
 
 


### PR DESCRIPTION
## Summary

- Add English and Chinese flows to the interactive-output demo across all three question stages and the final receipt.
- Localize persisted question and answer headings while retaining English behavior and add coverage for both languages.