### PR TITLE
ci(desktop): publish release installers to OSS

### DIFF
--- a/.desktop-release-oss.env.example
+++ b/.desktop-release-oss.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .desktop-release-oss.env and fill the two credential values locally.
+# Never commit the populated file.
+OSS_ACCESS_KEY_ID=""
+OSS_ACCESS_KEY_SECRET=""
+
+OSS_REGION="cn-beijing"
+OSS_ENDPOINT="https://oss-cn-beijing.aliyuncs.com"
+OSS_BUCKET="opencsg-public-resource"
+OSS_PREFIX="csgclaw-desktop"
+OSS_PUBLIC_BASE_URL="https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csgclaw-desktop"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
       desktop_matrix: ${{ steps.set-matrix.outputs.desktop_matrix }}
       version: ${{ steps.release_meta.outputs.version }}
       release_channel: ${{ steps.release_meta.outputs.release_channel }}
-      oss_environment: ${{ steps.release_meta.outputs.oss_environment }}
       oss_manifest_url: ${{ steps.release_meta.outputs.oss_manifest_url }}
       commit: ${{ steps.release_meta.outputs.commit }}
       build_time: ${{ steps.release_meta.outputs.build_time }}
@@ -89,14 +88,8 @@ jobs:
             version="${GITHUB_REF_NAME}"
           fi
           release_channel="$(node scripts/desktop-release-artifacts.mjs channel "${version}")"
-          case "${release_channel}" in
-            beta) oss_environment="stg" ;;
-            release) oss_environment="prd" ;;
-            *) echo "unexpected release channel: ${release_channel}" >&2; exit 1 ;;
-          esac
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "release_channel=${release_channel}" >> "$GITHUB_OUTPUT"
-          echo "oss_environment=${oss_environment}" >> "$GITHUB_OUTPUT"
           echo "oss_manifest_url=https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csgclaw-desktop/channels/${release_channel}/downloads.json" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -404,7 +397,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: ${{ needs.prepare.outputs.oss_environment }}
