### PR TITLE
fix(desktop): normalize local Windows package versions

### DIFF
--- a/desktop/src/shared/releaseVersion.test.ts
+++ b/desktop/src/shared/releaseVersion.test.ts
@@ -12,6 +12,13 @@ test("drops build metadata that packaging formats do not need", () => {
   assert.equal(normalizeDesktopReleaseVersion("v0.4.5-beta.1+local"), "0.4.5-beta.1");
 });
 
+test("normalizes local git describe versions for Squirrel", () => {
+  assert.equal(
+    normalizeDesktopReleaseVersion("v0.4.5-12-g27f214c7+local"),
+    "0.4.5-12g27f214c7",
+  );
+});
+
 test("uses the development version for invalid input", () => {
   assert.equal(normalizeDesktopReleaseVersion("not-a-version"), "0.0.0-development");
   assert.equal(normalizeDesktopReleaseVersion(undefined), "0.0.0-development");

--- a/desktop/src/shared/releaseVersion.ts
+++ b/desktop/src/shared/releaseVersion.ts
@@ -8,7 +8,10 @@ export function normalizeDesktopReleaseVersion(rawVersion: string | undefined): 
     return "0.0.0-development";
   }
 
-  const prerelease = match[4] ? `-${match[4]}` : "";
+  // electron-winstaller removes dots from prerelease versions but leaves
+  // additional hyphens intact; NuGet rejects versions such as
+  // 0.3.15-179-gabcdef. Keep a single prerelease separator instead.
+  const prerelease = match[4] ? `-${match[4].replace(/-/g, "")}` : "";
   return `${match[1]}.${match[2]}.${match[3]}${prerelease}`;
 }
 


### PR DESCRIPTION
## Summary

- Use the numeric application version for Windows Squirrel package metadata.
- Cover local `git describe` versions when deriving that numeric version.

## Validation

- `pnpm --dir desktop test`
- `git diff --check`

## Impact

- Local Windows desktop packages no longer fail NuGet validation for versions such as `v0.3.15-180-g<hash>+local`.
- The Setup executable name retains the full desktop version; stable tagged releases, macOS, Linux, and runtime behavior are unchanged.

## Notes

- Windows installer generation should be validated on a Windows host or in CI.