### PR TITLE
fix(desktop): prevent crash when reopening during shutdown

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm run build && node --test dist/main/desktopLogger.test.js dist/main/navigationPolicy.test.js dist/main/sidecar/childEnvironment.test.js dist/main/sidecar/systemProxy.test.js dist/main/updatePolicy.test.js dist/preload/index.test.js dist/shared/desktopEnvironment.test.js dist/shared/desktopTheme.test.js dist/shared/releaseVersion.test.js",
+    "test": "pnpm run build && node --test dist/main/deferredRelaunch.test.js dist/main/desktopLogger.test.js dist/main/navigationPolicy.test.js dist/main/sidecar/childEnvironment.test.js dist/main/sidecar/systemProxy.test.js dist/main/updatePolicy.test.js dist/preload/index.test.js dist/shared/desktopEnvironment.test.js dist/shared/desktopTheme.test.js dist/shared/releaseVersion.test.js",
     "start": "pnpm run build && electron-forge start",
     "make": "pnpm run build && electron-forge make",
     "publish": "pnpm run build && electron-forge publish"

--- a/desktop/src/main/appLifecycle.ts
+++ b/desktop/src/main/appLifecycle.ts
@@ -15,6 +15,7 @@ import {
 } from "../shared/desktopBridge.types";
 import { DesktopPlatform } from "../shared/desktopEnvironment";
 import { shouldUseDarkDockIcon } from "../shared/desktopTheme";
+import { DeferredRelaunch } from "./deferredRelaunch";
 import { logDesktopError, logDesktopInfo } from "./desktopLogger";
 import { registerIPCHandlers } from "./ipcHandlers";
 import { desktopIconResourcePath, isMacOSDesktop, windowsAppIconPath } from "./platform";
