### PR TITLE
fix(desktop): normalize local Windows package versions

### DIFF
--- a/desktop/src/shared/releaseVersion.test.ts
+++ b/desktop/src/shared/releaseVersion.test.ts
@@ -15,7 +15,11 @@ test("drops build metadata that packaging formats do not need", () => {
 test("normalizes local git describe versions for Squirrel", () => {
   assert.equal(
     normalizeDesktopReleaseVersion("v0.4.5-12-g27f214c7+local"),
-    "0.4.5-12g27f214c7",
+    "0.4.5-dev12g27f214c7",
+  );
+  assert.equal(
+    normalizeDesktopReleaseVersion("v0.4.5-test6-12-g27f214c7+local"),
+    "0.4.5-test6dev12g27f214c7",
   );
 });
 

--- a/desktop/src/shared/releaseVersion.ts
+++ b/desktop/src/shared/releaseVersion.ts
@@ -1,5 +1,6 @@
 const semanticVersionPattern =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const gitDescribePrereleasePattern = /^(.*?)(?:-)?(\d+)-g([0-9a-f]+)(-dirty)?$/i;
 
 export function normalizeDesktopReleaseVersion(rawVersion: string | undefined): string {
   const requested = (rawVersion || "").trim().replace(/^v/, "");
@@ -8,11 +9,19 @@ export function normalizeDesktopReleaseVersion(rawVersion: string | undefined): 
     return "0.0.0-development";
   }
 
-  // electron-winstaller removes dots from prerelease versions but leaves
-  // additional hyphens intact; NuGet rejects versions such as
-  // 0.3.15-179-gabcdef. Keep a single prerelease separator instead.
-  const prerelease = match[4] ? `-${match[4].replace(/-/g, "")}` : "";
-  return `${match[1]}.${match[2]}.${match[3]}${prerelease}`;
+  const prerelease = match[4];
+  if (prerelease) {
+    const gitDescribeMatch = gitDescribePrereleasePattern.exec(prerelease);
+    if (gitDescribeMatch) {
+      const [, label, distance, commit, dirty] = gitDescribeMatch;
+      const normalizedLabel = label?.replace(/[^0-9A-Za-z]/g, "") || "";
+      const prereleaseLabel = normalizedLabel ? `${normalizedLabel}dev` : "dev";
+      const normalizedPrerelease = `${prereleaseLabel}${distance}g${commit}${dirty ? "dirty" : ""}`;
+      return `${match[1]}.${match[2]}.${match[3]}-${normalizedPrerelease}`;
+    }
+    return `${match[1]}.${match[2]}.${match[3]}-${prerelease}`;
+  }
+  return `${match[1]}.${match[2]}.${match[3]}`;
 }
 
 export function numericDesktopAppVersion(releaseVersion: string): string {


### PR DESCRIPTION
## Summary

- Convert only local `git describe` suffixes to the single, alphabetic prerelease label required by the bundled Squirrel/NuGet toolchain.
- Preserve stable and tagged prerelease desktop versions unchanged.
- Cover stable-tag and prerelease-tag local describe forms.

## Validation

- `pnpm --dir desktop test`
- Verified the electron-winstaller conversion chain for local, stable-tag, and prerelease-tag versions.
- `git diff --check`

## Impact

- Local Windows desktop packages no longer fail NuGet validation for versions such as `v0.3.15-180-g<hash>+local`.
- Official stable and prerelease release tags, macOS, Linux, and runtime behavior remain unchanged.

## Notes

- Supersedes the incomplete suffix normalization in #444.
- Windows installer generation should be validated on a Windows host or in CI.