### PR TITLE
fix(sandbox): defer Docker availability checks

### DIFF
--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1840,6 +1840,29 @@ func TestNewAgentServiceExplainsMissingConfiguredBoxLite(t *testing.T) {
 	}
 }
 
+func TestNewAgentServiceAllowsMissingConfiguredDockerAtStartup(t *testing.T) {
+	prevLookPath := sandboxprovidersTestOnlyLookPath(t, func(string) (string, error) {
+		return "", fmt.Errorf("not found")
+	})
+	defer prevLookPath()
+
+	prevStatPath := sandboxprovidersTestOnlyStatPath(t, func(string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	})
+	defer prevStatPath()
+	t.Setenv("HOME", t.TempDir())
+
+	svc, err := newAgentService(config.Config{
+		Sandbox: config.SandboxConfig{
+			Provider: config.DockerProvider,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("newAgentService() error = %v, want host-only startup to succeed", err)
+	}
+	defer svc.Close()
+}
+
 func TestNewAgentServiceRegistersCodexRuntime(t *testing.T) {
 	restoreBoxLite := stubBoxLiteAvailable(t)
 	defer restoreBoxLite()

--- a/docs/tech/config.md
+++ b/docs/tech/config.md
@@ -192,6 +192,8 @@ provider = "docker"
 
 For `provider = "boxlite"`, CSGClaw resolves the bundled sibling `boxlite` binary next to `csgclaw` first, then falls back to `PATH` if that bundle is missing. If neither exists, startup fails with an actionable error instead of silently rewriting the provider.
 
+For `provider = "docker"`, Docker executable availability is checked when an operation actually opens the provider, such as creating or starting a sandbox Agent or listing local images. The server and a host-only manager can therefore start without Docker installed; the first Docker-backed operation still returns an actionable error.
+
 `debian_registries_override` controls where BoxLite pulls `debian:bookworm-slim` when you need to override the built-in default order. If omitted or empty, CSGClaw uses `harbor.opencsg.com` then `docker.io`. When CSGClaw writes `config.toml`, it keeps this field visible as an empty array so it can be edited in place:
 
 ```toml

--- a/docs/tech/config.zh.md
+++ b/docs/tech/config.zh.md
@@ -191,6 +191,8 @@ provider = "docker"
 
 对于 `provider = "boxlite"`，CSGClaw 会优先解析与 `csgclaw` 同 bundle 的 `boxlite`，只有 bundle 缺失时才回退到 `PATH`。如果两者都找不到，启动会直接报带操作建议的错误，而不是静默改写 provider。
 
+对于 `provider = "docker"`，Docker 可执行文件会在真正打开 provider 的操作中检查，例如创建或启动 sandbox Agent、列出本地镜像。这样，即使未安装 Docker，服务和仅使用宿主机 runtime 的 manager 也可以正常启动；第一次 Docker sandbox 操作仍会返回带操作建议的错误。
+
 `debian_registries_override` 用于在你需要覆盖内置顺序时，控制 BoxLite 拉取 `debian:bookworm-slim` 的仓库顺序。若省略或为空，CSGClaw 会使用默认顺序 `harbor.opencsg.com`、`docker.io`。当 CSGClaw 写入 `config.toml` 时，会把该字段保留为空数组，方便直接原地修改：
 
 ```toml

--- a/internal/sandboxproviders/docker_provider.go
+++ b/internal/sandboxproviders/docker_provider.go
@@ -8,9 +8,6 @@ import (
 
 func init() {
 	Register(config.DockerProvider, func(cfg config.SandboxConfig) (sandbox.Provider, error) {
-		if err := Availability(config.SandboxConfig{Provider: config.DockerProvider, DockerCLIPath: cfg.DockerCLIPath}); err != nil {
-			return nil, err
-		}
 		return dockercli.NewProvider(dockercli.WithPath(cfg.EffectiveDockerCLIPath())), nil
 	})
 }

--- a/internal/sandboxproviders/docker_provider_test.go
+++ b/internal/sandboxproviders/docker_provider_test.go
@@ -95,12 +95,12 @@ func TestDockerServiceOptionWiresProvider(t *testing.T) {
 	}
 	field := reflect.ValueOf(svc).Elem().FieldByName("sandbox")
 	got := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(sandbox.Provider)
-	if _, ok := got.(dockercli.Provider); !ok {
-		t.Fatalf("sandbox provider = %T, want dockercli.Provider", got)
+	if got.Name() != config.DockerProvider {
+		t.Fatalf("sandbox provider name = %q, want %q", got.Name(), config.DockerProvider)
 	}
 }
 
-func TestDockerProviderFactoryErrorsWhenCLIUnavailable(t *testing.T) {
+func TestDockerProviderDefersCLIAvailabilityUntilOpen(t *testing.T) {
 	restore := stubDockerAvailability(t, func(string) (string, error) {
 		return "", os.ErrNotExist
 	}, func(string) (os.FileInfo, error) {
@@ -108,13 +108,16 @@ func TestDockerProviderFactoryErrorsWhenCLIUnavailable(t *testing.T) {
 	})
 	defer restore()
 
-	factory := factories[config.DockerProvider]
-	_, err := factory(config.SandboxConfig{Provider: config.DockerProvider})
+	provider, err := Provider(config.SandboxConfig{Provider: config.DockerProvider})
+	if err != nil {
+		t.Fatalf("Provider() error = %v, want deferred availability check", err)
+	}
+	_, err = provider.Open(t.Context(), t.TempDir())
 	if err == nil {
-		t.Fatal("factory() error = nil, want docker CLI availability error")
+		t.Fatal("provider.Open() error = nil, want docker CLI availability error")
 	}
 	if got := err.Error(); !strings.Contains(got, `sandbox provider "docker" is configured`) || !strings.Contains(got, `"docker" is not available`) {
-		t.Fatalf("factory() error = %q, want docker availability warning", got)
+		t.Fatalf("provider.Open() error = %q, want docker availability warning", got)
 	}
 }
 

--- a/internal/sandboxproviders/registry.go
+++ b/internal/sandboxproviders/registry.go
@@ -1,6 +1,7 @@
 package sandboxproviders
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -41,7 +42,43 @@ func Provider(cfg config.SandboxConfig) (sandbox.Provider, error) {
 	if !ok {
 		return nil, fmt.Errorf("unsupported sandbox provider %q; supported values are %s", cfg.Provider, SupportedProvidersText())
 	}
-	return factory(cfg)
+	provider, err := factory(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Provider != config.DockerProvider {
+		return provider, nil
+	}
+	return deferredAvailabilityProvider{
+		cfg:      cfg,
+		provider: provider,
+	}, nil
+}
+
+// deferredAvailabilityProvider keeps host-only runtimes usable when Docker is
+// not installed. Availability is checked at the first operation that actually
+// needs Docker instead of while the Agent service is starting.
+type deferredAvailabilityProvider struct {
+	cfg      config.SandboxConfig
+	provider sandbox.Provider
+}
+
+func (p deferredAvailabilityProvider) Name() string {
+	return p.provider.Name()
+}
+
+func (p deferredAvailabilityProvider) Open(ctx context.Context, homeDir string) (sandbox.Runtime, error) {
+	if err := Availability(p.cfg); err != nil {
+		return nil, err
+	}
+	return p.provider.Open(ctx, homeDir)
+}
+
+func (p deferredAvailabilityProvider) ListImages(ctx context.Context, homeDir string) ([]string, error) {
+	if err := Availability(p.cfg); err != nil {
+		return nil, err
+	}
+	return p.provider.ListImages(ctx, homeDir)
 }
 
 // ServiceOptions resolves the configured sandbox provider against the set of


### PR DESCRIPTION
- Allow the server and host-only manager to start when the configured Docker CLI is unavailable by deferring the availability check until Docker is actually used.
- Preserve actionable errors for Docker-backed agent operations and local image listing while leaving other sandbox providers unchanged.
