### PR TITLE
ci(desktop): publish native installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      desktop_matrix: ${{ steps.set-matrix.outputs.desktop_matrix }}
+      version: ${{ steps.release_meta.outputs.version }}
+      commit: ${{ steps.release_meta.outputs.commit }}
+      build_time: ${{ steps.release_meta.outputs.build_time }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,6 +43,14 @@ jobs:
           from pathlib import Path
 
           rows = []
+          desktop_rows = []
+          desktop_runners = {
+              ("linux", "amd64"): "ubuntu-24.04",
+              ("linux", "arm64"): "ubuntu-24.04-arm",
+              ("darwin", "arm64"): "macos-15",
+              ("darwin", "amd64"): "macos-15-intel",
+              ("windows", "amd64"): "windows-2025",
+          }
           for line in Path("scripts/release-platforms.txt").read_text().splitlines():
               line = line.strip()
               if not line or line.startswith("#"):
@@ -47,9 +59,28 @@ jobs:
               if len(parts) != 2:
                   raise SystemExit(f"bad platform line: {line!r}")
               goos, goarch = parts
-              rows.append({"goos": goos, "goarch": goarch})
+              row = {"goos": goos, "goarch": goarch}
+              rows.append(row)
+              try:
+                  desktop_rows.append({**row, "runner": desktop_runners[(goos, goarch)]})
+              except KeyError:
+                  raise SystemExit(f"no desktop runner configured for {goos}/{goarch}")
           print("matrix=" + json.dumps({"include": rows}))
+          print("desktop_matrix=" + json.dumps({"include": desktop_rows}))
           PY
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME}"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
   web:
     runs-on: ubuntu-latest
@@ -149,31 +180,13 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Resolve version
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ github.event.inputs.version }}"
-          else
-            version="${GITHUB_REF_NAME}"
-          fi
-          echo "value=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve build metadata
-        id: build_meta
-        shell: bash
-        run: |
-          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-
       - name: Package release archives (one platform)
         shell: bash
         run: |
           chmod +x scripts/release-build-all.sh
-          VERSION="${{ steps.version.outputs.value }}" \
-          COMMIT="${{ steps.build_meta.outputs.commit }}" \
-          BUILD_TIME="${{ steps.build_meta.outputs.build_time }}" \
+          VERSION="${{ needs.prepare.outputs.version }}" \
+          COMMIT="${{ needs.prepare.outputs.commit }}" \
+          BUILD_TIME="${{ needs.prepare.outputs.build_time }}" \
           DIST_DIR=dist \
           GOCACHE="${{ github.workspace }}/.gocache" \
           BOXLITE_CLI_VERSION="${{ env.BOXLITE_CLI_VERSION }}" \
@@ -186,21 +199,165 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  merge-and-release:
-    needs: [build]
-    runs-on: ubuntu-latest
+  desktop-build:
+    needs: [prepare]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.desktop_matrix) }}
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      COMMIT: ${{ needs.prepare.outputs.commit }}
+      BUILD_TIME: ${{ needs.prepare.outputs.build_time }}
+      CI_MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.CSGCLAW_MACOS_CERTIFICATE_P12_BASE64 }}
+      CI_MACOS_CERTIFICATE_PASSWORD: ${{ secrets.CSGCLAW_MACOS_CERTIFICATE_PASSWORD }}
+      CI_MACOS_SIGN_IDENTITY: ${{ secrets.CSGCLAW_MACOS_SIGN_IDENTITY }}
+      CI_APPLE_ID: ${{ secrets.APPLE_ID }}
+      CI_APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      CI_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CI_WINDOWS_CERTIFICATE_PFX_BASE64: ${{ secrets.CSGCLAW_WINDOWS_CERTIFICATE_PFX_BASE64 }}
+      CI_WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD }}
+      CI_WINDOWS_SIGN_TOOL: ${{ secrets.CSGCLAW_WINDOWS_SIGN_TOOL }}
+      CI_WINDOWS_SIGN_PARAMS: ${{ secrets.CSGCLAW_WINDOWS_SIGN_PARAMS }}
     steps:
