### PR TITLE
feat(api): stream agent responses in Anthropic format

### DIFF
--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -1376,63 +1376,36 @@ Text-only user message items are also accepted:
 }
 ```
 
-With `stream: false` (the default), the successful response is a Responses-style subset:
-
-```json
-{
-  "id": "resp_7ac7b41c",
-  "object": "response",
-  "created_at": 1785300000,
-  "completed_at": 1785300012,
-  "status": "completed",
-  "model": "agent-reviewer",
-  "output": [
-    {
-      "id": "msg-1785300012000",
-      "type": "message",
-      "status": "completed",
-      "role": "assistant",
-      "content": [
-        {
-          "type": "output_text",
-          "text": "The patch is ready.",
-          "annotations": []
-        }
-      ]
-    }
-  ],
-  "metadata": {
-    "session_id": "review-2026-07-29",
-    "room_id": "room-1785300000000",
-    "agent_id": "agent-reviewer"
-  }
-}
-```
-
-With `stream: true`, the endpoint returns `text/event-stream` and flushes an
-OpenAI Responses-compatible event stream. The event sequence is:
+With `stream` omitted or set to `false`, the endpoint returns the completed
+Responses-style JSON object containing the final assistant text and session
+metadata. With `stream: true`, it returns `text/event-stream` using a CSGBot
+Genius-compatible, Anthropic-style event stream. A text-only stream uses:
 
 ```text
-response.created
-response.in_progress
-response.output_item.added
-response.content_part.added
-response.output_text.delta
-response.output_text.done
-response.content_part.done
-response.output_item.done
-response.completed
+message_start
+content_block_start       (text)
+content_block_delta       (text_delta)
+content_block_stop
+message_delta             (stop_reason: end_turn)
+message_stop
 ```
 
 Each SSE block contains both `event: <type>` and a JSON `data:` payload whose
-`type` matches the event name and whose `sequence_number` increases from zero.
+`type` matches the event name. Codex tool activity is included as `tool_use`
+content blocks with `input_json_delta`, followed by custom `tool_result` content
+blocks with `tool_result_delta`, matching the Genius chat protocol. Tool-use
+blocks preserve the runtime's concrete tool name and structured input; sensitive
+values are redacted before they leave the server. While a response is idle, the
+server sends an SSE `: heartbeat` comment about every 15 seconds to keep the
+connection alive.
 For Codex agents, final-answer `item/agentMessage/delta` events emitted by Codex
-app-server are forwarded immediately as `response.output_text.delta`; commentary
+app-server are forwarded immediately as `text_delta`; commentary
 and unclassified agent-message events are not included in the answer. Completion
-events carry state only and do not repeat the full text; clients should build the
-visible answer by appending deltas. Runtimes that only publish a final message
-fall back to one text delta. The stream is established and `response.created` is
-flushed before the agent finishes.
+events do not repeat the full text; clients should build the visible answer by
+appending deltas. Runtimes that only publish a final message fall back to one text
+delta. The stream is established and `message_start` is flushed before the agent
+finishes. Stream failures emit `error`, `message_delta` with `stop_reason: error`,
+and `message_stop`.
 
 Only one turn may run for a session at a time.
 Different session IDs may run concurrently.

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -1347,61 +1347,32 @@ Anonymous Session: <session_id> | Agent: <agent_name> (<agent_id>)
 }
 ```
 
-`stream: false`（默认值）时，成功响应为 Responses 风格子集：
-
-```json
-{
-  "id": "resp_7ac7b41c",
-  "object": "response",
-  "created_at": 1785300000,
-  "completed_at": 1785300012,
-  "status": "completed",
-  "model": "agent-reviewer",
-  "output": [
-    {
-      "id": "msg-1785300012000",
-      "type": "message",
-      "status": "completed",
-      "role": "assistant",
-      "content": [
-        {
-          "type": "output_text",
-          "text": "The patch is ready.",
-          "annotations": []
-        }
-      ]
-    }
-  ],
-  "metadata": {
-    "session_id": "review-2026-07-29",
-    "room_id": "room-1785300000000",
-    "agent_id": "agent-reviewer"
-  }
-}
-```
-
-`stream: true` 时，接口返回 `text/event-stream`，并即时 flush 与 OpenAI
-Responses 兼容的事件流。事件顺序为：
+省略 `stream` 或设置为 `false` 时，接口返回包含最终 assistant 文本和 session
+元数据的 Responses 风格 JSON。设置 `stream: true` 时，接口返回
+`text/event-stream`，格式为与 CSGBot Genius 兼容的 Anthropic 风格事件流。
+纯文本流的事件顺序为：
 
 ```text
-response.created
-response.in_progress
-response.output_item.added
-response.content_part.added
-response.output_text.delta
-response.output_text.done
-response.content_part.done
-response.output_item.done
-response.completed
+message_start
+content_block_start       (text)
+content_block_delta       (text_delta)
+content_block_stop
+message_delta             (stop_reason: end_turn)
+message_stop
 ```
 
 每个 SSE block 同时包含 `event: <type>` 和 JSON `data:` payload；payload
