### PR TITLE
fix(web): hide activity from agent profiles

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -2450,7 +2450,6 @@ export function useAgentController({
       saveError: agentPageError,
       notice: selectedAgentPageNotice?.message || "",
       noticeTone: selectedAgentPageNotice?.tone || "warning",
-      rooms,
       feishuConnectBusy: selectedAgentActionBusy.includes(`:${FEISHU_CHANNEL_ACTION}:`) ? selectedAgentActionBusy : "",
       feishuPendingRegistration: selectedFeishuPendingRegistration,
       authStatuses: cliproxyAuthStatuses,

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -95,13 +95,11 @@ import {
   Select,
   Tooltip,
 } from "@/components/ui";
-import { AgentActivityPanel } from "./AgentActivityPanel";
-
 type VoidOrPromise = void | Promise<void>;
 type AgentActionHandler = (item: AgentLike) => VoidOrPromise;
 type AgentMetadataSavePatch = Pick<Partial<AgentDraft>, "description" | "name">;
 type AgentNoticeTone = "info" | "warning" | "success";
-const AGENT_PROFILE_TAB_IDS = ["profile", "activity", "channels", "instructions", "skills", "mcp"] as const;
+const AGENT_PROFILE_TAB_IDS = ["profile", "channels", "instructions", "skills", "mcp"] as const;
 type AgentProfileTabID = (typeof AGENT_PROFILE_TAB_IDS)[number];
 type UpdateAgentDraft = (patch: Partial<AgentDraft>) => void;
 type RuntimeOptionSchemaList = ReturnType<typeof runtimeOptionSchemasForAgent>;
@@ -157,7 +155,6 @@ export type AgentDetailPaneProps = {
   publishDisabled?: boolean;
   publishError?: string;
   locale?: LocaleCode;
-  rooms?: IMConversation[];
   saveError?: string;
   savedDraft?: AgentDraft | null;
   saving?: boolean;
@@ -221,7 +218,6 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
     modelProviders = null,
     saveError = "",
     locale = "en",
-    rooms = [],
     notifierWebhookPublicOrigin = "",
     skills = [],
     skillsLoading = false,
@@ -434,7 +430,6 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
       draft
         ? [
             { id: "profile" as const, label: t("agentProfileTab") },
-            { id: "activity" as const, label: t("agentActivityTab") },
             ...(!isNotifierDraft ? [{ id: "instructions" as const, label: t("agentInstructions") }] : []),
             ...(workspaceSupported
               ? [{ id: "skills" as const, label: t("agentProfileSkillsTab"), count: skills.length }]
@@ -864,9 +859,6 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 )}
                 <AgentAdvancedPanel draft={draft} item={item} t={t} updateDraft={updateDraft} />
               </div>
-            ) : null}
-            {visibleActiveProfileTab === "activity" ? (
-              <AgentActivityPanel item={item} locale={locale} rooms={rooms} t={t} />
             ) : null}
             {visibleActiveProfileTab === "channels" && !isNotificationBotAgent(item) ? (
               <AgentChannelsSection

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -1202,7 +1202,7 @@ describe("agent action visibility", () => {
       within(navigation)
         .getAllByRole("button")
         .map((button) => button.textContent),
-    ).toEqual(["Profile", "Activity", "Instructions", "Skills0", "MCP", "Channels"]);
+    ).toEqual(["Profile", "Instructions", "Skills0", "MCP", "Channels"]);
 
     await user.click(within(navigation).getByRole("button", { name: "MCP" }));
 
@@ -1603,9 +1603,10 @@ describe("agent action visibility", () => {
     expect(within(advancedSection as HTMLElement).getByText("Request options")).toBeInTheDocument();
   });
 
-  it("navigates to profile sections from the horizontal tabs", async () => {
+  it("omits activity and navigates to profile sections from the horizontal tabs", async () => {
     const user = userEvent.setup();
     const draft = agentToDraft(worker);
+    window.localStorage.setItem(AGENT_PROFILE_ACTIVE_TAB_STORAGE_KEY, "activity");
     render(
       <AgentDetailPane
         item={worker}
@@ -1628,14 +1629,7 @@ describe("agent action visibility", () => {
 
     const navigation = screen.getByRole("navigation", { name: "Profile sections" });
     const tabs = within(navigation).getAllByRole("button");
-    expect(tabs.map((tab) => tab.textContent)).toEqual([
-      "Profile",
-      "Activity",
-      "Instructions",
-      "Skills0",
-      "MCP",
-      "Channels",
-    ]);
+    expect(tabs.map((tab) => tab.textContent)).toEqual(["Profile", "Instructions", "Skills0", "MCP", "Channels"]);
     expect(tabs[0]).toHaveAttribute("aria-current", "location");
     expect(screen.getByText("Request options")).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Channels" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- remove the Activity tab from public agent profile pages
- stop passing conversation rooms into the agent profile pane
- fall back to Profile when local storage contains the removed `activity` tab value

## Why

Agent profiles are public, while the activity feed only reflects CSGClaw channel activity. Hiding it avoids exposing channel-specific activity on a public profile and prevents an incomplete activity view from being presented as comprehensive.

## Impact

Conversation activity panels, working indicators, activity cards, and backend activity APIs are unchanged.

## Validation

- `vitest run tests/components/AgentActions.test.tsx src/components/business/ConversationPane/ConversationComposer.test.tsx src/pages/ConversationPage/components/ConversationActivityPanel/conversationActivity.test.ts`
- `tsc --noEmit`
- ESLint on changed files
- Prettier check on changed files