### PR TITLE
fix(codex): allow active turns to run past 30 minutes

### DIFF
--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -29,7 +29,8 @@ var (
 	appServerStopTimeout                = 3 * time.Second
 	appServerSemanticInactivityTimeout  = 10 * time.Minute
 	appServerFirstTurnNoProgressTimeout = 5 * time.Minute
-	appServerMaximumTurnDuration        = 30 * time.Minute
+	// Active turns are bounded by inactivity and caller cancellation, not total elapsed time.
+	appServerMaximumTurnDuration = time.Duration(0)
 )
 
 var appServerCommandContext = codexcli.AppServerCommandContext

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -935,6 +935,9 @@ func TestAppServerManagerDefaultNoProgressTimeoutIsFastFail(t *testing.T) {
 	if appServerSemanticInactivityTimeout <= appServerFirstTurnNoProgressTimeout {
 		t.Fatalf("semantic timeout = %s, no-progress timeout = %s, want semantic timeout longer than no-progress timeout", appServerSemanticInactivityTimeout, appServerFirstTurnNoProgressTimeout)
 	}
+	if appServerMaximumTurnDuration != 0 {
+		t.Fatalf("maximum turn duration = %s, want disabled so active long-running turns can finish", appServerMaximumTurnDuration)
+	}
 }
 
 func TestAppServerManagerAutoAcceptsCommandApproval(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove the fixed 30-minute duration cap from active Codex turns.
- Keep inactivity and cancellation safeguards with regression coverage.