### PR TITLE
fix(desktop): install Windows package dependencies reliably

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -30,6 +30,7 @@
     "@types/node": "24.9.0",
     "electron": "43.2.0",
     "electron-winstaller": "5.4.4",
+    "lodash": "4.18.1",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       electron-winstaller:
         specifier: 5.4.4
         version: 5.4.4
+      lodash:
+        specifier: 4.18.1
+        version: 4.18.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -297,12 +297,7 @@ function Ensure-DesktopDeps {
     }
 
     Assert-WebToolchain | Out-Null
-    $forge = Join-Path $script:DesktopDir "node_modules/.bin/electron-forge.cmd"
-    if (Test-Path -LiteralPath $forge -PathType Leaf) {
-        return
-    }
-
-    Write-Host "Electron Desktop dependencies are missing; installing them before continuing."
+    Write-Host "Checking Electron Desktop dependencies..."
     Invoke-Pnpm -Arguments @("--dir", $script:DesktopDir, "install", "--frozen-lockfile")
 }
 


### PR DESCRIPTION
- Fix Windows desktop packaging by adding the required lodash dependency and checking dependencies with pnpm before each build.
