### PR TITLE
fix(api): fix Windows directory picker focus and encoding

### DIFF
--- a/internal/api/directory_picker.go
+++ b/internal/api/directory_picker.go
@@ -189,10 +189,18 @@ func pickDirectoryLinux(ctx context.Context) (string, error) {
 
 func pickDirectoryWindows(ctx context.Context) (string, error) {
 	script := strings.Join([]string{
+		`[Console]::OutputEncoding = [System.Text.Encoding]::UTF8`,
 		`Add-Type -AssemblyName System.Windows.Forms`,
+		`Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; using System.Windows.Forms; namespace CSGClaw { public sealed class WindowOwner : IWin32Window { [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow(); private WindowOwner(IntPtr handle) { Handle = handle; } public IntPtr Handle { get; private set; } public static WindowOwner Foreground() { IntPtr handle = GetForegroundWindow(); return handle == IntPtr.Zero ? null : new WindowOwner(handle); } } }' -ReferencedAssemblies System.Windows.Forms`,
+		`$owner = [CSGClaw.WindowOwner]::Foreground()`,
 		`$dialog = New-Object System.Windows.Forms.FolderBrowserDialog`,
 		`$dialog.Description = 'Select a directory for CSGClaw'`,
-		`if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {`,
+		`if ($null -ne $owner) {`,
+		`  $result = $dialog.ShowDialog($owner)`,
+		`} else {`,
+		`  $result = $dialog.ShowDialog()`,
+		`}`,
+		`if ($result -eq [System.Windows.Forms.DialogResult]::OK) {`,
 		`  [Console]::Out.Write($dialog.SelectedPath)`,
 		`} else {`,
 		`  exit 1`,

--- a/internal/api/directory_picker_test.go
+++ b/internal/api/directory_picker_test.go
@@ -150,15 +150,15 @@ func TestPickDirectoryWindowsUsesSeparatedSTACommands(t *testing.T) {
 	runDirectoryPickerCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
 		commandName = name
 		commandArgs = slices.Clone(args)
-		return []byte(`C:\workspace`), nil
+		return []byte(`C:\工作目录`), nil
 	}
 
 	path, err := pickDirectoryWindows(context.Background())
 	if err != nil {
 		t.Fatalf("pickDirectoryWindows() error = %v", err)
 	}
-	if path != `C:\workspace` {
-		t.Fatalf("pickDirectoryWindows() = %q, want %q", path, `C:\workspace`)
+	if path != `C:\工作目录` {
+		t.Fatalf("pickDirectoryWindows() = %q, want %q", path, `C:\工作目录`)
 	}
 	if commandName != "powershell" {
 		t.Fatalf("command name = %q, want powershell", commandName)
@@ -170,7 +170,16 @@ func TestPickDirectoryWindowsUsesSeparatedSTACommands(t *testing.T) {
 		t.Fatalf("command args = %q, want -Command followed by script", commandArgs)
 	}
 	script := commandArgs[len(commandArgs)-1]
-	if !strings.Contains(script, "System.Windows.Forms\n$dialog =") {
+	if !strings.HasPrefix(script, "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n") {
+		t.Fatalf("PowerShell output encoding is not set to UTF-8 first: %q", script)
+	}
+	if !strings.Contains(script, "System.Windows.Forms\nAdd-Type") {
 		t.Fatalf("PowerShell statements are not separated by a newline: %q", script)
+	}
+	if !strings.Contains(script, `WindowOwner : IWin32Window`) {
+		t.Fatalf("PowerShell script does not define a browser window owner: %q", script)
+	}
+	if !strings.Contains(script, `$dialog.ShowDialog($owner)`) {
+		t.Fatalf("PowerShell dialog is not attached to the foreground browser window: %q", script)
 	}
 }


### PR DESCRIPTION
- Emit PowerShell output as UTF-8 so non-ASCII directory paths round-trip correctly.
- Attach FolderBrowserDialog to the foreground window so it stays above the browser.
- Extend Windows picker coverage for UTF-8 paths and owner-window binding.