### PR TITLE
fix(store): exclude runtime lock from migration backups

### DIFF
--- a/internal/localstore/migrate_ids.go
+++ b/internal/localstore/migrate_ids.go
@@ -79,6 +79,7 @@ const (
 	legacyAuthDirName           = "auth"
 	cliproxyAuthDirName         = "cliproxy-auth"
 	legacyCSGHubAuthFileName    = "csghub.json"
+	runtimeLockFileName         = "runtime.lock"
 	rootAuthSectionName         = "auth"
 	rootOpenCSGAuthKey          = "opencsg"
 	rootCSGHubAuthKey           = "csghub"
@@ -2293,6 +2294,12 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		if isExcludedBackupEntry(rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		target := filepath.Join(dst, rel)
 		if d.IsDir() {
 			info, err := d.Info()
@@ -2332,6 +2339,10 @@ func copyDir(src, dst string) error {
 		}
 		return nil
 	})
+}
+
+func isExcludedBackupEntry(rel string) bool {
+	return strings.EqualFold(filepath.Clean(rel), runtimeLockFileName)
 }
 
 func isVolatileBackupEntry(rel string) bool {

--- a/internal/localstore/migrate_ids_test.go
+++ b/internal/localstore/migrate_ids_test.go
@@ -9,6 +9,22 @@ import (
 	"time"
 )
 
+func TestCreateSiblingBackupExcludesRuntimeLock(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, ".csgclaw")
+	writeFile(t, filepath.Join(root, "config.toml"), "version = 1\n")
+	writeFile(t, filepath.Join(root, runtimeLockFileName), "12345\n")
+
+	backupPath, err := CreateSiblingBackup(root, time.Date(2026, 8, 11, 12, 0, 0, 0, time.Local))
+	if err != nil {
+		t.Fatalf("CreateSiblingBackup() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(backupPath, "config.toml")); err != nil {
+		t.Fatalf("backup missing config.toml: %v", err)
+	}
+	assertMissing(t, filepath.Join(backupPath, runtimeLockFileName))
+}
+
 func TestMigrateStoreCreatesSiblingBackupAndRootState(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, ".csgclaw")

--- a/internal/localstore/migrate_ids_windows_test.go
+++ b/internal/localstore/migrate_ids_windows_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package localstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestCreateSiblingBackupWithLockedRuntimeLock(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, ".csgclaw")
+	writeFile(t, filepath.Join(root, "config.toml"), "version = 1\n")
+	lockPath := filepath.Join(root, runtimeLockFileName)
+	writeFile(t, lockPath, "12345\n")
+
+	lockFile, err := os.OpenFile(lockPath, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile(runtime lock) error = %v", err)
+	}
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(lockFile.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		_ = lockFile.Close()
+		t.Fatalf("LockFileEx() error = %v", err)
+	}
+	t.Cleanup(func() {
+		var unlockOverlapped windows.Overlapped
+		if err := windows.UnlockFileEx(windows.Handle(lockFile.Fd()), 0, 1, 0, &unlockOverlapped); err != nil {
+			t.Errorf("UnlockFileEx() error = %v", err)
+		}
+		if err := lockFile.Close(); err != nil {
+			t.Errorf("Close(runtime lock) error = %v", err)
+		}
+	})
+
+	backupPath, err := CreateSiblingBackup(root, time.Date(2026, 8, 11, 12, 0, 0, 0, time.Local))
+	if err != nil {
+		t.Fatalf("CreateSiblingBackup() with locked runtime.lock error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(backupPath, "config.toml")); err != nil {
+		t.Fatalf("backup missing config.toml: %v", err)
+	}
+	assertMissing(t, filepath.Join(backupPath, runtimeLockFileName))
+}


### PR DESCRIPTION
## What changed

- Exclude the root `runtime.lock` file from configuration migration backups.
- Add a cross-platform regression test for backup contents.
- Add a Windows regression test that holds `runtime.lock` with `LockFileEx` while the backup is created.

## Why

CSGClaw acquires an exclusive runtime lock before migrating legacy configuration. The migration previously copied the entire configuration directory and reopened `runtime.lock`. On Windows, that second handle can fail with a locked-region error and prevent startup. Removing the configuration directory bypasses the migration, which matches the reported customer behavior.

## Impact

Existing Windows users with legacy configuration can start CSGClaw without deleting their configuration directory. The lock file is runtime-only and is no longer included in migration backups.

## Validation

- `go test ./internal/localstore ./internal/onboard ./cli/serve -count=1`
- `GOOS=windows GOARCH=amd64 go test -run "^$" -exec=/usr/bin/true ./internal/localstore`

The Windows-specific regression test is cross-compiled locally and is expected to run on Windows CI.