### PR TITLE
fix(agent): avoid inheriting runtime restart state

### DIFF
--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -100,6 +100,16 @@ type ProfileDetectionResult struct {
 	Error    string `json:"error,omitempty"`
 }
 
+// profileDefaultsSnapshot keeps lifecycle signals out of model defaults. These
+// flags describe whether one existing runtime has applied its profile; carrying
+// them into a newly-created runtime incorrectly makes that runtime look stale.
+func profileDefaultsSnapshot(profile AgentProfile) AgentProfile {
+	out := cloneProfile(profile)
+	out.EnvRestartRequired = false
+	out.ImageUpgradeRequired = false
+	return out
+}
+
 type ProfileModelRequest struct {
 	AgentID  string            `json:"agent_id,omitempty"`
 	Provider string            `json:"provider"`

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -536,6 +536,63 @@ func TestProfileForCreateRequestUsesDefaultAPIKeyWithoutReplacingSelectedModel(t
 	}
 }
 
+func TestProfileForCreateRequestClearsInheritedRuntimeLifecycleSignals(t *testing.T) {
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	profile, err := svc.profileForCreateRequest(context.Background(), &CreateAgentSpec{
+		Name:        "alice",
+		RuntimeKind: RuntimeKindCodex,
+		AgentProfile: AgentProfile{
+			Provider:             ProviderAPI,
+			BaseURL:              "https://api.example/v1",
+			APIKey:               "api-key",
+			ModelID:              "gpt-selected",
+			ProfileComplete:      true,
+			EnvRestartRequired:   true,
+			ImageUpgradeRequired: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("profileForCreateRequest() error = %v", err)
+	}
+	if profile.EnvRestartRequired || profile.ImageUpgradeRequired {
+		t.Fatalf("new runtime lifecycle signals = env:%t image:%t, want both false", profile.EnvRestartRequired, profile.ImageUpgradeRequired)
+	}
+}
+
+func TestNormalizeLoadedAgentClearsRestartSignalInheritedAtCreation(t *testing.T) {
+	svc, err := NewService(config.ModelConfig{}, config.ServerConfig{}, "manager-image:test", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	createdAt := time.Date(2026, time.August, 10, 5, 35, 2, 0, time.UTC)
+
+	got, err := svc.normalizeLoadedAgent(Agent{
+		ID:          "agent-dev",
+		Name:        "dev",
+		RuntimeKind: RuntimeKindCodex,
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+		AgentProfile: AgentProfile{
+			Provider:           ProviderAPI,
+			BaseURL:            "https://api.example/v1",
+			APIKey:             "api-key",
+			ModelID:            "gpt-selected",
+			ProfileComplete:    true,
+			EnvRestartRequired: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalizeLoadedAgent() error = %v", err)
+	}
+	if got.AgentProfile.EnvRestartRequired {
+		t.Fatal("normalizeLoadedAgent().EnvRestartRequired = true, want false for never-updated runtime")
+	}
+}
+
 func TestListModelsForRequestDoesNotReuseStoredAPIKeyForChangedBaseURL(t *testing.T) {
 	var authHeader string
 	otherUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -849,7 +849,7 @@ func (s *Service) persistManagerAgent(ctx context.Context, manager Agent, runtim
 	s.agents[ManagerUserID] = manager
 	s.syncRuntimeRecordLocked(manager)
 	if manager.AgentProfile.ProfileComplete {
-		s.profileDefaults = cloneProfile(manager.AgentProfile)
+		s.profileDefaults = profileDefaultsSnapshot(manager.AgentProfile)
 	}
 	s.detectionResults = append([]ProfileDetectionResult(nil), manager.DetectionResults...)
 	err := s.saveLocked()
@@ -2504,7 +2504,7 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 	s.agents[worker.ID] = worker
 	s.syncRuntimeRecordLocked(worker)
 	if worker.AgentProfile.ProfileComplete {
-		s.profileDefaults = cloneProfile(worker.AgentProfile)
+		s.profileDefaults = profileDefaultsSnapshot(worker.AgentProfile)
 	}
 	if err := s.saveLocked(); err != nil {
 		delete(s.agents, worker.ID)

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -127,7 +127,7 @@ func (s *Service) UpdateAgentProfile(id string, profile AgentProfile) (AgentProf
 	}
 	s.agents[key] = current
 	if normalized.ProfileComplete {
-		s.profileDefaults = cloneProfile(normalized)
+		s.profileDefaults = profileDefaultsSnapshot(normalized)
 		s.detectionResults = nil
 	}
 	if err := s.saveLocked(); err != nil {
@@ -480,7 +480,7 @@ func (s *Service) update(ctx context.Context, id string, req UpdateRequest) (Age
 		}
 	}
 	if runtimeAffectingUpdate && current.ProfileComplete {
-		s.profileDefaults = cloneProfile(current.AgentProfile)
+		s.profileDefaults = profileDefaultsSnapshot(current.AgentProfile)
 		s.detectionResults = nil
 	}
 	current.UpdatedAt = time.Now().UTC()
@@ -1314,6 +1314,8 @@ func (s *Service) profileForCreateRequest(ctx context.Context, spec *CreateAgent
 		return AgentProfile{}, err
 	}
 	profile = normalizeProfileForAgentRuntime(profile, nil, spec.Name, spec.Description, spec.RuntimeKind, runtimeOptionsAfterPatch)
+	profile.EnvRestartRequired = false
+	profile.ImageUpgradeRequired = false
 	runtimeProfile := s.hydrateProfileFromCatalog(profile)
 	if !profile.ProfileComplete {
 		detected, _ := s.DetectDefaultProfile(ctx)
@@ -1321,6 +1323,8 @@ func (s *Service) profileForCreateRequest(ctx context.Context, spec *CreateAgent
 			detected.Name = strings.TrimSpace(spec.Name)
 			detected.Description = strings.TrimSpace(spec.Description)
 			det := normalizeProfileForAgentRuntime(detected, nil, spec.Name, spec.Description, spec.RuntimeKind, nil)
+			det.EnvRestartRequired = false
+			det.ImageUpgradeRequired = false
 			return det, nil
 		}
 		return AgentProfile{}, fmt.Errorf("agent profile is incomplete")

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -410,7 +410,7 @@ func (s *Service) readState() (map[string]Agent, error) {
 	var state persistedState
 	if err := json.Unmarshal(data, &state); err == nil && state.isObject() {
 		if strings.TrimSpace(state.ProfileDefaults.Provider) != "" || strings.TrimSpace(state.ProfileDefaults.ModelID) != "" || strings.TrimSpace(state.ProfileDefaults.BaseURL) != "" {
-			s.profileDefaults = s.catalogReferenceForLoadedProfile(normalizeProfile(state.ProfileDefaults, "", ""))
+			s.profileDefaults = profileDefaultsSnapshot(s.catalogReferenceForLoadedProfile(normalizeProfile(state.ProfileDefaults, "", "")))
 		}
 		s.detectionResults = append([]ProfileDetectionResult(nil), state.DetectionResults...)
 		runtimes := make(map[string]RuntimeRecord, len(state.Runtimes))
@@ -508,7 +508,7 @@ func (s *Service) agentsFromRootState(root rootAgentsState) (map[string]Agent, e
 		strings.TrimSpace(root.ProfileDefaults.ModelProviderID) != "" ||
 		strings.TrimSpace(root.ProfileDefaults.ModelID) != "" ||
 		strings.TrimSpace(root.ProfileDefaults.BaseURL) != "" {
-		s.profileDefaults = s.catalogReferenceForLoadedProfile(normalizeProfile(root.ProfileDefaults, "", ""))
+		s.profileDefaults = profileDefaultsSnapshot(s.catalogReferenceForLoadedProfile(normalizeProfile(root.ProfileDefaults, "", "")))
 	}
 	s.detectionResults = append([]ProfileDetectionResult(nil), root.DetectionResults...)
 	runtimes := make(map[string]RuntimeRecord, len(root.Items))
@@ -697,6 +697,12 @@ func (s *Service) normalizeLoadedAgent(a Agent) (Agent, error) {
 	a.AgentProfile = normalizeProfile(a.AgentProfile, a.Name, a.Description)
 	a.AgentProfile = s.catalogReferenceForLoadedProfile(a.AgentProfile)
 	a.AgentProfile = normalizeProfileForAgentRuntime(a.AgentProfile, a.RuntimeOptions, a.Name, a.Description, a.RuntimeKind, nil)
+	// A runtime cannot need a profile restart before it has ever been updated:
+	// its initial profile was applied as part of creation. Older versions could
+	// inherit this flag from model defaults, so repair that persisted state.
+	if a.AgentProfile.EnvRestartRequired && !a.CreatedAt.IsZero() && a.CreatedAt.Equal(a.UpdatedAt) {
+		a.AgentProfile.EnvRestartRequired = false
+	}
 	a.ProfileComplete = a.AgentProfile.ProfileComplete
 	a.Profile = profileSelector(a.AgentProfile)
 	if a.UpdatedAt.IsZero() {


### PR DESCRIPTION
- Fixes newly created agents incorrectly showing “Recreate required” by preventing runtime lifecycle flags from leaking into profile defaults.