### PR TITLE
fix(hub): harden template lifecycle workflows

### DIFF
--- a/internal/api/community_instance.go
+++ b/internal/api/community_instance.go
@@ -161,7 +161,7 @@ func createCommunityAgentInstanceOnce(req *http.Request) (bool, error) {
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("create community instance: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
 	}
-	if communityInstanceCode(result.Code) != "0" {
+	if code := communityInstanceCode(result.Code); code != "" && code != "0" {
 		return false, fmt.Errorf("create community instance: %s", message)
 	}
 	if len(result.Data) == 0 || string(result.Data) == "null" {

--- a/internal/api/community_instance_test.go
+++ b/internal/api/community_instance_test.go
@@ -67,6 +67,28 @@ func TestCreateCommunityAgentInstanceUsesCSGClawType(t *testing.T) {
 	}
 }
 
+func TestCreateCommunityAgentInstanceAcceptsOKResponseWithoutCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"msg":"OK","data":{"id":"instance-1"}}`))
+	}))
+	defer server.Close()
+
+	previousCredentials := loadCommunityInstanceCredentials
+	loadCommunityInstanceCredentials = func() (string, string, bool, error) {
+		return server.URL, "hub-token", true, nil
+	}
+	t.Cleanup(func() { loadCommunityInstanceCredentials = previousCredentials })
+
+	err := createCommunityAgentInstanceRequest(context.Background(), hub.Template{
+		Namespace: "alice",
+		Name:      "ReviewBot",
+	}, auth.Status{UserID: "alice", UserUUID: "uuid-alice"})
+	if err != nil {
+		t.Fatalf("createCommunityAgentInstanceRequest() error = %v", err)
+	}
+}
+
 func TestCreateCommunityAgentInstanceRetriesTemplatePendingCode(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1614,6 +1614,9 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 			if !publishingTemplate {
 				status = http.StatusBadRequest
 			}
+			if errors.Is(err, hub.ErrTemplateAlreadyExists) {
+				status = http.StatusConflict
+			}
 			if strings.Contains(strings.ToLower(err.Error()), "not found") {
 				status = http.StatusNotFound
 			}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4916,6 +4916,15 @@ func TestHandleHubTemplatesPublishesAgentSnapshot(t *testing.T) {
 	} else if strings.TrimSpace(string(data)) != "published workspace" {
 		t.Fatalf("PLAYBOOK.md = %q, want %q", strings.TrimSpace(string(data)), "published workspace")
 	}
+
+	duplicateReq := httptest.NewRequest(http.MethodPost, "/api/v1/hub/templates", strings.NewReader(
+		`{"agent_id":"u-alice","registry":"local","name":"ReviewBot_2","description":"Duplicate"}`,
+	))
+	duplicateRec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(duplicateRec, duplicateReq)
+	if duplicateRec.Code != http.StatusConflict {
+		t.Fatalf("duplicate status = %d, want %d; body=%s", duplicateRec.Code, http.StatusConflict, duplicateRec.Body.String())
+	}
 }
 
 func TestHandleHubTemplatesRequiresOpenCSGLoginForOfficialPublish(t *testing.T) {

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -32,6 +32,7 @@ var (
 	ErrTemplateIDRequired     = errors.New("hub template id is required")
 	ErrTemplateNameRequired   = errors.New("hub template name is required")
 	ErrTemplateNameInvalid    = errors.New("hub template name must start with an English letter, be at most 24 characters long, and contain only English letters, numbers, underscores, or hyphens")
+	ErrTemplateAlreadyExists  = errors.New("hub template already exists")
 	ErrRuntimeKindRequired    = errors.New("hub runtime kind is required")
 	ErrWorkspaceDirRequired   = errors.New("hub workspace directory is required")
 	ErrWorkspacePathUnsafe    = errors.New("hub workspace path is unsafe")
@@ -153,6 +154,12 @@ func (s *LocalStore) Publish(_ context.Context, spec PublishSpec) (Template, err
 	if err := os.MkdirAll(s.templatesRoot(), 0o755); err != nil {
 		return Template{}, fmt.Errorf("create local hub templates dir: %w", err)
 	}
+	targetDir := s.templateRoot(normalized.ID)
+	if _, err := os.Stat(targetDir); err == nil {
+		return Template{}, fmt.Errorf("%w: %s", ErrTemplateAlreadyExists, normalized.Name)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Template{}, fmt.Errorf("stat local hub template %q: %w", normalized.ID, err)
+	}
 
 	tmpDir, err := os.MkdirTemp(s.templatesRoot(), localPublishTempPrefix)
 	if err != nil {
@@ -174,12 +181,8 @@ func (s *LocalStore) Publish(_ context.Context, spec PublishSpec) (Template, err
 		}
 	}
 
-	targetDir := s.templateRoot(normalized.ID)
-	if err := os.RemoveAll(targetDir); err != nil {
-		return Template{}, fmt.Errorf("replace local hub template %q: %w", normalized.ID, err)
-	}
 	if err := os.Rename(tmpDir, targetDir); err != nil {
-		return Template{}, fmt.Errorf("replace local hub template %q: %w", normalized.ID, err)
+		return Template{}, fmt.Errorf("publish local hub template %q: %w", normalized.ID, err)
 	}
 	cleanup = false
 

--- a/internal/template/local_store_test.go
+++ b/internal/template/local_store_test.go
@@ -104,6 +104,35 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLocalStorePublishRejectsDuplicateName(t *testing.T) {
+	store := NewLocalStore(t.TempDir())
+	first, err := store.Publish(context.Background(), PublishSpec{
+		Name:        "review-bot",
+		Description: "original",
+		Role:        TemplateRoleWorker,
+		RuntimeKind: runtime.KindCodex,
+	})
+	if err != nil {
+		t.Fatalf("first Publish() error = %v", err)
+	}
+	_, err = store.Publish(context.Background(), PublishSpec{
+		Name:        "review-bot",
+		Description: "replacement",
+		Role:        TemplateRoleWorker,
+		RuntimeKind: runtime.KindCodex,
+	})
+	if !errors.Is(err, ErrTemplateAlreadyExists) {
+		t.Fatalf("second Publish() error = %v, want ErrTemplateAlreadyExists", err)
+	}
+	got, err := store.Get(context.Background(), first.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Description != "original" {
+		t.Fatalf("Description = %q, want original template preserved", got.Description)
+	}
+}
+
 func TestLocalStoreListSkipsInvalidTemplates(t *testing.T) {
 	registryRoot := t.TempDir()
 	store := NewLocalStore(registryRoot)

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useBlocker } from "react-router-dom";
-import { errorMessage } from "@/api/client";
+import { errorMessage, type ApiError } from "@/api/client";
 import { loginCLIProxyProviderRequest } from "@/api/cliproxy";
 import {
   batchAddAgentMCPServersRequest,
@@ -480,6 +480,7 @@ export function useAgentController({
   const [agentPageSavedDraft, setAgentPageSavedDraft] = useState<AgentDraft | null>(null);
   const [agentPageBusy, setAgentPageBusy] = useState(false);
   const [agentPagePublishBusy, setAgentPagePublishBusy] = useState(false);
+  const [agentPagePublishError, setAgentPagePublishError] = useState("");
   const [agentPageError, setAgentPageError] = useState("");
   const [agentSkillAddBusy, setAgentSkillAddBusy] = useState(false);
   const [agentSkillAddError, setAgentSkillAddError] = useState("");
@@ -1649,6 +1650,7 @@ export function useAgentController({
       return false;
     }
     setAgentPagePublishBusy(true);
+    setAgentPagePublishError("");
     setAgentPageError("");
     try {
       const published = await publishAgentTemplateRequest(selectedAgentForPage.id, target, name, description);
@@ -1661,7 +1663,12 @@ export function useAgentController({
       }
       return true;
     } catch (err) {
-      setAgentPageError(errorMessage(err, t("agentActionFailed")));
+      const message =
+        target === "local" && (err as ApiError | null)?.status === 409
+          ? t("agentPublishLocalNameExists")
+          : errorMessage(err, t("agentActionFailed"));
+      setAgentPagePublishError(message);
+      setAgentPageError(message);
       return false;
     } finally {
       setAgentPagePublishBusy(false);
@@ -2429,6 +2436,7 @@ export function useAgentController({
       saving: agentPageBusy,
       publishBusy: agentPagePublishBusy,
       publishDisabled: !openCSGAuthenticated,
+      publishError: agentPagePublishError,
       saveError: agentPageError,
       notice: selectedAgentPageNotice?.message || "",
       noticeTone: selectedAgentPageNotice?.tone || "warning",

--- a/web/app/src/hooks/workspace/useWorkspaceHubController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubController.ts
@@ -18,6 +18,28 @@ export type InstallRemoteSkillOptions = {
   replace?: boolean;
 };
 
+export function workspaceHubMutationError(
+  resourceType: "mcp" | "skill" | "template",
+  deleteError: string,
+  publishError: string,
+  skillDeleteError: string,
+): string {
+  if (resourceType === "template") {
+    return deleteError || publishError;
+  }
+  if (resourceType === "skill") {
+    return skillDeleteError;
+  }
+  return "";
+}
+
+export function visibleWorkspaceHubTemplates(
+  templates: readonly HubTemplate[],
+  deletingTemplateID: string,
+): HubTemplate[] {
+  return templates.filter((item) => item.id !== deletingTemplateID && isVisibleInHubTemplateList(item));
+}
+
 export type WorkspaceHubController = {
   hub: Omit<WorkspaceHubSelection, "detailPaneProps"> & {
     deleteBusy: boolean;
@@ -61,6 +83,7 @@ export function useWorkspaceHubController({
   const [resourcesManualError, setResourcesManualError] = useState("");
   const [resourcesDeleteBusy, setResourcesDeleteBusy] = useState(false);
   const [resourcesDeleteError, setResourcesDeleteError] = useState("");
+  const [deletingTemplateID, setDeletingTemplateID] = useState("");
   const [resourcesPublishBusy, setResourcesPublishBusy] = useState(false);
   const [resourcesPublishError, setResourcesPublishError] = useState("");
   const [skillDeleteBusy, setSkillDeleteBusy] = useState(false);
@@ -86,20 +109,36 @@ export function useWorkspaceHubController({
   }, [hubTemplatesQuery.isSuccess, hubTemplatesQuery.dataUpdatedAt]);
 
   const visibleHubTemplates = useMemo(
-    () => hubTemplates.filter((item) => isVisibleInHubTemplateList(item)),
-    [hubTemplates],
+    () => visibleWorkspaceHubTemplates(hubTemplates, deletingTemplateID),
+    [deletingTemplateID, hubTemplates],
   );
 
   const hub = useWorkspaceHubSelection({
     templates: visibleHubTemplates,
     templatesQuery: hubTemplatesQuery,
     loaded: hubLoaded,
-    manualError: resourcesManualError || resourcesDeleteError || resourcesPublishError || skillDeleteError,
+    manualError: resourcesManualError,
     refreshTemplates: refreshHubTemplates,
     t,
   });
   const { setSelectedHubResourceType, setSelectedHubSkillName, setSelectedHubSkillPath, setSelectedHubTemplateId } =
     hub;
+  const mutationError = workspaceHubMutationError(
+    hub.selectedHubResourceType,
+    resourcesDeleteError,
+    resourcesPublishError,
+    skillDeleteError,
+  );
+
+  useEffect(() => {
+    if (hub.selectedHubResourceType !== "template") {
+      setResourcesDeleteError("");
+      setResourcesPublishError("");
+    }
+    if (hub.selectedHubResourceType !== "skill") {
+      setSkillDeleteError("");
+    }
+  }, [hub.selectedHubResourceType]);
 
   const deleteHubTemplate = useCallback(
     async (template: HubTemplate | null | undefined): Promise<boolean> => {
@@ -112,19 +151,29 @@ export function useWorkspaceHubController({
       }
       setResourcesDeleteBusy(true);
       setResourcesDeleteError("");
+      setDeletingTemplateID(template.id);
+      setSelectedHubTemplateId("");
       try {
+        await Promise.all([
+          queryClient.cancelQueries({ queryKey: workspaceQueryKeys.hubTemplate(template.id) }),
+          queryClient.cancelQueries({ queryKey: workspaceQueryKeys.hubWorkspaceScope(template.id) }),
+          queryClient.cancelQueries({ queryKey: workspaceQueryKeys.hubWorkspaceFileScope(template.id) }),
+        ]);
         await deleteHubTemplateRequest(template.id);
-        setSelectedHubTemplateId("");
+        queryClient.removeQueries({ queryKey: workspaceQueryKeys.hubTemplate(template.id) });
+        queryClient.removeQueries({ queryKey: workspaceQueryKeys.hubWorkspaceScope(template.id) });
+        queryClient.removeQueries({ queryKey: workspaceQueryKeys.hubWorkspaceFileScope(template.id) });
         await refreshHubTemplates();
         return true;
       } catch (err) {
         setResourcesDeleteError(errorMessage(err, t("resourcesDeleteFailed")));
         return false;
       } finally {
+        setDeletingTemplateID("");
         setResourcesDeleteBusy(false);
       }
     },
-    [refreshHubTemplates, setSelectedHubTemplateId, t],
+    [queryClient, refreshHubTemplates, setSelectedHubTemplateId, t],
   );
 
   const deleteSkill = useCallback(
@@ -245,6 +294,7 @@ export function useWorkspaceHubController({
   return {
     hub: {
       ...hub,
+      error: hub.error || mutationError,
       deleteBusy: resourcesDeleteBusy,
       deleteHubTemplate,
       publishBusy: resourcesPublishBusy,
@@ -259,6 +309,7 @@ export function useWorkspaceHubController({
       uploadSkill,
       detailPaneProps: {
         ...hub.detailPaneProps,
+        error: hub.detailPaneProps.error || mutationError,
         deleteBusy: resourcesDeleteBusy,
         onDeleteTemplate: deleteHubTemplate,
         onPublishTemplate: publishHubTemplate,

--- a/web/app/src/hooks/workspace/workspaceQueries.ts
+++ b/web/app/src/hooks/workspace/workspaceQueries.ts
@@ -116,8 +116,12 @@ export const workspaceQueryKeys = {
     [WORKSPACE_QUERY_SCOPE, "remote-mcp-servers", String(search || "").trim()] as const,
   hubTemplate: (templateID: string | null | undefined) =>
     [WORKSPACE_QUERY_SCOPE, "hub-template", templateID || ""] as const,
+  hubWorkspaceScope: (templateID: string | null | undefined) =>
+    [WORKSPACE_QUERY_SCOPE, "hub-workspace", templateID || ""] as const,
   hubWorkspace: (templateID: string | null | undefined, workspacePath: string | null | undefined) =>
     [WORKSPACE_QUERY_SCOPE, "hub-workspace", templateID || "", workspacePath || ""] as const,
+  hubWorkspaceFileScope: (templateID: string | null | undefined) =>
+    [WORKSPACE_QUERY_SCOPE, "hub-workspace-file", templateID || ""] as const,
   hubWorkspaceFile: (templateID: string | null | undefined, workspacePath: string | null | undefined) =>
     [WORKSPACE_QUERY_SCOPE, "hub-workspace-file", templateID || "", workspacePath || ""] as const,
   officialSkills: (search: string | null | undefined = "") =>

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -148,6 +148,7 @@ export type AgentDetailPaneProps = {
   onUpgrade?: AgentActionHandler;
   publishBusy?: boolean;
   publishDisabled?: boolean;
+  publishError?: string;
   locale?: LocaleCode;
   rooms?: IMConversation[];
   saveError?: string;
@@ -207,6 +208,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
     saving = false,
     publishBusy = false,
     publishDisabled = false,
+    publishError = "",
     modelProviders = null,
     saveError = "",
     locale = "en",
@@ -267,6 +269,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
   const [publishTemplateName, setPublishTemplateName] = useState("");
   const [publishTemplateDescription, setPublishTemplateDescription] = useState("");
   const [publishTemplateNameError, setPublishTemplateNameError] = useState("");
+  const [publishAttempted, setPublishAttempted] = useState(false);
   const [isProfileScrolling, setIsProfileScrolling] = useState(false);
   const descriptionInputRef = useRef<HTMLTextAreaElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
@@ -300,6 +303,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
       setPublishTemplateName(String(item.name || "").trim());
       setPublishTemplateDescription(String(item.description || "").trim());
       setPublishTemplateNameError("");
+      setPublishAttempted(false);
     },
     [item.description, item.name],
   );
@@ -314,6 +318,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
         return;
       }
       setPublishTemplateNameError("");
+      setPublishAttempted(true);
       const published = await onPublish(target, name, publishTemplateDescription.trim());
       if (published) {
         setPublishTarget(null);
@@ -1169,6 +1174,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 onChange={(event) => {
                   setPublishTemplateName(event.target.value);
                   setPublishTemplateNameError("");
+                  setPublishAttempted(false);
                 }}
               />
               <small>{t("agentPublishTemplateNameHint")}</small>
@@ -1187,6 +1193,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 onChange={(event) => setPublishTemplateDescription(event.target.value)}
               />
             </label>
+            {publishAttempted && publishError ? <div className="form-error">{publishError}</div> : null}
           </DialogBody>
           <DialogFooter>
             <Button variant="secondaryGray" size="md" disabled={publishBusy} onClick={() => setPublishTarget(null)}>

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -1149,6 +1149,7 @@ export const messages = {
     agentPublishTemplateNameHint: "必须以英文字母开头，最多 24 个字符，仅支持英文字母、数字、下划线和短横线。",
     agentPublishTemplateNameInvalid:
       "模板名称必须以英文字母开头，最多 24 个字符，且只能包含英文字母、数字、下划线和短横线。",
+    agentPublishLocalNameExists: "保存失败：本地已存在同名模板，请修改模板名称后重试。",
     agentPublishTemplateDescription: "模板描述",
     resourcesPublishCommunityFailed: "发布到社区失败。",
     resourcesPublishCommunityNameExists: "发布失败：社区中已存在同名模板，请修改模板名称后重试。",
@@ -2470,6 +2471,8 @@ export const messages = {
       "Start with an English letter; use up to 24 English letters, numbers, underscores, or hyphens.",
     agentPublishTemplateNameInvalid:
       "Template name must start with an English letter, contain at most 24 characters, and use only English letters, numbers, underscores, or hyphens.",
+    agentPublishLocalNameExists:
+      "Saving failed: a local template with the same name already exists. Choose a different name and try again.",
     agentPublishTemplateDescription: "Template description",
     resourcesPublishCommunityFailed: "Failed to publish the template to the community.",
     resourcesPublishCommunityNameExists:

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -32,6 +32,7 @@ const labels: Record<string, string> = {
   agentPublishTemplateName: "Template name",
   agentPublishTemplateNameHint: "Use letters, numbers, and underscores.",
   agentPublishTemplateNameInvalid: "Invalid template name",
+  agentPublishLocalNameExists: "A local template with this name already exists.",
   agentPublishTemplateDescription: "Template description",
   agentProfileSectionNavLabel: "Profile sections",
   agentProfileTab: "Profile",
@@ -278,6 +279,36 @@ describe("agent action visibility", () => {
     await user.type(nameInput, "review-bot_2");
     await user.click(screen.getByRole("button", { name: "Save as local template" }));
     expect(onPublish).toHaveBeenCalledWith("local", "review-bot_2", "Agent description");
+  });
+
+  it("keeps the publish dialog open and shows duplicate local template errors", async () => {
+    const user = userEvent.setup();
+    const onPublish = vi.fn().mockResolvedValue(false);
+    render(
+      <AgentDetailPane
+        item={worker}
+        t={t}
+        busyKey=""
+        draft={null}
+        models={[]}
+        publishError={t("agentPublishLocalNameExists")}
+        onDelete={vi.fn()}
+        onDraftChange={vi.fn()}
+        onInvite={vi.fn()}
+        onOpenDM={vi.fn()}
+        onPublish={onPublish}
+        onRecreate={vi.fn()}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+    await user.click(screen.getByRole("menuitem", { name: "Save as local template" }));
+    await user.click(screen.getByRole("button", { name: "Save as local template" }));
+
+    expect(screen.getByRole("dialog", { name: "Publish agent template" })).toBeInTheDocument();
+    expect(screen.getByText("A local template with this name already exists.")).toBeInTheDocument();
   });
 
   it("shows a recreate warning when backend marks an agent restart required", () => {

--- a/web/app/tests/hooks/useWorkspaceHubController.test.ts
+++ b/web/app/tests/hooks/useWorkspaceHubController.test.ts
@@ -1,0 +1,21 @@
+import { visibleWorkspaceHubTemplates, workspaceHubMutationError } from "@/hooks/workspace/useWorkspaceHubController";
+import type { HubTemplate } from "@/models/hubWorkspace";
+
+describe("workspace hub controller errors", () => {
+  it("only exposes mutation errors on their owning resource page", () => {
+    expect(workspaceHubMutationError("template", "", "Publishing failed", "")).toBe("Publishing failed");
+    expect(workspaceHubMutationError("skill", "", "Publishing failed", "Skill delete failed")).toBe(
+      "Skill delete failed",
+    );
+    expect(workspaceHubMutationError("mcp", "Delete failed", "Publishing failed", "Skill delete failed")).toBe("");
+  });
+
+  it("hides a deleting template before the refreshed list arrives", () => {
+    const templates: HubTemplate[] = [
+      { id: "local.alpha", role: "worker", source: { kind: "local" } },
+      { id: "local.beta", role: "worker", source: { kind: "local" } },
+    ];
+
+    expect(visibleWorkspaceHubTemplates(templates, "local.alpha").map((item) => item.id)).toEqual(["local.beta"]);
+  });
+});


### PR DESCRIPTION
Summary:
- reject duplicate local template names and surface actionable inline errors
- keep Hub lists interactive after publish failures and scope mutation errors to their resource pages
- hide deleting templates immediately and cancel stale detail and workspace queries
- accept successful deployment responses without a code field while preserving delayed-template retries