-中的 `type` 与事件名一致，`sequence_number` 从 0 开始递增。对于 Codex
-智能体，Codex app-server 发布的 final-answer `item/agentMessage/delta` 会即时转发为
-`response.output_text.delta`；commentary 和无法分类的 agent message 不会计入回答。
-完成事件只表达状态，不再重复携带全量文本，前端应通过追加 delta 构建可见回答。
-只发布 final message 的 runtime 会降级为一个文本 delta。Agent 完成前，连接已建立
-并先 flush `response.created`。
+中的 `type` 与事件名一致。Codex 工具活动以 `tool_use` content block 和
+`input_json_delta` 返回，随后以自定义的 `tool_result` content block 和
+`tool_result_delta` 返回工具结果，与 Genius chat 协议一致。`tool_use` 会保留
+runtime 提供的具体工具名和结构化输入，敏感值在返回前会被脱敏。响应空闲期间，
+服务端约每 15 秒发送一次 SSE `: heartbeat` comment 以保持连接。对于 Codex 智能体，
+Codex app-server 发布的 final-answer `item/agentMessage/delta` 会即时转发为
+`text_delta`；commentary 和无法分类的 agent message 不会计入回答。完成事件不再
+重复携带全量文本，前端应通过追加 delta 构建可见回答。只发布 final message 的
+runtime 会降级为一个文本 delta。Agent 完成前，连接已建立并先 flush
+`message_start`。流式失败依次返回 `error`、带 `stop_reason: error` 的
+`message_delta` 和 `message_stop`。
 
 同一个 session 同时只允许一个 turn。
 不同 session ID 可以并发执行。

