### PR TITLE
fix(team): keep manager selected in member dialog

### DIFF
--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -103,7 +103,7 @@ import type {
 } from "@/models/agents";
 import { isDirectConversation, localIdentitiesMatch, upsertUserInData } from "@/models/conversations";
 import { mcpServersFromMap } from "@/models/mcp";
-import { displayTeam } from "@/models/tasks";
+import { displayTeam, teamMemberIDs } from "@/models/tasks";
 import type { WorkspaceTeam } from "@/models/tasks";
 import {
   modelProviderCatalogForAgentAvailability,
@@ -612,6 +612,11 @@ export function useAgentController({
   const createTeamCandidateIDs = useMemo(
     () => createTeamCandidates.map((item) => String(item.id)),
     [createTeamCandidates],
+  );
+  const managerTeamMemberID = matchingTeamCandidateID(managerAgent?.id || MANAGER_AGENT_ID, createTeamCandidateIDs);
+  const lockedTeamMemberID = matchingTeamCandidateID(
+    editingTeam?.lead_agent_id || managerTeamMemberID,
+    createTeamCandidateIDs,
   );
   const runningAgentCount = agentItems.filter(isAgentRunning).length;
   const notifierWebhookPublicOrigin = useMemo(() => resolvedNotifierWebhookOrigin(bootstrapConfig), [bootstrapConfig]);
@@ -1334,10 +1339,9 @@ export function useAgentController({
   }
 
   function openCreateTeamModal(): void {
-    const firstAgentID = createTeamCandidateIDs[0] || "";
     setEditingTeam(null);
     setCreateTeamTitle("");
-    setCreateTeamMemberIDs(firstAgentID ? [firstAgentID] : []);
+    setCreateTeamMemberIDs(managerTeamMemberID ? [managerTeamMemberID] : []);
     setTeamActionError("");
     setShowCreateTeamModal(true);
   }
@@ -1354,7 +1358,7 @@ export function useAgentController({
     }
     setEditingTeam(item);
     setCreateTeamTitle(displayTeam(item));
-    setCreateTeamMemberIDs([...(item.member_agent_ids ?? [])]);
+    setCreateTeamMemberIDs(teamSelectionMemberIDs(item, createTeamCandidateIDs));
     setTeamActionError("");
     setShowCreateTeamModal(true);
   }
@@ -2184,7 +2188,9 @@ export function useAgentController({
     setTeamActionError("");
     try {
       await updateTeamRequest(editingTeam.id, {
-        member_agent_ids: createTeamMemberIDs,
+        member_agent_ids: createTeamMemberIDs.filter(
+          (memberID) => !localIdentitiesMatch(memberID, editingTeam.lead_agent_id),
+        ),
       });
       await teamsQuery.refetch();
       await refreshWorkspaceBootstrap();
@@ -2544,6 +2550,7 @@ export function useAgentController({
           t,
           mode: editingTeam ? ("edit" as const) : ("create" as const),
           candidates: createTeamCandidates,
+          lockedTeamMemberIDs: lockedTeamMemberID ? [lockedTeamMemberID] : [],
           teamTitle: createTeamTitle,
           onTeamTitleChange: setCreateTeamTitle,
           teamMemberIDs: createTeamMemberIDs,
@@ -2555,6 +2562,26 @@ export function useAgentController({
         }
       : null,
   };
+}
+
+function matchingTeamCandidateID(identity: string | null | undefined, candidateIDs: readonly string[]): string {
+  const normalizedIdentity = String(identity || "").trim();
+  if (!normalizedIdentity) {
+    return "";
+  }
+  return (
+    candidateIDs.find((candidateID) => localIdentitiesMatch(candidateID, normalizedIdentity)) || normalizedIdentity
+  );
+}
+
+function teamSelectionMemberIDs(team: WorkspaceTeam, candidateIDs: readonly string[]): string[] {
+  return Array.from(
+    new Set(
+      teamMemberIDs(team)
+        .map((memberID) => matchingTeamCandidateID(memberID, candidateIDs))
+        .filter(Boolean),
+    ),
+  );
 }
 
 function csgclawParticipantIDForAgent(item: AgentLike): string {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateTeamModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateTeamModal.tsx
@@ -10,6 +10,7 @@ type CreateTeamModalProps = {
   t: TranslateFn;
   candidates: AgentLike[];
   mode?: "create" | "edit";
+  lockedTeamMemberIDs?: string[];
   teamTitle: string;
   onTeamTitleChange: (value: string) => void;
   teamMemberIDs: string[];
@@ -24,6 +25,7 @@ export function CreateTeamModal({
   t,
   candidates,
   mode = "create",
+  lockedTeamMemberIDs = [],
   teamTitle,
   onTeamTitleChange,
   teamMemberIDs,
@@ -35,8 +37,10 @@ export function CreateTeamModal({
 }: CreateTeamModalProps) {
   const editing = mode === "edit";
   const candidateIDs = candidates.map((item) => item.id).filter((id): id is string => Boolean(id));
-  const allCandidatesSelected = candidateIDs.length > 0 && candidateIDs.every((id) => teamMemberIDs.includes(id));
-  const selectedMemberCount = candidateIDs.filter((id) => teamMemberIDs.includes(id)).length;
+  const selectableCandidateIDs = candidateIDs.filter((id) => !lockedTeamMemberIDs.includes(id));
+  const isMemberSelected = (id: string) => lockedTeamMemberIDs.includes(id) || teamMemberIDs.includes(id);
+  const allCandidatesSelected = candidateIDs.length > 0 && candidateIDs.every(isMemberSelected);
+  const selectedMemberCount = candidateIDs.filter(isMemberSelected).length;
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -70,13 +74,17 @@ export function CreateTeamModal({
                   <input
                     type="checkbox"
                     checked={allCandidatesSelected}
-                    onChange={() =>
-                      onTeamMemberIDsChange((current) =>
-                        allCandidatesSelected
-                          ? current.filter((id) => !candidateIDs.includes(id))
-                          : Array.from(new Set([...current, ...candidateIDs])),
-                      )
-                    }
+                    disabled={selectableCandidateIDs.length === 0}
+                    onChange={() => {
+                      onTeamMemberIDsChange((current) => {
+                        const allSelected = candidateIDs.every(
+                          (id) => lockedTeamMemberIDs.includes(id) || current.includes(id),
+                        );
+                        return allSelected
+                          ? current.filter((id) => !selectableCandidateIDs.includes(id))
+                          : Array.from(new Set([...current, ...selectableCandidateIDs]));
+                      });
+                    }}
                   />
                   <span>{t("allMembers")}</span>
                   <small>
@@ -85,12 +93,13 @@ export function CreateTeamModal({
                 </label>
                 {candidates.map((item) => {
                   const itemID = item.id || "";
+                  const memberLocked = itemID ? lockedTeamMemberIDs.includes(itemID) : false;
                   return (
                     <label key={itemID || item.name} className="selection-item">
                       <input
                         type="checkbox"
-                        checked={itemID ? teamMemberIDs.includes(itemID) : false}
-                        disabled={!itemID}
+                        checked={itemID ? memberLocked || teamMemberIDs.includes(itemID) : false}
+                        disabled={!itemID || memberLocked}
                         onChange={() =>
                           itemID ? onTeamMemberIDsChange((current) => toggleSelection(current, itemID)) : undefined
                         }

--- a/web/app/tests/components/WorkspaceModals.test.tsx
+++ b/web/app/tests/components/WorkspaceModals.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { CreateRoomModal, CreateTeamModal, InviteMembersModal } from "@/pages/WorkspacePage/components/WorkspaceModals";
 import type { TranslateFn } from "@/models/conversations";
 
@@ -79,5 +80,43 @@ describe("WorkspaceModals", () => {
     });
 
     expect(onTeamTitleChange).toHaveBeenCalledWith("Windows 测试团队");
+  });
+
+  it("keeps locked team members selected when toggling all members", () => {
+    function Harness() {
+      const [teamMemberIDs, setTeamMemberIDs] = useState(["agent-manager"]);
+      return (
+        <CreateTeamModal
+          candidates={[
+            { id: "agent-manager", name: "Manager", role: "manager" },
+            { id: "agent-worker", name: "Worker", role: "worker" },
+          ]}
+          lockedTeamMemberIDs={["agent-manager"]}
+          onClose={() => {}}
+          onCreate={async () => {}}
+          onTeamMemberIDsChange={setTeamMemberIDs}
+          onTeamTitleChange={() => {}}
+          submitError=""
+          t={t}
+          teamActionBusy={false}
+          teamMemberIDs={teamMemberIDs}
+          teamTitle="Team"
+        />
+      );
+    }
+
+    render(<Harness />);
+    const [allMembers, manager, worker] = screen.getAllByRole("checkbox");
+
+    expect(manager).toBeChecked();
+    expect(manager).toBeDisabled();
+    expect(worker).not.toBeChecked();
+
+    fireEvent.click(allMembers);
+    expect(worker).toBeChecked();
+
+    fireEvent.click(allMembers);
+    expect(manager).toBeChecked();
+    expect(worker).not.toBeChecked();
   });
 });

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -30,7 +30,7 @@ import {
 import { createUserRequest } from "@/api/im";
 import { patchCsgclawUserRequest } from "@/api/participants";
 import { fetchSkills } from "@/api/skills";
-import { createTeamRequest, deleteTeamRequest, fetchTeams } from "@/api/tasks";
+import { createTeamRequest, deleteTeamRequest, fetchTeams, updateTeamRequest } from "@/api/tasks";
 import { useAgentController } from "@/hooks/workspace/useAgentController";
 import { WorkspacePaneTypes } from "@/models/routing";
 import type { WorkspacePane } from "@/models/routing";
@@ -67,6 +67,7 @@ vi.mock("@/api/tasks", async () => {
     createTeamRequest: vi.fn(),
     deleteTeamRequest: vi.fn(),
     fetchTeams: vi.fn(async () => []),
+    updateTeamRequest: vi.fn(),
   };
 });
 
@@ -316,6 +317,7 @@ describe("useAgentController", () => {
     vi.mocked(createTeamRequest).mockReset();
     vi.mocked(deleteTeamRequest).mockReset();
     vi.mocked(fetchTeams).mockReset();
+    vi.mocked(updateTeamRequest).mockReset();
     vi.mocked(runAgentActionRequest).mockReset();
     vi.mocked(startFeishuRegistrationRequest).mockReset();
     vi.mocked(updateAgentRequest).mockReset();
@@ -393,6 +395,15 @@ describe("useAgentController", () => {
     });
     vi.mocked(deleteTeamRequest).mockResolvedValue(undefined);
     vi.mocked(fetchTeams).mockResolvedValue([]);
+    vi.mocked(updateTeamRequest).mockResolvedValue({
+      created_at: "2026-06-10T00:00:00Z",
+      id: "team-1",
+      lead_agent_id: "agent-manager",
+      member_agent_ids: ["agent-worker"],
+      status: "active",
+      title: "Team",
+      updated_at: "2026-06-10T00:00:00Z",
+    });
     vi.mocked(runAgentActionRequest).mockResolvedValue({
       ...oldAgent,
       image: actionImage,
@@ -1766,6 +1777,45 @@ describe("useAgentController", () => {
       lead_agent_id: "u-manager",
       member_agent_ids: ["u-manager"],
       title: "teamNewFallbackTitle",
+    });
+  });
+
+  it("locks the team lead and restores existing members across compatible agent ids", async () => {
+    const manager = { ...oldAgent, id: "agent-manager" };
+    const worker: AgentLike = {
+      ...oldAgent,
+      id: "agent-worker",
+      name: "worker",
+      role: "worker",
+    };
+    const team: WorkspaceTeam = {
+      id: "team-1",
+      title: "Team",
+      lead_agent_id: "u-manager",
+      member_agent_ids: ["u-worker"],
+      status: "active",
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+    };
+    const { result } = renderHook(() => useAgentControllerHarness({ agents: [manager, worker] }), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.controller.openManageTeamMembers(team);
+    });
+
+    await waitFor(() => {
+      expect(result.current.controller.createTeamModalProps?.teamMemberIDs).toEqual(["agent-worker", "agent-manager"]);
+      expect(result.current.controller.createTeamModalProps?.lockedTeamMemberIDs).toEqual(["agent-manager"]);
+    });
+
+    await act(async () => {
+      await result.current.controller.createTeamModalProps?.onCreate();
+    });
+
+    expect(updateTeamRequest).toHaveBeenCalledWith("team-1", {
+      member_agent_ids: ["agent-worker"],
     });
   });
 


### PR DESCRIPTION
## Summary

- keep the team manager selected and non-removable in create and edit dialogs
- restore existing team members while normalizing legacy and current agent IDs
- keep the team lead out of `member_agent_ids` when saving member changes

## Root cause

The edit dialog initialized its selection from `member_agent_ids` only, while the manager is stored separately as `lead_agent_id`. This made the manager appear unselected and allowed the UI selection state to remove it even though the backend continued treating it as the team lead.

## Impact

Team creation and member management now consistently reflect the backend lead/member model without changing the API contract or stored team data.

## Validation

- `pnpm --dir web/app exec vitest run` — 118 test files, 846 tests passed
- `pnpm --dir web/app typecheck`
- ESLint and Prettier checks for the changed files

## Related issue

- https://git-devops.opencsg.com/product/agentichub/requirements/-/issues/3298
