### PR TITLE
fix(skill): prefer Hub archive downloads

### DIFF
--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -152,7 +152,7 @@ The server keeps the current Hub catalog ordering and returns normalized Skill s
 
 ### `POST /api/v1/skills:install`
 
-Installs one remote Skill from the same effective OpenCSG Hub. Set `replace` to overwrite an existing local Skill with the same name.
+Installs one remote Skill from the same effective OpenCSG Hub. The server downloads the repository archive in one request when the Hub supports it and falls back to the legacy tree/blob APIs for compatibility. Set `replace` to overwrite an existing local Skill with the same name.
 
 ```json
 {

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -152,7 +152,7 @@ Server 保持当前 Hub catalog 的排序，并返回归一化后的 Skill 摘�
 
 ### `POST /api/v1/skills:install`
 
-从同一个有效 OpenCSG Hub 安装远端 Skill。设置 `replace` 可覆盖同名本地 Skill。
+从同一个有效 OpenCSG Hub 安装远端 Skill。Hub 支持时，Server 通过单个请求下载仓库压缩包；旧版 Hub 则兼容回退到 tree/blob API。设置 `replace` 可覆盖同名本地 Skill。
 
 ```json
 {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -4600,69 +4599,23 @@ func TestHandleSkillInstallFromOfficialHub(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	rootTreePages := 0
+	archiveRequests := 0
 	officialHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/skills/AIWizards/agent-builder/refs/dev/tree/":
-			rootTreePages++
-			cursor := r.URL.Query().Get("cursor")
-			if r.URL.Query().Get("limit") != "500" {
-				t.Errorf("root tree query = %s, want limit=500", r.URL.RawQuery)
-				http.Error(w, "bad query", http.StatusBadRequest)
-				return
+		case "/api/v1/skills/AIWizards/agent-builder/download_archive/refs/dev":
+			archiveRequests++
+			if got := r.Header.Get("Accept"); got != "application/zip" {
+				t.Errorf("Accept = %q, want application/zip", got)
 			}
-			if cursor == "" {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"data": map[string]any{
-						"Cursor": "next-root-page",
-						"Files":  []map[string]any{},
-					},
-				})
-				return
-			}
-			if cursor != "next-root-page" {
-				t.Errorf("root tree cursor = %q, want next-root-page", cursor)
-				http.Error(w, "bad cursor", http.StatusBadRequest)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{
-					"Files": []map[string]any{
-						{"name": "SKILL.md", "path": "SKILL.md", "type": "file"},
-						{"name": "scripts", "path": "scripts", "type": "dir"},
-					},
-				},
-			})
-		case "/api/v1/skills/AIWizards/agent-builder/refs/dev/tree/scripts":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{
-					"Files": []map[string]any{
-						{"name": "run.sh", "path": "scripts/run.sh", "type": "file"},
-					},
-				},
-			})
-		case "/api/v1/skills/AIWizards/agent-builder/blob/SKILL.md":
-			if r.URL.Query().Get("ref") != "dev" {
-				t.Errorf("blob ref = %q, want dev", r.URL.Query().Get("ref"))
-				http.Error(w, "bad ref", http.StatusBadRequest)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{
-					"content": base64.StdEncoding.EncodeToString([]byte("---\ndescription: Build agents\n---\n# Agent Builder\n")),
-					"path":    "SKILL.md",
-					"type":    "file",
-				},
-			})
-		case "/api/v1/skills/AIWizards/agent-builder/blob/scripts/run.sh":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{
-					"content": base64.StdEncoding.EncodeToString([]byte("#!/bin/sh\necho ready\n")),
-					"path":    "scripts/run.sh",
-					"type":    "file",
-				},
-			})
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(mustZipBytes(t, map[string]string{
+				"SKILL.md":       "---\ndescription: Build agents\n---\n# Agent Builder\n",
+				"scripts/run.sh": "#!/bin/sh\necho ready\n",
+			}))
+		case "/api/v1/skills/AIWizards/agent-builder/download_archive/refs/broken":
+			archiveRequests++
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = io.WriteString(w, "<html>not a zip</html>")
 		default:
 			http.NotFound(w, r)
 		}
@@ -4744,8 +4697,18 @@ enabled = true
 	if _, err := os.Stat(staleFile); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stale file still exists after replace, err=%v", err)
 	}
-	if rootTreePages != 4 {
-		t.Fatalf("root tree pages = %d, want 4", rootTreePages)
+
+	invalidReq := httptest.NewRequest(http.MethodPost, "/api/v1/skills:install", strings.NewReader(`{
+		"remote_path": "AIWizards/agent-builder",
+		"ref": "broken"
+	}`))
+	invalidRec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(invalidRec, invalidReq)
+	if invalidRec.Code != http.StatusBadGateway {
+		t.Fatalf("invalid archive status = %d, want %d; body=%s", invalidRec.Code, http.StatusBadGateway, invalidRec.Body.String())
+	}
+	if archiveRequests != 3 {
+		t.Fatalf("archive requests = %d, want 3", archiveRequests)
 	}
 }
 

