### PR TITLE
fix(modelprovider): probe streaming chat completions

### DIFF
--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -259,7 +259,7 @@ func CheckChatCompletionsAPIWithClient(ctx context.Context, client *http.Client,
 		"messages": []map[string]string{
 			{"role": "user", "content": "ping"},
 		},
-		"stream":     false,
+		"stream":     true,
 		"max_tokens": 16,
 	}
 	body, err := json.Marshal(payload)
@@ -271,6 +271,7 @@ func CheckChatCompletionsAPIWithClient(ctx context.Context, client *http.Client,
 		return fmt.Errorf("build chat completions probe request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
@@ -297,11 +298,42 @@ func CheckChatCompletionsAPIWithClient(ctx context.Context, client *http.Client,
 	}
 
 	var probe openAIChatCompletionsProbeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&probe); err != nil {
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0]))
+	if mediaType == "text/event-stream" {
+		probe, err = decodeOpenAIChatCompletionsProbeStream(resp.Body)
+	} else {
+		err = json.NewDecoder(resp.Body).Decode(&probe)
+	}
+	if err != nil {
 		return fmt.Errorf("decode chat completions probe from %s: %w", baseURL, err)
 	}
 	if len(probe.Choices) == 0 {
 		return fmt.Errorf("chat completions probe from %s returned no choices", baseURL)
 	}
 	return nil
+}
+
+func decodeOpenAIChatCompletionsProbeStream(r io.Reader) (openAIChatCompletionsProbeResponse, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var probe openAIChatCompletionsProbeResponse
+		if err := json.Unmarshal([]byte(data), &probe); err != nil {
+			return openAIChatCompletionsProbeResponse{}, err
+		}
+		if len(probe.Choices) > 0 {
+			return probe, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return openAIChatCompletionsProbeResponse{}, err
+	}
+	return openAIChatCompletionsProbeResponse{}, fmt.Errorf("stream returned no chat completion chunk")
 }

--- a/internal/modelprovider/openai_test.go
+++ b/internal/modelprovider/openai_test.go
@@ -140,6 +140,28 @@ func TestCheckResponsesAPIWithClientClassifiesUnsupportedEndpoint(t *testing.T) 
 	}
 }
 
+func TestCheckChatCompletionsAPIWithClientAcceptsStreamingResponse(t *testing.T) {
+	var gotPayload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Fatalf("Accept = %q, want text/event-stream", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"pong\"},\"finish_reason\":null}]}\n\n"))
+	}))
+	defer srv.Close()
+
+	if err := CheckChatCompletionsAPIWithClient(context.Background(), srv.Client(), srv.URL+"/v1", "sk-test", "gpt-test", nil); err != nil {
+		t.Fatalf("CheckChatCompletionsAPIWithClient() error = %v", err)
+	}
+	if gotPayload["stream"] != true {
+		t.Fatalf("stream = %#v, want true", gotPayload["stream"])
+	}
+}
+
 func TestCheckResponsesOrChatCompletionsAPIWithClientFallsBackToChat(t *testing.T) {
 	var chatPayload map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -164,6 +186,9 @@ func TestCheckResponsesOrChatCompletionsAPIWithClientFallsBackToChat(t *testing.
 	}
 	if chatPayload["model"] != "gpt-test" {
 		t.Fatalf("chat model = %#v, want gpt-test", chatPayload["model"])
+	}
+	if chatPayload["stream"] != true {
+		t.Fatalf("chat stream = %#v, want true", chatPayload["stream"])
 	}
 	messages, ok := chatPayload["messages"].([]any)
 	if !ok || len(messages) != 1 {


### PR DESCRIPTION
## Summary

- Follow up on the preceding streaming Responses API probe change by aligning the Chat Completions fallback probe with Codex streaming requests.
- Parse Chat Completions SSE chunks while retaining compatibility with gateways that return a JSON response.
- Add regression coverage for the streaming Chat Completions probe.