### PR TITLE
fix(web): localize auth network errors

### DIFF
--- a/web/app/src/hooks/workspace/useAuthController.ts
+++ b/web/app/src/hooks/workspace/useAuthController.ts
@@ -133,7 +133,7 @@ export function useAuthController(t: TranslateFn): AuthController {
         navigation.close();
         clearPendingAuthLogin();
         setLoginPending(false);
-        setAuthError(errorMessage(err, t("csghubLoginFailed")));
+        setAuthError(authErrorMessage(err, t("csghubLoginFailed")));
       } finally {
         setBusyAction("");
       }
@@ -279,7 +279,7 @@ export function useAuthController(t: TranslateFn): AuthController {
     environment,
     busy: Boolean(busyAction),
     dismissNotice,
-    error: authError || (statusQuery.isError ? errorMessage(statusQuery.error, t("csghubStatusFailed")) : ""),
+    error: authError || (statusQuery.isError ? authErrorMessage(statusQuery.error, t("csghubStatusFailed")) : ""),
     login,
     logout,
     notice: authNotice,
@@ -291,6 +291,10 @@ export function useAuthController(t: TranslateFn): AuthController {
 
 async function fetchNormalizedAuthStatus(): Promise<AuthStatus> {
   return normalizeAuthStatus(await fetchAuthStatus());
+}
+
+function authErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof TypeError ? fallback : errorMessage(error, fallback);
 }
 
 function markPendingAuthLogin() {

--- a/web/app/tests/hooks/useAuthController.test.tsx
+++ b/web/app/tests/hooks/useAuthController.test.tsx
@@ -69,6 +69,14 @@ describe("useAuthController", () => {
     expect(result.current.notice).toBeNull();
   });
 
+  it("uses the localized status failure message when the status request cannot be fetched", async () => {
+    vi.mocked(fetchAuthStatus).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const { result } = renderHook(() => useAuthController(t), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.error).toBe("csghubStatusFailed"));
+  });
+
   it("restores the completed login notice from the callback result", async () => {
     window.history.replaceState({}, "", "/#/settings?auth_result=success");
     vi.mocked(fetchAuthStatus).mockResolvedValue({
@@ -136,6 +144,23 @@ describe("useAuthController", () => {
     });
     expect(window.location.hash).toBe("#/opencsg-login?redirect_url=callback");
     expect(window.sessionStorage.getItem(loginPendingStorageKey)).toBe("1");
+  });
+
+  it("uses the localized login failure message when the login request cannot be fetched", async () => {
+    vi.mocked(fetchAuthStatus).mockResolvedValue({ authenticated: false });
+    vi.mocked(beginAuthLogin).mockRejectedValue(new TypeError("Failed to fetch"));
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuthController(t), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(result.current.error).toBe("csghubLoginFailed");
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#/settings");
+    expect(window.sessionStorage.getItem(loginPendingStorageKey)).toBeNull();
   });
 
   it("uses the shared selected environment when login is triggered without an override", async () => {


### PR DESCRIPTION
## Summary

- Map browser-level authentication network failures to the existing localized UI messages.
- Show the predefined login-status error when `/api/v1/auth/status` cannot be reached.
- Keep specific non-network authentication errors unchanged.
