### PR TITLE
fix(auth): refresh rotated OpenCSG API keys

### DIFF
--- a/internal/auth/aigateway.go
+++ b/internal/auth/aigateway.go
@@ -26,7 +26,24 @@ func (s Store) EnsureAIGatewayCredentials(ctx context.Context, client *http.Clie
 			return baseURL, apiKey, baseURL != "", nil
 		}
 	}
+	return s.refreshAIGatewayCredentials(ctx, client, baseURL)
+}
 
+// RefreshAIGatewayCredentials fetches the current built-in API key from
+// OpenCSG even when a previously cached key is available.
+func (s Store) RefreshAIGatewayCredentials(ctx context.Context, client *http.Client) (baseURL, apiKey string, ok bool, err error) {
+	baseURL = AIGatewayBaseURL("")
+	credentials, found, err := s.LoadCSGHubProviderCredentials()
+	if err != nil {
+		return "", "", false, err
+	}
+	if found && credentials.AIGatewayBaseURL != "" {
+		baseURL = credentials.AIGatewayBaseURL
+	}
+	return s.refreshAIGatewayCredentials(ctx, client, baseURL)
+}
+
+func (s Store) refreshAIGatewayCredentials(ctx context.Context, client *http.Client, baseURL string) (string, string, bool, error) {
 	record, found, err := s.Load()
 	if err != nil {
 		return "", "", false, err
@@ -47,7 +64,7 @@ func (s Store) EnsureAIGatewayCredentials(ctx context.Context, client *http.Clie
 		return baseURL, "", false, fmt.Errorf("csghub user uuid is required to fetch aigateway api key")
 	}
 
-	apiKey, err = fetchBuiltinAPIKey(ctx, client, record.Account.BaseURL, record.Tokens.AccessToken, record.Account.UserID, record.Account.UserUUID)
+	apiKey, err := fetchBuiltinAPIKey(ctx, client, record.Account.BaseURL, record.Tokens.AccessToken, record.Account.UserID, record.Account.UserUUID)
 	if err != nil {
 		return baseURL, "", false, err
 	}

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -264,6 +264,57 @@ func TestEnsureAIGatewayCredentialsFetchesAndCachesBuiltinAPIKey(t *testing.T) {
 	}
 }
 
+func TestRefreshAIGatewayCredentialsReplacesCachedBuiltinAPIKey(t *testing.T) {
+	t.Setenv("CSGHUB_AIGATEWAY_BASE_URL", "https://gateway.example.test")
+	t.Setenv("CSGHUB_AIGATEWAY_URL", "")
+
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Fatalf("Authorization = %q, want access token", got)
+		}
+		writeJSON(t, w, map[string]any{
+			"msg": "OK",
+			"data": map[string]any{
+				"token": "gk_refreshed",
+			},
+		})
+	}))
+	defer hub.Close()
+
+	store := newTestStore(t)
+	if err := store.Save(Record{
+		Tokens: Tokens{AccessToken: "access-token"},
+		Account: Account{
+			UserID:   "alice",
+			UserUUID: "user-1",
+			BaseURL:  hub.URL,
+		},
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if err := store.SaveCSGHubProviderCredentials(CSGHubProviderCredentials{
+		AIGatewayBaseURL:       "https://gateway.example.test/v1",
+		AIGatewayBuiltinAPIKey: "gk_stale",
+	}); err != nil {
+		t.Fatalf("SaveCSGHubProviderCredentials() error = %v", err)
+	}
+
+	baseURL, apiKey, ok, err := store.RefreshAIGatewayCredentials(context.Background(), hub.Client())
+	if err != nil {
+		t.Fatalf("RefreshAIGatewayCredentials() error = %v", err)
+	}
+	if !ok || baseURL != "https://gateway.example.test/v1" || apiKey != "gk_refreshed" {
+		t.Fatalf("RefreshAIGatewayCredentials() = %q, %q, %v", baseURL, apiKey, ok)
+	}
+	credentials, found, err := store.LoadCSGHubProviderCredentials()
+	if err != nil || !found {
+		t.Fatalf("LoadCSGHubProviderCredentials() = %+v, %v, %v", credentials, found, err)
+	}
+	if credentials.AIGatewayBuiltinAPIKey != "gk_refreshed" {
+		t.Fatalf("stored AIGatewayBuiltinAPIKey = %q, want refreshed key", credentials.AIGatewayBuiltinAPIKey)
+	}
+}
+
 func TestDefaultStorePersistsOpenCSGAuthInRootState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -29,6 +29,7 @@ type Service struct {
 	defaults                      config.ModelConfig
 	agents                        *agent.Service
 	client                        *http.Client
+	openCSGCredentialRefreshMu    sync.Mutex
 	responsesCapabilityMu         sync.Mutex
 	responsesUnsupported          map[string]struct{}
 	responsesReasoningUnsupported map[string]struct{}
@@ -242,6 +243,10 @@ func (s *Service) resolveProfile(botID string) (agent.AgentProfile, error) {
 }
 
 func (s *Service) forwardRemoteChat(ctx context.Context, profile agent.AgentProfile, body []byte) (*UpstreamResponse, error) {
+	return s.forwardRemoteChatWithAuthRefresh(ctx, profile, body, true)
+}
+
+func (s *Service) forwardRemoteChatWithAuthRefresh(ctx context.Context, profile agent.AgentProfile, body []byte, allowAuthRefresh bool) (*UpstreamResponse, error) {
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("decode request: %v", err)}
@@ -270,6 +275,12 @@ func (s *Service) forwardRemoteChat(ctx context.Context, profile agent.AgentProf
 	if err != nil {
 		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("send upstream request: %v", err)}
 	}
+	if allowAuthRefresh && resp.StatusCode == http.StatusUnauthorized && profile.Provider == agent.ProviderCSGHub {
+		if _, _, refreshed := s.refreshOpenCSGAIGatewayCredentials(ctx, apiKey); refreshed {
+			_ = resp.Body.Close()
+			return s.forwardRemoteChatWithAuthRefresh(ctx, profile, body, false)
+		}
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return compactUpstreamErrorStream(resp)
 	}
@@ -290,6 +301,10 @@ func (s *Service) forwardRemoteChat(ctx context.Context, profile agent.AgentProf
 }
 
 func (s *Service) forwardRemoteResponses(ctx context.Context, profile agent.AgentProfile, body []byte) (*UpstreamResponse, error) {
+	return s.forwardRemoteResponsesWithAuthRefresh(ctx, profile, body, true)
+}
+
+func (s *Service) forwardRemoteResponsesWithAuthRefresh(ctx context.Context, profile agent.AgentProfile, body []byte, allowAuthRefresh bool) (*UpstreamResponse, error) {
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("decode request: %v", err)}
@@ -311,7 +326,7 @@ func (s *Service) forwardRemoteResponses(ctx context.Context, profile agent.Agen
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: fmt.Sprintf("encode request: %v", err)}
 	}
 	if s.responsesAPIUnsupportedCached(profile, baseURL) {
-		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey)
+		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey, allowAuthRefresh)
 	}
 	upstreamURL := strings.TrimRight(baseURL, "/") + "/responses"
 	sendResponses := func(encoded []byte) (*http.Response, error) {
@@ -329,6 +344,12 @@ func (s *Service) forwardRemoteResponses(ctx context.Context, profile agent.Agen
 	if err != nil {
 		return nil, err
 	}
+	if allowAuthRefresh && resp.StatusCode == http.StatusUnauthorized && profile.Provider == agent.ProviderCSGHub {
+		if _, _, refreshed := s.refreshOpenCSGAIGatewayCredentials(ctx, apiKey); refreshed {
+			_ = resp.Body.Close()
+			return s.forwardRemoteResponsesWithAuthRefresh(ctx, profile, body, false)
+		}
+	}
 	return s.handleRemoteResponsesResult(ctx, profile, payload, baseURL, apiKey, resp, true, sendResponses)
 }
 
@@ -338,11 +359,11 @@ func (s *Service) handleRemoteResponsesResult(ctx context.Context, profile agent
 	if responsesAPIUnsupportedStatus(resp.StatusCode) {
 		_ = resp.Body.Close()
 		s.markResponsesAPIUnsupported(profile, baseURL)
-		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey)
+		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey, true)
 	}
 	if responsesAPITransientFallbackStatus(profile, resp.StatusCode) && !responsesPayloadHasToolSemantics(payload) {
 		_ = resp.Body.Close()
-		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey)
+		return s.forwardResponsesViaChat(ctx, profile, payload, baseURL, apiKey, true)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		body, err := readAndCloseUpstreamBody(resp)
@@ -374,7 +395,7 @@ func (s *Service) handleRemoteResponsesResult(ctx context.Context, profile agent
 	}, nil
 }
 
