### PR TITLE
feat(template): improve community publishing flow

### DIFF
--- a/cli/template/hub.go
+++ b/cli/template/hub.go
@@ -96,7 +96,7 @@ func (c cmd) runPublish(ctx context.Context, run *command.Context, args []string
 	fs := run.NewFlagSet("template publish", run.Program+" template publish --agent <id> [flags]", "Publish an agent as a template.")
 	agentID := fs.String("agent", "", "existing agent id to publish")
 	registry := fs.String("registry", "official", "template registry to publish into")
-	name := fs.String("name", "", "template name (starts with a letter; letters, numbers, and underscores only)")
+	name := fs.String("name", "", "template name (starts with a letter; up to 24 letters, numbers, underscores, or hyphens)")
 	description := fs.String("description", "", "template description")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -31,7 +31,7 @@ var (
 	ErrTemplateNotFound       = errors.New("hub template not found")
 	ErrTemplateIDRequired     = errors.New("hub template id is required")
 	ErrTemplateNameRequired   = errors.New("hub template name is required")
-	ErrTemplateNameInvalid    = errors.New("hub template name must start with an English letter and contain only English letters, numbers, and underscores")
+	ErrTemplateNameInvalid    = errors.New("hub template name must start with an English letter, be at most 24 characters long, and contain only English letters, numbers, underscores, or hyphens")
 	ErrRuntimeKindRequired    = errors.New("hub runtime kind is required")
 	ErrWorkspaceDirRequired   = errors.New("hub workspace directory is required")
 	ErrWorkspacePathUnsafe    = errors.New("hub workspace path is unsafe")

--- a/internal/template/template_manifest.go
+++ b/internal/template/template_manifest.go
@@ -12,7 +12,7 @@ import (
 
 const currentAgentFileSchemaVersion = "agentfile/v1"
 
-var publishTemplateNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+var publishTemplateNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]{0,23}$`)
 
 func ValidatePublishTemplateName(name string) error {
 	name = strings.TrimSpace(name)

--- a/internal/template/template_manifest_test.go
+++ b/internal/template/template_manifest_test.go
@@ -68,12 +68,12 @@ func TestValidateImageEnvRejectsSecretDefault(t *testing.T) {
 }
 
 func TestValidatePublishTemplateName(t *testing.T) {
-	for _, name := range []string{"ReviewBot", "review_bot_2", "A1"} {
+	for _, name := range []string{"ReviewBot", "review_bot_2", "review-bot", "A1", "a23456789012345678901234"} {
 		if err := ValidatePublishTemplateName(name); err != nil {
 			t.Errorf("ValidatePublishTemplateName(%q) error = %v", name, err)
 		}
 	}
-	for _, name := range []string{"", "2review", "review-bot", "中文模板", "review bot"} {
+	for _, name := range []string{"", "2review", "中文模板", "review bot", "a234567890123456789012345"} {
 		if err := ValidatePublishTemplateName(name); err == nil {
 			t.Errorf("ValidatePublishTemplateName(%q) error = nil, want rejection", name)
 		}

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -303,21 +303,24 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
     },
     [item.description, item.name],
   );
-  const submitPublishTemplate = useCallback(async () => {
-    const name = publishTemplateName.trim();
-    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(name)) {
-      setPublishTemplateNameError(t("agentPublishTemplateNameInvalid"));
-      return;
-    }
-    if (!publishTarget || !onPublish) {
-      return;
-    }
-    setPublishTemplateNameError("");
-    const published = await onPublish(publishTarget, name, publishTemplateDescription.trim());
-    if (published) {
-      setPublishTarget(null);
-    }
-  }, [onPublish, publishTarget, publishTemplateDescription, publishTemplateName, t]);
+  const submitPublishTemplate = useCallback(
+    async (target = publishTarget) => {
+      const name = publishTemplateName.trim();
+      if (!/^[A-Za-z][A-Za-z0-9_-]{0,23}$/.test(name)) {
+        setPublishTemplateNameError(t("agentPublishTemplateNameInvalid"));
+        return;
+      }
+      if (!target || !onPublish) {
+        return;
+      }
+      setPublishTemplateNameError("");
+      const published = await onPublish(target, name, publishTemplateDescription.trim());
+      if (published) {
+        setPublishTarget(null);
+      }
+    },
+    [onPublish, publishTarget, publishTemplateDescription, publishTemplateName, t],
+  );
   const saveMetadataField = useCallback(
     <K extends keyof AgentMetadataSavePatch>(field: K, value: AgentMetadataSavePatch[K]): boolean => {
       if (skipMetadataAutosaveRef.current[field]) {
@@ -1159,6 +1162,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
               <span>{t("agentPublishTemplateName")}</span>
               <input
                 value={publishTemplateName}
+                maxLength={24}
                 aria-label={t("agentPublishTemplateName")}
                 aria-invalid={Boolean(publishTemplateNameError)}
                 aria-describedby={publishTemplateNameError ? "agent-publish-template-name-error" : undefined}
@@ -1188,20 +1192,41 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
             <Button variant="secondaryGray" size="md" disabled={publishBusy} onClick={() => setPublishTarget(null)}>
               {t("cancel")}
             </Button>
-            <Button
-              variant="primary"
-              size="md"
-              loading={publishBusy}
-              loadingLabel={t("agentPublishing")}
-              disabled={publishBusy}
-              onClick={() => void submitPublishTemplate()}
-            >
-              {publishTarget === "official_deploy"
-                ? t("agentPublishCommunityAndDeploy")
-                : publishTarget === "official"
-                  ? t("agentPublishCommunityTemplateOnly")
-                  : t("agentSaveLocalTemplate")}
-            </Button>
+            {publishTarget === "local" ? (
+              <Button
+                variant="primary"
+                size="md"
+                loading={publishBusy}
+                loadingLabel={t("agentPublishing")}
+                disabled={publishBusy}
+                onClick={() => void submitPublishTemplate("local")}
+              >
+                {t("agentSaveLocalTemplate")}
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="secondaryGray"
+                  size="md"
+                  loading={publishBusy}
+                  loadingLabel={t("agentPublishing")}
+                  disabled={publishBusy}
+                  onClick={() => void submitPublishTemplate("official")}
+                >
+                  {t("agentPublishCommunityTemplateOnly")}
+                </Button>
+                <Button
+                  variant="primary"
+                  size="md"
+                  loading={publishBusy}
+                  loadingLabel={t("agentPublishing")}
+                  disabled={publishBusy}
+                  onClick={() => void submitPublishTemplate("official_deploy")}
+                >
+                  {t("agentPublishCommunityAndDeploy")}
+                </Button>
+              </>
+            )}
           </DialogFooter>
         </DialogContent>
       </DialogRoot>
@@ -2000,22 +2025,13 @@ function AgentActionsMenu({
               {publishBusy ? t("agentPublishing") : t("agentSaveLocalTemplate")}
             </DropdownMenuItem>
             {canPublishCommunity ? (
-              <>
-                <DropdownMenuItem
-                  disabled={publishBusy || publishDisabled}
-                  title={publishDisabled ? t("agentPublishLoginRequired") : undefined}
-                  onSelect={() => onPublish?.("official")}
-                >
-                  {publishBusy ? t("agentPublishing") : t("agentPublishCommunityTemplateOnly")}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={publishBusy || publishDisabled}
-                  title={publishDisabled ? t("agentPublishLoginRequired") : undefined}
-                  onSelect={() => onPublish?.("official_deploy")}
-                >
-                  {publishBusy ? t("agentPublishing") : t("agentPublishCommunityAndDeploy")}
-                </DropdownMenuItem>
-              </>
+              <DropdownMenuItem
+                disabled={publishBusy || publishDisabled}
+                title={publishDisabled ? t("agentPublishLoginRequired") : undefined}
+                onSelect={() => onPublish?.("official")}
+              >
+                {publishBusy ? t("agentPublishing") : t("agentPublishCommunity")}
+              </DropdownMenuItem>
             ) : null}
           </>
         ) : null}

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -1146,8 +1146,9 @@ export const messages = {
     agentPublishTemplateLocalSubtitle: "填写模板信息并保存到本地模板。",
     agentPublishTemplateCommunitySubtitle: "填写模板信息并发布到社区。",
     agentPublishTemplateName: "模板名称",
-    agentPublishTemplateNameHint: "必须以英文字母开头，仅支持英文字母、数字和下划线。",
-    agentPublishTemplateNameInvalid: "模板名称必须以英文字母开头，且只能包含英文字母、数字和下划线。",
+    agentPublishTemplateNameHint: "必须以英文字母开头，最多 24 个字符，仅支持英文字母、数字、下划线和短横线。",
+    agentPublishTemplateNameInvalid:
+      "模板名称必须以英文字母开头，最多 24 个字符，且只能包含英文字母、数字、下划线和短横线。",
     agentPublishTemplateDescription: "模板描述",
     resourcesPublishCommunityFailed: "发布到社区失败。",
     resourcesPublishCommunityNameExists: "发布失败：社区中已存在同名模板，请修改模板名称后重试。",
@@ -2465,9 +2466,10 @@ export const messages = {
     agentPublishTemplateLocalSubtitle: "Enter template details and save it as a local template.",
     agentPublishTemplateCommunitySubtitle: "Enter template details and publish it to the community.",
     agentPublishTemplateName: "Template name",
-    agentPublishTemplateNameHint: "Start with an English letter; use only English letters, numbers, and underscores.",
+    agentPublishTemplateNameHint:
+      "Start with an English letter; use up to 24 English letters, numbers, underscores, or hyphens.",
     agentPublishTemplateNameInvalid:
-      "Template name must start with an English letter and contain only English letters, numbers, and underscores.",
+      "Template name must start with an English letter, contain at most 24 characters, and use only English letters, numbers, underscores, or hyphens.",
     agentPublishTemplateDescription: "Template description",
     resourcesPublishCommunityFailed: "Failed to publish the template to the community.",
     resourcesPublishCommunityNameExists:

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -171,13 +171,17 @@ describe("agent action visibility", () => {
 
     await user.click(screen.getByRole("button", { name: "More" }));
     expect(screen.getByRole("menuitem", { name: "Save as local template" })).toBeInTheDocument();
-    await user.click(screen.getByRole("menuitem", { name: "Publish template only" }));
+    expect(screen.queryByRole("menuitem", { name: "Publish template only" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Publish and deploy" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("menuitem", { name: "Publish to community" }));
+    expect(screen.getByRole("button", { name: "Publish template only" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Publish and deploy" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Publish template only" }));
 
     expect(onPublish).toHaveBeenCalledWith("official", "Worker", "Agent description");
 
     await user.click(screen.getByRole("button", { name: "More" }));
-    await user.click(screen.getByRole("menuitem", { name: "Publish and deploy" }));
+    await user.click(screen.getByRole("menuitem", { name: "Publish to community" }));
     await user.click(screen.getByRole("button", { name: "Publish and deploy" }));
     expect(onPublish).toHaveBeenCalledWith("official_deploy", "Worker", "Agent description");
   });
@@ -208,11 +212,9 @@ describe("agent action visibility", () => {
       "aria-disabled",
       "true",
     );
-    for (const name of ["Publish template only", "Publish and deploy"]) {
-      const publishCommunity = screen.getByRole("menuitem", { name });
-      expect(publishCommunity).toHaveAttribute("aria-disabled", "true");
-      expect(publishCommunity).toHaveAttribute("title", "Sign in to OpenCSG before publishing a template.");
-    }
+    const publishCommunity = screen.getByRole("menuitem", { name: "Publish to community" });
+    expect(publishCommunity).toHaveAttribute("aria-disabled", "true");
+    expect(publishCommunity).toHaveAttribute("title", "Sign in to OpenCSG before publishing a template.");
   });
 
   it("rejects an invalid template name before publishing", async () => {
@@ -239,12 +241,18 @@ describe("agent action visibility", () => {
     await user.click(screen.getByRole("button", { name: "More" }));
     await user.click(screen.getByRole("menuitem", { name: "Save as local template" }));
     const nameInput = screen.getByRole("textbox", { name: "Template name" });
+    expect(nameInput).toHaveAttribute("maxlength", "24");
     await user.clear(nameInput);
     await user.type(nameInput, "2-invalid");
     await user.click(screen.getByRole("button", { name: "Save as local template" }));
 
     expect(screen.getByRole("alert")).toHaveTextContent("Invalid template name");
     expect(onPublish).not.toHaveBeenCalled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "review-bot_2");
+    await user.click(screen.getByRole("button", { name: "Save as local template" }));
+    expect(onPublish).toHaveBeenCalledWith("local", "review-bot_2", "Agent description");
   });
 
   it("shows a recreate warning when backend marks an agent restart required", () => {


### PR DESCRIPTION
##Summary

- consolidate community publishing into one menu action with separate publish and deploy dialog buttons
- allow hyphens in template names and enforce a 24-character limit across UI, CLI, and backend validation