@@ -26,6 +27,7 @@ export class AppLifecycle {
   private cleanupIPC: (() => void) | null = null;
   private cleanupDockThemeIcon: (() => void) | null = null;
   private desktopThemeSource: DesktopThemeSource = "system";
+  private readonly deferredRelaunch = new DeferredRelaunch();
   private quitting = false;
   private recoveryActive = false;
   private rendererOrigin = "";
@@ -103,6 +105,12 @@ export class AppLifecycle {
   }
 
   show(): void {
+    if (this.quitting) {
+      if (this.deferredRelaunch.request()) {
+        logDesktopInfo("quit-relaunch-requested");
+      }
+      return;
+    }
     this.windowManager?.showAndFocus();
   }
 
@@ -129,6 +137,9 @@ export class AppLifecycle {
     this.tray?.destroy();
     this.tray = null;
     await this.supervisor?.stop("app-quit");
+    if (this.deferredRelaunch.scheduleIfRequested(() => app.relaunch())) {
+      logDesktopInfo("quit-relaunch-scheduled");
+    }
     this.shutdownComplete = true;
     logDesktopInfo("shutdown-complete");
     app.quit();

--- a/desktop/src/main/deferredRelaunch.test.ts
+++ b/desktop/src/main/deferredRelaunch.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DeferredRelaunch } from "./deferredRelaunch";
+
+test("does not schedule a relaunch without an open request", () => {
+  const deferred = new DeferredRelaunch();
+  let schedules = 0;
+
+  assert.equal(deferred.scheduleIfRequested(() => schedules++), false);
+  assert.equal(schedules, 0);
+});
+
+test("coalesces repeated open requests into one relaunch", () => {
+  const deferred = new DeferredRelaunch();
+  let schedules = 0;
+
+  assert.equal(deferred.request(), true);
+  assert.equal(deferred.request(), false);
+  assert.equal(deferred.scheduleIfRequested(() => schedules++), true);
+  assert.equal(deferred.scheduleIfRequested(() => schedules++), false);
+  assert.equal(schedules, 1);
+});

--- a/desktop/src/main/deferredRelaunch.ts
+++ b/desktop/src/main/deferredRelaunch.ts
@@ -1,0 +1,21 @@
+export class DeferredRelaunch {
+  private requested = false;
+  private scheduled = false;
+
+  request(): boolean {
+    if (this.requested) {
+      return false;
+    }
+    this.requested = true;
+    return true;
+  }
+
+  scheduleIfRequested(schedule: () => void): boolean {
+    if (!this.requested || this.scheduled) {
+      return false;
+    }
+    this.scheduled = true;
+    schedule();
+    return true;
+  }
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -48,6 +48,13 @@ const (
 
 const agentListRuntimeProbeConcurrency = 4
 
+const stopRunningSandboxAgentsConcurrency = 4
+
+var (
+	stopRunningSandboxAgentsTimeout    = 3 * time.Second
+	sandboxShutdownAvailabilityTimeout = time.Second
+)
+
 var localIPv4Resolver = localIPv4
 
 var osRemoveAll = os.RemoveAll
@@ -2130,27 +2137,90 @@ func (s *Service) StopRunningSandboxAgents(ctx context.Context) error {
 	if s == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	s.mu.RLock()
 	agents := sortedAgentsFromMap(s.agents)
 	s.mu.RUnlock()
 
-	var stopErr error
+	candidates := agents[:0]
 	for _, a := range agents {
-		if err := ctx.Err(); err != nil {
-			return errors.Join(stopErr, err)
+		if isGatewayRuntimeKind(strings.TrimSpace(a.RuntimeKind)) {
+			candidates = append(candidates, a)
 		}
-		if !isGatewayRuntimeKind(strings.TrimSpace(a.RuntimeKind)) {
-			continue
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, stopRunningSandboxAgentsTimeout)
+	defer cancel()
+	if err := s.checkSandboxProviderForShutdown(shutdownCtx); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
-		live := s.hydrateAgentStatus(ctx, a)
-		if !isRuntimeRunning(live) {
-			continue
+		slog.Info("sandbox provider unavailable during shutdown; skipping sandbox agent stops",
+			"provider", s.sandboxProviderName(),
+			"agent_count", len(candidates),
+			"error", err,
+		)
+		return nil
+	}
+
+	workers := min(stopRunningSandboxAgentsConcurrency, len(candidates))
+	jobs := make(chan Agent)
+	results := make(chan error, len(candidates))
+	for range workers {
+		go func() {
+			for a := range jobs {
+				live := s.hydrateAgentStatus(shutdownCtx, a)
+				if !isRuntimeRunning(live) {
+					results <- nil
+					continue
+				}
+				_, err := s.Stop(shutdownCtx, live.ID)
+				if err != nil {
+					err = fmt.Errorf("%s: %w", live.Name, err)
+				}
+				results <- err
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, a := range candidates {
+			select {
+			case jobs <- a:
+			case <-shutdownCtx.Done():
+				return
+			}
 		}
-		if _, err := s.Stop(ctx, live.ID); err != nil {
-			stopErr = errors.Join(stopErr, fmt.Errorf("%s: %w", live.Name, err))
+	}()
+
+	var stopErr error
+	for range candidates {
+		select {
+		case err := <-results:
+			stopErr = errors.Join(stopErr, err)
+		case <-shutdownCtx.Done():
+			return errors.Join(stopErr, fmt.Errorf("stop running sandbox agents: %w", shutdownCtx.Err()))
 		}
 	}
 	return stopErr
+}
+
+func (s *Service) checkSandboxProviderForShutdown(ctx context.Context) error {
+	if s == nil || s.sandbox == nil {
+		return nil
+	}
+	checker, ok := s.sandbox.(sandbox.AvailabilityChecker)
+	if !ok {
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, sandboxShutdownAvailabilityTimeout)
+	defer cancel()
+	return checker.CheckAvailability(probeCtx)
 }
 
 func (s *Service) startupAgentCandidates() []Agent {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -78,10 +78,15 @@ type fakeRuntime struct {
 }
 
 type fakeProvider struct {
-	open func(context.Context, string) (sandbox.Runtime, error)
+	name              string
+	open              func(context.Context, string) (sandbox.Runtime, error)
+	checkAvailability func(context.Context) error
 }
 
 func (f fakeProvider) Name() string {
+	if f.name != "" {
+		return f.name
+	}
 	return "fake"
 }
 
@@ -94,6 +99,13 @@ func (f fakeProvider) Open(ctx context.Context, homeDir string) (sandbox.Runtime
 
 func (fakeProvider) ListImages(context.Context, string) ([]string, error) {
 	return []string{}, nil
+}
+
+func (f fakeProvider) CheckAvailability(ctx context.Context) error {
+	if f.checkAvailability != nil {
+		return f.checkAvailability(ctx)
+	}
+	return nil
 }
 
 func (f *fakeRuntime) Create(context.Context, sandbox.CreateSpec) (sandbox.Instance, error) {
@@ -9268,6 +9280,152 @@ func TestStopRunningSandboxAgentsStopsOnlyLiveSandboxRuntimes(t *testing.T) {
 	alice, ok := svc.Agent("u-alice")
 	if !ok || alice.Status != string(agentruntime.StateStopped) {
 		t.Fatalf("Agent(u-alice) = %+v, %v, want stopped", alice, ok)
+	}
+}
+
+func TestStopRunningSandboxAgentsSkipsAllStopsWhenProviderIsUnavailable(t *testing.T) {
+	checks := 0
+	stops := 0
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{},
+		"manager-image:test",
+		"",
+		WithSandboxProvider(fakeProvider{
+			name: config.DockerProvider,
+			checkAvailability: func(context.Context) error {
+				checks++
+				return fmt.Errorf("%w: docker engine stopped", sandbox.ErrUnavailable)
+			},
+		}),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindPicoClawSandbox,
+			stop: func(context.Context, agentruntime.Handle) (agentruntime.State, error) {
+				stops++
+				return agentruntime.StateStopped, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	for _, id := range []string{"agent-alice", "agent-bob"} {
+		svc.agents[id] = Agent{
+			ID:          id,
+			Name:        strings.TrimPrefix(id, "agent-"),
+			RuntimeID:   "rt-" + id,
+			RuntimeKind: RuntimeKindPicoClawSandbox,
+			Status:      string(agentruntime.StateRunning),
+		}
+	}
+
+	if err := svc.StopRunningSandboxAgents(context.Background()); err != nil {
+		t.Fatalf("StopRunningSandboxAgents() error = %v", err)
+	}
+	if checks != 1 {
+		t.Fatalf("availability checks = %d, want 1", checks)
+	}
+	if stops != 0 {
+		t.Fatalf("stop calls = %d, want 0", stops)
+	}
+}
+
+func TestStopRunningSandboxAgentsStopsAgentsConcurrently(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{},
+		"manager-image:test",
+		"",
+		WithSandboxProvider(fakeProvider{name: config.DockerProvider}),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindPicoClawSandbox,
+			stop: func(ctx context.Context, handle agentruntime.Handle) (agentruntime.State, error) {
+				started <- handle.RuntimeID
+				select {
+				case <-release:
+					return agentruntime.StateStopped, nil
+				case <-ctx.Done():
+					return agentruntime.StateUnknown, ctx.Err()
+				}
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	for _, id := range []string{"agent-alice", "agent-bob"} {
+		svc.agents[id] = Agent{
+			ID:          id,
+			Name:        strings.TrimPrefix(id, "agent-"),
+			RuntimeID:   "rt-" + id,
+			RuntimeKind: RuntimeKindPicoClawSandbox,
+			Status:      string(agentruntime.StateRunning),
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.StopRunningSandboxAgents(context.Background())
+	}()
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("sandbox agent stops did not start concurrently")
+		}
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("StopRunningSandboxAgents() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StopRunningSandboxAgents() did not finish")
+	}
+}
+
+func TestStopRunningSandboxAgentsHonorsTotalTimeout(t *testing.T) {
+	originalTimeout := stopRunningSandboxAgentsTimeout
+	stopRunningSandboxAgentsTimeout = 25 * time.Millisecond
+	t.Cleanup(func() {
+		stopRunningSandboxAgentsTimeout = originalTimeout
+	})
+
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{},
+		"manager-image:test",
+		"",
+		WithSandboxProvider(fakeProvider{name: config.DockerProvider}),
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindPicoClawSandbox,
+			stop: func(ctx context.Context, _ agentruntime.Handle) (agentruntime.State, error) {
+				<-ctx.Done()
+				return agentruntime.StateUnknown, ctx.Err()
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["agent-alice"] = Agent{
+		ID:          "agent-alice",
+		Name:        "alice",
+		RuntimeID:   "rt-agent-alice",
+		RuntimeKind: RuntimeKindPicoClawSandbox,
+		Status:      string(agentruntime.StateRunning),
+	}
+
+	startedAt := time.Now()
+	err = svc.StopRunningSandboxAgents(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("StopRunningSandboxAgents() error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("StopRunningSandboxAgents() elapsed = %s, want bounded shutdown", elapsed)
 	}
 }
 

--- a/internal/sandbox/dockercli/provider.go
+++ b/internal/sandbox/dockercli/provider.go
@@ -37,6 +37,23 @@ func (Provider) Name() string {
 	return providerName
 }
 
+// CheckAvailability verifies both that the Docker CLI can run and that its
+// configured engine is reachable. Unlike construction-time path checks, this
+// catches Docker Desktop being installed but stopped.
+func (p Provider) CheckAvailability(ctx context.Context) error {
+	if strings.TrimSpace(p.path) == "" {
+		return fmt.Errorf("docker path is required")
+	}
+	if p.runner == nil {
+		return fmt.Errorf("docker command runner is required")
+	}
+	result, err := p.runner.Run(ctx, CommandRequest{
+		Path: p.path,
+		Args: []string{"info", "--format", "{{.ServerVersion}}"},
+	})
+	return wrapRunError("docker info", result, err)
+}
+
 func (p Provider) Open(_ context.Context, _ string) (sandbox.Runtime, error) {
 	return &Runtime{
 		path:   p.path,
@@ -50,6 +67,7 @@ type Runtime struct {
 }
 
 var _ sandbox.Provider = Provider{}
+var _ sandbox.AvailabilityChecker = Provider{}
 var _ sandbox.Runtime = (*Runtime)(nil)
 
 func (r *Runtime) Create(ctx context.Context, spec sandbox.CreateSpec) (sandbox.Instance, error) {

--- a/internal/sandbox/dockercli/provider_test.go
+++ b/internal/sandbox/dockercli/provider_test.go
@@ -16,8 +16,21 @@ import (
 
 func TestProviderImplementsSandboxProvider(t *testing.T) {
 	var _ sandbox.Provider = NewProvider()
+	var _ sandbox.AvailabilityChecker = NewProvider()
 	if got, want := NewProvider().Name(), "docker"; got != want {
 		t.Fatalf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestCheckAvailabilityBuildsDockerInfoArgs(t *testing.T) {
+	runner := &fakeRunner{results: []fakeResult{{result: CommandResult{Stdout: []byte("28.0.0\n")}}}}
+	provider := NewProvider(WithPath("/usr/local/bin/docker"), WithRunner(runner))
+
+	if err := provider.CheckAvailability(context.Background()); err != nil {
+		t.Fatalf("CheckAvailability() error = %v", err)
+	}
+	if got, want := runner.requests[0].Args, []string{"info", "--format", "{{.ServerVersion}}"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CheckAvailability() args = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -46,6 +46,14 @@ type Provider interface {
 	ListImages(ctx context.Context, homeDir string) ([]string, error)
 }
 
+// AvailabilityChecker is an optional provider capability for verifying that
+// the provider control plane can accept lifecycle operations. Callers should
+// bound checks with a short context deadline because an unavailable daemon must
+// not delay application shutdown.
+type AvailabilityChecker interface {
+	CheckAvailability(ctx context.Context) error
+}
+
 // Runtime manages sandbox instances under one sandbox home.
 type Runtime interface {
 	// Create creates and starts an instance from spec.

--- a/internal/sandboxproviders/docker_provider_test.go
+++ b/internal/sandboxproviders/docker_provider_test.go
@@ -98,6 +98,9 @@ func TestDockerServiceOptionWiresProvider(t *testing.T) {
 	if got.Name() != config.DockerProvider {
 		t.Fatalf("sandbox provider name = %q, want %q", got.Name(), config.DockerProvider)
 	}
+	if _, ok := got.(sandbox.AvailabilityChecker); !ok {
+		t.Fatalf("sandbox provider = %T, want shutdown availability checker", got)
+	}
 }
 
 func TestDockerProviderDefersCLIAvailabilityUntilOpen(t *testing.T) {

--- a/internal/sandboxproviders/registry.go
+++ b/internal/sandboxproviders/registry.go
@@ -81,6 +81,17 @@ func (p deferredAvailabilityProvider) ListImages(ctx context.Context, homeDir st
 	return p.provider.ListImages(ctx, homeDir)
 }
 
+func (p deferredAvailabilityProvider) CheckAvailability(ctx context.Context) error {
+	if err := Availability(p.cfg); err != nil {
+		return err
+	}
+	checker, ok := p.provider.(sandbox.AvailabilityChecker)
+	if !ok {
+		return nil
+	}
+	return checker.CheckAvailability(ctx)
+}
+
 // ServiceOptions resolves the configured sandbox provider against the set of
 // providers compiled into the current binary.
 func ServiceOptions(cfg config.SandboxConfig) ([]agent.ServiceOption, error) {


### PR DESCRIPTION
- Prevent the desktop app from appearing to crash when reopened before the previous process finishes shutting down.
- Relaunch automatically after shutdown completes instead of opening a window against the stopped local service.
- Bound Docker sandbox-agent shutdown with a single availability probe and concurrent stops.
