### PR TITLE
fix: prevent stale room updates and shutdown hangs

### DIFF
--- a/internal/runtime/codex/appserver_client.go
+++ b/internal/runtime/codex/appserver_client.go
@@ -293,7 +293,6 @@ func (c *appServerClient) closeAllPending(err error) {
 	if err == nil {
 		err = fmt.Errorf("codex app-server client closed")
 	}
-	c.writeMu.Lock()
 	c.mu.Lock()
 	if c.closed == nil {
 		c.closed = err
@@ -302,7 +301,6 @@ func (c *appServerClient) closeAllPending(err error) {
 	pending := c.pending
 	c.pending = make(map[int64]*appServerPendingRequest)
 	c.mu.Unlock()
-	c.writeMu.Unlock()
 	for _, req := range pending {
 		req.ch <- appServerRPCResult{err: err}
 	}

--- a/internal/runtime/codex/appserver_client_test.go
+++ b/internal/runtime/codex/appserver_client_test.go
@@ -282,6 +282,45 @@ func TestAppServerClientCloseAllPending(t *testing.T) {
 	}
 }
 
+func TestAppServerClientCloseAllPendingDoesNotWaitForBlockedWrite(t *testing.T) {
+	writer := newBlockingWriter()
+	defer writer.unblock()
+	client := newAppServerClient(writer, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.request(context.Background(), "turn/start", map[string]any{"threadId": "thread-1"})
+		errCh <- err
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked app-server write")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		client.closeAllPending(errors.New("app-server stopping"))
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("closeAllPending waited for blocked app-server write")
+	}
+
+	writer.unblock()
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "app-server stopping") {
+			t.Fatalf("request() error = %v, want app-server stopping", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request to observe app-server shutdown")
+	}
+}
+
 func TestAppServerClientRejectsRequestsAfterClose(t *testing.T) {
 	writer := &lockedStringWriter{}
 	client := newAppServerClient(writer, nil)
@@ -299,6 +338,30 @@ func TestAppServerClientRejectsRequestsAfterClose(t *testing.T) {
 type lockedStringWriter struct {
 	mu sync.Mutex
 	b  strings.Builder
+}
+
+type blockingWriter struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.startedOnce.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+func (w *blockingWriter) unblock() {
+	w.releaseOnce.Do(func() { close(w.release) })
 }
 
 func (w *lockedStringWriter) Write(p []byte) (int, error) {

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -23,6 +23,7 @@ import {
   isThreadReply,
   isToolCallMessage,
   localIdentitiesMatch,
+  mergeRoomNotificationUpdateInData,
   participantIDForLocalIdentity,
   removeConversationFromData,
   resolveConversationUser,
@@ -1148,7 +1149,7 @@ export function useConversationController({
     setNotifyAllAgentsError("");
     try {
       const updated = await updateRoomRequest(activeConversation.id, { notify_all_agents: enabled });
-      setBootstrapData((current) => upsertConversationInData(current, updated));
+      setBootstrapData((current) => mergeRoomNotificationUpdateInData(current, updated));
     } catch (err) {
       if (notifyAllAgentsRequestRef.current === requestID) {
         setNotifyAllAgentsError(localizeError(errorMessage(err, ""), t) || t("notifyAllAgentsUpdateFailed"));

--- a/web/app/src/models/conversations.ts
+++ b/web/app/src/models/conversations.ts
@@ -870,11 +870,13 @@ export function applyIMEvent<T extends IMData | null | undefined>(
   if ((event.type === "thread.created" || event.type === "thread.updated") && event.thread) {
     return applyThreadToData(current, event.room_id || event.thread.room_id, event.thread);
   }
+  if (event.type === "room.updated" && event.room?.id) {
+    return mergeRoomNotificationUpdateInData(current, event.room as IMConversation);
+  }
   if (
     (event.type === "conversation.created" ||
       event.type === "conversation.members_added" ||
       event.type === "room.created" ||
-      event.type === "room.updated" ||
       event.type === "room.members_added" ||
       event.type === "room.members_removed" ||
       event.type === "room.messages_cleared") &&
@@ -1071,6 +1073,26 @@ export function upsertConversationInData<T extends IMData | null | undefined>(
     ? current.rooms.map((item) => (item.id === conversation.id ? normalized : item))
     : [normalized, ...current.rooms];
   return { ...current, rooms: sortConversations(rooms) };
+}
+
+export function mergeRoomNotificationUpdateInData<T extends IMData | null | undefined>(
+  current: T,
+  conversation: IMConversation | null | undefined,
+): T | IMData {
+  if (!current || !conversation) {
+    return current;
+  }
+
+  const existing = current.rooms.some((item) => item.id === conversation.id);
+  if (!existing) {
+    return upsertConversationInData(current, conversation);
+  }
+  const rooms = current.rooms.map((item) =>
+    item.id === conversation.id
+      ? { ...item, notify_all_agents: conversation.notify_all_agents ?? item.notify_all_agents }
+      : item,
+  );
+  return { ...current, rooms };
 }
 
 export function upsertUserInData<T extends IMData | null | undefined>(

--- a/web/app/tests/models/conversations.test.ts
+++ b/web/app/tests/models/conversations.test.ts
@@ -16,6 +16,7 @@ import {
   isAgentRosterEvent,
   isToolCallMessage,
   latestAt,
+  mergeRoomNotificationUpdateInData,
   removeUserFromData,
   resolveAgentForUser,
   sortConversations,
@@ -402,14 +403,55 @@ describe("conversation model helpers", () => {
     expect(next.rooms.find((item) => item.id === "other")?.messages.map((item) => item.id)).toEqual(["other-message"]);
   });
 
-  it("applies room notification updates as authoritative room updates", () => {
+  it("preserves newer messages when applying an older room notification event", () => {
+    const staleRoom = room("general", "2026-05-15T00:00:00Z", { notify_all_agents: false });
+    const current = appendMessageToData(
+      {
+        rooms: [staleRoom],
+        users: [],
+      },
+      "general",
+      message("new-message", "2026-05-15T00:01:00Z"),
+    );
+
+    const next = applyIMEvent(current, {
+      room: { ...staleRoom, notify_all_agents: true },
+      room_id: "general",
+      type: "room.updated",
+    });
+
+    expect(next.rooms[0].notify_all_agents).toBe(true);
+    expect(next.rooms[0].messages.map((item) => item.id)).toEqual(["general-message", "new-message"]);
+  });
+
+  it("preserves newer messages when merging an older room notification response", () => {
+    const staleRoom = room("general", "2026-05-15T00:00:00Z", { notify_all_agents: false });
+    const current = appendMessageToData(
+      {
+        rooms: [staleRoom],
+        users: [],
+      },
+      "general",
+      message("new-message", "2026-05-15T00:01:00Z"),
+    );
+
+    const next = mergeRoomNotificationUpdateInData(current, {
+      ...staleRoom,
+      notify_all_agents: true,
+    });
+
+    expect(next.rooms[0].notify_all_agents).toBe(true);
+    expect(next.rooms[0].messages.map((item) => item.id)).toEqual(["general-message", "new-message"]);
+  });
+
+  it("adds an unknown room received through a room notification event", () => {
     const current = {
-      rooms: [room("general", "2026-05-15T00:00:00Z", { notify_all_agents: false })],
+      rooms: [],
       users: [],
     };
 
     const next = applyIMEvent(current, {
-      room: { ...current.rooms[0], notify_all_agents: true },
+      room: room("general", "2026-05-15T00:00:00Z", { notify_all_agents: true }),
       room_id: "general",
       type: "room.updated",
     });


### PR DESCRIPTION
## Summary

- Preserve current room messages when notify-all updates arrive from events or PATCH responses.
- Prevent Codex app-server shutdown from waiting behind blocked stdin writes.