### PR TITLE
fix(upgrade): restore Windows auto-upgrades

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -101,9 +101,10 @@ var (
 		}
 		return svc.StopRunningSandboxAgents(ctx)
 	}
-	NewCodexBridgeManager = newCodexBridgeManager
-	OpenBrowser           = openBrowser
-	WaitForHealthy        = waitForHealthy
+	NewCodexBridgeManager  = newCodexBridgeManager
+	OpenBrowser            = openBrowser
+	WaitForHealthy         = waitForHealthy
+	stopServerProcessByPID = stopServerProcess
 )
 
 type serveCmd struct{}
@@ -240,11 +241,7 @@ func (c stopCmd) Run(_ context.Context, run *command.Context, args []string, glo
 	if err != nil {
 		return err
 	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
-	}
-	if err := proc.Signal(syscall.SIGTERM); err != nil {
+	if err := stopServerProcessByPID(pid); err != nil {
 		if errors.Is(err, os.ErrProcessDone) {
 			removePIDFile(*pidPath)
 			return command.RenderAction(globals.Output, run.Stdout, command.ActionResult{
@@ -256,7 +253,7 @@ func (c stopCmd) Run(_ context.Context, run *command.Context, args []string, glo
 				Message: fmt.Sprintf("removed stale pid file %s", *pidPath),
 			})
 		}
-		return fmt.Errorf("signal process %d: %w", pid, err)
+		return fmt.Errorf("stop process %d: %w", pid, err)
 	}
 	return command.RenderAction(globals.Output, run.Stdout, command.ActionResult{
 		Command: "stop",
@@ -264,7 +261,7 @@ func (c stopCmd) Run(_ context.Context, run *command.Context, args []string, glo
 		Status:  "signaled",
 		PID:     pid,
 		PIDPath: *pidPath,
-		Message: fmt.Sprintf("sent SIGTERM to server process %d", pid),
+		Message: fmt.Sprintf("requested server process %d to stop", pid),
 	})
 }
 

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1881,6 +1881,56 @@ func TestValidateModelConfigAllowsDynamicProfileSetupWhenIncomplete(t *testing.T
 	}
 }
 
+func TestStopCommandUsesPlatformProcessControl(t *testing.T) {
+	originalStop := stopServerProcessByPID
+	t.Cleanup(func() { stopServerProcessByPID = originalStop })
+
+	const pid = 4321
+	var stoppedPID int
+	stopServerProcessByPID = func(got int) error {
+		stoppedPID = got
+		return nil
+	}
+
+	pidPath := filepath.Join(t.TempDir(), "server.pid")
+	if err := os.WriteFile(pidPath, []byte("4321\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", pidPath, err)
+	}
+	var stdout bytes.Buffer
+	err := (stopCmd{}).Run(context.Background(), &command.Context{
+		Program: "csgclaw",
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}, []string{"--pid", pidPath}, command.GlobalOptions{Output: "json"})
+	if err != nil {
+		t.Fatalf("stopCmd.Run() error = %v", err)
+	}
+	if stoppedPID != pid {
+		t.Fatalf("stopServerProcessByPID pid = %d, want %d", stoppedPID, pid)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"status": "signaled"`) || !strings.Contains(got, `"pid": 4321`) {
+		t.Fatalf("stop output = %q, want signaled status and pid", got)
+	}
+}
+
+func TestStopCommandRemovesStalePIDFile(t *testing.T) {
+	originalStop := stopServerProcessByPID
+	t.Cleanup(func() { stopServerProcessByPID = originalStop })
+	stopServerProcessByPID = func(int) error { return os.ErrProcessDone }
+
+	pidPath := filepath.Join(t.TempDir(), "server.pid")
+	if err := os.WriteFile(pidPath, []byte("4321\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", pidPath, err)
+	}
+	err := (stopCmd{}).Run(context.Background(), testContext(), []string{"--pid", pidPath}, command.GlobalOptions{Output: "json"})
+	if err != nil {
+		t.Fatalf("stopCmd.Run() error = %v", err)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("pid file still exists, stat error = %v", err)
+	}
+}
+
 func testContext() *command.Context {
 	return &command.Context{
 		Program: "csgclaw",

--- a/cli/serve/stop_process_unix.go
+++ b/cli/serve/stop_process_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package serve
+
+import (
+	"os"
+	"syscall"
+)
+
+func stopServerProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(syscall.SIGTERM)
+}

--- a/cli/serve/stop_process_windows.go
+++ b/cli/serve/stop_process_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package serve
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func stopServerProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return proc.Kill()
+}

--- a/internal/upgrade/process_probe_unix.go
+++ b/internal/upgrade/process_probe_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package upgrade
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func processRunning(pid int) (running bool, stale bool, err error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, false, err
+	}
+	err = proc.Signal(syscall.Signal(0))
+	switch {
+	case err == nil:
+		return true, false, nil
+	case errors.Is(err, syscall.ESRCH), errors.Is(err, os.ErrProcessDone):
+		return false, true, nil
+	case errors.Is(err, syscall.EPERM):
+		return true, false, nil
+	default:
+		return false, false, err
+	}
+}

--- a/internal/upgrade/process_probe_windows.go
+++ b/internal/upgrade/process_probe_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+const waitTimeout = 0x00000102
+
+func processRunning(pid int) (running bool, stale bool, err error) {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		switch {
+		case errors.Is(err, windows.ERROR_INVALID_PARAMETER):
+			return false, true, nil
+		case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+			return true, false, nil
+		default:
+			return false, false, err
+		}
+	}
+	defer windows.CloseHandle(handle)
+
+	result, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false, false, err
+	}
+	switch result {
+	case windows.WAIT_OBJECT_0:
+		return false, true, nil
+	case waitTimeout:
+		return true, false, nil
+	default:
+		return false, false, fmt.Errorf("unexpected wait result %#x", result)
+	}
+}

--- a/internal/upgrade/restart.go
+++ b/internal/upgrade/restart.go
@@ -8,16 +8,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"csgclaw/internal/config"
 )
 
 var (
-	readPIDFileData    = os.ReadFile
-	removePIDFilePath  = os.Remove
-	findProcessByPID   = os.FindProcess
-	execCommandContext = exec.CommandContext
+	readPIDFileData     = os.ReadFile
+	removePIDFilePath   = os.Remove
+	findProcessByPID    = os.FindProcess
+	processRunningByPID = processRunning
+	execCommandContext  = exec.CommandContext
 )
 
 type RestartOptions struct {
@@ -74,21 +74,11 @@ func daemonRunning(pidPath string) (running bool, stale bool, err error) {
 		}
 		return false, false, err
 	}
-	proc, err := findProcessByPID(pid)
+	running, stale, err = processRunningByPID(pid)
 	if err != nil {
-		return false, false, fmt.Errorf("find process %d: %w", pid, err)
+		return false, false, fmt.Errorf("check process %d: %w", pid, err)
 	}
-	err = proc.Signal(syscall.Signal(0))
-	switch {
-	case err == nil:
-		return true, false, nil
-	case errors.Is(err, syscall.ESRCH), errors.Is(err, os.ErrProcessDone):
-		return false, true, nil
-	case errors.Is(err, syscall.EPERM):
-		return true, false, nil
-	default:
-		return false, false, fmt.Errorf("signal process %d: %w", pid, err)
-	}
+	return running, stale, nil
 }
 
 func readUpgradePID(path string) (int, error) {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1152,11 +1152,11 @@ func TestClientRestartIfRunningRemovesStalePID(t *testing.T) {
 		t.Fatalf("WriteFile(%q) error = %v", pidPath, err)
 	}
 
-	originalFindProcess := findProcessByPID
-	findProcessByPID = func(int) (*os.Process, error) {
-		return &os.Process{Pid: 424242}, nil
+	originalProcessRunning := processRunningByPID
+	processRunningByPID = func(int) (bool, bool, error) {
+		return false, true, nil
 	}
-	t.Cleanup(func() { findProcessByPID = originalFindProcess })
+	t.Cleanup(func() { processRunningByPID = originalProcessRunning })
 
 	originalExec := execCommandContext
 	execCommandContext = func(context.Context, string, ...string) *exec.Cmd {


### PR DESCRIPTION
- Replace unsupported POSIX process probes with native Windows process liveness checks during self-upgrade.
- Terminate Windows daemons before replacing locked bundles while preserving SIGTERM behavior on Unix systems.
- Keep stale PID cleanup and daemon restart behavior consistent across platforms.