+      name: oss-publish
       url: ${{ needs.prepare.outputs.oss_manifest_url }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ permissions:
 
 env:
   BOXLITE_CLI_VERSION: v0.9.0
+  OSSUTIL_VERSION: "2.3.0"
+  OSSUTIL_LINUX_AMD64_SHA256: 3ae4d9fc85a7a6e9f5654d1599766f1a3a42a3692870887b5ae9338d582ef65a
 
 jobs:
   prepare:
@@ -29,11 +31,19 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       desktop_matrix: ${{ steps.set-matrix.outputs.desktop_matrix }}
       version: ${{ steps.release_meta.outputs.version }}
+      release_channel: ${{ steps.release_meta.outputs.release_channel }}
+      oss_environment: ${{ steps.release_meta.outputs.oss_environment }}
+      oss_manifest_url: ${{ steps.release_meta.outputs.oss_manifest_url }}
       commit: ${{ steps.release_meta.outputs.commit }}
       build_time: ${{ steps.release_meta.outputs.build_time }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: desktop/package.json
 
       - name: Build matrix from release-platforms.txt
         id: set-matrix
@@ -78,7 +88,16 @@ jobs:
           else
             version="${GITHUB_REF_NAME}"
           fi
+          release_channel="$(node scripts/desktop-release-artifacts.mjs channel "${version}")"
+          case "${release_channel}" in
+            beta) oss_environment="stg" ;;
+            release) oss_environment="prd" ;;
+            *) echo "unexpected release channel: ${release_channel}" >&2; exit 1 ;;
+          esac
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_channel=${release_channel}" >> "$GITHUB_OUTPUT"
+          echo "oss_environment=${oss_environment}" >> "$GITHUB_OUTPUT"
+          echo "oss_manifest_url=https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csgclaw-desktop/channels/${release_channel}/downloads.json" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
@@ -377,3 +396,66 @@ jobs:
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
           files: dist/*
+
+  publish-desktop-oss:
+    needs: [prepare, merge-and-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    environment:
+      name: ${{ needs.prepare.outputs.oss_environment }}
+      url: ${{ needs.prepare.outputs.oss_manifest_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: desktop/package.json
+
+      - name: Download desktop release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-dist-*
+          path: desktop-release
+          merge-multiple: true
+
+      - name: Install ossutil
+        shell: bash
+        run: |
+          archive="${RUNNER_TEMP}/ossutil-${OSSUTIL_VERSION}-linux-amd64.zip"
+          extract_dir="${RUNNER_TEMP}/ossutil"
+          bin_dir="${RUNNER_TEMP}/ossutil-bin"
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "${archive}" \
+            "https://gosspublic.alicdn.com/ossutil/v2/${OSSUTIL_VERSION}/ossutil-${OSSUTIL_VERSION}-linux-amd64.zip"
+          printf '%s  %s\n' "${OSSUTIL_LINUX_AMD64_SHA256}" "${archive}" | sha256sum --check -
+          unzip -q "${archive}" -d "${extract_dir}"
+          install -Dm755 \
+            "${extract_dir}/ossutil-${OSSUTIL_VERSION}-linux-amd64/ossutil" \
+            "${bin_dir}/ossutil"
+          echo "${bin_dir}" >> "${GITHUB_PATH}"
+
+      - name: Validate OSS credentials
+        shell: bash
+        env:
+          OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+        run: |
+          if [ -z "${OSS_ACCESS_KEY_ID}" ] || [ -z "${OSS_ACCESS_KEY_SECRET}" ]; then
+            echo "::error::Configure OSS_ACCESS_KEY_ID and OSS_ACCESS_KEY_SECRET in the selected GitHub environment."
+            exit 1
+          fi
+
+      - name: Publish desktop installers to OSS
+        shell: bash
+        env:
+          OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+        run: |
+          make desktop-oss-publish \
+            VERSION="${{ needs.prepare.outputs.version }}" \
+            DESKTOP_OSS_CHANNEL="${{ needs.prepare.outputs.release_channel }}" \
+            DESKTOP_OSS_RELEASE_DIR=desktop-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,6 +393,10 @@ jobs:
 
   publish-desktop-oss:
     needs: [prepare, merge-and-release]
+    concurrency:
+      group: desktop-oss-${{ needs.prepare.outputs.release_channel }}
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,6 +388,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
+          prerelease: ${{ needs.prepare.outputs.release_channel == 'beta' }}
           files: dist/*
 
   publish-desktop-oss:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/
 bin-csghub/
 dist/
 picoclaw-build.env
+.desktop-release-oss.env
 *.test
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BOXLITE_CLI_BASE_URL ?= https://github.com/boxlite-ai/boxlite/releases/download
 
 GO ?= go
 GOFMT ?= gofmt
+NODE ?= node
 CGO_ENABLED ?= 0
 WEB_APP_DIR ?= web/app
 WEB_STATIC_DIST_DIR ?= web/static-dist
@@ -24,6 +25,15 @@ WEB_BUILD_PNPM_ARGS ?= $(if $(filter summary,$(WEB_BUILD_REPORT)),--silent exec 
 DESKTOP_DIR ?= desktop
 DESKTOP_PNPM ?= $(CURDIR)/scripts/desktop-pnpm.sh
 DESKTOP_PACKAGE_REPORT ?= summary
+DESKTOP_OSS_RELEASE_SCRIPT ?= $(CURDIR)/scripts/desktop-oss-release.mjs
+DESKTOP_OSS_CHANNEL ?=
+DESKTOP_OSS_TARGETS ?=
+DESKTOP_OSS_RELEASE_DIR ?=
+DESKTOP_OSS_OUTPUT_ROOT ?=
+DESKTOP_OSS_ENV_FILE ?=
+DESKTOP_OSS_FORCE ?= 0
+DESKTOP_OSS_ALLOW_PARTIAL ?= 0
+DESKTOP_OSS_COMMON_ARGS = --version "$(VERSION)" $(if $(strip $(DESKTOP_OSS_CHANNEL)),--channel "$(DESKTOP_OSS_CHANNEL)",) $(if $(strip $(DESKTOP_OSS_RELEASE_DIR)),--release-directory "$(DESKTOP_OSS_RELEASE_DIR)",) $(if $(strip $(DESKTOP_OSS_OUTPUT_ROOT)),--output-root "$(DESKTOP_OSS_OUTPUT_ROOT)",)
 TARGET_OS ?= $(shell $(GO) env GOOS)
 TARGET_ARCH ?= $(shell $(GO) env GOARCH)
 DESKTOP_PLATFORM ?= $(if $(filter windows,$(TARGET_OS)),win32,$(TARGET_OS))
@@ -37,7 +47,7 @@ SANDBOX_CLI_BIN ?= $(SANDBOX_BUNDLE_TOOLS_DIR)/csgclaw-cli
 
 .DEFAULT_GOAL := build
 
-.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev web-typecheck web-build-assets build-web check-desktop-layout ensure-desktop-deps desktop-dev desktop-backend-bundle desktop-package build build-all build-server build-server-bin build-codex-cli build-sandbox-cli install-sandbox-cli run clean package package-all release
+.PHONY: help fmt test check-web-toolchain check-web-layout ensure-web-deps web-install web-dev web-typecheck web-build-assets build-web check-desktop-layout ensure-desktop-deps desktop-dev desktop-backend-bundle desktop-package desktop-package-oss desktop-oss-manifest desktop-oss-publish desktop-oss-release build build-all build-server build-server-bin build-codex-cli build-sandbox-cli install-sandbox-cli run clean package package-all release
 
 help:
 	@printf '%s\n' \
@@ -51,6 +61,9 @@ help:
 		'make build-web  - build Web UI app into web/static-dist' \
 		'make desktop-dev - install dependencies when needed, build the local backend, and start Electron Forge' \
 		'make desktop-package - create platform Electron installers/archives (set CSGCLAW_DESKTOP_WINDOWS_CHANNEL=store for MSIX)' \
+		'make desktop-package-oss - build and stage this host desktop OSS artifacts' \
+		'make desktop-oss-manifest - validate the collected macOS/Windows installers and write downloads.json' \
+		'make desktop-oss-publish - validate the complete installer set, then upload artifacts and downloads.json to OSS' \
 		'make build-server-bin - build bin/csgclaw, bin/csgclaw-cli, and bundled Codex' \
 		'make build-sandbox-cli - build Linux csgclaw-cli into bin/sandbox-tools' \
 		'make run        - build (no docker images), then run the server' \
@@ -214,6 +227,21 @@ desktop-package: ensure-desktop-deps desktop-backend-bundle
 	else \
 		run_package && print_artifacts; \
 	fi
+
+# These are thin release wrappers. desktop-package remains the single-platform
+# build primitive used by CI; the Node script calls it and then reuses the same
+# release asset collector as the existing GitHub workflow.
+desktop-package-oss:
+	@$(NODE) "$(DESKTOP_OSS_RELEASE_SCRIPT)" build $(DESKTOP_OSS_COMMON_ARGS) $(if $(strip $(DESKTOP_OSS_TARGETS)),--targets "$(DESKTOP_OSS_TARGETS)",) $(if $(filter 1 true yes,$(DESKTOP_OSS_FORCE)),--force,)
+
+desktop-oss-manifest:
+	@$(NODE) "$(DESKTOP_OSS_RELEASE_SCRIPT)" manifest $(DESKTOP_OSS_COMMON_ARGS) $(if $(filter 1 true yes,$(DESKTOP_OSS_ALLOW_PARTIAL)),--allow-partial,)
+
+desktop-oss-publish:
+	@$(NODE) "$(DESKTOP_OSS_RELEASE_SCRIPT)" manifest $(DESKTOP_OSS_COMMON_ARGS)
+	@$(NODE) "$(DESKTOP_OSS_RELEASE_SCRIPT)" upload $(DESKTOP_OSS_COMMON_ARGS) $(if $(strip $(DESKTOP_OSS_ENV_FILE)),--env-file "$(DESKTOP_OSS_ENV_FILE)",)
+
+desktop-oss-release: desktop-oss-publish
 
 build: build-web build-server-bin build-sandbox-cli
 

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -15,6 +15,10 @@ import {
   goArchForDesktopArch,
   goOSForDesktopPlatform,
 } from "./src/shared/desktopEnvironment";
+import {
+  normalizeDesktopReleaseVersion,
+  numericDesktopAppVersion,
+} from "./src/shared/releaseVersion";
 
 const targetGoOS = process.env.CSGCLAW_DESKTOP_GOOS || goOSForDesktopPlatform(process.platform);
 const targetGoArch = process.env.CSGCLAW_DESKTOP_GOARCH || goArchForDesktopArch(process.arch);
@@ -23,9 +27,8 @@ const isMacTarget = targetGoOS === GoOperatingSystem.MacOS;
 const isWindowsTarget = targetGoOS === GoOperatingSystem.Windows;
 const backendResources = path.resolve(
   __dirname,
-  "..",
-  "dist",
-  "desktop-input",
+  "out",
+  "input",
   `${targetGoOS}-${targetGoArch}`,
   "backend",
 );
@@ -49,11 +52,8 @@ const adHocEntitlements = path.resolve(
   "macos-adhoc.plist",
 );
 const updateConfig = path.resolve(__dirname, ".forge-generated", "desktop-update.json");
-const requestedVersion = (process.env.CSGCLAW_DESKTOP_VERSION || "").trim().replace(/^v/, "");
-const versionParts = /^(\d+)\.(\d+)\.(\d+)/.exec(requestedVersion);
-const desktopVersion = versionParts
-  ? `${versionParts[1]}.${versionParts[2]}.${versionParts[3]}`
-  : "0.0.0-development";
+const desktopVersion = normalizeDesktopReleaseVersion(process.env.CSGCLAW_DESKTOP_VERSION);
+const desktopAppVersion = numericDesktopAppVersion(desktopVersion);
 const updateBaseURL = normalizeHTTPSBaseURL(process.env.CSGCLAW_DESKTOP_UPDATE_BASE_URL);
 fs.mkdirSync(path.dirname(updateConfig), { recursive: true });
 fs.writeFileSync(updateConfig, `${JSON.stringify({ base_url: updateBaseURL || "" }, null, 2)}\n`, { mode: 0o600 });
@@ -64,6 +64,7 @@ const hasAppleNotarizationCredentials = Boolean(
 const macSignIdentity =
   requestedMacSignIdentity || (!hasAppleNotarizationCredentials ? "-" : undefined);
 const usesAdHocMacSignature = macSignIdentity === "-";
+const skipMacSigning = process.env.CSGCLAW_MACOS_SKIP_SIGN === "1";
 const enableCookieEncryption = !isMacTarget || !usesAdHocMacSignature;
 const windowsSign =
   process.env.CSGCLAW_WINDOWS_SIGN_TOOL && process.env.CSGCLAW_WINDOWS_SIGN_PARAMS
@@ -89,7 +90,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     appBundleId: "com.opencsg.csgclaw.desktop",
     appCategoryType: "public.app-category.developer-tools",
-    appVersion: desktopVersion,
+    appVersion: desktopAppVersion,
     asar: true,
     executableName: "CSGClaw",
     extraResource: [
@@ -102,29 +103,33 @@ const config: ForgeConfig = {
     ],
     icon: appIcon,
     name: "CSGClaw",
-    osxSign: {
-      hardenedRuntime: true,
-      entitlements,
-      entitlementsInherit: entitlements,
-      continueOnError: false,
-      ignore: (filePath) =>
-        filePath.endsWith(path.join("sandbox-tools", "csgclaw-cli")),
-      ...(macSignIdentity
-        ? {
-            identity: macSignIdentity,
-            identityValidation: !usesAdHocMacSignature,
-            ...(usesAdHocMacSignature
+    ...(isMacTarget && !skipMacSigning
+      ? {
+          osxSign: {
+            hardenedRuntime: true,
+            entitlements,
+            entitlementsInherit: entitlements,
+            continueOnError: false,
+            ignore: (filePath: string) =>
+              filePath.endsWith(path.join("sandbox-tools", "csgclaw-cli")),
+            ...(macSignIdentity
               ? {
-                  timestamp: "none",
-                  optionsForFile: (filePath: string) =>
-                    path.extname(filePath) === ".app"
-                      ? { entitlements: adHocEntitlements }
-                      : {},
+                  identity: macSignIdentity,
+                  identityValidation: !usesAdHocMacSignature,
+                  ...(usesAdHocMacSignature
+                    ? {
+                        timestamp: "none",
+                        optionsForFile: (filePath: string) =>
+                          path.extname(filePath) === ".app"
+                            ? { entitlements: adHocEntitlements }
+                            : {},
+                      }
+                    : {}),
                 }
               : {}),
-          }
-        : {}),
-    },
+          },
+        }
+      : {}),
     ...(windowsSign ? { windowsSign } : {}),
     ...(hasAppleNotarizationCredentials
       ? {
@@ -189,7 +194,6 @@ const config: ForgeConfig = {
     ),
     new MakerDMG({
       format: "ULFO",
-      name: `CSGClaw-Desktop-${desktopVersion}-${targetElectronArch}`,
     }),
     new MakerDeb({
       options: {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm run build && node --test dist/main/navigationPolicy.test.js dist/main/sidecar/childEnvironment.test.js dist/main/sidecar/systemProxy.test.js dist/main/updatePolicy.test.js dist/shared/desktopEnvironment.test.js",
+    "test": "pnpm run build && node --test dist/main/navigationPolicy.test.js dist/main/sidecar/childEnvironment.test.js dist/main/sidecar/systemProxy.test.js dist/main/updatePolicy.test.js dist/shared/desktopEnvironment.test.js dist/shared/releaseVersion.test.js",
     "start": "pnpm run build && electron-forge start",
     "make": "pnpm run build && electron-forge make",
     "publish": "pnpm run build && electron-forge publish"

--- a/desktop/src/main/sidecar/locateBundle.ts
+++ b/desktop/src/main/sidecar/locateBundle.ts
@@ -25,9 +25,8 @@ export function locateBackendBundle(): BackendBundle {
           path.resolve(app.getAppPath(), "..", "bin", binaryName),
           path.resolve(
             app.getAppPath(),
-            "..",
-            "dist",
-            "desktop-input",
+            "out",
+            "input",
             `${goOS}-${goArch}`,
             "backend",
             "csgclaw",

--- a/desktop/src/shared/releaseVersion.test.ts
+++ b/desktop/src/shared/releaseVersion.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeDesktopReleaseVersion, numericDesktopAppVersion } from "./releaseVersion";
+
+test("preserves stable and prerelease desktop versions", () => {
+  assert.equal(normalizeDesktopReleaseVersion("v0.4.5"), "0.4.5");
+  assert.equal(normalizeDesktopReleaseVersion("0.4.5-beta.1"), "0.4.5-beta.1");
+});
+
+test("drops build metadata that packaging formats do not need", () => {
+  assert.equal(normalizeDesktopReleaseVersion("v0.4.5-beta.1+local"), "0.4.5-beta.1");
+});
+
+test("uses the development version for invalid input", () => {
+  assert.equal(normalizeDesktopReleaseVersion("not-a-version"), "0.0.0-development");
+  assert.equal(normalizeDesktopReleaseVersion(undefined), "0.0.0-development");
+});
+
+test("uses a numeric system app version for prerelease packages", () => {
+  assert.equal(numericDesktopAppVersion("0.4.5-beta.1"), "0.4.5");
+  assert.equal(numericDesktopAppVersion("invalid"), "0.0.0");
+});

--- a/desktop/src/shared/releaseVersion.ts
+++ b/desktop/src/shared/releaseVersion.ts
@@ -1,0 +1,21 @@
+const semanticVersionPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function normalizeDesktopReleaseVersion(rawVersion: string | undefined): string {
+  const requested = (rawVersion || "").trim().replace(/^v/, "");
+  const match = semanticVersionPattern.exec(requested);
+  if (!match) {
+    return "0.0.0-development";
+  }
+
+  const prerelease = match[4] ? `-${match[4]}` : "";
+  return `${match[1]}.${match[2]}.${match[3]}${prerelease}`;
+}
+
+export function numericDesktopAppVersion(releaseVersion: string): string {
+  const match = semanticVersionPattern.exec(releaseVersion);
+  if (!match) {
+    return "0.0.0";
+  }
+  return `${match[1]}.${match[2]}.${match[3]}`;
+}

--- a/docs/tech/build.md
+++ b/docs/tech/build.md
@@ -107,11 +107,16 @@ The installer exposes both host binaries from the same `INSTALL_DIR` and copies 
 | `make package-all` | Build and package the current platform artifacts |
 | `make desktop-package` | Build native desktop installers on macOS/Linux |
 | `scripts\build.cmd desktop-package` | Build native desktop installers on Windows without `make` |
+| `make desktop-package-oss VERSION=<version>` | Reuse `desktop-package` and stage this host's OSS desktop artifacts |
+| `make desktop-oss-manifest VERSION=<version>` | Validate all three website installers and generate `downloads.json` |
+| `make desktop-oss-publish VERSION=<version>` | Validate and publish all three website installers to OSS |
 | `make release` | Build the configured cross-platform release bundles |
 
-Release CI uses `.github/workflows/release.yml` and `.gitlab/ci.yml`. GitHub attaches the CLI and native desktop installers to the matching GitHub Release. GitLab uploads CLI release artifacts to `https://csgclaw.opencsg.com/releases/<tag>/` and publishes the CSGClaw product image. Its desktop jobs are optional manual builds: successful installers remain GitLab artifacts for one day and are not uploaded to the public release directory. GitLab macOS and Windows desktop jobs require native runners tagged `csgclaw-macos-arm64`, `csgclaw-macos-amd64`, and `csgclaw-windows-amd64`.
+Release CI uses `.github/workflows/release.yml` and `.gitlab/ci.yml`. GitHub attaches the CLI and native desktop installers to the matching GitHub Release, then publishes the two macOS DMGs and Windows x64 installer to the beta or release OSS channel. GitLab uploads CLI release artifacts to `https://csgclaw.opencsg.com/releases/<tag>/` and publishes the CSGClaw product image. Its desktop jobs are optional manual builds: successful installers remain GitLab artifacts for one day and are not uploaded to the public release directory. GitLab macOS and Windows desktop jobs require native runners tagged `csgclaw-macos-arm64`, `csgclaw-macos-amd64`, and `csgclaw-windows-amd64`.
 
 Desktop installers use names such as `csgclaw-desktop_v0.4.3_darwin_arm64.dmg`. Signing and notarization values are optional CI secrets/variables: when they are absent or incomplete, Electron Forge keeps its macOS ad-hoc and Windows unsigned defaults. Release CI does not configure a desktop update feed.
+
+Local desktop outputs are kept under `desktop/out/`: backend inputs in `input/`, raw Forge artifacts in `make/`, and OSS release files and manifests in `oss/`. The repository-root `dist/` remains the Go release and CI runner staging directory.
 
 ## Related docs
 

--- a/docs/tech/build.zh.md
+++ b/docs/tech/build.zh.md
@@ -107,11 +107,18 @@ PowerShell 和 Docker 打包均读取该文件。正式 release 平台仍维护�
 | `make package-all` | 构建并打包当前平台产物 |
 | `make desktop-package` | 在 macOS/Linux 构建当前平台的桌面安装包 |
 | `scripts\build.cmd desktop-package` | 在 Windows 无需 `make` 构建桌面安装包 |
+| `make desktop-package-oss VERSION=<version>` | 复用 `desktop-package` 构建并归档本机支持的 OSS 桌面产物 |
+| `make desktop-oss-manifest VERSION=<version>` | 收齐三平台安装器后生成 `downloads.json` |
+| `make desktop-oss-publish VERSION=<version>` | 严格检查三平台安装器并发布到 OSS |
 | `make release` | 构建配置的跨平台 release bundle |
 
-发布 CI 使用 `.github/workflows/release.yml` 和 `.gitlab/ci.yml`。GitHub 将 CLI 和原生桌面安装包附加到对应的 GitHub Release。GitLab 将 CLI release 产物上传到 `https://csgclaw.opencsg.com/releases/<tag>/`，并发布 CSGClaw 产品镜像。其桌面 job 是可选手动构建：成功的安装包作为 GitLab artifact 保留一天，不会上传到公开发布目录。GitLab 的 macOS 和 Windows 桌面 job 需要提供并打上 `csgclaw-macos-arm64`、`csgclaw-macos-amd64`、`csgclaw-windows-amd64` tag 的原生 runner。
+发布 CI 使用 `.github/workflows/release.yml` 和 `.gitlab/ci.yml`。GitHub 将 CLI 和原生桌面安装包附加到对应的 GitHub Release，随后把两个 macOS DMG 和 Windows x64 安装器发布到 beta 或 release OSS channel。GitLab 将 CLI release 产物上传到 `https://csgclaw.opencsg.com/releases/<tag>/`，并发布 CSGClaw 产品镜像。其桌面 job 是可选手动构建：成功的安装包作为 GitLab artifact 保留一天，不会上传到公开发布目录。GitLab 的 macOS 和 Windows 桌面 job 需要提供并打上 `csgclaw-macos-arm64`、`csgclaw-macos-amd64`、`csgclaw-windows-amd64` tag 的原生 runner。
 
 桌面安装包采用如 `csgclaw-desktop_v0.4.3_darwin_arm64.dmg` 的命名。签名和公证信息是可选 CI secrets/variables：未配置或配置不完整时，Electron Forge 保持 macOS ad-hoc、Windows 未签名的默认行为。发布 CI 不配置桌面端更新源。
+
+OSS 桌面发布命令的完整说明见 [Electron Desktop OSS 发布](electron-desktop-oss-release.zh.md)。`desktop-package` 仍是单平台原子构建，OSS 上传只放在聚合命令中，避免并行 runner 使用不完整产物发布。
+
+本地桌面构建文件统一维护在 `desktop/out/`：`input/` 是后端 bundle 中间件，`make/` 是 Forge 原始产物，`oss/` 是可上传版本、外部导入包和 channel manifest。仓库根 `dist/` 继续作为 Go release 与 CI runner 的临时平铺汇总目录。
 
 ## 相关文档
 

--- a/docs/tech/electron-desktop-migration-plan.zh.md
+++ b/docs/tech/electron-desktop-migration-plan.zh.md
@@ -241,7 +241,7 @@ make desktop-package TARGET_OS=darwin TARGET_ARCH=amd64
 
 打包配置按目标平台分别使用 `csgclaw.icns`、`csgclaw.ico` 和 `csgclaw.png`，Windows 安装器和 Linux DEB 也显式复用对应图标。
 
-输出目录是 `desktop/out/`，backend 中间产物位于 `dist/desktop-input/<os>-<arch>/backend/`。GitHub Release CI 会从 `desktop/out/make/` 归档最终文件，生成如 `csgclaw-desktop_v0.4.3_darwin_arm64.dmg` 的稳定名称并附加到对应 GitHub Release。GitLab 的桌面 job 仅供可选手动构建，成功产物作为 GitLab artifact 保留一天，不上传到 `https://csgclaw.opencsg.com/releases/<tag>/`。
+所有本地桌面构建产物统一位于 `desktop/out/`：backend 中间产物在 `desktop/out/input/<os>-<arch>/backend/`，Forge 原始安装包在 `desktop/out/make/`，OSS 发布工作区在 `desktop/out/oss/`。GitHub Release CI 会从 `desktop/out/make/` 归档最终文件到 runner 的临时 `dist/`，生成如 `csgclaw-desktop_v0.4.3_darwin_arm64.dmg` 的稳定名称并附加到对应 GitHub Release。GitLab 的桌面 job 仅供可选手动构建，成功产物作为 GitLab artifact 保留一天，不上传到 `https://csgclaw.opencsg.com/releases/<tag>/`。
 
 正式安装包建议在目标系统构建。跨平台编译成功不代表签名、安装、启动和更新已经通过目标系统验证。
 

--- a/docs/tech/electron-desktop-oss-release.zh.md
+++ b/docs/tech/electron-desktop-oss-release.zh.md
@@ -1,0 +1,109 @@
+# CSGClaw Desktop OSS 发布
+
+桌面端官网下载安装包沿用 CSGLite 的 channel manifest 结构：版本文件不可变，`channels/beta/downloads.json` 和 `channels/release/downloads.json` 分别指向当前 beta 和稳定版本。
+
+发布流程只按 SemVer 是否带预发布段分流，构建、归档、校验和上传步骤完全相同：`v0.4.6-beta.1` 进入 `beta` channel，`v0.4.6` 进入 `release` channel。版本必须使用 `-beta.1` 形式；`v0.4.6.beta.1` 不是有效 SemVer，会在构建 matrix 启动前失败。
+
+## 首个 beta 版本
+
+命令接受带或不带 `v` 的 SemVer，例如 `0.4.5-beta.1`。版本目录和 `downloads.json` 中的版本号不带 `v`；安装包文件名保留现有 GitHub Release 的 `v` 前缀，例如 `csgclaw-desktop_v0.4.5-beta.1_darwin_arm64.dmg`。
+
+在 macOS 上同时构建 Apple Silicon 和 Intel 包：
+
+```bash
+make desktop-package-oss \
+  VERSION=0.4.5-beta.1 \
+  DESKTOP_OSS_TARGETS=darwin-arm64,darwin-amd64 \
+  DESKTOP_OSS_FORCE=1
+```
+
+在 Apple Silicon Mac 上交叉构建 Intel 且没有配置正式证书时，脚本会跳过容易失败的临时 ad-hoc 签名。该包仅用于内部验证；公开上传前必须在签名构建机或 macOS CI 中配置 Developer ID，并完成签名、公证和 staple。
+
+Windows Squirrel 安装器必须在 Windows 上构建。在 Windows PowerShell 或 Windows CI 中执行：
+
+```powershell
+node scripts/desktop-oss-release.mjs build `
+  --version 0.4.5-beta.1 `
+  --channel beta `
+  --targets windows-amd64 `
+  --force
+```
+
+把两台构建机生成的文件合并到同一个目录：
+
+```text
+desktop/out/oss/releases/0.4.5-beta.1/
+```
+
+生成官网清单：
+
+```bash
+make desktop-oss-manifest VERSION=0.4.5-beta.1
+```
+
+生成位置：
+
+```text
+desktop/out/oss/channels/beta/downloads.json
+```
+
+## 上传 OSS
+
+安装并配置 `ossutil` 后，复制凭证模板：
+
+```bash
+cp .desktop-release-oss.env.example .desktop-release-oss.env
+```
+
+只在本地 `.desktop-release-oss.env` 填写 `OSS_ACCESS_KEY_ID` 和 `OSS_ACCESS_KEY_SECRET`。该文件已加入 `.gitignore`。
+
+上传时先传不可变的版本文件，最后覆盖 channel manifest：
+
+```bash
+make desktop-oss-publish VERSION=0.4.5-beta.1
+```
+
+`make desktop-oss-release` 是 `desktop-oss-publish` 的发布别名。两个命令都会先严格检查 macOS arm64、macOS Intel 和 Windows x64 三个安装器是否已经收齐；不完整时不会上传。脚本上传前会读取远端现有 `downloads.json` 并保留历史版本；上传成功后会再次读取公开清单，验证 `latest` 是否等于本次版本。
+
+## GitHub Release 与 OSS 自动发布
+
+`.github/workflows/release.yml` 与本地流程复用相同的三层能力：
+
+- 构建层：`make desktop-package` / `scripts/build.cmd desktop-package`，继续统一调用 Electron Forge；
+- 产物契约层：`desktop-release-artifacts.mjs`，集中维护版本、平台和最终文件名；
+- 归档层：`collect-desktop-release-assets.mjs`，按产物契约筛选 Forge 输出，供现有 CI 和本地脚本共同调用。
+
+`desktop-oss-release.mjs build` 是本地编排层，只组合以上能力，不另写一套打包实现。CI 继续负责各平台 runner、macOS/Windows 签名、公证以及 GitHub Release；本地和 CI 生成的文件可直接交给同一套 manifest/upload 命令。
+
+GitHub Release 成功后，`publish-desktop-oss` job 会重新下载 `desktop-dist-*`，严格确认 Mac ARM DMG、Mac Intel DMG 和 Windows x64 Setup EXE 均存在，然后安装经过 SHA-256 校验的 `ossutil` 并执行：
+
+```bash
+make desktop-oss-publish \
+  VERSION="$VERSION" \
+  DESKTOP_OSS_RELEASE_DIR=desktop-release
+```
+
+GitHub Release 中仍保留 macOS ZIP 和 Linux DEB，但 OSS 上传只包含官网清单使用的三个安装器，不会上传 Linux 包。预发布版本自动发布到 `beta` channel 并使用 `stg` GitHub Environment；稳定版本自动发布到 `release` channel 并使用 `prd` GitHub Environment。
+
+在仓库 Settings → Environments 中为 `stg` 和 `prd` 分别配置同名 secrets：
+
+- `OSS_ACCESS_KEY_ID`
+- `OSS_ACCESS_KEY_SECRET`
+
+也可以先把这两个值配置为 repository secrets；同名 environment secrets 存在时会覆盖 repository secrets。建议为 `prd` Environment 配置 required reviewers，避免稳定 channel 被未经确认的手动发布更新。
+
+OSS 区域、endpoint、bucket、对象前缀和公开地址由发布脚本统一维护，GitHub Environment 不需要重复配置。CI 只读取上述两项 secrets。
+
+OSS job 不完整、凭证缺失、上传失败或公开清单回读验证失败时会明确失败。版本对象先上传，最后才替换 channel manifest。
+
+可选 Make 变量：
+
+| 变量 | 用途 |
+|---|---|
+| `DESKTOP_OSS_TARGETS` | 本机构建目标，逗号分隔 |
+| `DESKTOP_OSS_RELEASE_DIR` | 已汇总安装包的目录；CI 使用 `desktop-release` |
+| `DESKTOP_OSS_OUTPUT_ROOT` | 覆盖默认的 `desktop/out/oss` 工作区 |
+| `DESKTOP_OSS_CHANNEL` | 显式指定 `beta` 或 `release` |
+| `DESKTOP_OSS_ENV_FILE` | 指定本地 OSS 凭证文件 |
+| `DESKTOP_OSS_FORCE=1` | 覆盖本地已有的同版本归档 |
+| `DESKTOP_OSS_ALLOW_PARTIAL=1` | 仅供本地检查部分 manifest；发布命令不会使用 |

--- a/docs/tech/electron-desktop-oss-release.zh.md
+++ b/docs/tech/electron-desktop-oss-release.zh.md
@@ -83,14 +83,14 @@ make desktop-oss-publish \
   DESKTOP_OSS_RELEASE_DIR=desktop-release
 ```
 
-GitHub Release 中仍保留 macOS ZIP 和 Linux DEB，但 OSS 上传只包含官网清单使用的三个安装器，不会上传 Linux 包。预发布版本自动发布到 `beta` channel 并使用 `stg` GitHub Environment；稳定版本自动发布到 `release` channel 并使用 `prd` GitHub Environment。
+GitHub Release 中仍保留 macOS ZIP 和 Linux DEB，但 OSS 上传只包含官网清单使用的三个安装器，不会上传 Linux 包。预发布版本自动发布到 `beta` channel，稳定版本自动发布到 `release` channel；两个 channel 共用 `oss-publish` GitHub Environment，只通过不同的 `downloads.json` 路径分流。
 
-在仓库 Settings → Environments 中为 `stg` 和 `prd` 分别配置同名 secrets：
+在仓库 Settings → Environments 中创建 `oss-publish`，并配置以下 secrets：
 
 - `OSS_ACCESS_KEY_ID`
 - `OSS_ACCESS_KEY_SECRET`
 
-也可以先把这两个值配置为 repository secrets；同名 environment secrets 存在时会覆盖 repository secrets。建议为 `prd` Environment 配置 required reviewers，避免稳定 channel 被未经确认的手动发布更新。
+`oss-publish` 只负责为最终上传 job 提供凭证和部署记录；版本中的预发布段仍由 `release_channel` 单独解析，不影响凭证选择。如果将来稳定 channel 需要独立的人工审批或独立凭证，再拆分为两个受保护的 GitHub Environment。
 
 OSS 区域、endpoint、bucket、对象前缀和公开地址由发布脚本统一维护，GitHub Environment 不需要重复配置。CI 只读取上述两项 secrets。
 

--- a/docs/tech/electron-desktop-oss-release.zh.md
+++ b/docs/tech/electron-desktop-oss-release.zh.md
@@ -83,7 +83,18 @@ make desktop-oss-publish \
   DESKTOP_OSS_RELEASE_DIR=desktop-release
 ```
 
-GitHub Release 中仍保留 macOS ZIP 和 Linux DEB，但 OSS 上传只包含官网清单使用的三个安装器，不会上传 Linux 包。预发布版本自动发布到 `beta` channel，稳定版本自动发布到 `release` channel；两个 channel 共用 `oss-publish` GitHub Environment，只通过不同的 `downloads.json` 路径分流。
+GitHub Release 中仍保留 macOS ZIP 和 Linux DEB，但 OSS 上传只包含官网清单使用的三个安装器，不会上传 Linux 包。
+
+### Tag 路由规则
+
+GitHub 不会仅根据 tag 名称自动设置 Pre-release。CI 使用 `desktop-release-artifacts.mjs channel` 解析 SemVer，再把同一个 `release_channel` 同时用于 GitHub Release 类型和 OSS channel：
+
+| Tag 示例 | `release_channel` | GitHub Release | OSS manifest |
+|---|---|---|---|
+| `v0.4.6-beta.2`、`v0.4.6-alpha.1`、`v0.4.6-rc.1` | `beta` | Pre-release | `channels/beta/downloads.json` |
+| `v0.4.6` | `release` | 普通 Release | `channels/release/downloads.json` |
+
+所有合法的 SemVer 预发布版本都会进入 `beta`；稳定版本进入 `release`。两个 channel 共用 `oss-publish` GitHub Environment，只通过不同的 `downloads.json` 路径分流。
 
 在仓库 Settings → Environments 中创建 `oss-publish`，并配置以下 secrets：
 

--- a/docs/tech/electron-desktop-oss-release.zh.md
+++ b/docs/tech/electron-desktop-oss-release.zh.md
@@ -98,6 +98,8 @@ GitHub 不会仅根据 tag 名称自动设置 Pre-release。CI 使用 `desktop-r
 
 发布脚本会按 SemVer 比较待发布版本和远端 manifest 的 `latest`。可以重新发布同一版本，但不能发布比当前 `latest` 更旧的版本；遇到旧 tag 时任务会失败并提示当前 `latest`，需要改用更高的版本号重新打 tag。
 
+CI 只对最终的 `publish-desktop-oss` job 按 channel 串行：相同 channel 的 OSS 发布依次排队，`beta` 和 `release` 使用不同的并发组。多平台构建和 GitHub Release 仍可并行执行；等待中的发布不会取消正在上传的任务，也不会因后续发布进入队列而被替换。
+
 在仓库 Settings → Environments 中创建 `oss-publish`，并配置以下 secrets：
 
 - `OSS_ACCESS_KEY_ID`

--- a/docs/tech/electron-desktop-oss-release.zh.md
+++ b/docs/tech/electron-desktop-oss-release.zh.md
@@ -96,6 +96,8 @@ GitHub 不会仅根据 tag 名称自动设置 Pre-release。CI 使用 `desktop-r
 
 所有合法的 SemVer 预发布版本都会进入 `beta`；稳定版本进入 `release`。两个 channel 共用 `oss-publish` GitHub Environment，只通过不同的 `downloads.json` 路径分流。
 
+发布脚本会按 SemVer 比较待发布版本和远端 manifest 的 `latest`。可以重新发布同一版本，但不能发布比当前 `latest` 更旧的版本；遇到旧 tag 时任务会失败并提示当前 `latest`，需要改用更高的版本号重新打 tag。
+
 在仓库 Settings → Environments 中创建 `oss-publish`，并配置以下 secrets：
 
 - `OSS_ACCESS_KEY_ID`

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -476,7 +476,7 @@ function Invoke-DesktopBackendBundle {
         [Parameter(Mandatory = $true)][string]$Goarch
     )
 
-    $outputRoot = Join-Path (Join-Path $script:DistDir "desktop-input") "$Goos-$Goarch"
+    $outputRoot = Join-Path (Join-Path (Join-Path $script:DesktopDir "out") "input") "$Goos-$Goarch"
     if (Test-Path -LiteralPath $outputRoot) {
         Remove-Item -LiteralPath $outputRoot -Recurse -Force
     }

--- a/scripts/collect-desktop-release-assets.mjs
+++ b/scripts/collect-desktop-release-assets.mjs
@@ -4,10 +4,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import {
+  desktopReleaseArtifactNames,
+  normalizeReleaseVersion,
+} from "./desktop-release-artifacts.mjs";
+
 export function collectDesktopReleaseAssets({ version, goos, goarch, makeDirectory, outputDirectory }) {
   const files = listFiles(makeDirectory);
-  const prefix = `csgclaw-desktop_${version}_${goos}_${goarch}`;
-  const assets = releaseAssetsFor(goos, goarch, files, prefix);
+  const names = desktopReleaseArtifactNames({ version, goos, goarch });
+  const assets = releaseAssetsFor(goos, goarch, files, names, normalizeReleaseVersion(version));
 
   fs.mkdirSync(outputDirectory, { recursive: true });
   for (const asset of assets) {
@@ -28,22 +33,43 @@ function listFiles(directory) {
     .map((entry) => path.join(entry.parentPath, entry.name));
 }
 
-function releaseAssetsFor(goos, goarch, files, prefix) {
+function releaseAssetsFor(goos, goarch, files, names, packageVersion) {
+  const electronArch = goarch === "amd64" ? "x64" : goarch;
   switch (`${goos}/${goarch}`) {
     case "darwin/arm64":
     case "darwin/amd64":
       return [
-        asset(files, (file) => file.endsWith(".dmg"), `${prefix}.dmg`),
-        asset(files, (file) => file.endsWith(".zip"), `${prefix}.zip`),
+        asset(
+          files,
+          (file) => path.basename(file) === `CSGClaw-${packageVersion}-${electronArch}.dmg`,
+          names[0],
+        ),
+        asset(
+          files,
+          (file) =>
+            path.basename(file).endsWith(`-${packageVersion}.zip`) &&
+            normalizedPath(file).includes(`/zip/darwin/${electronArch}/`),
+          names[1],
+        ),
       ];
     case "windows/amd64":
-      return [asset(files, (file) => file.endsWith("-Setup.exe"), `${prefix}.exe`)];
+      return [
+        asset(
+          files,
+          (file) => path.basename(file) === `CSGClaw-Desktop-${packageVersion}-${electronArch}-Setup.exe`,
+          names[0],
+        ),
+      ];
     case "linux/amd64":
     case "linux/arm64":
-      return [asset(files, (file) => file.endsWith(".deb"), `${prefix}.deb`)];
+      return [asset(files, (file) => file.endsWith(".deb"), names[0])];
     default:
       throw new Error(`unsupported desktop release target: ${goos}/${goarch}`);
   }
+}
+
+function normalizedPath(file) {
+  return `/${file.split(path.sep).join("/")}`;
 }
 
 function asset(files, matches, name) {

--- a/scripts/collect-desktop-release-assets.test.mjs
+++ b/scripts/collect-desktop-release-assets.test.mjs
@@ -10,9 +10,9 @@ const version = "v0.4.3";
 
 test("collects the public asset set for each supported target", async (t) => {
   for (const fixture of [
-    { goos: "darwin", goarch: "arm64", files: ["dmg/CSGClaw.dmg", "zip/darwin/arm64/CSGClaw.zip"], want: [".dmg", ".zip"] },
-    { goos: "darwin", goarch: "amd64", files: ["dmg/CSGClaw.dmg", "zip/darwin/x64/CSGClaw.zip"], want: [".dmg", ".zip"] },
-    { goos: "windows", goarch: "amd64", files: ["squirrel.windows/x64/CSGClaw-Setup.exe"], want: [".exe"] },
+    { goos: "darwin", goarch: "arm64", files: ["dmg/CSGClaw-0.4.3-arm64.dmg", "zip/darwin/arm64/CSGClaw-darwin-arm64-0.4.3.zip"], want: [".dmg", ".zip"] },
+    { goos: "darwin", goarch: "amd64", files: ["dmg/CSGClaw-0.4.3-x64.dmg", "zip/darwin/x64/CSGClaw-darwin-x64-0.4.3.zip"], want: [".dmg", ".zip"] },
+    { goos: "windows", goarch: "amd64", files: ["squirrel.windows/x64/CSGClaw-Desktop-0.4.3-x64-Setup.exe"], want: [".exe"] },
     { goos: "linux", goarch: "amd64", files: ["deb/x64/csgclaw.deb"], want: [".deb"] },
     { goos: "linux", goarch: "arm64", files: ["deb/arm64/csgclaw.deb"], want: [".deb"] },
   ]) {
@@ -32,7 +32,7 @@ test("collects the public asset set for each supported target", async (t) => {
 });
 
 test("rejects a missing expected asset", () => {
-  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(["CSGClaw.dmg"]);
+  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(["CSGClaw-0.4.3-arm64.dmg"]);
   try {
     assert.throws(
       () => collectDesktopReleaseAssets({ version, goos: "darwin", goarch: "arm64", makeDirectory, outputDirectory }),
@@ -50,6 +50,43 @@ test("rejects ambiguous Forge output", () => {
       () => collectDesktopReleaseAssets({ version, goos: "linux", goarch: "amd64", makeDirectory, outputDirectory }),
       /expected exactly one source/,
     );
+  } finally {
+    cleanup();
+  }
+});
+
+test("ignores stale artifacts for another version", () => {
+  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories([
+    "dmg/CSGClaw-0.4.2-arm64.dmg",
+    "dmg/CSGClaw-0.4.3-arm64.dmg",
+    "zip/darwin/arm64/CSGClaw-darwin-arm64-0.4.2.zip",
+    "zip/darwin/arm64/CSGClaw-darwin-arm64-0.4.3.zip",
+  ]);
+  try {
+    collectDesktopReleaseAssets({ version, goos: "darwin", goarch: "arm64", makeDirectory, outputDirectory });
+    assert.deepEqual(
+      fs.readdirSync(outputDirectory).sort(),
+      [
+        "csgclaw-desktop_v0.4.3_darwin_arm64.dmg",
+        "csgclaw-desktop_v0.4.3_darwin_arm64.zip",
+      ],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("uses the same canonical asset name for versions with or without v", () => {
+  const { makeDirectory, outputDirectory, cleanup } = fixtureDirectories(["deb/x64/csgclaw.deb"]);
+  try {
+    collectDesktopReleaseAssets({
+      version: "0.4.3",
+      goos: "linux",
+      goarch: "amd64",
+      makeDirectory,
+      outputDirectory,
+    });
+    assert.deepEqual(fs.readdirSync(outputDirectory), ["csgclaw-desktop_v0.4.3_linux_amd64.deb"]);
   } finally {
     cleanup();
   }

--- a/scripts/desktop-oss-release.mjs
+++ b/scripts/desktop-oss-release.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { collectDesktopReleaseAssets } from "./collect-desktop-release-assets.mjs";
+import {
+  desktopDownloadArtifacts,
+  desktopReleaseArtifactNames,
+  inferReleaseChannel,
+  normalizeReleaseVersion,
+  releaseTag,
+  validateReleaseChannel,
+} from "./desktop-release-artifacts.mjs";
+
+export {
+  inferReleaseChannel,
+  normalizeReleaseVersion,
+  releaseTag,
+  validateReleaseChannel,
+} from "./desktop-release-artifacts.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+const defaultOutputRoot = path.join(repositoryRoot, "desktop", "out", "oss");
+const defaultEnvironmentFile = path.join(repositoryRoot, ".desktop-release-oss.env");
+const defaultBucket = "opencsg-public-resource";
+const defaultPrefix = "csgclaw-desktop";
+const defaultPublicBaseURL =
+  "https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csgclaw-desktop";
+
+const targetDefinitions = {
+  "darwin-arm64": { goos: "darwin", goarch: "arm64", host: "darwin" },
+  "darwin-amd64": { goos: "darwin", goarch: "amd64", host: "darwin" },
+  "windows-amd64": { goos: "windows", goarch: "amd64", host: "win32" },
+};
+
+export function desktopUploadPaths(version, releaseDirectory) {
+  return desktopDownloadArtifacts(version).map(({ fileName }) =>
+    path.join(releaseDirectory, fileName));
+}
+
+export function generateDownloadsManifest({
+  version,
+  channel,
+  releaseDirectory,
+  manifestPath,
+  publicBaseURL = defaultPublicBaseURL,
+  publishedAt = new Date().toISOString(),
+  allowPartial = false,
+}) {
+  validateReleaseChannel(version, channel);
+  const artifacts = [];
+  const missing = [];
+
+  for (const definition of desktopDownloadArtifacts(version)) {
+    const { fileName } = definition;
+    const filePath = path.join(releaseDirectory, fileName);
+    if (!fs.existsSync(filePath)) {
+      missing.push(fileName);
+      continue;
+    }
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile() || stat.size === 0) {
+      throw new Error(`release artifact is empty or not a file: ${filePath}`);
+    }
+    artifacts.push({
+      platform: definition.platform,
+      arch: definition.arch,
+      url: `${publicBaseURL.replace(/\/+$/, "")}/releases/${encodeURIComponent(version)}/${fileName}`,
+      size_bytes: stat.size,
+      sha256: sha256File(filePath),
+    });
+  }
+
+  if (!allowPartial && missing.length > 0) {
+    throw new Error(`cannot generate complete downloads.json; missing: ${missing.join(", ")}`);
+  }
+  if (artifacts.length === 0) {
+    throw new Error(`no desktop installers found in ${releaseDirectory}`);
+  }
+
+  const previous = readExistingManifest(manifestPath, channel);
+  const versions = {
+    [version]: {
+      version,
+      published_at: publishedAt,
+      artifacts,
+    },
+  };
+  for (const [existingVersion, value] of Object.entries(previous?.versions || {})) {
+    if (existingVersion !== version) {
+      versions[existingVersion] = value;
+    }
+  }
+
+  const manifest = {
+    schema_version: 1,
+    channel,
+    latest: version,
+    versions,
+  };
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function readExistingManifest(manifestPath, channel) {
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (parsed.channel !== channel || parsed.schema_version !== 1 || typeof parsed.versions !== "object") {
+    throw new Error(`existing manifest has an incompatible schema: ${manifestPath}`);
+  }
+  return parsed;
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--force" || argument === "--allow-partial") {
+      options[argument.slice(2)] = true;
+      continue;
+    }
+    if (!argument.startsWith("--")) {
+      throw new Error(`unexpected argument: ${argument}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`missing value for ${argument}`);
+    }
+    options[argument.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function releaseContext(options) {
+  const version = normalizeReleaseVersion(options.version || process.env.VERSION);
+  const channel = String(
+    options.channel || process.env.DESKTOP_RELEASE_CHANNEL || inferReleaseChannel(version),
+  ).trim();
+  validateReleaseChannel(version, channel);
+  const outputRoot = path.resolve(options["output-root"] || defaultOutputRoot);
+  return {
+    version,
+    channel,
+    outputRoot,
+    releaseDirectory: options["release-directory"]
+      ? path.resolve(options["release-directory"])
+      : path.join(outputRoot, "releases", version),
+    manifestPath: path.join(outputRoot, "channels", channel, "downloads.json"),
+  };
+}
+
+function defaultTargets() {
+  if (process.platform === "darwin") {
+    return ["darwin-arm64", "darwin-amd64"];
+  }
+  if (process.platform === "win32") {
+    return ["windows-amd64"];
+  }
+  throw new Error(`desktop installer builds are not supported on ${process.platform}/${process.arch}`);
+}
+
+function requestedTargets(rawTargets) {
+  const targets = rawTargets
+    ? String(rawTargets).split(",").map((value) => value.trim()).filter(Boolean)
+    : defaultTargets();
+  for (const target of targets) {
+    const definition = targetDefinitions[target];
+    if (!definition) {
+      throw new Error(`unsupported target: ${target}`);
+    }
+    if (definition.host !== process.platform) {
+      const hostName = {
+        darwin: "macOS",
+        linux: "Linux",
+        win32: "Windows",
+      }[definition.host];
+      throw new Error(
+        `${target} must be built on ${hostName}; current host is ${process.platform}`,
+      );
+    }
+  }
+  return targets;
+}
+
+function buildDesktopInstallers(context, options) {
+  const targets = requestedTargets(options.targets);
+  fs.mkdirSync(context.releaseDirectory, { recursive: true });
+
+  for (const target of targets) {
+    const definition = targetDefinitions[target];
+    const versionTag = releaseTag(context.version);
+    for (const destination of desktopReleaseArtifactNames({
+      version: versionTag,
+      goos: definition.goos,
+      goarch: definition.goarch,
+    })) {
+      const destinationPath = path.join(context.releaseDirectory, destination);
+      if (options.force) {
+        fs.rmSync(destinationPath, { force: true });
+      } else if (fs.existsSync(destinationPath)) {
+        throw new Error(`staged artifact already exists; use --force to rebuild: ${destinationPath}`);
+      }
+    }
+
+    const makeDirectory = path.join(repositoryRoot, "desktop", "out", "make");
+    fs.rmSync(makeDirectory, { recursive: true, force: true });
+    const environment = {
+      ...process.env,
+      VERSION: versionTag,
+      TARGET_OS: definition.goos,
+      TARGET_ARCH: definition.goarch,
+    };
+    if (
+      process.platform === "darwin" &&
+      process.arch === "arm64" &&
+      definition.goos === "darwin" &&
+      definition.goarch === "amd64" &&
+      !environment.CSGCLAW_MACOS_SIGN_IDENTITY &&
+      !(environment.APPLE_ID && environment.APPLE_PASSWORD && environment.APPLE_TEAM_ID)
+    ) {
+      environment.CSGCLAW_MACOS_SKIP_SIGN = "1";
+      console.warn("building the Intel package without a temporary signature; sign and notarize it before public release");
+    }
+
+    if (process.platform !== "win32") {
+      runCommand(
+        "make",
+        [
+          "desktop-package",
+          `TARGET_OS=${definition.goos}`,
+          `TARGET_ARCH=${definition.goarch}`,
+          `VERSION=${versionTag}`,
+        ],
+        environment,
+      );
+    } else {
+      runCommand(
+        "cmd.exe",
+        ["/d", "/s", "/c", path.join(repositoryRoot, "scripts", "build.cmd"), "desktop-package"],
+        environment,
+      );
+    }
+
+    const staged = collectDesktopReleaseAssets({
+      version: versionTag,
+      goos: definition.goos,
+      goarch: definition.goarch,
+      makeDirectory,
+      outputDirectory: context.releaseDirectory,
+    });
+    for (const filePath of staged) {
+      console.log(`staged ${filePath}`);
+    }
+  }
+}
+
+function runCommand(command, args, environment = process.env) {
+  console.log(`> ${command} ${args.join(" ")}`);
+  const result = spawnSync(command, args, {
+    cwd: repositoryRoot,
+    env: environment,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} failed with exit code ${result.status}`);
+  }
+}
+
+function parseEnvironmentFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+  const values = {};
+  for (const rawLine of fs.readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const separator = line.indexOf("=");
+    if (separator < 1) {
+      throw new Error(`invalid environment line in ${filePath}: ${rawLine}`);
+    }
+    const key = line.slice(0, separator).trim();
+    let value = line.slice(separator + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+  return values;
+}
+
+async function uploadDesktopRelease(context, options) {
+  const environmentFile = path.resolve(options["env-file"] || defaultEnvironmentFile);
+  const fileEnvironment = parseEnvironmentFile(environmentFile);
+  const setting = (name, fallback = "") => process.env[name] || fileEnvironment[name] || fallback;
+  const accessKeyID = setting("OSS_ACCESS_KEY_ID");
+  const accessKeySecret = setting("OSS_ACCESS_KEY_SECRET");
+  if (!accessKeyID || !accessKeySecret) {
+    throw new Error(
+      `OSS credentials are empty; copy .desktop-release-oss.env.example to ${path.basename(environmentFile)} and fill it locally`,
+    );
+  }
+
+  const bucket = setting("OSS_BUCKET", defaultBucket);
+  const prefix = setting("OSS_PREFIX", defaultPrefix).replace(/^\/+|\/+$/g, "");
+  const region = setting("OSS_REGION", "cn-beijing");
+  const endpoint = setting("OSS_ENDPOINT", "https://oss-cn-beijing.aliyuncs.com");
+  const publicBaseURL = setting("OSS_PUBLIC_BASE_URL", defaultPublicBaseURL).replace(/\/+$/, "");
+  const ossEnvironment = {
+    ...process.env,
+    OSS_ACCESS_KEY_ID: accessKeyID,
+    OSS_ACCESS_KEY_SECRET: accessKeySecret,
+    OSS_REGION: region,
+    OSS_ENDPOINT: endpoint,
+  };
+
+  runCommand("ossutil", ["version"], ossEnvironment);
+  const manifestURL = `${publicBaseURL}/channels/${context.channel}/downloads.json`;
+  const currentResponse = await fetch(`${manifestURL}?current=${Date.now()}`, { cache: "no-store" });
+  if (currentResponse.ok) {
+    const currentManifest = await currentResponse.json();
+    if (
+      currentManifest.schema_version !== 1 ||
+      currentManifest.channel !== context.channel ||
+      typeof currentManifest.versions !== "object"
+    ) {
+      throw new Error(`remote manifest has an incompatible schema: ${manifestURL}`);
+    }
+    fs.mkdirSync(path.dirname(context.manifestPath), { recursive: true });
+    fs.writeFileSync(context.manifestPath, `${JSON.stringify(currentManifest, null, 2)}\n`);
+  } else if (currentResponse.status !== 404) {
+    throw new Error(`cannot read current manifest: HTTP ${currentResponse.status} ${manifestURL}`);
+  }
+  generateDownloadsManifest({
+    ...context,
+    publicBaseURL,
+    allowPartial: Boolean(options["allow-partial"]),
+  });
+
+  // GitHub Release also contains macOS ZIP and Linux packages. The website
+  // manifest intentionally exposes only the two DMGs and the Windows setup
+  // executable, so keep the OSS object set aligned with that public contract.
+  const releaseFiles = desktopUploadPaths(context.version, context.releaseDirectory);
+  for (const filePath of releaseFiles) {
+    const objectPath = `oss://${bucket}/${prefix}/releases/${context.version}/${path.basename(filePath)}`;
+    runCommand(
+      "ossutil",
+      ["cp", filePath, objectPath, "-u", "--cache-control", "public,max-age=31536000,immutable"],
+      ossEnvironment,
+    );
+  }
+
+  const manifestObject = `oss://${bucket}/${prefix}/channels/${context.channel}/downloads.json`;
+  runCommand(
+    "ossutil",
+    [
+      "cp",
+      context.manifestPath,
+      manifestObject,
+      "-f",
+      "--content-type",
+      "application/json",
+      "--cache-control",
+      "no-cache",
+    ],
+    ossEnvironment,
+  );
+
+  const response = await fetch(`${manifestURL}?verify=${Date.now()}`, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`uploaded manifest verification failed: HTTP ${response.status} ${manifestURL}`);
+  }
+  const uploaded = await response.json();
+  if (uploaded.latest !== context.version) {
+    throw new Error(`uploaded manifest latest is ${uploaded.latest}, expected ${context.version}`);
+  }
+  console.log(`verified ${manifestURL}`);
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/desktop-oss-release.mjs build --version <semver> [--channel <beta|release>] [--targets <list>] [--release-directory <path>] [--force]
+  node scripts/desktop-oss-release.mjs manifest --version <semver> [--channel <beta|release>] [--release-directory <path>] [--allow-partial]
+  node scripts/desktop-oss-release.mjs upload --version <semver> [--channel <beta|release>] [--release-directory <path>] [--env-file <path>]
+
+Targets:
+  darwin-arm64,darwin-amd64  Build on macOS
+  windows-amd64              Build on Windows
+
+The channel defaults to beta for prerelease versions and release for stable versions.
+`);
+}
+
+async function main(args) {
+  const [command, ...optionArgs] = args;
+  if (!command || command === "help" || command === "--help") {
+    printHelp();
+    return;
+  }
+  const options = parseOptions(optionArgs);
+  const context = releaseContext(options);
+
+  switch (command) {
+    case "build":
+      buildDesktopInstallers(context, options);
+      break;
+    case "manifest": {
+      const manifest = generateDownloadsManifest({
+        ...context,
+        publicBaseURL: options["public-base-url"] || defaultPublicBaseURL,
+        allowPartial: Boolean(options["allow-partial"]),
+      });
+      console.log(`wrote ${context.manifestPath} with ${manifest.versions[context.version].artifacts.length} installers`);
+      break;
+    }
+    case "upload":
+      await uploadDesktopRelease(context, options);
+      break;
+    default:
+      throw new Error(`unknown command: ${command}`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/desktop-oss-release.mjs
+++ b/scripts/desktop-oss-release.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { collectDesktopReleaseAssets } from "./collect-desktop-release-assets.mjs";
 import {
+  compareReleaseVersions,
   desktopDownloadArtifacts,
   desktopReleaseArtifactNames,
   inferReleaseChannel,
@@ -18,6 +19,7 @@ import {
 } from "./desktop-release-artifacts.mjs";
 
 export {
+  compareReleaseVersions,
   inferReleaseChannel,
   normalizeReleaseVersion,
   releaseTag,
@@ -85,6 +87,11 @@ export function generateDownloadsManifest({
   }
 
   const previous = readExistingManifest(manifestPath, channel);
+  if (previous?.latest && compareReleaseVersions(version, previous.latest) < 0) {
+    throw new Error(
+      `refusing to publish ${version} to ${channel}: current latest is newer (${previous.latest}); create a tag newer than or equal to ${previous.latest}`,
+    );
+  }
   const versions = {
     [version]: {
       version,

--- a/scripts/desktop-oss-release.test.mjs
+++ b/scripts/desktop-oss-release.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  desktopUploadPaths,
+  generateDownloadsManifest,
+  inferReleaseChannel,
+  normalizeReleaseVersion,
+  releaseTag,
+  validateReleaseChannel,
+} from "./desktop-oss-release.mjs";
+
+test("normalizes public desktop versions", () => {
+  assert.equal(normalizeReleaseVersion("v0.4.5-beta.1"), "0.4.5-beta.1");
+  assert.equal(normalizeReleaseVersion("0.4.5+local"), "0.4.5");
+  assert.equal(releaseTag("v0.4.5-beta.1"), "v0.4.5-beta.1");
+  assert.equal(inferReleaseChannel("0.4.5-beta.1"), "beta");
+  assert.equal(inferReleaseChannel("0.4.5"), "release");
+  assert.equal(inferReleaseChannel("v0.4.6-beta.1"), "beta");
+  assert.equal(inferReleaseChannel("v0.4.6"), "release");
+  assert.throws(() => inferReleaseChannel("v0.4.6.beta.1"), /invalid release version/);
+});
+
+test("keeps beta and release versions in their channels", () => {
+  assert.doesNotThrow(() => validateReleaseChannel("0.4.5-beta.1", "beta"));
+  assert.doesNotThrow(() => validateReleaseChannel("0.4.5", "release"));
+  assert.throws(() => validateReleaseChannel("0.4.5-beta.1", "release"), /cannot publish/);
+});
+
+test("selects only website installers for OSS upload", () => {
+  assert.deepEqual(
+    desktopUploadPaths("0.4.5-beta.1", "/release").map((file) => path.basename(file)),
+    [
+      "csgclaw-desktop_v0.4.5-beta.1_darwin_arm64.dmg",
+      "csgclaw-desktop_v0.4.5-beta.1_darwin_amd64.dmg",
+      "csgclaw-desktop_v0.4.5-beta.1_windows_amd64.exe",
+    ],
+  );
+});
+
+test("generates a downloads manifest compatible with the existing csglite schema", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "csgclaw-desktop-manifest-"));
+  const version = "0.4.5-beta.1";
+  const releaseDirectory = path.join(root, "releases", version);
+  const manifestPath = path.join(root, "channels", "beta", "downloads.json");
+  fs.mkdirSync(releaseDirectory, { recursive: true });
+  for (const suffix of ["darwin_arm64.dmg", "darwin_amd64.dmg", "windows_amd64.exe"]) {
+    fs.writeFileSync(path.join(releaseDirectory, `csgclaw-desktop_v${version}_${suffix}`), suffix);
+  }
+
+  try {
+    const manifest = generateDownloadsManifest({
+      version,
+      channel: "beta",
+      releaseDirectory,
+      manifestPath,
+      publicBaseURL: "https://downloads.example/csgclaw-desktop",
+      publishedAt: "2026-08-04T00:00:00.000Z",
+    });
+    assert.equal(manifest.latest, version);
+    assert.deepEqual(
+      manifest.versions[version].artifacts.map(({ platform, arch }) => ({ platform, arch })),
+      [
+        { platform: "macos", arch: "arm64" },
+        { platform: "macos", arch: "x86_64" },
+        { platform: "windows", arch: "x86_64" },
+      ],
+    );
+    assert.match(manifest.versions[version].artifacts[0].sha256, /^[a-f0-9]{64}$/);
+    assert.match(manifest.versions[version].artifacts[0].url, /csgclaw-desktop_v0\.4\.5-beta\.1_darwin_arm64\.dmg$/);
+    assert.equal(JSON.parse(fs.readFileSync(manifestPath, "utf8")).channel, "beta");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/desktop-oss-release.test.mjs
+++ b/scripts/desktop-oss-release.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  compareReleaseVersions,
   desktopUploadPaths,
   generateDownloadsManifest,
   inferReleaseChannel,
@@ -22,6 +23,15 @@ test("normalizes public desktop versions", () => {
   assert.equal(inferReleaseChannel("v0.4.6-beta.1"), "beta");
   assert.equal(inferReleaseChannel("v0.4.6"), "release");
   assert.throws(() => inferReleaseChannel("v0.4.6.beta.1"), /invalid release version/);
+  assert.throws(() => inferReleaseChannel("v0.4.6-beta.01"), /invalid release version/);
+});
+
+test("orders public desktop versions using SemVer precedence", () => {
+  assert.equal(compareReleaseVersions("v0.4.6", "0.4.6+build.2"), 0);
+  assert.ok(compareReleaseVersions("0.4.6", "0.4.6-rc.1") > 0);
+  assert.ok(compareReleaseVersions("0.4.6-beta.10", "0.4.6-beta.2") > 0);
+  assert.ok(compareReleaseVersions("0.4.6-beta.2", "0.4.6-beta.2.1") < 0);
+  assert.ok(compareReleaseVersions("0.4.5", "0.4.6") < 0);
 });
 
 test("keeps beta and release versions in their channels", () => {
@@ -72,6 +82,51 @@ test("generates a downloads manifest compatible with the existing csglite schema
     assert.match(manifest.versions[version].artifacts[0].sha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.versions[version].artifacts[0].url, /csgclaw-desktop_v0\.4\.5-beta\.1_darwin_arm64\.dmg$/);
     assert.equal(JSON.parse(fs.readFileSync(manifestPath, "utf8")).channel, "beta");
+
+    const repeated = generateDownloadsManifest({
+      version,
+      channel: "beta",
+      releaseDirectory,
+      manifestPath,
+      publishedAt: "2026-08-05T00:00:00.000Z",
+    });
+    assert.equal(repeated.latest, version);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects moving a channel latest backward", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "csgclaw-desktop-rollback-"));
+  const version = "0.4.5-beta.1";
+  const currentLatest = "0.4.5-beta.2";
+  const releaseDirectory = path.join(root, "releases", version);
+  const manifestPath = path.join(root, "channels", "beta", "downloads.json");
+  fs.mkdirSync(releaseDirectory, { recursive: true });
+  for (const suffix of ["darwin_arm64.dmg", "darwin_amd64.dmg", "windows_amd64.exe"]) {
+    fs.writeFileSync(path.join(releaseDirectory, `csgclaw-desktop_v${version}_${suffix}`), suffix);
+  }
+  const existingManifest = `${JSON.stringify({
+    schema_version: 1,
+    channel: "beta",
+    latest: currentLatest,
+    versions: {
+      [currentLatest]: {
+        version: currentLatest,
+        published_at: "2026-08-04T00:00:00.000Z",
+        artifacts: [],
+      },
+    },
+  }, null, 2)}\n`;
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, existingManifest);
+
+  try {
+    assert.throws(
+      () => generateDownloadsManifest({ version, channel: "beta", releaseDirectory, manifestPath }),
+      /refusing to publish 0\.4\.5-beta\.1 to beta: current latest is newer \(0\.4\.5-beta\.2\)/,
+    );
+    assert.equal(fs.readFileSync(manifestPath, "utf8"), existingManifest);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/desktop-release-artifacts.mjs
+++ b/scripts/desktop-release-artifacts.mjs
@@ -1,0 +1,90 @@
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const semanticVersionPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+const targetArtifacts = {
+  "linux-amd64": ["deb"],
+  "linux-arm64": ["deb"],
+  "darwin-arm64": ["dmg", "zip"],
+  "darwin-amd64": ["dmg", "zip"],
+  "windows-amd64": ["exe"],
+};
+
+export function normalizeReleaseVersion(rawVersion) {
+  const requested = String(rawVersion || "").trim().replace(/^v/, "");
+  const match = semanticVersionPattern.exec(requested);
+  if (!match) {
+    throw new Error(`invalid release version: ${rawVersion || "<empty>"}`);
+  }
+  const prerelease = match[4] ? `-${match[4]}` : "";
+  return `${match[1]}.${match[2]}.${match[3]}${prerelease}`;
+}
+
+export function releaseTag(version) {
+  return `v${normalizeReleaseVersion(version)}`;
+}
+
+export function inferReleaseChannel(version) {
+  return normalizeReleaseVersion(version).includes("-") ? "beta" : "release";
+}
+
+export function validateReleaseChannel(version, channel) {
+  if (channel !== "beta" && channel !== "release") {
+    throw new Error(`channel must be beta or release, got: ${channel}`);
+  }
+  const prerelease = normalizeReleaseVersion(version).includes("-");
+  if (channel === "beta" && !prerelease) {
+    throw new Error(`beta channel requires a prerelease version such as ${version}-beta.1`);
+  }
+  if (channel === "release" && prerelease) {
+    throw new Error("release channel cannot publish a prerelease version");
+  }
+}
+
+export function desktopReleaseArtifactNames({ version, goos, goarch }) {
+  const extensions = targetArtifacts[`${goos}-${goarch}`];
+  if (!extensions) {
+    throw new Error(`unsupported desktop release target: ${goos}/${goarch}`);
+  }
+  const prefix = `csgclaw-desktop_${releaseTag(version)}_${goos}_${goarch}`;
+  return extensions.map((extension) => `${prefix}.${extension}`);
+}
+
+export function desktopDownloadArtifacts(version) {
+  return [
+    {
+      fileName: desktopReleaseArtifactNames({ version, goos: "darwin", goarch: "arm64" })[0],
+      platform: "macos",
+      arch: "arm64",
+    },
+    {
+      fileName: desktopReleaseArtifactNames({ version, goos: "darwin", goarch: "amd64" })[0],
+      platform: "macos",
+      arch: "x86_64",
+    },
+    {
+      fileName: desktopReleaseArtifactNames({ version, goos: "windows", goarch: "amd64" })[0],
+      platform: "windows",
+      arch: "x86_64",
+    },
+  ];
+}
+
+function main(args) {
+  const [command, version] = args;
+  if (command !== "channel" || !version || args.length !== 2) {
+    throw new Error("usage: desktop-release-artifacts.mjs channel <version>");
+  }
+  process.stdout.write(`${inferReleaseChannel(version)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/desktop-release-artifacts.mjs
+++ b/scripts/desktop-release-artifacts.mjs
@@ -12,14 +12,74 @@ const targetArtifacts = {
   "windows-amd64": ["exe"],
 };
 
-export function normalizeReleaseVersion(rawVersion) {
+function parseReleaseVersion(rawVersion) {
   const requested = String(rawVersion || "").trim().replace(/^v/, "");
   const match = semanticVersionPattern.exec(requested);
   if (!match) {
     throw new Error(`invalid release version: ${rawVersion || "<empty>"}`);
   }
+  const prereleaseIdentifiers = match[4] ? match[4].split(".") : [];
+  if (
+    prereleaseIdentifiers.some(
+      (identifier) => /^\d+$/.test(identifier) && identifier.length > 1 && identifier.startsWith("0"),
+    )
+  ) {
+    throw new Error(`invalid release version: ${rawVersion || "<empty>"}`);
+  }
   const prerelease = match[4] ? `-${match[4]}` : "";
-  return `${match[1]}.${match[2]}.${match[3]}${prerelease}`;
+  return {
+    normalized: `${match[1]}.${match[2]}.${match[3]}${prerelease}`,
+    core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    prerelease: prereleaseIdentifiers,
+  };
+}
+
+export function normalizeReleaseVersion(rawVersion) {
+  return parseReleaseVersion(rawVersion).normalized;
+}
+
+export function compareReleaseVersions(leftVersion, rightVersion) {
+  const left = parseReleaseVersion(leftVersion);
+  const right = parseReleaseVersion(rightVersion);
+
+  for (let index = 0; index < left.core.length; index += 1) {
+    if (left.core[index] < right.core[index]) {
+      return -1;
+    }
+    if (left.core[index] > right.core[index]) {
+      return 1;
+    }
+  }
+
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    if (left.prerelease.length === right.prerelease.length) {
+      return 0;
+    }
+    return left.prerelease.length === 0 ? 1 : -1;
+  }
+
+  const identifierCount = Math.min(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < identifierCount; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === rightIdentifier) {
+      continue;
+    }
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return BigInt(leftIdentifier) < BigInt(rightIdentifier) ? -1 : 1;
+    }
+    if (leftNumeric !== rightNumeric) {
+      return leftNumeric ? -1 : 1;
+    }
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+
+  if (left.prerelease.length === right.prerelease.length) {
+    return 0;
+  }
+  return left.prerelease.length < right.prerelease.length ? -1 : 1;
 }
 
 export function releaseTag(version) {

--- a/scripts/package-desktop-backend.sh
+++ b/scripts/package-desktop-backend.sh
@@ -10,13 +10,13 @@ GOOS_TARGET="$1"
 GOARCH_TARGET="$2"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-OUTPUT_ROOT="$ROOT_DIR/dist/desktop-input/${GOOS_TARGET}-${GOARCH_TARGET}"
+OUTPUT_ROOT="$ROOT_DIR/desktop/out/input/${GOOS_TARGET}-${GOARCH_TARGET}"
 BACKEND_ROOT="$OUTPUT_ROOT/backend"
 TEMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEMP_ROOT"' EXIT
 
 case "$OUTPUT_ROOT" in
-  "$ROOT_DIR"/dist/desktop-input/*) ;;
+  "$ROOT_DIR"/desktop/out/input/*) ;;
   *)
     printf 'refuse to replace unexpected desktop output path: %s\n' "$OUTPUT_ROOT" >&2
     exit 1


### PR DESCRIPTION
- Publish signed macOS and Windows desktop installers to immutable OSS version paths after the GitHub Release succeeds.
- Generate beta and release channel manifests from SemVer tags, and mark prerelease tags as GitHub Pre-releases.
- Reuse the desktop artifact contract across local Make targets and CI while loading OSS credentials from the shared `oss-publish` environment.
