### PR TITLE
fix: clean up notification deletion and stale routes

### DIFF
--- a/internal/participant/service.go
+++ b/internal/participant/service.go
@@ -478,7 +478,11 @@ func (s *Service) Delete(ctx context.Context, channel, id string, opts DeleteOpt
 		if err := s.agents.Delete(ctx, deleted.AgentID); err != nil {
 			return deleted, true, err
 		}
-		if err := s.deleteUnreferencedCSGClawAgentUser(deleted); err != nil {
+		if err := s.deleteUnreferencedCSGClawParticipantUser(deleted); err != nil {
+			return deleted, true, err
+		}
+	} else if deleted.Type == TypeNotification {
+		if err := s.deleteUnreferencedCSGClawParticipantUser(deleted); err != nil {
 			return deleted, true, err
 		}
 	}
@@ -514,7 +518,7 @@ func (s *Service) DeleteAgent(ctx context.Context, agentID string) ([]apitypes.P
 		deleted = append(deleted, item)
 	}
 	for _, item := range deleted {
-		if err := s.deleteUnreferencedCSGClawAgentUser(item); err != nil {
+		if err := s.deleteUnreferencedCSGClawParticipantUser(item); err != nil {
 			return deleted, err
 		}
 	}
@@ -548,7 +552,7 @@ func (s *Service) RepairDanglingCSGClawAgentParticipants() ([]apitypes.Participa
 			continue
 		}
 		deleted = append(deleted, removed)
-		if err := s.deleteUnreferencedCSGClawAgentUser(removed); err != nil {
+		if err := s.deleteUnreferencedCSGClawParticipantUser(removed); err != nil {
 			return deleted, err
 		}
 	}
@@ -587,11 +591,13 @@ func participantLookupIDs(id string) []string {
 	return []string{typed, id}
 }
 
-func (s *Service) deleteUnreferencedCSGClawAgentUser(deleted apitypes.Participant) error {
+func (s *Service) deleteUnreferencedCSGClawParticipantUser(deleted apitypes.Participant) error {
 	if s == nil || s.store == nil || s.im == nil {
 		return nil
 	}
-	if deleted.Channel != ChannelCSGClaw || deleted.Type != TypeAgent || deleted.ChannelUserKind != ChannelUserKindLocalUserID {
+	if deleted.Channel != ChannelCSGClaw ||
+		(deleted.Type != TypeAgent && deleted.Type != TypeNotification) ||
+		deleted.ChannelUserKind != ChannelUserKindLocalUserID {
 		return nil
 	}
 	userID := strings.TrimSpace(deleted.ChannelUserRef)

--- a/internal/participant/service_test.go
+++ b/internal/participant/service_test.go
@@ -670,6 +670,37 @@ func TestDeleteParticipantDoesNotDeleteAgentByDefault(t *testing.T) {
 	}
 }
 
+func TestDeleteNotificationParticipantRemovesLocalUserAndDirectRoom(t *testing.T) {
+	imSvc := im.NewService()
+	svc := NewService(NewMemoryStore(nil), WithIMService(imSvc))
+	created, err := svc.Create(context.Background(), CreateRequest{
+		ID:      "alerts",
+		Channel: ChannelCSGClaw,
+		Type:    TypeNotification,
+		Name:    "Alerts",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	roomIDs := imSvc.RoomIDsForMember(created.ChannelUserRef)
+	if len(roomIDs) != 1 {
+		t.Fatalf("notification direct rooms = %v, want one", roomIDs)
+	}
+
+	if _, ok, err := svc.Delete(context.Background(), ChannelCSGClaw, created.ID, DeleteOptions{}); err != nil || !ok {
+		t.Fatalf("Delete() ok=%v error=%v, want ok", ok, err)
+	}
+	if _, ok := svc.Get(ChannelCSGClaw, created.ID); ok {
+		t.Fatalf("participant %s still exists after delete", created.ID)
+	}
+	if _, ok := imSvc.User(created.ChannelUserRef); ok {
+		t.Fatalf("local user %s still exists after notification participant delete", created.ChannelUserRef)
+	}
+	if _, ok := imSvc.Room(roomIDs[0]); ok {
+		t.Fatalf("direct room %s still exists after notification participant delete", roomIDs[0])
+	}
+}
+
 func TestDeleteParticipantRejectsAgentCleanupWhenStillReferenced(t *testing.T) {
 	agentSvc := mustNewAgentService(t)
 	svc := NewService(NewMemoryStore(nil), WithAgentService(agentSvc), WithIMService(im.NewService()))

--- a/web/app/src/routes/AppRouter.tsx
+++ b/web/app/src/routes/AppRouter.tsx
@@ -3,23 +3,40 @@ import type { ComponentType, ReactElement } from "react";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 import type { RouteObject } from "react-router-dom";
 import { WorkspacePage } from "@/pages/WorkspacePage/WorkspacePage";
+import { loadRouteModule } from "./loadRouteModule";
 
-const AgentPage = lazy(() => import("@/pages/AgentPage").then((module) => ({ default: module.AgentPage })));
-const ComputerPage = lazy(() => import("@/pages/ComputerPage").then((module) => ({ default: module.ComputerPage })));
+const AgentPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/AgentPage").then((module) => ({ default: module.AgentPage }))),
+);
+const ComputerPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/ComputerPage").then((module) => ({ default: module.ComputerPage }))),
+);
 const ConversationPage = lazy(() =>
-  import("@/pages/ConversationPage").then((module) => ({ default: module.ConversationPage })),
+  loadRouteModule(() => import("@/pages/ConversationPage").then((module) => ({ default: module.ConversationPage }))),
 );
-const HubPage = lazy(() => import("@/pages/HubPage").then((module) => ({ default: module.HubPage })));
-const HumanPage = lazy(() => import("@/pages/HumanPage").then((module) => ({ default: module.HumanPage })));
+const HubPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/HubPage").then((module) => ({ default: module.HubPage }))),
+);
+const HumanPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/HumanPage").then((module) => ({ default: module.HumanPage }))),
+);
 const ModelProviderPage = lazy(() =>
-  import("@/pages/ModelProviderPage/ModelProviderPage").then((module) => ({ default: module.ModelProviderPage })),
+  loadRouteModule(() =>
+    import("@/pages/ModelProviderPage/ModelProviderPage").then((module) => ({ default: module.ModelProviderPage })),
+  ),
 );
-const SettingsPage = lazy(() => import("@/pages/SettingsPage").then((module) => ({ default: module.SettingsPage })));
+const SettingsPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/SettingsPage").then((module) => ({ default: module.SettingsPage }))),
+);
 const SessionDemoPage = lazy(() =>
-  import("@/pages/SessionDemoPage").then((module) => ({ default: module.SessionDemoPage })),
+  loadRouteModule(() => import("@/pages/SessionDemoPage").then((module) => ({ default: module.SessionDemoPage }))),
 );
-const TeamPage = lazy(() => import("@/pages/TeamPage").then((module) => ({ default: module.TeamPage })));
-const TasksPage = lazy(() => import("@/pages/TasksPage").then((module) => ({ default: module.TasksPage })));
+const TeamPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/TeamPage").then((module) => ({ default: module.TeamPage }))),
+);
+const TasksPage = lazy(() =>
+  loadRouteModule(() => import("@/pages/TasksPage").then((module) => ({ default: module.TasksPage }))),
+);
 
 function routeElement(Page: ComponentType): ReactElement {
   return (

--- a/web/app/src/routes/loadRouteModule.test.ts
+++ b/web/app/src/routes/loadRouteModule.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { isRouteChunkLoadError, loadRouteModule, type RouteChunkRecoveryEnvironment } from "./loadRouteModule";
+
+function recoveryEnvironment(retryMarker: string | null = null): {
+  environment: RouteChunkRecoveryEnvironment;
+  reload: ReturnType<typeof vi.fn>;
+  setRetryMarker: ReturnType<typeof vi.fn>;
+} {
+  const reload = vi.fn();
+  const setRetryMarker = vi.fn();
+  return {
+    environment: {
+      clearRetryMarker: vi.fn(),
+      getRetryMarker: vi.fn(() => retryMarker),
+      reload,
+      setRetryMarker,
+    },
+    reload,
+    setRetryMarker,
+  };
+}
+
+describe("loadRouteModule", () => {
+  it("reloads once when a stale route chunk cannot be imported", async () => {
+    const error = new TypeError(
+      "Failed to fetch dynamically imported module: http://127.0.0.1:18080/assets/ComputerPage-old.js",
+    );
+    const { environment, reload, setRetryMarker } = recoveryEnvironment();
+
+    void loadRouteModule(() => Promise.reject(error), environment);
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+    expect(setRetryMarker).toHaveBeenCalledWith(error.message);
+  });
+
+  it("surfaces the error instead of reloading repeatedly", async () => {
+    const error = new TypeError(
+      "Failed to fetch dynamically imported module: http://127.0.0.1:18080/assets/ComputerPage-old.js",
+    );
+    const { environment, reload } = recoveryEnvironment(error.message);
+
+    await expect(loadRouteModule(() => Promise.reject(error), environment)).rejects.toBe(error);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does not reload for route module evaluation errors", async () => {
+    const error = new Error("ComputerPage initialization failed");
+    const { environment, reload } = recoveryEnvironment();
+
+    await expect(loadRouteModule(() => Promise.reject(error), environment)).rejects.toBe(error);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("clears a previous retry marker after a successful import", async () => {
+    const { environment } = recoveryEnvironment("old failure");
+    const loaded = { default: "ComputerPage" };
+
+    await expect(loadRouteModule(() => Promise.resolve(loaded), environment)).resolves.toBe(loaded);
+    expect(environment.clearRetryMarker).toHaveBeenCalledOnce();
+  });
+});
+
+describe("isRouteChunkLoadError", () => {
+  it.each([
+    "Failed to fetch dynamically imported module: /assets/ComputerPage-old.js",
+    "error loading dynamically imported module: /assets/ComputerPage-old.js",
+    "Importing a module script failed.",
+    "Failed to load module script: Expected a JavaScript module script",
+    "Unable to preload CSS for /assets/ComputerPage-old.css",
+  ])("recognizes browser chunk-load failure: %s", (message) => {
+    expect(isRouteChunkLoadError(new TypeError(message))).toBe(true);
+  });
+});

--- a/web/app/src/routes/loadRouteModule.ts
+++ b/web/app/src/routes/loadRouteModule.ts
@@ -1,0 +1,65 @@
+const ROUTE_CHUNK_RETRY_KEY = "csgclaw.route-chunk-retry";
+
+export type RouteChunkRecoveryEnvironment = {
+  clearRetryMarker: () => void;
+  getRetryMarker: () => string | null;
+  reload: () => void;
+  setRetryMarker: (marker: string) => void;
+};
+
+export function isRouteChunkLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|failed to load module script|unable to preload css/i.test(
+    message,
+  );
+}
+
+export async function loadRouteModule<T>(
+  importer: () => Promise<T>,
+  environment: RouteChunkRecoveryEnvironment = browserRouteChunkRecoveryEnvironment(),
+): Promise<T> {
+  try {
+    const loaded = await importer();
+    try {
+      environment.clearRetryMarker();
+    } catch {
+      // Storage can be unavailable in hardened browser contexts. A successful
+      // import should still render normally.
+    }
+    return loaded;
+  } catch (error) {
+    if (!isRouteChunkLoadError(error)) {
+      throw error;
+    }
+
+    const marker = error instanceof Error ? error.message : String(error);
+    let previousMarker: string | null;
+    try {
+      previousMarker = environment.getRetryMarker();
+      if (previousMarker !== marker) {
+        environment.setRetryMarker(marker);
+      }
+    } catch {
+      throw error;
+    }
+    if (previousMarker === marker) {
+      throw error;
+    }
+
+    try {
+      environment.reload();
+    } catch {
+      throw error;
+    }
+    return new Promise<T>(() => {});
+  }
+}
+
+function browserRouteChunkRecoveryEnvironment(): RouteChunkRecoveryEnvironment {
+  return {
+    clearRetryMarker: () => window.sessionStorage.removeItem(ROUTE_CHUNK_RETRY_KEY),
+    getRetryMarker: () => window.sessionStorage.getItem(ROUTE_CHUNK_RETRY_KEY),
+    reload: () => window.location.reload(),
+    setRetryMarker: (marker) => window.sessionStorage.setItem(ROUTE_CHUNK_RETRY_KEY, marker),
+  };
+}


### PR DESCRIPTION
## Summary

- Remove the orphaned local IM user and direct room when a notification participant is deleted.
- Reload once when a deployed lazy route chunk becomes stale, preventing the raw application error after updates.