-func (s *Service) forwardResponsesViaChat(ctx context.Context, profile agent.AgentProfile, responsesPayload map[string]any, baseURL, apiKey string) (*UpstreamResponse, error) {
+func (s *Service) forwardResponsesViaChat(ctx context.Context, profile agent.AgentProfile, responsesPayload map[string]any, baseURL, apiKey string, allowAuthRefresh bool) (*UpstreamResponse, error) {
 	chatPayload, err := responsesPayloadToChatPayload(responsesPayload)
 	if err != nil {
 		return nil, &HTTPError{Status: http.StatusBadRequest, Message: err.Error()}
@@ -394,6 +415,12 @@ func (s *Service) forwardResponsesViaChat(ctx context.Context, profile agent.Age
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, &HTTPError{Status: http.StatusBadGateway, Message: fmt.Sprintf("send chat fallback request: %v", err)}
+	}
+	if allowAuthRefresh && resp.StatusCode == http.StatusUnauthorized && profile.Provider == agent.ProviderCSGHub {
+		if refreshedBaseURL, refreshedAPIKey, refreshed := s.refreshOpenCSGAIGatewayCredentials(ctx, apiKey); refreshed {
+			_ = resp.Body.Close()
+			return s.forwardResponsesViaChat(ctx, profile, responsesPayload, refreshedBaseURL, refreshedAPIKey, false)
+		}
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return compactUpstreamErrorStream(resp)
@@ -1402,6 +1429,31 @@ func csghubAIGatewayTarget(ctx context.Context, client *http.Client) (string, st
 		return "", "", &HTTPError{Status: http.StatusUnauthorized, Message: "csghub login is required"}
 	}
 	return baseURL, apiKey, nil
+}
+
+func (s *Service) refreshOpenCSGAIGatewayCredentials(ctx context.Context, rejectedAPIKey string) (string, string, bool) {
+	s.openCSGCredentialRefreshMu.Lock()
+	defer s.openCSGCredentialRefreshMu.Unlock()
+
+	store, err := auth.DefaultStore()
+	if err != nil {
+		slog.Warn("resolve OpenCSG auth store after unauthorized response", "error", err)
+		return "", "", false
+	}
+	baseURL, apiKey, ok, err := store.AIGatewayCredentials()
+	if err != nil {
+		slog.Warn("read OpenCSG AI Gateway credentials after unauthorized response", "error", err)
+		return "", "", false
+	}
+	if ok && apiKey != "" && apiKey != rejectedAPIKey {
+		return baseURL, apiKey, true
+	}
+	baseURL, apiKey, ok, err = store.RefreshAIGatewayCredentials(ctx, s.client)
+	if err != nil {
+		slog.Warn("refresh OpenCSG AI Gateway credentials after unauthorized response", "error", err)
+		return "", "", false
+	}
+	return baseURL, apiKey, ok && apiKey != rejectedAPIKey
 }
 
 func ensureCLIProxyAuthenticated(ctx context.Context, provider string) error {

--- a/internal/llm/service_test.go
+++ b/internal/llm/service_test.go
@@ -197,6 +197,108 @@ func TestChatCompletionsUsesCSGHubAIGatewayAuthStore(t *testing.T) {
 	}
 }
 
+func TestResponsesRefreshesOpenCSGAIGatewayKeyAfterUnauthorized(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var upstreamAuth []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Fatalf("path = %q, want /v1/responses", r.URL.Path)
+		}
+		upstreamAuth = append(upstreamAuth, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "Bearer gk_stale" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"code":"AUTH-ERR-5","msg":"Invalid authorization header"}`))
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer gk_refreshed" {
+			t.Fatalf("Authorization = %q, want refreshed key", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-1","object":"response","status":"completed","output":[]}`))
+	}))
+	defer upstream.Close()
+	t.Setenv("CSGHUB_AIGATEWAY_BASE_URL", upstream.URL)
+
+	var refreshRequests int
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshRequests++
+		if r.URL.Path != "/api/v1/namespaces/user-1/apikeys/builtin" {
+			t.Fatalf("hub path = %q, want builtin api key path", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Fatalf("hub Authorization = %q, want access token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"msg":"OK","data":{"token":"gk_refreshed"}}`))
+	}))
+	defer hub.Close()
+
+	store, err := auth.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore() error = %v", err)
+	}
+	if err := store.Save(auth.Record{
+		Tokens: auth.Tokens{AccessToken: "access-token"},
+		Account: auth.Account{
+			BaseURL:  hub.URL,
+			UserID:   "alice",
+			UserUUID: "user-1",
+		},
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if err := store.SaveCSGHubProviderCredentials(auth.CSGHubProviderCredentials{
+		AIGatewayBaseURL:       upstream.URL + "/v1",
+		AIGatewayBuiltinAPIKey: "gk_stale",
+	}); err != nil {
+		t.Fatalf("SaveCSGHubProviderCredentials() error = %v", err)
+	}
+
+	agentSvc := mustSeededAgentService(t, config.LLMConfig{}, []agent.Agent{
+		{
+			ID:          agent.ManagerUserID,
+			Name:        agent.ManagerName,
+			Role:        agent.RoleManager,
+			RuntimeKind: agent.RuntimeKindPicoClawSandbox,
+			AgentProfile: agent.AgentProfile{
+				Name:            agent.ManagerName,
+				Provider:        agent.ProviderCSGHub,
+				ModelID:         "qwen-test",
+				ProfileComplete: true,
+			},
+			ProfileComplete: true,
+			CreatedAt:       time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+
+	resp, err := NewService(config.ModelConfig{}, agentSvc).Responses(
+		context.Background(),
+		agent.ManagerUserID,
+		[]byte(`{"model":"client-model","input":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got, want := strings.Join(upstreamAuth, ","), "Bearer gk_stale,Bearer gk_refreshed"; got != want {
+		t.Fatalf("upstream Authorization sequence = %q, want %q", got, want)
+	}
+	if refreshRequests != 1 {
+		t.Fatalf("refresh requests = %d, want 1", refreshRequests)
+	}
+	credentials, found, err := store.LoadCSGHubProviderCredentials()
+	if err != nil || !found {
+		t.Fatalf("LoadCSGHubProviderCredentials() = %+v, %v, %v", credentials, found, err)
+	}
+	if credentials.AIGatewayBuiltinAPIKey != "gk_refreshed" {
+		t.Fatalf("stored AIGatewayBuiltinAPIKey = %q, want refreshed key", credentials.AIGatewayBuiltinAPIKey)
+	}
+}
+
 func TestNewServiceDoesNotImposeFixedUpstreamTimeout(t *testing.T) {
 	svc := NewService(config.ModelConfig{}, nil)
 	if svc.client == nil {


### PR DESCRIPTION
## Summary

- Refresh the built-in OpenCSG AI Gateway API key after an upstream 401 and retry once.
- Persist the refreshed key, serialize concurrent refreshes, and cover the behavior with tests.
