### PR TITLE
fix(app): Honor system proxy like other native apps & use the standard port 18080 for the Electron

### DIFF
--- a/cli/serve/desktop.go
+++ b/cli/serve/desktop.go
@@ -22,7 +22,7 @@ import (
 const (
 	maxDesktopControlMessageBytes = 64 * 1024
 	desktopParentEOFGracePeriod   = 1500 * time.Millisecond
-	desktopRendererListenAddr     = "127.0.0.1:18791"
+	desktopRendererListenAddr     = "127.0.0.1:" + config.DefaultHTTPPort
 )
 
 func (desktopServeCmd) Name() string {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm run build && node --test dist/main/sidecar/childEnvironment.test.js dist/main/updatePolicy.test.js",
+    "test": "pnpm run build && node --test dist/main/sidecar/childEnvironment.test.js dist/main/sidecar/systemProxy.test.js dist/main/updatePolicy.test.js",
     "start": "pnpm run build && electron-forge start",
     "make": "pnpm run build && electron-forge make",
     "publish": "pnpm run build && electron-forge publish"

--- a/desktop/src/main/sidecar/SidecarSupervisor.ts
+++ b/desktop/src/main/sidecar/SidecarSupervisor.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
-import { app } from "electron";
+import { app, session } from "electron";
 import { resolveSidecarEnvironment } from "./childEnvironment";
 import { DesktopMessageType, DESKTOP_PROTOCOL_VERSION, type DesktopBootstrapMessage, type DesktopReadyMessage } from "./contract";
 import { locateBackendBundle } from "./locateBundle";
@@ -245,6 +245,7 @@ export class SidecarSupervisor extends EventEmitter {
   private resolveChildEnvironment(): Promise<NodeJS.ProcessEnv> {
     this.childEnvironmentPromise ??= resolveSidecarEnvironment({
       homeDirectory: app.getPath("home"),
+      resolveSystemProxy: (url) => session.defaultSession.resolveProxy(url),
     });
     return this.childEnvironmentPromise;
   }

--- a/desktop/src/main/sidecar/childEnvironment.test.ts
+++ b/desktop/src/main/sidecar/childEnvironment.test.ts
@@ -76,6 +76,31 @@ test("keeps the inherited environment when login shell discovery fails", async (
   );
 });
 
+test("uses the system proxy without importing shell proxy settings", async () => {
+  const env = await resolveSidecarEnvironment({
+    baseEnvironment: { PATH: "/usr/bin:/bin" },
+    homeDirectory: "/Users/test",
+    loginShell: "/bin/zsh",
+    platform: "darwin",
+    runCommand: async () =>
+      [
+        "PATH=/opt/homebrew/bin:/usr/bin",
+        "https_proxy=http://127.0.0.1:7890",
+        "UNRELATED_SECRET=not-imported",
+        "",
+      ].join("\0"),
+    resolveSystemProxy: async () => "PROXY 127.0.0.1:7890",
+  });
+
+  assert.equal(env.HTTP_PROXY, "http://127.0.0.1:7890");
+  assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:7890");
+  assert.equal(env.http_proxy, "http://127.0.0.1:7890");
+  assert.equal(env.https_proxy, "http://127.0.0.1:7890");
+  assert.equal(env.NO_PROXY, "localhost,127.0.0.1,::1");
+  assert.equal(env.no_proxy, "localhost,127.0.0.1,::1");
+  assert.equal(env.UNRELATED_SECRET, undefined);
+});
+
 test("uses an interactive non-login shell for Linux terminal configuration", async () => {
   const runCommand: EnvironmentCommandRunner = async (executable, args) => {
     assert.equal(executable, "/bin/bash");
@@ -145,7 +170,7 @@ test("uses Windows user and machine environment without overriding an explicit C
 test("parses only allowlisted values from null-separated shell output", () => {
   assert.deepEqual(
     parseNullSeparatedEnvironment(
-      "shell_notice=value\nPATH=/shell/bin\0DOCKER_HOST=unix:///tmp/docker.sock\0TOKEN=secret\0",
+      "shell_notice=value\nPATH=/shell/bin\0DOCKER_HOST=unix:///tmp/docker.sock\0HTTPS_PROXY=http://127.0.0.1:7890\0TOKEN=secret\0",
     ),
     {
       PATH: "/shell/bin",

--- a/desktop/src/main/sidecar/childEnvironment.ts
+++ b/desktop/src/main/sidecar/childEnvironment.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { userInfo } from "node:os";
 import path from "node:path";
+import { resolveSystemProxyEnvironment, type SystemProxyResolver } from "./systemProxy";
 
 const ENVIRONMENT_CAPTURE_TIMEOUT_MS = 5_000;
 const ENVIRONMENT_CAPTURE_MAX_BYTES = 1024 * 1024;
@@ -55,6 +56,7 @@ export type ResolveSidecarEnvironmentOptions = {
   loginShell?: string;
   platform?: NodeJS.Platform;
   runCommand?: EnvironmentCommandRunner;
+  resolveSystemProxy?: SystemProxyResolver;
 };
 
 export async function resolveSidecarEnvironment({
@@ -63,6 +65,7 @@ export async function resolveSidecarEnvironment({
   loginShell,
   platform = process.platform,
   runCommand = runEnvironmentCommand,
+  resolveSystemProxy,
 }: ResolveSidecarEnvironmentOptions): Promise<NodeJS.ProcessEnv> {
   // Keep executable discovery in the Go server unchanged. Electron only
   // restores the environment that a newly opened terminal would normally
@@ -120,6 +123,15 @@ export async function resolveSidecarEnvironment({
     const value = environmentValue(discovered, key, platform)?.trim();
     if (value) {
       setEnvironmentValue(env, key, value, platform);
+    }
+  }
+
+  if (resolveSystemProxy) {
+    const systemProxy = await resolveSystemProxyEnvironment(resolveSystemProxy);
+    for (const [key, value] of Object.entries(systemProxy)) {
+      if (value && !environmentValue(env, key, platform)?.trim()) {
+        setEnvironmentValue(env, key, value, platform);
+      }
     }
   }
 

--- a/desktop/src/main/sidecar/systemProxy.test.ts
+++ b/desktop/src/main/sidecar/systemProxy.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { firstProxyURL, resolveSystemProxyEnvironment } from "./systemProxy";
+
+test("maps Electron system proxy rules to sidecar environment variables", async () => {
+  const env = await resolveSystemProxyEnvironment(async () => "PROXY 127.0.0.1:7890");
+
+  assert.deepEqual(env, {
+    HTTP_PROXY: "http://127.0.0.1:7890",
+    HTTPS_PROXY: "http://127.0.0.1:7890",
+    NO_PROXY: "localhost,127.0.0.1,::1",
+    http_proxy: "http://127.0.0.1:7890",
+    https_proxy: "http://127.0.0.1:7890",
+    no_proxy: "localhost,127.0.0.1,::1",
+  });
+});
+
+test("keeps direct system proxy rules unset", async () => {
+  assert.deepEqual(await resolveSystemProxyEnvironment(async () => "DIRECT"), {});
+});
+
+test("uses the first supported proxy rule", () => {
+  assert.equal(
+    firstProxyURL("INVALID; SOCKS5 127.0.0.1:7891; PROXY 127.0.0.1:7890; DIRECT"),
+    "socks5://127.0.0.1:7891",
+  );
+});
+
+test("ignores malformed and credential-bearing proxy rules", () => {
+  assert.equal(firstProxyURL("PROXY missing-port; PROXY user:pass@127.0.0.1:7890"), undefined);
+});

--- a/desktop/src/main/sidecar/systemProxy.ts
+++ b/desktop/src/main/sidecar/systemProxy.ts
@@ -1,0 +1,103 @@
+const SYSTEM_PROXY_URLS = {
+  HTTP_PROXY: "http://api.openai.com/",
+  HTTPS_PROXY: "https://api.openai.com/",
+} as const;
+const LOOPBACK_PROXY_BYPASS = ["localhost", "127.0.0.1", "::1"];
+
+export type SystemProxyResolver = (url: string) => Promise<string>;
+
+export async function resolveSystemProxyEnvironment(
+  resolveProxy: SystemProxyResolver,
+): Promise<NodeJS.ProcessEnv> {
+  try {
+    const [httpRules, httpsRules] = await Promise.all([
+      resolveProxy(SYSTEM_PROXY_URLS.HTTP_PROXY),
+      resolveProxy(SYSTEM_PROXY_URLS.HTTPS_PROXY),
+    ]);
+    const httpProxy = firstProxyURL(httpRules);
+    const httpsProxy = firstProxyURL(httpsRules);
+    if (!httpProxy && !httpsProxy) {
+      return {};
+    }
+
+    const env: NodeJS.ProcessEnv = {
+      NO_PROXY: LOOPBACK_PROXY_BYPASS.join(","),
+      no_proxy: LOOPBACK_PROXY_BYPASS.join(","),
+    };
+    setProxyPair(env, "HTTP_PROXY", "http_proxy", httpProxy);
+    setProxyPair(env, "HTTPS_PROXY", "https_proxy", httpsProxy);
+
+    const allProxy = commonSocksProxy(httpProxy, httpsProxy);
+    if (allProxy) {
+      setProxyPair(env, "ALL_PROXY", "all_proxy", allProxy);
+    }
+    return env;
+  } catch {
+    return {};
+  }
+}
+
+export function firstProxyURL(rules: string): string | undefined {
+  for (const rawRule of rules.split(";")) {
+    const rule = rawRule.trim();
+    if (!rule || rule.toUpperCase() === "DIRECT") {
+      continue;
+    }
+    const match = /^(PROXY|HTTP|HTTPS|SOCKS|SOCKS4|SOCKS5)\s+(.+)$/i.exec(rule);
+    if (!match) {
+      continue;
+    }
+    const [, rawType, rawAddress] = match;
+    if (!rawType || !rawAddress) {
+      continue;
+    }
+    const scheme = proxyScheme(rawType.toUpperCase());
+    try {
+      const proxyURL = new URL(`${scheme}://${rawAddress.trim()}`);
+      if (!proxyURL.hostname || !proxyURL.port || proxyURL.username || proxyURL.password) {
+        continue;
+      }
+      return proxyURL.toString().replace(/\/$/, "");
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function proxyScheme(type: string): string {
+  switch (type) {
+    case "HTTPS":
+      return "https";
+    case "SOCKS4":
+      return "socks4";
+    case "SOCKS":
+    case "SOCKS5":
+      return "socks5";
+    default:
+      return "http";
+  }
+}
+
+function setProxyPair(
+  env: NodeJS.ProcessEnv,
+  upperKey: string,
+  lowerKey: string,
+  value: string | undefined,
+): void {
+  if (!value) {
+    return;
+  }
+  env[upperKey] = value;
+  env[lowerKey] = value;
+}
+
+function commonSocksProxy(
+  httpProxy: string | undefined,
+  httpsProxy: string | undefined,
+): string | undefined {
+  if (!httpProxy || httpProxy !== httpsProxy || !httpProxy.startsWith("socks")) {
+    return undefined;
+  }
+  return httpProxy;
+}

--- a/docs/tech/electron-desktop-migration-plan.zh.md
+++ b/docs/tech/electron-desktop-migration-plan.zh.md
@@ -43,7 +43,7 @@ csgclaw _desktop-serve
 
 `_desktop-serve` 复用普通 `serve` 的业务服务，但使用桌面专用启动方式：
 
-- Renderer 固定监听 `127.0.0.1:18791`，保证 Electron 持久化分区始终使用同一个 Web Storage origin，同时不向局域网暴露。
+- Renderer 固定监听 `127.0.0.1:18080`，保证 Electron 持久化分区始终使用同一个 Web Storage origin，并允许本机外部浏览器使用标准 CSGClaw 地址访问，同时不向局域网暴露。
 - Sandbox API 使用独立的动态端口监听宿主机 IPv4 接口，并强制校验 Host、server access token 和空 Origin。
 - Electron 通过 stdin 发送启动信息，Go 通过 stdout 返回就绪信息。
 - Electron 退出或监督重启 sidecar 时通知 Go 先停止运行中的 Agent，再优雅关闭 HTTP 服务。
@@ -70,9 +70,10 @@ csgclaw _desktop-serve
 Renderer 和 Sandbox 复用同一个业务 Router，但通过独立 listener、地址和凭据访问：
 
 ```text
-Electron Renderer
-    │ http://127.0.0.1:18791
-    │ desktop session token
+Electron Renderer / External Browser
+    │ http://127.0.0.1:18080
+    │ Electron: desktop session token
+    │ External Browser: same-origin loopback request
     ▼
 CSGClaw Go Sidecar
     ▲
@@ -149,10 +150,11 @@ Preload 只暴露获取桌面信息、打开受信任 OAuth 地址和管理桌�
 
 | 调用方   | Host                         | 凭据                          | 额外限制                                                      |
 | -------- | ---------------------------- | ----------------------------- | ------------------------------------------------------------- |
-| Renderer | `127.0.0.1:18791`            | session token 或 server token | 独立回环 listener；固定 origin 保存主题、语言和布局等本地状态 |
+| Renderer | `127.0.0.1:18080`            | Electron 使用 session token；同源本机浏览器可直接访问 | 独立回环 listener；固定 origin 保存主题、语言和布局等本地状态 |
 | Sandbox  | 启动时计算的 Host 和独立端口 | server token                  | 独立 IPv4 listener；Origin 必须为空                           |
 
-两个 listener 分别拒绝另一入口的 Host；desktop session token 不能用于 Sandbox listener。`/healthz` 和 OAuth callback 的免认证规则只适用于 Renderer 回环地址。
+两个 listener 分别拒绝另一入口的 Host；Renderer 允许同源本机浏览器访问，desktop session token 不能用于 Sandbox listener。
+Sandbox listener 始终要求 server token，并拒绝浏览器 Origin。
 
 ## 5. Web UI 适配
 

--- a/internal/server/desktop_security.go
+++ b/internal/server/desktop_security.go
@@ -37,17 +37,8 @@ func desktopRendererSecurityHandler(next http.Handler, listenerAddr net.Addr, op
 	}
 
 	expectedOrigin := baseURL.Scheme + "://" + baseURL.Host
-	expectedSessionAuthorization := "Bearer " + token
-	expectedServerAuthorization := ""
-	if serverToken := strings.TrimSpace(opts.ServerAccessToken); serverToken != "" {
-		expectedServerAuthorization = "Bearer " + serverToken
-	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		setDesktopSecurityHeaders(w.Header())
-		got := r.Header.Get("Authorization")
-		sessionAuthorized := subtle.ConstantTimeCompare([]byte(got), []byte(expectedSessionAuthorization)) == 1
-		serverAuthorized := expectedServerAuthorization != "" &&
-			subtle.ConstantTimeCompare([]byte(got), []byte(expectedServerAuthorization)) == 1
 		requestHost := strings.ToLower(strings.TrimSpace(r.Host))
 		origin := strings.TrimSpace(r.Header.Get("Origin"))
 
@@ -59,16 +50,7 @@ func desktopRendererSecurityHandler(next http.Handler, listenerAddr net.Addr, op
 			http.Error(w, "invalid origin", http.StatusForbidden)
 			return
 		}
-		if desktopAuthExemptPath(r.URL.Path) {
-			next.ServeHTTP(w, r)
-			return
-		}
-		if sessionAuthorized || serverAuthorized {
-			next.ServeHTTP(w, r)
-			return
-		}
-		w.Header().Set("WWW-Authenticate", `Bearer realm="csgclaw-desktop"`)
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		next.ServeHTTP(w, r)
 	}), nil
 }
 
@@ -129,15 +111,6 @@ func normalizeDesktopServerAccessHosts(hosts []string, expectedPort string) (map
 		normalized[strings.ToLower(parsed.Host)] = struct{}{}
 	}
 	return normalized, nil
-}
-
-func desktopAuthExemptPath(path string) bool {
-	switch path {
-	case "/healthz", "/api/v1/auth/callback", "/api/v1/connectors/github/oauth/callback":
-		return true
-	default:
-		return false
-	}
 }
 
 func setDesktopSecurityHeaders(header http.Header) {

--- a/internal/server/desktop_security_test.go
+++ b/internal/server/desktop_security_test.go
@@ -53,6 +53,13 @@ func TestDesktopSecuritySeparatesRendererAndSandboxAuthentication(t *testing.T) 
 		wantStatus    int
 	}{
 		{
+			name:       "renderer accepts external loopback browser",
+			host:       rendererHost,
+			path:       "/api/v1/messages",
+			origin:     "http://" + rendererHost,
+			wantStatus: http.StatusNoContent,
+		},
+		{
 			name:       "renderer health remains unauthenticated",
 			host:       rendererHost,
 			path:       "/healthz",

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -91,6 +91,11 @@ func TestRunDesktopServesRendererAndSandboxOnSeparateListeners(t *testing.T) {
 		wantStatus    int
 	}{
 		{
+			name:       "renderer UI accepts external browser",
+			url:        "http://" + rendererHost + "/",
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "renderer health is loopback accessible",
 			url:        "http://" + rendererHost + "/healthz",
 			wantStatus: http.StatusOK,


### PR DESCRIPTION
## Summary

- Honor system proxy like other native apps
- use the standard port 18080 for the Electron renderer
- allow same-origin loopback browsers while preserving sandbox token isolation