--- a/internal/skill/remote/agentichub.go
+++ b/internal/skill/remote/agentichub.go
@@ -27,6 +27,7 @@ const (
 	agenticHubMaxTreePages      = 1000
 	agenticHubMaxJSONBytes      = 4 << 20
 	agenticHubMaxArchiveBytes   = 64 << 20
+	agenticHubArchiveTimeout    = 5 * time.Minute
 	agenticHubRequestTimeout    = 60 * time.Second
 	agenticHubSkillsAPIPathRoot = "skills"
 )
@@ -114,9 +115,26 @@ func FetchAgenticHubSkillArchive(ctx context.Context, baseURL, remotePath, ref s
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidAgenticHubRequest, err)
 	}
+	archiveClient := &http.Client{Timeout: agenticHubArchiveTimeout}
+	archive, available, err := downloadAgenticHubSkillArchive(ctx, archiveClient, baseURL, remotePath, ref)
+	if err != nil {
+		return nil, err
+	}
+	if available {
+		return archive, nil
+	}
+	requestClient := &http.Client{Timeout: agenticHubRequestTimeout}
+	return buildAgenticHubSkillArchive(ctx, requestClient, baseURL, remotePath, ref, skillName)
+}
+
+func buildAgenticHubSkillArchive(
+	ctx context.Context,
+	client *http.Client,
+	baseURL, remotePath, ref, skillName string,
+) ([]byte, error) {
 	builder := &agenticHubArchiveBuilder{
 		baseURL:    baseURL,
-		client:     &http.Client{Timeout: agenticHubRequestTimeout},
+		client:     client,
 		ref:        ref,
 		remotePath: remotePath,
 		skillName:  skillName,
@@ -136,6 +154,48 @@ func FetchAgenticHubSkillArchive(ctx context.Context, baseURL, remotePath, ref s
 		return nil, fmt.Errorf("close remote skill archive: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+func downloadAgenticHubSkillArchive(
+	ctx context.Context,
+	client *http.Client,
+	baseURL, remotePath, ref string,
+) ([]byte, bool, error) {
+	endpoint, err := agenticHubSkillArchiveURL(baseURL, remotePath, ref)
+	if err != nil {
+		return nil, false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("create AgenticHub archive request: %w", err)
+	}
+	req.Header.Set("Accept", "application/zip")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("AgenticHub archive request %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		// Older Hub deployments expose only tree/blob endpoints.
+		return nil, false, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, agenticHubMaxArchiveBytes+1))
+	if err != nil {
+		return nil, false, fmt.Errorf("read AgenticHub archive response: %w", err)
+	}
+	if int64(len(body)) > agenticHubMaxArchiveBytes {
+		return nil, false, fmt.Errorf("remote skill archive exceeds %d bytes", agenticHubMaxArchiveBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, false, fmt.Errorf("AgenticHub archive request failed with status %d: %s", resp.StatusCode, truncateAgenticHubBody(body))
+	}
+	if len(body) == 0 {
+		return nil, false, skilllocal.ErrSkillArchiveEmpty
+	}
+	if _, err := zip.NewReader(bytes.NewReader(body), int64(len(body))); err != nil {
+		return nil, false, fmt.Errorf("invalid AgenticHub skill archive: %w", err)
+	}
+	return body, true, nil
 }
 
 func ListAgenticHubSkills(ctx context.Context, baseURL string, options AgenticHubSkillListOptions) (AgenticHubSkillList, error) {
@@ -339,6 +399,13 @@ func agenticHubSkillTreeURL(baseURL, remotePath, ref, treePath, cursor string) (
 	query.Set("cursor", cursor)
 	query.Set("limit", fmt.Sprintf("%d", agenticHubSkillTreeLimit))
 	return buildAgenticHubURL(baseURL, parts, treePath == "", query)
+}
+
+func agenticHubSkillArchiveURL(baseURL, remotePath, ref string) (string, error) {
+	parts := []string{"api", "v1", agenticHubSkillsAPIPathRoot}
+	parts = append(parts, strings.Split(remotePath, "/")...)
+	parts = append(parts, "download_archive", "refs", ref)
+	return buildAgenticHubURL(baseURL, parts, false, nil)
 }
 
 func agenticHubSkillBlobURL(baseURL, remotePath, ref, filePath string) (string, error) {

--- a/internal/skill/remote/agentichub_test.go
+++ b/internal/skill/remote/agentichub_test.go
@@ -8,14 +8,45 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestFetchAgenticHubSkillArchiveReadsTreeCursorPages(t *testing.T) {
+func TestFetchAgenticHubSkillArchivePrefersArchiveDownload(t *testing.T) {
+	want := testAgenticHubZip(t, map[string]string{
+		"SKILL.md":       "name: agent-builder\n",
+		"scripts/run.sh": "echo ready\n",
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/skills/AIWizards/agent-builder/download_archive/refs/main" {
+			t.Fatalf("unexpected AgenticHub request path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "application/zip" {
+			t.Fatalf("Accept = %q, want application/zip", got)
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(want)
+	}))
+	defer server.Close()
+
+	got, err := FetchAgenticHubSkillArchive(context.Background(), server.URL, "AIWizards/agent-builder", "")
+	if err != nil {
+		t.Fatalf("FetchAgenticHubSkillArchive() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("archive download was modified")
+	}
+}
+
+func TestFetchAgenticHubSkillArchiveFallsBackToTreeCursorPages(t *testing.T) {
+	archiveRequests := 0
 	treeRequests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
+		case "/api/v1/skills/AIWizards/agent-builder/download_archive/refs/main":
+			archiveRequests++
+			http.NotFound(w, r)
 		case "/api/v1/skills/AIWizards/agent-builder/refs/main/tree/":
 			treeRequests++
 			if r.URL.Query().Get("cursor") == "" {
@@ -39,6 +70,9 @@ func TestFetchAgenticHubSkillArchiveReadsTreeCursorPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchAgenticHubSkillArchive() error = %v", err)
 	}
+	if archiveRequests != 1 {
+		t.Fatalf("archive requests = %d, want 1", archiveRequests)
+	}
 	if treeRequests != 2 {
 		t.Fatalf("tree requests = %d, want 2", treeRequests)
 	}
@@ -57,6 +91,39 @@ func TestFetchAgenticHubSkillArchiveReadsTreeCursorPages(t *testing.T) {
 	}
 	if string(data) != "name: agent-builder\n" {
 		t.Fatalf("skill file content = %q", string(data))
+	}
+}
+
+func TestFetchAgenticHubSkillArchiveDoesNotFallbackAfterArchiveFailure(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "archive unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	_, err := FetchAgenticHubSkillArchive(context.Background(), server.URL, "AIWizards/agent-builder", "")
+	if err == nil {
+		t.Fatal("FetchAgenticHubSkillArchive() error = nil, want archive failure")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want no tree fallback", requests)
+	}
+}
+
+func TestFetchAgenticHubSkillArchiveRejectsInvalidArchive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, "<html>not a zip</html>")
+	}))
+	defer server.Close()
+
+	_, err := FetchAgenticHubSkillArchive(context.Background(), server.URL, "AIWizards/agent-builder", "")
+	if err == nil {
+		t.Fatal("FetchAgenticHubSkillArchive() error = nil, want invalid archive error")
+	}
+	if !strings.Contains(err.Error(), "invalid AgenticHub skill archive") {
+		t.Fatalf("FetchAgenticHubSkillArchive() error = %q, want invalid archive error", err)
 	}
 }
 
@@ -80,6 +147,21 @@ func TestAgenticHubSkillTreeURLEscapesSlashRef(t *testing.T) {
 	want := "https://example.test/hub/api/v1/skills/AIWizards/agent-builder/refs/feature%2Finstall/tree/?cursor=next-page&limit=500"
 	if got != want {
 		t.Fatalf("tree URL = %q, want %q", got, want)
+	}
+}
+
+func TestAgenticHubSkillArchiveURLEscapesSlashRef(t *testing.T) {
+	got, err := agenticHubSkillArchiveURL(
+		"https://example.test/hub",
+		"AIWizards/agent-builder",
+		"feature/install",
+	)
+	if err != nil {
+		t.Fatalf("agenticHubSkillArchiveURL() error = %v", err)
+	}
+	want := "https://example.test/hub/api/v1/skills/AIWizards/agent-builder/download_archive/refs/feature%2Finstall"
+	if got != want {
+		t.Fatalf("archive URL = %q, want %q", got, want)
 	}
 }
 
@@ -170,4 +252,23 @@ func TestAgenticHubTotalTreatsNullAsUnknown(t *testing.T) {
 	if got := agenticHubTotal([]byte("null")); got != nil {
 		t.Fatalf("agenticHubTotal(null) = %v, want nil", got)
 	}
+}
+
+func testAgenticHubZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		writer, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %q: %v", name, err)
+		}
+		if _, err := writer.Write([]byte(content)); err != nil {
+			t.Fatalf("write zip entry %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
## Summary

- download remote Skills through the Hub archive endpoint when available
- retain the tree/blob fallback for older Hub deployments
- validate downloaded ZIPs before installation and use an archive-specific timeout

## Why

Remote Skill installation currently fetches every repository file through separate tree/blob calls. Large Skills can require thousands of requests and take several minutes even when the Hub exposes a repository archive endpoint. A malformed successful response also reached the local installer and surfaced as a 500.

## Impact

Supported Hub deployments install Skills with one archive request. Older deployments continue to work through the existing fallback. Invalid upstream archives now return 502, and large archive transfers have a five-minute deadline instead of the JSON request timeout.

## Validation

- `go test ./internal/skill/remote ./internal/skill/local -count=1`
- `go test ./internal/api -run '^(TestHandleSkillInstallFromOfficialHub|TestHandleRemoteSkillsUsesEffectiveOfficialHub|TestHandleSkillUploadRejectsDuplicate|TestHandleSkillUploadRejectsInvalidArchive)$' -count=1`
- `go vet ./internal/skill/remote ./internal/skill/local`
- validated the staging Hub archive endpoint and local install/replace flow
