### PR TITLE
fix(web): align attachments and gate unsupported downloads

### DIFF
--- a/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
@@ -338,13 +338,19 @@ export function MessageAttachments({
           {files.map((attachment) => {
             const downloadURL = resolveRequestPath(attachment.download_url);
             const inlinePreviewable = isInlinePreviewableMediaType(attachment.media_type);
+            const filename = splitAttachmentFilename(attachment.name || t("attachment"));
             const content = (
               <>
                 <span className="attachment-file-icon" aria-hidden="true">
                   <FileText size={18} />
                 </span>
                 <span className="attachment-draft-meta">
-                  <span className="attachment-name truncate">{attachment.name || t("attachment")}</span>
+                  <span className="attachment-name" title={attachment.name || t("attachment")}>
+                    <span className="attachment-name-stem">{filename.stem}</span>
+                    {filename.extension ? (
+                      <span className="attachment-name-extension">{filename.extension}</span>
+                    ) : null}
+                  </span>
                   <span className="attachment-size">{formatAttachmentSize(attachment.size_bytes)}</span>
                 </span>
               </>

--- a/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationAttachments.tsx
@@ -337,6 +337,7 @@ export function MessageAttachments({
         <div className="message-file-list">
           {files.map((attachment) => {
             const downloadURL = resolveRequestPath(attachment.download_url);
+            const inlinePreviewable = isInlinePreviewableMediaType(attachment.media_type);
             const content = (
               <>
                 <span className="attachment-file-icon" aria-hidden="true">
@@ -350,29 +351,23 @@ export function MessageAttachments({
             );
             return (
               <Tooltip key={attachment.id} content={attachment.name}>
-                {isInlinePreviewableMediaType(attachment.media_type) ? (
-                  <button
-                    type="button"
-                    className="message-file-attachment"
-                    aria-label={t("previewAttachmentNamed", { name: attachment.name })}
-                    onClick={() =>
-                      setPreview({
-                        downloadURL,
-                        id: attachment.id,
-                        mediaType: attachment.media_type,
-                        name: attachment.name,
-                        previewURL: resolveRequestPath(attachment.preview_url || attachment.download_url),
-                        requiresFetch: true,
-                      })
-                    }
-                  >
-                    {content}
-                  </button>
-                ) : (
-                  <a className="message-file-attachment" href={downloadURL} download referrerPolicy="no-referrer">
-                    {content}
-                  </a>
-                )}
+                <button
+                  type="button"
+                  className="message-file-attachment"
+                  aria-label={t("previewAttachmentNamed", { name: attachment.name })}
+                  onClick={() =>
+                    setPreview({
+                      downloadURL,
+                      id: attachment.id,
+                      mediaType: attachment.media_type,
+                      name: attachment.name,
+                      previewURL: resolveRequestPath(attachment.preview_url || attachment.download_url),
+                      requiresFetch: inlinePreviewable,
+                    })
+                  }
+                >
+                  {content}
+                </button>
               </Tooltip>
             );
           })}

--- a/web/app/src/components/business/ConversationPane/ConversationPane.css
+++ b/web/app/src/components/business/ConversationPane/ConversationPane.css
@@ -1405,6 +1405,14 @@ button.composer-working-item:active {
   margin-left: auto;
 }
 
+.message-row.own .message-attachment-grid {
+  justify-content: end;
+}
+
+.message-row.own .message-file-list {
+  justify-items: end;
+}
+
 .message-attachment-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(104px, 148px));

--- a/web/app/tests/components/ConversationAttachments.test.tsx
+++ b/web/app/tests/components/ConversationAttachments.test.tsx
@@ -51,6 +51,16 @@ describe("MessageAttachments", () => {
         created_at: "2026-07-10T00:00:00Z",
         download_url: "/api/v1/attachments/att-file?token=file-token",
       },
+      {
+        id: "att-unsupported",
+        name: "report.docx",
+        kind: "file",
+        media_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        size_bytes: 256,
+        sha256: "unsupported-sha",
+        created_at: "2026-07-10T00:00:00Z",
+        download_url: "/api/v1/attachments/att-unsupported?token=unsupported-token",
+      },
     ];
 
     try {
@@ -76,6 +86,16 @@ describe("MessageAttachments", () => {
         credentials: "same-origin",
         signal: expect.any(AbortSignal),
       });
+      await user.click(screen.getByRole("button", { name: "Close" }));
+
+      await user.click(screen.getByRole("button", { name: "Preview attachment: report.docx" }));
+      expect(screen.getByRole("dialog", { name: "report.docx" })).toBeInTheDocument();
+      expect(screen.getByText("Preview unavailable")).toBeInTheDocument();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const unsupportedDownload = screen.getByRole("link", { name: "download" }) as HTMLAnchorElement;
+      expect(new URL(unsupportedDownload.href).pathname).toBe(
+        "/v1/sandboxes/csgship-test/api/v1/attachments/att-unsupported",
+      );
     } finally {
       base.remove();
       vi.unstubAllGlobals();

--- a/web/app/tests/components/ConversationAttachments.test.tsx
+++ b/web/app/tests/components/ConversationAttachments.test.tsx
@@ -72,6 +72,10 @@ describe("MessageAttachments", () => {
       expect(image).toHaveAttribute("loading", "lazy");
       expect(image).toHaveAttribute("referrerpolicy", "no-referrer");
 
+      const unsupportedName = screen.getByTitle("report.docx");
+      expect(unsupportedName.querySelector(".attachment-name-stem")).toHaveTextContent("report");
+      expect(unsupportedName.querySelector(".attachment-name-extension")).toHaveTextContent(".docx");
+
       await user.click(screen.getByRole("button", { name: "Preview attachment: diagram.png" }));
       expect(screen.getByRole("dialog", { name: "diagram.png" })).toBeInTheDocument();
       const download = screen.getByRole("link", { name: "download" }) as HTMLAnchorElement;


### PR DESCRIPTION
## Summary

- right-align attachments in messages sent by the current user
- truncate sent attachment names like composer cards while keeping file extensions visible
- open the attachment preview dialog for unsupported file types instead of downloading immediately
- let users explicitly choose whether to download after seeing the unavailable-preview state
