### PR TITLE
fix: validate desktop artifacts and sync manager status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,19 @@ desktop-package: ensure-desktop-deps desktop-backend-bundle
 		CSGCLAW_DESKTOP_VERSION=$(VERSION) \
 		$(DESKTOP_PNPM) $(if $(filter summary,$(DESKTOP_PACKAGE_REPORT)),--silent make,make) --platform=$(DESKTOP_PLATFORM) --arch=$(DESKTOP_ARCH); \
 	}; \
+	print_artifacts() { \
+		artifacts=$$(find "$(abspath $(DESKTOP_DIR)/out/make)" -type f -size +0c \( \
+			-name '*.dmg' -o -name '*.zip' -o -name '*.deb' -o \
+			-name '*.rpm' -o -name '*-Setup.exe' -o -name '*.msi' \
+		\) -print 2>/dev/null); \
+		if [ -z "$$artifacts" ]; then \
+			printf 'Desktop packaging produced no distributables under %s\n' "$(abspath $(DESKTOP_DIR)/out/make)" >&2; \
+			return 1; \
+		fi; \
+		printf '%s\n' "Desktop packages ready:"; \
+		printf '%s\n' "$$artifacts" | sed 's/^/  /'; \
+	}; \
+	rm -rf "$(DESKTOP_DIR)/out/make"; \
 	if [ "$(DESKTOP_PACKAGE_REPORT)" = "summary" ]; then \
 		log_file=$$(mktemp); \
 		trap 'rm -f "$$log_file"' EXIT; \
@@ -181,9 +194,13 @@ desktop-package: ensure-desktop-deps desktop-backend-bundle
 			cat "$$log_file" >&2; \
 			exit $$status; \
 		fi; \
-		printf 'Desktop packages ready: %s\n' "$(abspath $(DESKTOP_DIR)/out/make)"; \
+		print_artifacts || { \
+			printf '%s\n' "Electron Forge output follows:" >&2; \
+			cat "$$log_file" >&2; \
+			exit 1; \
+		}; \
 	else \
-		run_package; \
+		run_package && print_artifacts; \
 	fi
 
 build: build-web build-server-bin build-sandbox-cli

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yauzl: 3.3.1
+
 importers:
 
   .:
@@ -856,9 +859,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   filename-reserved-regex@2.0.0:
     resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
@@ -2010,8 +2010,9 @@ packages:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.1:
+    resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3190,7 +3191,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.3.1
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
@@ -3211,10 +3212,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   filename-reserved-regex@2.0.0: {}
 
@@ -4366,10 +4363,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@2.10.0:
+  yauzl@3.3.1:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/desktop/pnpm-workspace.yaml
+++ b/desktop/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ blockExoticSubdeps: false
 
 nodeLinker: hoisted
 