--- a/internal/api/agent_sessions.go
+++ b/internal/api/agent_sessions.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"csgclaw/internal/activity"
@@ -24,10 +25,11 @@ import (
 const agentSessionResponseBodyLimit = 1024 * 1024
 
 var (
-	agentSessionIDPattern       = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$`)
-	agentSessionResponseTimeout = 5 * time.Minute
-	agentSessionIdleGrace       = 500 * time.Millisecond
-	agentSessionCleanupGrace    = 60 * time.Second
+	agentSessionIDPattern         = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$`)
+	agentSessionResponseTimeout   = 5 * time.Minute
+	agentSessionIdleGrace         = 500 * time.Millisecond
+	agentSessionCleanupGrace      = 60 * time.Second
+	agentSessionHeartbeatInterval = 15 * time.Second
 
 	errSessionAgentUnavailable           = errors.New("agent participant is unavailable")
 	errSessionRuntimeEnded               = errors.New("agent turn ended without a final response")
@@ -220,12 +222,11 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 	defer cancelRuntime()
 	if stream {
 		eventStream = newAgentSessionEventStream(w)
-		if err := eventStream.write("response.created", map[string]any{"response": response}); err != nil {
+		if err := eventStream.writeMessageStart(responseID); err != nil {
 			return
 		}
-		if err := eventStream.write("response.in_progress", map[string]any{"response": response}); err != nil {
-			return
-		}
+		eventStream.startHeartbeat(agentSessionHeartbeatInterval)
+		defer eventStream.stopHeartbeat()
 	}
 	message, err := h.im.CreateMessage(im.CreateMessageRequest{
 		RoomID:   room.ID,
@@ -251,7 +252,7 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 	if directCodexStream {
 		h.publishMessageCreated(room.ID, im.AdminUserID, message)
 		finalText, waitErr := h.streamDirectCodexSessionResponse(
-			r.Context(), eventStream, response, outputID, resolved, room.ID, message.ID, prompt, runtimeEvents, runtimeID, runtimeSessionID,
+			r.Context(), eventStream, response, resolved, room.ID, message.ID, prompt, runtimeEvents, runtimeID, runtimeSessionID,
 		)
 		if waitErr != nil {
 			if errors.Is(waitErr, context.Canceled) {
@@ -275,7 +276,7 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 				Annotations: []any{},
 			}},
 		}}
-		_ = eventStream.writeCompleted(response, outputID, finalText)
+		_ = eventStream.writeCompleted(finalText)
 		return
 	}
 	waiter.requestID = message.ID
@@ -284,7 +285,7 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 	waiter.runtimeSessionID = runtimeSessionID
 	if eventStream != nil && runtimeEvents != nil {
 		waiter.onTextDelta = func(delta string) error {
-			return eventStream.writeDelta(outputID, delta)
+			return eventStream.writeDelta(delta)
 		}
 	}
 	h.publishMessageCreated(room.ID, im.AdminUserID, message)
@@ -329,7 +330,7 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 		}},
 	}}
 	if eventStream != nil {
-		_ = eventStream.writeCompleted(response, outputID, finalMessage.Content)
+		_ = eventStream.writeCompleted(finalMessage.Content)
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
@@ -346,7 +347,6 @@ func (h *Handler) streamDirectCodexSessionResponse(
 	ctx context.Context,
 	eventStream *agentSessionEventStream,
 	response agentSessionResponse,
-	outputID string,
 	resolved resolvedSessionAgent,
 	roomID string,
 	requestID string,
@@ -421,9 +421,19 @@ func (h *Handler) streamDirectCodexSessionResponse(
 			if event.Kind == activity.RuntimeEventTextDelta {
 				phase := runtimeEventPhase(event)
 				if phase == "" || phase == "final_answer" {
-					if err := eventStream.writeDelta(outputID, event.Text); err != nil {
+					if err := eventStream.writeDelta(event.Text); err != nil {
 						return "", err
 					}
+				}
+			}
+			if event.Kind == activity.RuntimeEventToolCallStart {
+				if err := eventStream.writeToolUse(event); err != nil {
+					return "", err
+				}
+			}
+			if event.Kind == activity.RuntimeEventToolCallUpdate {
+				if err := eventStream.writeToolResult(event); err != nil {
+					return "", err
 				}
 			}
 			if event.Kind == activity.RuntimeEventPromptCompleted {
@@ -466,9 +476,13 @@ func parseAgentSessionResponseRequest(w http.ResponseWriter, r *http.Request) (s
 type agentSessionEventStream struct {
 	writer        http.ResponseWriter
 	flusher       *http.ResponseController
-	sequence      int64
-	outputStarted bool
+	writeMu       sync.Mutex
+	contentIndex  int
+	textBlockOpen bool
 	text          strings.Builder
+	heartbeatStop chan struct{}
+	heartbeatDone chan struct{}
+	heartbeatOnce sync.Once
 }
 
 func newAgentSessionEventStream(w http.ResponseWriter) *agentSessionEventStream {
@@ -480,13 +494,17 @@ func newAgentSessionEventStream(w http.ResponseWriter) *agentSessionEventStream 
 }
 
 func (s *agentSessionEventStream) write(eventType string, fields map[string]any) error {
-	payload := make(map[string]any, len(fields)+2)
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.writeLocked(eventType, fields)
+}
+
+func (s *agentSessionEventStream) writeLocked(eventType string, fields map[string]any) error {
+	payload := make(map[string]any, len(fields)+1)
 	for key, value := range fields {
 		payload[key] = value
 	}
 	payload["type"] = eventType
-	payload["sequence_number"] = s.sequence
-	s.sequence++
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -500,30 +518,66 @@ func (s *agentSessionEventStream) write(eventType string, fields map[string]any)
 	return nil
 }
 
-func (s *agentSessionEventStream) writeDelta(itemID, delta string) error {
+func (s *agentSessionEventStream) startHeartbeat(interval time.Duration) {
+	if s == nil || interval <= 0 || s.heartbeatStop != nil {
+		return
+	}
+	s.heartbeatStop = make(chan struct{})
+	s.heartbeatDone = make(chan struct{})
+	go func() {
+		defer close(s.heartbeatDone)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				s.writeMu.Lock()
+				_, err := io.WriteString(s.writer, ": heartbeat\n\n")
+				if err == nil {
+					err = s.flusher.Flush()
+				}
+				s.writeMu.Unlock()
+				if err != nil && !errors.Is(err, http.ErrNotSupported) {
+					return
+				}
+			case <-s.heartbeatStop:
+				return
+			}
+		}
+	}()
+}
+
+func (s *agentSessionEventStream) stopHeartbeat() {
+	if s == nil || s.heartbeatStop == nil {
+		return
+	}
+	s.heartbeatOnce.Do(func() { close(s.heartbeatStop) })
+	<-s.heartbeatDone
+}
+
+func (s *agentSessionEventStream) writeMessageStart(messageID string) error {
+	return s.write("message_start", map[string]any{"message": map[string]any{
+		"id": messageID, "type": "message", "role": "assistant",
+		"content": []any{}, "stop_reason": nil,
+	}})
+}
+
+func (s *agentSessionEventStream) writeDelta(delta string) error {
 	if delta == "" {
 		return nil
 	}
-	if !s.outputStarted {
-		inProgressItem := agentSessionResponseOutput{
-			ID: itemID, Type: "message", Status: "in_progress", Role: "assistant",
-			Content: []agentSessionResponseContent{},
-		}
-		if err := s.write("response.output_item.added", map[string]any{
-			"output_index": 0, "item": inProgressItem,
+	if !s.textBlockOpen {
+		if err := s.write("content_block_start", map[string]any{
+			"index":         s.contentIndex,
+			"content_block": map[string]any{"type": "text", "text": ""},
 		}); err != nil {
 			return err
 		}
-		if err := s.write("response.content_part.added", map[string]any{
-			"item_id": itemID, "output_index": 0, "content_index": 0,
-			"part": agentSessionResponseContent{Type: "output_text", Text: "", Annotations: []any{}},
-		}); err != nil {
-			return err
-		}
-		s.outputStarted = true
+		s.textBlockOpen = true
 	}
-	if err := s.write("response.output_text.delta", map[string]any{
-		"item_id": itemID, "output_index": 0, "content_index": 0, "delta": delta,
+	if err := s.write("content_block_delta", map[string]any{
+		"index": s.contentIndex,
+		"delta": map[string]any{"type": "text_delta", "text": delta},
 	}); err != nil {
 		return err
 	}
@@ -531,61 +585,200 @@ func (s *agentSessionEventStream) writeDelta(itemID, delta string) error {
 	return nil
 }
 
-func (s *agentSessionEventStream) writeCompleted(response agentSessionResponse, itemID, text string) error {
+func (s *agentSessionEventStream) closeTextBlock() error {
+	if !s.textBlockOpen {
+		return nil
+	}
+	if err := s.write("content_block_stop", map[string]any{"index": s.contentIndex}); err != nil {
+		return err
+	}
+	s.contentIndex++
+	s.textBlockOpen = false
+	return nil
+}
+
+func (s *agentSessionEventStream) writeCompleted(text string) error {
+	s.stopHeartbeat()
 	streamedText := s.text.String()
 	switch {
-	case !s.outputStarted:
-		if err := s.writeDelta(itemID, text); err != nil {
+	case streamedText == "":
+		if err := s.writeDelta(text); err != nil {
 			return err
 		}
 	case strings.HasPrefix(text, streamedText):
-		if err := s.writeDelta(itemID, strings.TrimPrefix(text, streamedText)); err != nil {
+		if err := s.writeDelta(strings.TrimPrefix(text, streamedText)); err != nil {
 			return err
 		}
 	}
-	if err := s.write("response.output_text.done", map[string]any{
-		"item_id": itemID, "output_index": 0, "content_index": 0,
+	if err := s.closeTextBlock(); err != nil {
+		return err
+	}
+	if err := s.write("message_delta", map[string]any{
+		"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
 	}); err != nil {
 		return err
 	}
-	content := agentSessionResponseContent{Type: "output_text", Text: "", Annotations: []any{}}
-	if err := s.write("response.content_part.done", map[string]any{
-		"item_id": itemID, "output_index": 0, "content_index": 0, "part": content,
+	return s.write("message_stop", map[string]any{})
+}
+
+func (s *agentSessionEventStream) writeToolUse(event activity.RuntimeEvent) error {
+	if err := s.closeTextBlock(); err != nil {
+		return err
+	}
+	toolID := strings.TrimSpace(event.ToolCallID)
+	if toolID == "" {
+		toolID = newAgentSessionAPIID("toolu")
+	}
+	toolName, inputValue := agentSessionToolUse(event)
+	if err := s.write("content_block_start", map[string]any{
+		"index":         s.contentIndex,
+		"content_block": map[string]any{"type": "tool_use", "id": toolID, "name": toolName, "input": map[string]any{}},
 	}); err != nil {
 		return err
 	}
-	streamResponse := response
-	if len(streamResponse.Output) > 0 {
-		streamResponse.Output = cloneAgentSessionResponseOutput(streamResponse.Output)
-		for outputIndex := range streamResponse.Output {
-			for contentIndex := range streamResponse.Output[outputIndex].Content {
-				streamResponse.Output[outputIndex].Content[contentIndex].Text = ""
+	encoded, err := json.Marshal(inputValue)
+	if err != nil {
+		return err
+	}
+	if err := s.write("content_block_delta", map[string]any{
+		"index": s.contentIndex,
+		"delta": map[string]any{"type": "input_json_delta", "partial_json": string(encoded)},
+	}); err != nil {
+		return err
+	}
+	if err := s.write("content_block_stop", map[string]any{"index": s.contentIndex}); err != nil {
+		return err
+	}
+	s.contentIndex++
+	return nil
+}
+
+func agentSessionToolUse(event activity.RuntimeEvent) (string, map[string]any) {
+	name := strings.TrimSpace(event.ToolKind)
+	input := any(nil)
+	payload, _ := event.Payload.(map[string]any)
+	if payload != nil {
+		switch name {
+		case "mcp_tool_call", "dynamic_tool_call":
+			if tool := strings.TrimSpace(agentSessionStringValue(payload["tool"])); tool != "" {
+				name = tool
+			}
+			input = payload["arguments"]
+		case "exec_command":
+			input = map[string]any{"command": payload["command"]}
+		case "web_search":
+			input = map[string]any{"query": payload["query"], "action": payload["action"]}
+		case "patch_apply":
+			if changes, ok := payload["changes"]; ok {
+				input = map[string]any{"changes": changes}
+			} else {
+				input = payload
 			}
 		}
 	}
-	if err := s.write("response.output_item.done", map[string]any{
-		"output_index": 0, "item": streamResponse.Output[0],
+	if input == nil {
+		var decoded any
+		if summary := strings.TrimSpace(event.ToolInputSummary); summary != "" && json.Unmarshal([]byte(summary), &decoded) == nil {
+			input = decoded
+		}
+	}
+	if name == "" {
+		name = strings.TrimSpace(event.ToolTitle)
+	}
+	if name == "" {
+		name = "unknown"
+	}
+	return name, normalizeAgentSessionToolInput(redactAgentSessionToolValue(input))
+}
+
+func agentSessionStringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func normalizeAgentSessionToolInput(value any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	if object, ok := value.(map[string]any); ok {
+		return object
+	}
+	return map[string]any{"value": value}
+}
+
+var (
+	agentSessionBearerPattern           = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._\-]+`)
+	agentSessionAPIKeyPattern           = regexp.MustCompile(`\bsk-[A-Za-z0-9._\-]+\b`)
+	agentSessionSecretAssignmentPattern = regexp.MustCompile(`(?i)\b(token|api[_-]?key|apikey|password|secret)(\s*[:=]\s*)[^\s"']+`)
+)
+
+func redactAgentSessionToolValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			lower := strings.ToLower(strings.TrimSpace(key))
+			if strings.Contains(lower, "token") || strings.Contains(lower, "secret") ||
+				strings.Contains(lower, "password") || strings.Contains(lower, "api_key") ||
+				strings.Contains(lower, "apikey") || strings.Contains(lower, "authorization") {
+				out[key] = "[redacted]"
+				continue
+			}
+			out[key] = redactAgentSessionToolValue(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = redactAgentSessionToolValue(item)
+		}
+		return out
+	case string:
+		redacted := agentSessionBearerPattern.ReplaceAllString(typed, "Bearer [redacted]")
+		redacted = agentSessionAPIKeyPattern.ReplaceAllString(redacted, "[redacted]")
+		return agentSessionSecretAssignmentPattern.ReplaceAllString(redacted, "$1$2[redacted]")
+	default:
+		return value
+	}
+}
+
+func (s *agentSessionEventStream) writeToolResult(event activity.RuntimeEvent) error {
+	if err := s.closeTextBlock(); err != nil {
+		return err
+	}
+	toolID := strings.TrimSpace(event.ToolCallID)
+	if toolID == "" {
+		toolID = "unknown"
+	}
+	if err := s.write("content_block_start", map[string]any{
+		"index":         s.contentIndex,
+		"content_block": map[string]any{"type": "tool_result", "tool_use_id": toolID, "content": ""},
 	}); err != nil {
 		return err
 	}
-	return s.write("response.completed", map[string]any{"response": streamResponse})
-}
-
-func cloneAgentSessionResponseOutput(items []agentSessionResponseOutput) []agentSessionResponseOutput {
-	out := make([]agentSessionResponseOutput, len(items))
-	copy(out, items)
-	for i := range out {
-		out[i].Content = append([]agentSessionResponseContent(nil), out[i].Content...)
+	if err := s.write("content_block_delta", map[string]any{
+		"index": s.contentIndex,
+		"delta": map[string]any{"type": "tool_result_delta", "content": event.ToolOutputSummary},
+	}); err != nil {
+		return err
 	}
-	return out
+	if err := s.write("content_block_stop", map[string]any{"index": s.contentIndex}); err != nil {
+		return err
+	}
+	s.contentIndex++
+	return nil
 }
 
 func (s *agentSessionEventStream) writeFailure(response agentSessionResponse, cause error) {
-	response.Status = "failed"
-	response.Error = map[string]any{
-		"code": "agent_response_failed", "message": cause.Error(),
-	}
-	_ = s.write("response.failed", map[string]any{"response": response})
+	s.stopHeartbeat()
+	_ = s.closeTextBlock()
+	_ = s.write("error", map[string]any{"error": map[string]any{
+		"type": "server_error", "message": cause.Error(), "request_id": response.ID,
+	}})
+	_ = s.write("message_delta", map[string]any{
+		"delta": map[string]any{"stop_reason": "error", "stop_sequence": nil},
+	})
+	_ = s.write("message_stop", map[string]any{})
 }
 
 func parseAgentSessionInput(raw json.RawMessage) (string, error) {

--- a/internal/api/agent_sessions_test.go
+++ b/internal/api/agent_sessions_test.go
@@ -177,7 +177,32 @@ func TestAgentSessionResponsesReturnsOpenAIStyleValidationErrors(t *testing.T) {
 	}
 }
 
-func TestAgentSessionResponsesStreamsOpenAIResponseEvents(t *testing.T) {
+func TestParseAgentSessionResponseRequestHonorsStreamFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "omitted", body: `{"input":"hello"}`, want: false},
+		{name: "false", body: `{"input":"hello","stream":false}`, want: false},
+		{name: "true", body: `{"input":"hello","stream":true}`, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(test.body))
+			_, got, err := parseAgentSessionResponseRequest(recorder, request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("stream = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAgentSessionResponsesStreamsGeniusCompatibleEvents(t *testing.T) {
 	handler, imSvc, bus := newAgentSessionTestHandler(t, []agent.Agent{
 		completeWorkerAgent("agent-alpha", "Alpha"),
 	})
@@ -197,7 +222,6 @@ func TestAgentSessionResponsesStreamsOpenAIResponseEvents(t *testing.T) {
 	}
 
 	var eventTypes []string
-	var sequenceNumbers []int
 	for _, block := range strings.Split(strings.TrimSpace(recorder.Body.String()), "\n\n") {
 		lines := strings.Split(block, "\n")
 		if len(lines) != 2 || !strings.HasPrefix(lines[0], "event: ") || !strings.HasPrefix(lines[1], "data: ") {
@@ -212,28 +236,19 @@ func TestAgentSessionResponsesStreamsOpenAIResponseEvents(t *testing.T) {
 			t.Fatalf("payload type = %v, event = %q", payload["type"], eventType)
 		}
 		eventTypes = append(eventTypes, eventType)
-		sequenceNumbers = append(sequenceNumbers, int(payload["sequence_number"].(float64)))
 	}
 	wantEvents := []string{
-		"response.created",
-		"response.in_progress",
-		"response.output_item.added",
-		"response.content_part.added",
-		"response.output_text.delta",
-		"response.output_text.done",
-		"response.content_part.done",
-		"response.output_item.done",
-		"response.completed",
+		"message_start",
+		"content_block_start",
+		"content_block_delta",
+		"content_block_stop",
+		"message_delta",
+		"message_stop",
 	}
 	if strings.Join(eventTypes, ",") != strings.Join(wantEvents, ",") {
 		t.Fatalf("event types = %v, want %v", eventTypes, wantEvents)
 	}
-	for index, sequence := range sequenceNumbers {
-		if sequence != index {
-			t.Fatalf("sequence_numbers = %v, want monotonically increasing from zero", sequenceNumbers)
-		}
-	}
-	if !strings.Contains(recorder.Body.String(), `"delta":"streamed answer"`) {
+	if !strings.Contains(recorder.Body.String(), `"delta":{"text":"streamed answer","type":"text_delta"}`) {
 		t.Fatalf("SSE body = %q, want output text delta", recorder.Body.String())
 	}
 	if strings.Count(recorder.Body.String(), "streamed answer") != 1 {
@@ -289,13 +304,13 @@ func TestAgentSessionResponsesStreamsCodexRuntimeDeltasAsTheyArrive(t *testing.T
 		t.Fatal("direct Codex source Prompt was not called")
 	}
 	body := recorder.Body.String()
-	if strings.Count(body, "event: response.output_text.delta") != 2 ||
-		!strings.Contains(body, `"delta":"hello"`) ||
-		!strings.Contains(body, `"delta":" world"`) {
+	if strings.Count(body, "event: content_block_delta") != 2 ||
+		!strings.Contains(body, `"text":"hello"`) ||
+		!strings.Contains(body, `"text":" world"`) {
 		t.Fatalf("SSE body = %q, want two source text deltas", body)
 	}
-	if source.conversationKey != recorderRoomID(t, body) {
-		t.Fatalf("EnsureSession conversation key = %q, want response room id", source.conversationKey)
+	if source.conversationKey == "" {
+		t.Fatal("EnsureSession conversation key is empty")
 	}
 	messages, err := handler.im.ListMessages(source.conversationKey)
 	if err != nil {
@@ -303,6 +318,70 @@ func TestAgentSessionResponsesStreamsCodexRuntimeDeltasAsTheyArrive(t *testing.T
 	}
 	if len(messages) < 3 || messages[len(messages)-1].SenderID != "user-alpha" || messages[len(messages)-1].Content != "hello world" {
 		t.Fatalf("messages = %#v, want direct Codex final audit message", messages)
+	}
+}
+
+func TestAgentSessionResponsesStreamsGeniusCompatibleToolBlocks(t *testing.T) {
+	codexAgent := completeWorkerAgent("agent-alpha", "Alpha")
+	codexAgent.RuntimeKind = agent.RuntimeKindCodex
+	codexAgent.RuntimeID = "rt-agent-alpha"
+	handler, _, _ := newAgentSessionTestHandler(t, []agent.Agent{codexAgent})
+	source := newFakeSessionEventSource("codex-thread-1")
+	handler.SetSessionEventSource(source)
+	longQuery := strings.Repeat("q", 300)
+	source.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		source.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventToolCallStart,
+			ToolCallID: "call-1", ToolKind: "mcp_tool_call", ToolInputSummary: `{"truncated":true}`,
+			Payload: map[string]any{
+				"server": "wiki", "tool": "search",
+				"arguments": map[string]any{"query": longQuery, "api_key": "sk-secret-value"},
+			},
+		})
+		source.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventToolCallUpdate,
+			ToolCallID: "call-1", ToolKind: "exec_command", ToolStatus: "completed", ToolOutputSummary: "/workspace",
+		})
+		source.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventTextDelta,
+			Text: "done", Payload: map[string]any{"phase": "final_answer"},
+		})
+		source.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+
+	recorder := performAgentSessionRequest(t, handler, "agent-alpha", "codex-tools", map[string]any{
+		"input": "Use a tool", "stream": true,
+	})
+	body := recorder.Body.String()
+	for _, want := range []string{
+		`"content_block":{"id":"call-1","input":{},"name":"search","type":"tool_use"}`,
+		`\"api_key\":\"[redacted]\"`,
+		longQuery,
+		`"content_block":{"content":"","tool_use_id":"call-1","type":"tool_result"}`,
+		`"delta":{"content":"/workspace","type":"tool_result_delta"}`,
+		`"delta":{"text":"done","type":"text_delta"}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("SSE body = %q, want %s", body, want)
+		}
+	}
+}
+
+func TestAgentSessionEventStreamEmitsAndStopsHeartbeat(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	stream := newAgentSessionEventStream(recorder)
+	stream.startHeartbeat(5 * time.Millisecond)
+	time.Sleep(18 * time.Millisecond)
+	stream.stopHeartbeat()
+
+	body := recorder.Body.String()
+	if count := strings.Count(body, ": heartbeat\n\n"); count < 2 {
+		t.Fatalf("heartbeat count = %d, body = %q", count, body)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if recorder.Body.String() != body {
+		t.Fatalf("heartbeat continued after stop: before=%q after=%q", body, recorder.Body.String())
 	}
 }
 
@@ -343,9 +422,9 @@ func TestAgentSessionResponsesWaitsForCodexPromptCompletion(t *testing.T) {
 	if time.Since(startedAt) < 30*time.Millisecond {
 		t.Fatal("request completed before Codex prompt completion")
 	}
-	if !strings.Contains(body, `"delta":"tail"`) ||
-		!strings.Contains(body, `"delta":" end"`) ||
-		!strings.Contains(body, "event: response.completed") {
+	if !strings.Contains(body, `"text":"tail"`) ||
+		!strings.Contains(body, `"text":" end"`) ||
+		!strings.Contains(body, "event: message_stop") {
 		t.Fatalf("SSE body = %q, want all deltas before completion", body)
 	}
 }
@@ -398,11 +477,11 @@ func TestAgentSessionResponsesFailFastForUnsupportedInteractiveEvents(t *testing
 				t.Fatalf("interactive request took %s, want fail-fast response", elapsed)
 			}
 			body := recorder.Body.String()
-			if !strings.Contains(body, "event: response.failed") ||
+			if !strings.Contains(body, "event: error") ||
 				!strings.Contains(body, "interactive approval and user-input requests are not supported") {
 				t.Fatalf("SSE body = %q, want unsupported-interactive failure", body)
 			}
-			if strings.Contains(body, "event: response.completed") {
+			if !strings.Contains(body, `"stop_reason":"error"`) {
 				t.Fatalf("SSE body = %q, must not report completion", body)
 			}
 		})
@@ -436,11 +515,11 @@ func TestAgentSessionResponsesFailsWhenFinalAuditMessageCannotBePersisted(t *tes
 		"input": "Stream this", "stream": true,
 	})
 	body := recorder.Body.String()
-	if !strings.Contains(body, "event: response.failed") ||
+	if !strings.Contains(body, "event: error") ||
 		!strings.Contains(body, "persist final assistant message") {
 		t.Fatalf("SSE body = %q, want persistence failure", body)
 	}
-	if strings.Contains(body, "event: response.completed") {
+	if !strings.Contains(body, `"stop_reason":"error"`) {
 		t.Fatalf("SSE body = %q, must not report completion", body)
 	}
 }
@@ -495,25 +574,6 @@ func (s *fakeSessionEventSource) publish(event activity.RuntimeEvent) {
 	for _, ch := range subscribers {
 		ch <- event
 	}
-}
-
-func recorderRoomID(t *testing.T, body string) string {
-	t.Helper()
-	for _, block := range strings.Split(strings.TrimSpace(body), "\n\n") {
-		lines := strings.Split(block, "\n")
-		if len(lines) != 2 || lines[0] != "event: response.created" {
-			continue
-		}
-		var payload struct {
-			Response agentSessionResponse `json:"response"`
-		}
-		if err := json.Unmarshal([]byte(strings.TrimPrefix(lines[1], "data: ")), &payload); err != nil {
-			t.Fatal(err)
-		}
-		return payload.Response.Metadata["room_id"]
-	}
-	t.Fatal("response.created event not found")
-	return ""
 }
 
 func newAgentSessionTestHandler(t *testing.T, agents []agent.Agent) (*Handler, *im.Service, *im.Bus) {


### PR DESCRIPTION
Summary:
- emit Genius-compatible text, tool-use, tool-result, and terminal SSE events
- preserve structured tool inputs with secret redaction and heartbeat keepalives
- retain non-streaming JSON responses and document the updated contract