-      - name: Resolve version
-        id: version
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: web/app/package.json
+
+      - name: Enable Corepack
+        shell: bash
+        run: corepack enable
+
+      - name: Resolve pnpm store path
+        id: pnpm_store
+        shell: bash
+        working-directory: desktop
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm_store.outputs.path }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('web/app/pnpm-lock.yaml', 'desktop/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-
+
+      - name: Install Linux package tools
+        if: ${{ matrix.goos == 'linux' }}
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ github.event.inputs.version }}"
-          else
-            version="${GITHUB_REF_NAME}"
-          fi
-          echo "value=${version}" >> "$GITHUB_OUTPUT"
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends fakeroot dpkg
 
+      - name: Configure macOS signing
+        if: ${{ matrix.goos == 'darwin' }}
+        shell: bash
+        run: |
+          requested_identity="${CI_MACOS_SIGN_IDENTITY:-}"
+          requested_apple_id="${CI_APPLE_ID:-}"
+          requested_apple_password="${CI_APPLE_PASSWORD:-}"
+          requested_apple_team_id="${CI_APPLE_TEAM_ID:-}"
+          unset CSGCLAW_MACOS_SIGN_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+
+          if [ -z "${CI_MACOS_CERTIFICATE_P12_BASE64:-}" ] || [ -z "${CI_MACOS_CERTIFICATE_PASSWORD:-}" ] || [ -z "${requested_identity}" ]; then
+            echo "macOS signing is not fully configured; using Forge defaults."
+            exit 0
+          fi
+
+          certificate_path="${RUNNER_TEMP}/csgclaw-signing.p12"
+          keychain_path="${RUNNER_TEMP}/csgclaw-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          node --input-type=module -e 'import fs from "node:fs"; fs.writeFileSync(process.argv[1], Buffer.from(process.env.CI_MACOS_CERTIFICATE_P12_BASE64, "base64"), { mode: 0o600 });' "${certificate_path}"
+          security create-keychain -p "${keychain_password}" "${keychain_path}"
+          security set-keychain-settings -lut 21600 "${keychain_path}"
+          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+          security import "${certificate_path}" -k "${keychain_path}" -P "${CI_MACOS_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${keychain_password}" "${keychain_path}"
+          security list-keychains -d user -s "${keychain_path}"
+          {
+            echo "CSGCLAW_CI_MACOS_KEYCHAIN=${keychain_path}"
+            echo "CSGCLAW_MACOS_SIGN_IDENTITY=${requested_identity}"
+          } >> "$GITHUB_ENV"
+
+          if [ -n "${requested_apple_id}" ] && [ -n "${requested_apple_password}" ] && [ -n "${requested_apple_team_id}" ]; then
+            {
+              echo "APPLE_ID=${requested_apple_id}"
+              echo "APPLE_PASSWORD=${requested_apple_password}"
+              echo "APPLE_TEAM_ID=${requested_apple_team_id}"
+            } >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure Windows signing
+        if: ${{ matrix.goos == 'windows' }}
+        shell: pwsh
+        run: |
+          Remove-Item Env:CSGCLAW_WINDOWS_CERTIFICATE_FILE -ErrorAction SilentlyContinue
+          Remove-Item Env:CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD -ErrorAction SilentlyContinue
+          Remove-Item Env:CSGCLAW_WINDOWS_SIGN_TOOL -ErrorAction SilentlyContinue
+          Remove-Item Env:CSGCLAW_WINDOWS_SIGN_PARAMS -ErrorAction SilentlyContinue
+
+          if ($env:CI_WINDOWS_CERTIFICATE_PFX_BASE64 -and $env:CI_WINDOWS_CERTIFICATE_PASSWORD) {
+            $certificatePath = Join-Path $env:RUNNER_TEMP "csgclaw-signing.pfx"
+            [System.IO.File]::WriteAllBytes($certificatePath, [Convert]::FromBase64String($env:CI_WINDOWS_CERTIFICATE_PFX_BASE64))
+            "CSGCLAW_WINDOWS_CERTIFICATE_FILE=$certificatePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD=$env:CI_WINDOWS_CERTIFICATE_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
+          if ($env:CI_WINDOWS_SIGN_TOOL -and $env:CI_WINDOWS_SIGN_PARAMS) {
+            "CSGCLAW_WINDOWS_SIGN_TOOL=$env:CI_WINDOWS_SIGN_TOOL" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "CSGCLAW_WINDOWS_SIGN_PARAMS=$env:CI_WINDOWS_SIGN_PARAMS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
+      - name: Package Unix desktop artifacts
+        if: ${{ matrix.goos != 'windows' }}
+        shell: bash
+        run: |
+          make desktop-package TARGET_OS="${{ matrix.goos }}" TARGET_ARCH="${{ matrix.goarch }}"
+
+      - name: Package Windows desktop artifacts
+        if: ${{ matrix.goos == 'windows' }}
+        shell: pwsh
+        run: .\scripts\build.cmd desktop-package
+
+      - name: Stage Unix release assets
+        if: ${{ matrix.goos != 'windows' }}
+        shell: bash
+        run: |
+          node scripts/collect-desktop-release-assets.mjs "$VERSION" "${{ matrix.goos }}" "${{ matrix.goarch }}" desktop/out/make dist
+
+      - name: Stage Windows release assets
+        if: ${{ matrix.goos == 'windows' }}
+        shell: pwsh
+        run: node scripts/collect-desktop-release-assets.mjs $env:VERSION "${{ matrix.goos }}" "${{ matrix.goarch }}" desktop/out/make dist
+
+      - name: Remove temporary macOS keychain
+        if: ${{ always() && matrix.goos == 'darwin' }}
+        shell: bash
+        run: |
+          if [ -n "${CSGCLAW_CI_MACOS_KEYCHAIN:-}" ]; then
+            security delete-keychain "${CSGCLAW_CI_MACOS_KEYCHAIN}" || true
+          fi
+
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/csgclaw-desktop_*
+          if-no-files-found: error
+
+  merge-and-release:
+    needs: [prepare, build, desktop-build]
+    runs-on: ubuntu-latest
+    steps:
       - name: Download all platform artifacts
         uses: actions/download-artifact@v4
         with:
@@ -208,8 +365,15 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Download all desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-dist-*
+          path: dist
+          merge-multiple: true
+
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.value }}
+          tag_name: ${{ needs.prepare.outputs.version }}
           files: dist/*

--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -25,6 +25,12 @@
 #   BOXLITE_CLI_VERSION – default v0.9.0
 #   BOXLITE_CLI_BASE_URL – boxlite-cli tarballs; default mirrors https://csgclaw.opencsg.com/boxlite-cli/{version}/{filename} (matches fetch-boxlite-cli.sh)
 #   BOXLITE_CURL_INSECURE – default 1 (TLS inspection); set 0 if csgclaw.opencsg.com is trusted as-is
+#   CSGCLAW_MACOS_CERTIFICATE_P12 – GitLab File variable for the Developer ID Application P12
+#   CSGCLAW_MACOS_CERTIFICATE_PASSWORD / CSGCLAW_MACOS_SIGN_IDENTITY – enable macOS signing when both are set
+#   APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID – optional macOS notarization (all three required)
+#   CSGCLAW_WINDOWS_CERTIFICATE_PFX – GitLab File variable for the Windows signing PFX
+#   CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD – enables Windows installer certificate signing when set with the PFX
+#   CSGCLAW_WINDOWS_SIGN_TOOL / CSGCLAW_WINDOWS_SIGN_PARAMS – optional full Windows signing command (both required)
 #
 # Debian apt: before install, rewrite official mirrors to Aliyun (faster in CN). Override DEBIAN_APT_MIRROR_* in CI vars if needed.
 #
@@ -146,6 +152,164 @@ release-build:
   artifacts:
     paths:
       - dist/
+    expire_in: 1 day
+
+desktop-build-linux:
+  extends:
+    - .release_image
+    - .release_rules
+  stage: release
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v/
+      when: manual
+      allow_failure: true
+  parallel:
+    matrix:
+      - GOOS: linux
+        GOARCH: amd64
+      - GOOS: linux
+        GOARCH: arm64
+  before_script:
+    - chmod +x .gitlab/bookworm-mirror.sh
+    - bash .gitlab/bookworm-mirror.sh
+    - apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates curl dpkg fakeroot xz-utils
+    - |
+      NODE_VERSION="$(tr -d '[:space:]' < .nvmrc)"
+      case "$(uname -m)" in
+        x86_64|amd64) NODE_ARCH=x64 ;;
+        aarch64|arm64) NODE_ARCH=arm64 ;;
+        *) echo "unsupported Linux runner architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+      curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz
+      tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
+      corepack enable
+      node --version
+      pnpm --version
+  script:
+    - export VERSION="$CI_COMMIT_TAG"
+    - export COMMIT="$(git rev-parse --short HEAD)"
+    - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    - export GOCACHE="${CI_PROJECT_DIR}/.gocache"
+    - make desktop-package TARGET_OS="$GOOS" TARGET_ARCH="$GOARCH"
+    - node scripts/collect-desktop-release-assets.mjs "$VERSION" "$GOOS" "$GOARCH" desktop/out/make dist
+  artifacts:
+    paths:
+      - dist/csgclaw-desktop_*
+    expire_in: 1 day
+
+desktop-build-macos:
+  extends: .release_rules
+  stage: release
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v/
+      when: manual
+      allow_failure: true
+  parallel:
+    matrix:
+      - GOARCH: arm64
+        RUNNER_TAG: csgclaw-macos-arm64
+      - GOARCH: amd64
+        RUNNER_TAG: csgclaw-macos-amd64
+  tags:
+    - $RUNNER_TAG
+  before_script:
+    - node --version
+    - corepack enable
+    - pnpm --version
+    - |
+      requested_identity="${CSGCLAW_MACOS_SIGN_IDENTITY:-}"
+      requested_apple_id="${APPLE_ID:-}"
+      requested_apple_password="${APPLE_PASSWORD:-}"
+      requested_apple_team_id="${APPLE_TEAM_ID:-}"
+      unset CSGCLAW_MACOS_SIGN_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+
+      if [ -z "${CSGCLAW_MACOS_CERTIFICATE_P12:-}" ] || [ -z "${CSGCLAW_MACOS_CERTIFICATE_PASSWORD:-}" ] || [ -z "${requested_identity}" ]; then
+        echo "macOS signing is not fully configured; using Forge defaults."
+      elif [ ! -f "${CSGCLAW_MACOS_CERTIFICATE_P12}" ]; then
+        echo "CSGCLAW_MACOS_CERTIFICATE_P12 must be a GitLab File variable." >&2
+        exit 1
+      else
+        keychain_path="${CI_PROJECT_DIR}/.csgclaw-signing.keychain-db"
+        keychain_password="$(openssl rand -hex 32)"
+        security create-keychain -p "${keychain_password}" "${keychain_path}"
+        security set-keychain-settings -lut 21600 "${keychain_path}"
+        security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+        security import "${CSGCLAW_MACOS_CERTIFICATE_P12}" -k "${keychain_path}" -P "${CSGCLAW_MACOS_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/security
+        security set-key-partition-list -S apple-tool:,apple: -s -k "${keychain_password}" "${keychain_path}"
+        security list-keychains -d user -s "${keychain_path}"
+        export CSGCLAW_MACOS_SIGN_IDENTITY="${requested_identity}"
+
+        if [ -n "${requested_apple_id}" ] && [ -n "${requested_apple_password}" ] && [ -n "${requested_apple_team_id}" ]; then
+          export APPLE_ID="${requested_apple_id}"
+          export APPLE_PASSWORD="${requested_apple_password}"
+          export APPLE_TEAM_ID="${requested_apple_team_id}"
+        fi
+      fi
+  script:
+    - export VERSION="$CI_COMMIT_TAG"
+    - export COMMIT="$(git rev-parse --short HEAD)"
+    - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    - export GOCACHE="${CI_PROJECT_DIR}/.gocache"
+    - make desktop-package TARGET_OS=darwin TARGET_ARCH="$GOARCH"
+    - node scripts/collect-desktop-release-assets.mjs "$VERSION" darwin "$GOARCH" desktop/out/make dist
+  after_script:
+    - security delete-keychain "${CI_PROJECT_DIR}/.csgclaw-signing.keychain-db" || true
+  artifacts:
+    paths:
+      - dist/csgclaw-desktop_*
+    expire_in: 1 day
+
+desktop-build-windows:
+  extends: .release_rules
+  stage: release
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^v/
+      when: manual
+      allow_failure: true
+  tags:
+    - csgclaw-windows-amd64
+  before_script:
+    - $ErrorActionPreference = 'Stop'
+    - node --version
+    - corepack enable
+    - pnpm --version
+    - |
+      $certificatePassword = $env:CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD
+      $signTool = $env:CSGCLAW_WINDOWS_SIGN_TOOL
+      $signParams = $env:CSGCLAW_WINDOWS_SIGN_PARAMS
+      Remove-Item Env:CSGCLAW_WINDOWS_CERTIFICATE_FILE -ErrorAction SilentlyContinue
+      Remove-Item Env:CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD -ErrorAction SilentlyContinue
+      Remove-Item Env:CSGCLAW_WINDOWS_SIGN_TOOL -ErrorAction SilentlyContinue
+      Remove-Item Env:CSGCLAW_WINDOWS_SIGN_PARAMS -ErrorAction SilentlyContinue
+
+      if ($env:CSGCLAW_WINDOWS_CERTIFICATE_PFX -and $certificatePassword) {
+        if (-not (Test-Path -LiteralPath $env:CSGCLAW_WINDOWS_CERTIFICATE_PFX -PathType Leaf)) {
+          throw 'CSGCLAW_WINDOWS_CERTIFICATE_PFX must be a GitLab File variable.'
+        }
+        $env:CSGCLAW_WINDOWS_CERTIFICATE_FILE = $env:CSGCLAW_WINDOWS_CERTIFICATE_PFX
+        $env:CSGCLAW_WINDOWS_CERTIFICATE_PASSWORD = $certificatePassword
+      }
+      else {
+        Write-Host 'Windows certificate signing is not fully configured; using Forge defaults.'
+      }
+
+      if ($signTool -and $signParams) {
+        $env:CSGCLAW_WINDOWS_SIGN_TOOL = $signTool
+        $env:CSGCLAW_WINDOWS_SIGN_PARAMS = $signParams
+      }
+  script:
+    - $env:VERSION = $env:CI_COMMIT_TAG
+    - $env:COMMIT = (git rev-parse --short HEAD)
+    - $env:BUILD_TIME = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    - $env:GOCACHE = Join-Path $env:CI_PROJECT_DIR '.gocache'
+    - .\scripts\build.cmd desktop-package
+    - node scripts/collect-desktop-release-assets.mjs $env:VERSION windows amd64 desktop/out/make dist
+  artifacts:
+    paths:
+      - dist/csgclaw-desktop_*
     expire_in: 1 day
 
 docker-build-amd64:

--- a/docs/tech/build.md
+++ b/docs/tech/build.md
@@ -103,7 +103,9 @@ The installer exposes both host binaries from the same `INSTALL_DIR` and copies 
 | `scripts\build.cmd desktop-package` | Build native desktop installers on Windows without `make` |
 | `make release` | Build the configured cross-platform release bundles |
 
-Release CI uses `.github/workflows/release.yml` and `.gitlab/ci.yml`. GitLab CI publishes CSGClaw release artifacts and the CSGClaw product image; it does not build PicoClaw/OpenClaw runtime images.
+Release CI uses `.github/workflows/release.yml` and `.gitlab/ci.yml`. GitHub attaches the CLI and native desktop installers to the matching GitHub Release. GitLab uploads CLI release artifacts to `https://csgclaw.opencsg.com/releases/<tag>/` and publishes the CSGClaw product image. Its desktop jobs are optional manual builds: successful installers remain GitLab artifacts for one day and are not uploaded to the public release directory. GitLab macOS and Windows desktop jobs require native runners tagged `csgclaw-macos-arm64`, `csgclaw-macos-amd64`, and `csgclaw-windows-amd64`.
+
+Desktop installers use names such as `csgclaw-desktop_v0.4.3_darwin_arm64.dmg`. Signing and notarization values are optional CI secrets/variables: when they are absent or incomplete, Electron Forge keeps its macOS ad-hoc and Windows unsigned defaults. Release CI does not configure a desktop update feed.
 
 ## Related docs
 

--- a/docs/tech/build.zh.md
+++ b/docs/tech/build.zh.md
@@ -103,7 +103,9 @@ csgclaw/
 | `scripts\build.cmd desktop-package` | 在 Windows 无需 `make` 构建桌面安装包 |
 | `make release` | 构建配置的跨平台 release bundle |
 
-发布 CI 使用 `.github/workflows/release.yml` 和 `.gitlab/ci.yml`。GitLab CI 发布 CSGClaw release 产物和 CSGClaw 产品镜像，不再构建 PicoClaw/OpenClaw 运行时镜像。
+发布 CI 使用 `.github/workflows/release.yml` 和 `.gitlab/ci.yml`。GitHub 将 CLI 和原生桌面安装包附加到对应的 GitHub Release。GitLab 将 CLI release 产物上传到 `https://csgclaw.opencsg.com/releases/<tag>/`，并发布 CSGClaw 产品镜像。其桌面 job 是可选手动构建：成功的安装包作为 GitLab artifact 保留一天，不会上传到公开发布目录。GitLab 的 macOS 和 Windows 桌面 job 需要提供并打上 `csgclaw-macos-arm64`、`csgclaw-macos-amd64`、`csgclaw-windows-amd64` tag 的原生 runner。
+
+桌面安装包采用如 `csgclaw-desktop_v0.4.3_darwin_arm64.dmg` 的命名。签名和公证信息是可选 CI secrets/variables：未配置或配置不完整时，Electron Forge 保持 macOS ad-hoc、Windows 未签名的默认行为。发布 CI 不配置桌面端更新源。
 
 ## 相关文档
 

--- a/docs/tech/electron-desktop-migration-plan.zh.md
+++ b/docs/tech/electron-desktop-migration-plan.zh.md
@@ -239,11 +239,11 @@ make desktop-package TARGET_OS=darwin TARGET_ARCH=amd64
 
 打包配置按目标平台分别使用 `csgclaw.icns`、`csgclaw.ico` 和 `csgclaw.png`，Windows 安装器和 Linux DEB 也显式复用对应图标。
 
-输出目录是 `desktop/out/`，backend 中间产物位于 `dist/desktop-input/<os>-<arch>/backend/`。
+输出目录是 `desktop/out/`，backend 中间产物位于 `dist/desktop-input/<os>-<arch>/backend/`。GitHub Release CI 会从 `desktop/out/make/` 归档最终文件，生成如 `csgclaw-desktop_v0.4.3_darwin_arm64.dmg` 的稳定名称并附加到对应 GitHub Release。GitLab 的桌面 job 仅供可选手动构建，成功产物作为 GitLab artifact 保留一天，不上传到 `https://csgclaw.opencsg.com/releases/<tag>/`。
 
 正式安装包建议在目标系统构建。跨平台编译成功不代表签名、安装、启动和更新已经通过目标系统验证。
 
-macOS 正式发布需要配置签名和公证账号；Windows 可通过 `CSGCLAW_WINDOWS_SIGN_*` 和证书变量接入签名。更新源通过 `CSGCLAW_DESKTOP_UPDATE_BASE_URL` 设置，必须使用 HTTPS。
+macOS 正式发布需要配置签名和公证账号；Windows 可通过 `CSGCLAW_WINDOWS_SIGN_*` 和证书变量接入签名。CI 仅在完整签名变量组存在时传递这些配置；否则 macOS 保持 ad-hoc 签名、Windows 保持未签名。GitLab 的 macOS/Windows 桌面 job 必须运行在对应原生 runner 上，且为可选手动 job。更新源可通过 `CSGCLAW_DESKTOP_UPDATE_BASE_URL` 设置且必须使用 HTTPS，但当前发布 CI 不设置它。
 
 ## 8. 开发约定
 

--- a/scripts/collect-desktop-release-assets.mjs
+++ b/scripts/collect-desktop-release-assets.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export function collectDesktopReleaseAssets({ version, goos, goarch, makeDirectory, outputDirectory }) {
+  const files = listFiles(makeDirectory);
+  const prefix = `csgclaw-desktop_${version}_${goos}_${goarch}`;
+  const assets = releaseAssetsFor(goos, goarch, files, prefix);
+
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  for (const asset of assets) {
+    const destination = path.join(outputDirectory, asset.name);
+    fs.copyFileSync(asset.source, destination, fs.constants.COPYFILE_EXCL);
+  }
+
+  return assets.map((asset) => path.join(outputDirectory, asset.name));
+}
+
+function listFiles(directory) {
+  if (!fs.statSync(directory).isDirectory()) {
+    throw new Error(`Forge make directory is not a directory: ${directory}`);
+  }
+
+  return fs.readdirSync(directory, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+function releaseAssetsFor(goos, goarch, files, prefix) {
+  switch (`${goos}/${goarch}`) {
+    case "darwin/arm64":
+    case "darwin/amd64":
+      return [
+        asset(files, (file) => file.endsWith(".dmg"), `${prefix}.dmg`),
+        asset(files, (file) => file.endsWith(".zip"), `${prefix}.zip`),
+      ];
+    case "windows/amd64":
+      return [asset(files, (file) => file.endsWith("-Setup.exe"), `${prefix}.exe`)];
+    case "linux/amd64":
+    case "linux/arm64":
+      return [asset(files, (file) => file.endsWith(".deb"), `${prefix}.deb`)];
+    default:
+      throw new Error(`unsupported desktop release target: ${goos}/${goarch}`);
+  }
+}
+
+function asset(files, matches, name) {
+  const matchesFiles = files.filter(matches);
+  if (matchesFiles.length !== 1) {
+    throw new Error(`expected exactly one source for ${name}, found ${matchesFiles.length}`);
+  }
+  return { source: matchesFiles[0], name };
+}
+
+function main(args) {
+  if (args.length !== 5) {
+    throw new Error("usage: collect-desktop-release-assets.mjs <version> <goos> <goarch> <make-dir> <output-dir>");
+  }
+
+  const [version, goos, goarch, makeDirectory, outputDirectory] = args;
+  const assets = collectDesktopReleaseAssets({ version, goos, goarch, makeDirectory, outputDirectory });
+  for (const assetPath of assets) {
+    console.log(`staged ${assetPath}`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/collect-desktop-release-assets.test.mjs
+++ b/scripts/collect-desktop-release-assets.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { collectDesktopReleaseAssets } from "./collect-desktop-release-assets.mjs";
+
+const version = "v0.4.3";
+
+test("collects the public asset set for each supported target", async (t) => {
+  for (const fixture of [
+    { goos: "darwin", goarch: "arm64", files: ["dmg/CSGClaw.dmg", "zip/darwin/arm64/CSGClaw.zip"], want: [".dmg", ".zip"] },
+    { goos: "darwin", goarch: "amd64", files: ["dmg/CSGClaw.dmg", "zip/darwin/x64/CSGClaw.zip"], want: [".dmg", ".zip"] },
+    { goos: "windows", goarch: "amd64", files: ["squirrel.windows/x64/CSGClaw-Setup.exe"], want: [".exe"] },
+    { goos: "linux", goarch: "amd64", files: ["deb/x64/csgclaw.deb"], want: [".deb"] },
+    { goos: "linux", goarch: "arm64", files: ["deb/arm64/csgclaw.deb"], want: [".deb"] },
+  ]) {
+    await t.test(`${fixture.goos}/${fixture.goarch}`, () => {
+      const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(fixture.files);
+      try {
+        collectDesktopReleaseAssets({ version, ...fixture, makeDirectory, outputDirectory });
+        assert.deepEqual(
+          fs.readdirSync(outputDirectory).sort(),
+          fixture.want.map((extension) => `csgclaw-desktop_${version}_${fixture.goos}_${fixture.goarch}${extension}`),
+        );
+      } finally {
+        cleanup();
+      }
+    });
+  }
+});
+
+test("rejects a missing expected asset", () => {
+  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(["CSGClaw.dmg"]);
+  try {
+    assert.throws(
+      () => collectDesktopReleaseAssets({ version, goos: "darwin", goarch: "arm64", makeDirectory, outputDirectory }),
+      /expected exactly one source/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("rejects ambiguous Forge output", () => {
+  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(["first.deb", "second.deb"]);
+  try {
+    assert.throws(
+      () => collectDesktopReleaseAssets({ version, goos: "linux", goarch: "amd64", makeDirectory, outputDirectory }),
+      /expected exactly one source/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+function fixtureDirectories(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "csgclaw-desktop-assets-"));
+  const makeDirectory = path.join(root, "make");
+  const outputDirectory = path.join(root, "output");
+  fs.mkdirSync(makeDirectory, { recursive: true });
+  for (const file of files) {
+    const fixturePath = path.join(makeDirectory, file);
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(fixturePath, "fixture");
+  }
+  return {
+    makeDirectory,
+    outputDirectory,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}


### PR DESCRIPTION
## Summary

- build native desktop installers for every release target in GitHub Actions
- stage stable installer names and attach them to GitHub Releases
- add optional manual GitLab desktop jobs and document signing, runners, and artifact retention

## Validation

- `node --test scripts/collect-desktop-release-assets.test.mjs`
- `actionlint .github/workflows/release.yml`
- GitLab CI YAML syntax check

## Impact

GitHub releases now wait for desktop packages; GitLab desktop installers remain one-day job artifacts.