### PR TITLE
fix(web): avoid Windows focus loss after team deletion

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -2183,10 +2183,6 @@ export function useAgentController({
     if (!teamID || teamActionBusy) {
       return false;
     }
-    const teamTitle = item ? displayTeam(item) : teamID;
-    if (!window.confirm(t("teamDeleteConfirm", { title: teamTitle }))) {
-      return false;
-    }
     setTeamActionBusy(true);
     setTeamActionError("");
     try {

--- a/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.tsx
+++ b/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.tsx
@@ -3,7 +3,17 @@ import type { ReactNode } from "react";
 import { AgentAvatarContent, RoomAvatar } from "@/components/business";
 import { ListChecks, Trash2, UserPlus, Users } from "lucide-react";
 import { TaskSubtaskIndicator } from "@/components/business";
-import { Button } from "@/components/ui";
+import {
+  Button,
+  DialogBody,
+  DialogCloseButton,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "@/components/ui";
 import { isAgentRunning } from "@/models/agents";
 import type { AgentLike } from "@/models/agents";
 import type { IMUser, TranslateFn, UsersById } from "@/models/conversations";
@@ -56,6 +66,17 @@ export function TeamDetailPane({
   onSelectTask = () => {},
 }: TeamDetailPaneProps) {
   const [activeTab, setActiveTab] = useState<ActiveTeamTab>("members");
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  async function handleDeleteTeam(): Promise<void> {
+    if (!team) {
+      return;
+    }
+    const deleted = await onDeleteTeam(team);
+    if (deleted !== false) {
+      setDeleteDialogOpen(false);
+    }
+  }
 
   if (!team) {
     return (
@@ -107,13 +128,58 @@ export function TeamDetailPane({
             variant="outlineDanger"
             size="md"
             disabled={teamActionBusy}
-            onClick={() => void onDeleteTeam(team)}
+            onClick={() => setDeleteDialogOpen(true)}
           >
             <Trash2 size={16} aria-hidden="true" />
             {t("teamDelete")}
           </Button>
         </div>
       </header>
+
+      <DialogRoot
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!teamActionBusy) {
+            setDeleteDialogOpen(open);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <div>
+              <DialogTitle>{t("teamDelete")}</DialogTitle>
+              <DialogDescription>{t("teamDeleteConfirm", { title: displayTeam(team) })}</DialogDescription>
+            </div>
+            <DialogCloseButton label={t("close")} size="sm" variant="tertiaryGray" disabled={teamActionBusy} />
+          </DialogHeader>
+          {teamActionError ? (
+            <DialogBody>
+              <div className="form-error" role="alert">
+                {teamActionError}
+              </div>
+            </DialogBody>
+          ) : null}
+          <DialogFooter>
+            <Button
+              variant="secondaryGray"
+              size="md"
+              disabled={teamActionBusy}
+              onClick={() => setDeleteDialogOpen(false)}
+            >
+              {t("cancel")}
+            </Button>
+            <Button
+              variant="danger"
+              size="md"
+              loading={teamActionBusy}
+              loadingLabel={t("teamSaving")}
+              onClick={() => void handleDeleteTeam()}
+            >
+              {t("teamDelete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </DialogRoot>
 
       {teamActionError ? (
         <div className={classNames("form-error", styles.contentWidth, styles.teamDetailActionError)} role="alert">

--- a/web/app/tests/components/TeamDetailPane.test.tsx
+++ b/web/app/tests/components/TeamDetailPane.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TeamDetailPane } from "@/pages/TeamPage/components";
+import type { TranslateFn } from "@/models/conversations";
+import type { WorkspaceTeam } from "@/models/tasks";
+
+const t: TranslateFn = (key) => key;
+
+const team: WorkspaceTeam = {
+  id: "team-1",
+  title: "Windows team",
+  lead_agent_id: "u-manager",
+  member_agent_ids: [],
+  status: "active",
+  created_at: "2026-08-01T00:00:00Z",
+  updated_at: "2026-08-01T00:00:00Z",
+};
+
+describe("TeamDetailPane", () => {
+  it("confirms team deletion in-app without opening a native browser dialog", async () => {
+    const user = userEvent.setup();
+    const onDeleteTeam = vi.fn().mockResolvedValue(true);
+    const confirmSpy = vi.spyOn(window, "confirm");
+
+    try {
+      render(<TeamDetailPane team={team} t={t} onDeleteTeam={onDeleteTeam} />);
+
+      await user.click(screen.getByRole("button", { name: "teamDelete" }));
+
+      const dialog = screen.getByRole("dialog", { name: "teamDelete" });
+      expect(within(dialog).getByText("teamDeleteConfirm")).toBeInTheDocument();
+      expect(onDeleteTeam).not.toHaveBeenCalled();
+      expect(confirmSpy).not.toHaveBeenCalled();
+
+      await user.click(within(dialog).getByRole("button", { name: "teamDelete" }));
+
+      await waitFor(() => expect(onDeleteTeam).toHaveBeenCalledWith(team));
+      expect(confirmSpy).not.toHaveBeenCalled();
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+});

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -30,7 +30,7 @@ import {
 import { createUserRequest } from "@/api/im";
 import { patchCsgclawUserRequest } from "@/api/participants";
 import { fetchSkills } from "@/api/skills";
-import { createTeamRequest, fetchTeams } from "@/api/tasks";
+import { createTeamRequest, deleteTeamRequest, fetchTeams } from "@/api/tasks";
 import { useAgentController } from "@/hooks/workspace/useAgentController";
 import { WorkspacePaneTypes } from "@/models/routing";
 import type { WorkspacePane } from "@/models/routing";
@@ -39,6 +39,7 @@ import type { IMConversation, IMData, TranslateFn } from "@/models/conversations
 import type { MCPServer } from "@/models/mcp";
 import { normalizeModelProviderCatalog } from "@/models/modelProviders";
 import type { ModelProviderCatalog } from "@/models/modelProviders";
+import type { WorkspaceTeam } from "@/models/tasks";
 import type { ApiError } from "@/api/client";
 import { AGENT_AVATAR_OPTIONS } from "@/shared/avatarOptions";
 import { ACTION_REBUILD_MANAGER } from "@/shared/constants/messages";
@@ -60,6 +61,7 @@ vi.mock("@/api/tasks", async () => {
   return {
     ...actual,
     createTeamRequest: vi.fn(),
+    deleteTeamRequest: vi.fn(),
     fetchTeams: vi.fn(async () => []),
   };
 });
@@ -307,6 +309,7 @@ describe("useAgentController", () => {
     vi.mocked(deleteFeishuParticipantRequest).mockReset();
     vi.mocked(finalizeFeishuRegistrationRequest).mockReset();
     vi.mocked(createTeamRequest).mockReset();
+    vi.mocked(deleteTeamRequest).mockReset();
     vi.mocked(fetchTeams).mockReset();
     vi.mocked(runAgentActionRequest).mockReset();
     vi.mocked(startFeishuRegistrationRequest).mockReset();
@@ -378,6 +381,7 @@ describe("useAgentController", () => {
       title: "Untitled Team",
       updated_at: "2026-06-10T00:00:00Z",
     });
+    vi.mocked(deleteTeamRequest).mockResolvedValue(undefined);
     vi.mocked(fetchTeams).mockResolvedValue([]);
     vi.mocked(runAgentActionRequest).mockResolvedValue({
       ...oldAgent,
@@ -1681,6 +1685,34 @@ describe("useAgentController", () => {
       member_agent_ids: ["u-manager"],
       title: "teamNewFallbackTitle",
     });
+  });
+
+  it("deletes teams after in-app confirmation without opening a native browser dialog", async () => {
+    const team: WorkspaceTeam = {
+      id: "team-1",
+      title: "Windows team",
+      lead_agent_id: "u-manager",
+      member_agent_ids: ["u-manager"],
+      status: "active",
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+    };
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    try {
+      const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
+      let deleted = false;
+
+      await act(async () => {
+        deleted = await result.current.deleteTeam(team);
+      });
+
+      expect(deleted).toBe(true);
+      expect(deleteTeamRequest).toHaveBeenCalledWith("team-1");
+      expect(confirmSpy).not.toHaveBeenCalled();
+    } finally {
+      confirmSpy.mockRestore();
+    }
   });
 
   it("starts Feishu connection by storing the pending registration and opening Feishu", async () => {


### PR DESCRIPTION
- Replace the native team deletion confirmation with an in-app dialog so Windows desktop users can create teams again without losing input focus.
- Preserve deletion loading and error feedback while preventing regressions back to `window.confirm`.