+# Forge 7 uses extract-zip through Packager 18. yauzl 3 avoids the Node.js
+# 24.16+ stream regression; remove this after upgrading to stable Forge 8.
+overrides:
+  yauzl: 3.3.1
+
 allowBuilds:
   electron-winstaller: true
   fs-xattr: true

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -728,13 +728,26 @@ function Invoke-TargetDesktopPackage {
     Write-Host "Building desktop backend ($($script:TargetOs)/$($script:TargetArch))..."
     Invoke-DesktopBackendBundle -Goos $script:TargetOs -Goarch $script:TargetArch
     Write-Host "Building desktop packages (win32/$desktopArch)..."
+    if (Test-Path -LiteralPath $script:DesktopMakeDir) {
+        Remove-Item -LiteralPath $script:DesktopMakeDir -Recurse -Force
+    }
     Invoke-Pnpm -Arguments @("--dir", $script:DesktopDir, "--silent", "make", "--platform=win32", "--arch=$desktopArch") -Env @{
         CSGCLAW_DESKTOP_GOOS    = $script:TargetOs
         CSGCLAW_DESKTOP_GOARCH  = $script:TargetArch
         CSGCLAW_DESKTOP_ARCH    = $desktopArch
         CSGCLAW_DESKTOP_VERSION = $script:Version
     }
-    Write-Host "Desktop packages ready: $script:DesktopMakeDir"
+
+    $installers = @(
+        Get-ChildItem -LiteralPath $script:DesktopMakeDir -Recurse -File -Filter "*-Setup.exe" -ErrorAction SilentlyContinue |
+            Where-Object { $_.Length -gt 0 }
+    )
+    if ($installers.Count -eq 0) {
+        throw "Electron Forge completed without producing a Windows installer under $script:DesktopMakeDir."
+    }
+
+    Write-Host "Desktop installer ready:"
+    $installers | ForEach-Object { Write-Host "  $($_.FullName)" }
 }
 
 function Invoke-TargetRun {

--- a/web/app/src/hooks/workspace/workspaceQueries.ts
+++ b/web/app/src/hooks/workspace/workspaceQueries.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { fetchAgentProfileModels, fetchAgentWorkspace, fetchAgentWorkspaceFile, fetchAgents } from "@/api/agents";
@@ -12,6 +13,8 @@ import { fetchRemoteSkillsPage, fetchSkillFile, fetchSkills, fetchSkillTree } fr
 import type { RemoteSkillsPage } from "@/api/skills";
 import { fetchManagerProfile } from "@/api/agents";
 import {
+  isAgentRunning,
+  isManagerAgent,
   modelRequestKey,
   normalizeRuntimeImageMap,
   normalizeRuntimeKind,
@@ -35,6 +38,19 @@ import type { UpgradeStatus } from "@/models/upgradeStatus";
 import { fetchPlatformUpgradeStatus } from "@/shared/platform/updatePort";
 
 const WORKSPACE_QUERY_SCOPE = "workspace";
+export const WORKSPACE_AGENTS_STARTUP_POLL_INTERVAL_MS = 1_500;
+export const WORKSPACE_AGENTS_STARTUP_POLL_WINDOW_MS = 120_000;
+
+export function workspaceAgentsStartupRefetchInterval(
+  items: AgentLike[] | undefined,
+  elapsedMs: number,
+): number | false {
+  if (elapsedMs >= WORKSPACE_AGENTS_STARTUP_POLL_WINDOW_MS) {
+    return false;
+  }
+  const manager = items?.find(isManagerAgent);
+  return manager && isAgentRunning(manager) ? false : WORKSPACE_AGENTS_STARTUP_POLL_INTERVAL_MS;
+}
 
 export const workspaceQueryKeys = {
   bootstrap: () => [WORKSPACE_QUERY_SCOPE, "bootstrap"] as const,
@@ -172,9 +188,12 @@ export function useWorkspaceManagerProfileQuery(): UseQueryResult<AgentProfileLi
 }
 
 export function useWorkspaceAgentsQuery(): UseQueryResult<AgentLike[]> {
+  const startupPollStartedAtRef = useRef(Date.now());
   return useQuery<AgentLike[]>({
     queryKey: workspaceQueryKeys.agents(),
     queryFn: () => fetchAgents(),
+    refetchInterval: (query) =>
+      workspaceAgentsStartupRefetchInterval(query.state.data, Date.now() - startupPollStartedAtRef.current),
   });
 }
 

--- a/web/app/tests/hooks/workspaceQueries.test.ts
+++ b/web/app/tests/hooks/workspaceQueries.test.ts
@@ -1,0 +1,33 @@
+import {
+  WORKSPACE_AGENTS_STARTUP_POLL_INTERVAL_MS,
+  WORKSPACE_AGENTS_STARTUP_POLL_WINDOW_MS,
+  workspaceAgentsStartupRefetchInterval,
+} from "@/hooks/workspace/workspaceQueries";
+import type { AgentLike } from "@/models/agents";
+
+const manager = (status: string): AgentLike => ({
+  id: "u-manager",
+  name: "manager",
+  role: "manager",
+  runtime_kind: "codex",
+  status,
+});
+
+describe("workspaceAgentsStartupRefetchInterval", () => {
+  it("polls every 1.5 seconds until the manager is running", () => {
+    expect(workspaceAgentsStartupRefetchInterval(undefined, 0)).toBe(WORKSPACE_AGENTS_STARTUP_POLL_INTERVAL_MS);
+    expect(workspaceAgentsStartupRefetchInterval([manager("stopped")], 60_000)).toBe(
+      WORKSPACE_AGENTS_STARTUP_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("stops immediately when the manager is running", () => {
+    expect(workspaceAgentsStartupRefetchInterval([manager("running")], 1_000)).toBe(false);
+  });
+
+  it("stops after the two-minute startup window", () => {
+    expect(workspaceAgentsStartupRefetchInterval([manager("stopped")], WORKSPACE_AGENTS_STARTUP_POLL_WINDOW_MS)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
- Fail desktop packaging when Electron Forge produces no non-empty distributable, report concrete artifact paths, and keep extraction compatible with Node.js 24.
- Reconcile manager runtime status every 1.5 seconds during the first two minutes after workspace startup, stopping as soon as the manager is running.
