### PR TITLE
fix(web): omit duplicate agent name in turn notifications

### DIFF
--- a/web/app/src/hooks/workspace/useAgentTurnNotifications.ts
+++ b/web/app/src/hooks/workspace/useAgentTurnNotifications.ts
@@ -10,6 +10,7 @@ import {
 } from "@/models/conversations";
 import type { IMConversation, IMMessage, IMServerEvent, TranslateFn, UsersById } from "@/models/conversations";
 import {
+  formatTurnNotificationBody,
   isCompletedAgentTurnEvent,
   shouldShowTurnNotification,
   TurnNotificationModes,
@@ -155,13 +156,12 @@ export function useAgentTurnNotifications(args: UseAgentTurnNotificationsArgs): 
     const message = input.message ?? latestVisibleAgentMessage(room, input.participantIdentities);
     const preview = truncateNotificationPreview(formatMessagePreviewText(message?.content));
     const roomTitle = String(room?.title || "").trim();
-    const body = preview
-      ? roomTitle
-        ? current.t("turnNotificationBody", { message: preview, room: roomTitle })
-        : preview
-      : roomTitle
-        ? current.t("turnNotificationRoomBody", { room: roomTitle })
-        : current.t("turnNotificationDefaultBody");
+    const body = formatTurnNotificationBody(current.t, {
+      agentName,
+      preview,
+      room,
+      roomTitle,
+    });
 
     try {
       const notification = new window.Notification(current.t("turnNotificationTitle", { agent: agentName }), {

--- a/web/app/src/models/turnNotifications.ts
+++ b/web/app/src/models/turnNotifications.ts
@@ -1,4 +1,5 @@
-import type { IMServerEvent } from "@/models/conversations";
+import { isDirectConversation, normalizeComparable } from "@/models/conversations";
+import type { IMServerEvent, TranslateFn } from "@/models/conversations";
 
 export const TurnNotificationModes = {
   off: "off",
@@ -36,4 +37,33 @@ export function isCompletedAgentTurnEvent(event: IMServerEvent | null | undefine
     event.work.state === "idle" &&
     event.work.reason === "released",
   );
+}
+
+export function resolveTurnNotificationRoomLabel(
+  agentName: string,
+  roomTitle: string,
+  room?: { is_direct?: boolean | null } | null,
+): string {
+  const title = roomTitle.trim();
+  if (!title || isDirectConversation(room) || normalizeComparable(title) === normalizeComparable(agentName)) {
+    return "";
+  }
+  return title;
+}
+
+export function formatTurnNotificationBody(
+  t: TranslateFn,
+  input: {
+    agentName: string;
+    preview: string;
+    room?: { is_direct?: boolean | null } | null;
+    roomTitle: string;
+  },
+): string {
+  const preview = input.preview.trim();
+  const roomLabel = resolveTurnNotificationRoomLabel(input.agentName, input.roomTitle, input.room);
+  if (preview) {
+    return roomLabel ? t("turnNotificationBody", { message: preview, room: roomLabel }) : preview;
+  }
+  return roomLabel ? t("turnNotificationRoomBody", { room: roomLabel }) : t("turnNotificationDefaultBody");
 }

--- a/web/app/tests/hooks/useAgentTurnNotifications.test.tsx
+++ b/web/app/tests/hooks/useAgentTurnNotifications.test.tsx
@@ -72,7 +72,10 @@ function workEvent(overrides: Partial<NonNullable<IMServerEvent["work"]>> = {}):
   };
 }
 
-function renderNotifications(mode: TurnNotificationMode = TurnNotificationModes.whenUnfocused) {
+function renderNotifications(
+  mode: TurnNotificationMode = TurnNotificationModes.whenUnfocused,
+  options: { isDirect?: boolean; roomTitle?: string } = {},
+) {
   const onSelectConversation = vi.fn();
   const users = [
     { id: "user-admin", name: "Admin" },
@@ -87,6 +90,7 @@ function renderNotifications(mode: TurnNotificationMode = TurnNotificationModes.
       rooms: [
         {
           id: "room-1",
+          is_direct: options.isDirect,
           members: ["user-admin", "user-worker"],
           messages: [
             {
@@ -95,7 +99,7 @@ function renderNotifications(mode: TurnNotificationMode = TurnNotificationModes.
               sender_id: "user-worker",
             },
           ],
-          title: "Research room",
+          title: options.roomTitle ?? "Research room",
         },
       ],
       t,
@@ -263,5 +267,35 @@ describe("useAgentTurnNotifications", () => {
     });
 
     expect(result.current.permission).toBe("granted");
+  });
+
+  it("omits the duplicated agent name from a direct-chat notification body", () => {
+    const { result } = renderNotifications(TurnNotificationModes.always, {
+      isDirect: true,
+      roomTitle: "Research Agent",
+    });
+
+    act(() => result.current.handleRealtimeEvent(workEvent({ reason: "released", revision: 2, state: "idle" })));
+
+    expect(notificationRecords).toHaveLength(1);
+    expect(notificationRecords[0]).toMatchObject({
+      body: "The report is ready.",
+      title: "Research Agent finished replying",
+    });
+  });
+
+  it("keeps the room name in a group-chat notification body", () => {
+    const { result } = renderNotifications(TurnNotificationModes.always, {
+      isDirect: false,
+      roomTitle: "11",
+    });
+
+    act(() => result.current.handleRealtimeEvent(workEvent({ reason: "released", revision: 2, state: "idle" })));
+
+    expect(notificationRecords).toHaveLength(1);
+    expect(notificationRecords[0]).toMatchObject({
+      body: "11: The report is ready.",
+      title: "Research Agent finished replying",
+    });
   });
 });

--- a/web/app/tests/models/turnNotifications.test.ts
+++ b/web/app/tests/models/turnNotifications.test.ts
@@ -1,10 +1,26 @@
+import type { TranslateFn } from "@/models/conversations";
 import {
   DEFAULT_TURN_NOTIFICATION_MODE,
+  formatTurnNotificationBody,
   isCompletedAgentTurnEvent,
   normalizeTurnNotificationMode,
+  resolveTurnNotificationRoomLabel,
   shouldShowTurnNotification,
   TurnNotificationModes,
 } from "@/models/turnNotifications";
+
+const t: TranslateFn = (key, params = {}) => {
+  if (key === "turnNotificationBody") {
+    return `${params.room}: ${params.message}`;
+  }
+  if (key === "turnNotificationRoomBody") {
+    return `Room: ${params.room}`;
+  }
+  if (key === "turnNotificationDefaultBody") {
+    return "The agent turn has finished.";
+  }
+  return key;
+};
 
 describe("turn notifications", () => {
   it("normalizes stored modes and defaults to unfocused notifications", () => {
@@ -50,5 +66,41 @@ describe("turn notifications", () => {
     expect(isCompletedAgentTurnEvent(completed)).toBe(true);
     expect(isCompletedAgentTurnEvent({ ...completed, work: { ...completed.work, state: "working" } })).toBe(false);
     expect(isCompletedAgentTurnEvent({ ...completed, work: { ...completed.work, reason: "expired" } })).toBe(false);
+  });
+
+  it("omits a room label that repeats the agent name or belongs to a direct chat", () => {
+    expect(resolveTurnNotificationRoomLabel("codex03", "codex03", { is_direct: true })).toBe("");
+    expect(resolveTurnNotificationRoomLabel("codex03", " Codex03 ", { is_direct: false })).toBe("");
+    expect(resolveTurnNotificationRoomLabel("codex03", "standup", { is_direct: true })).toBe("");
+    expect(resolveTurnNotificationRoomLabel("dev", "11", { is_direct: false })).toBe("11");
+  });
+
+  it("formats notification bodies without repeating the agent name in direct chats", () => {
+    expect(
+      formatTurnNotificationBody(t, {
+        agentName: "codex03",
+        preview: "Runtime error: Codex stopped responding after 5m0s.",
+        room: { is_direct: true },
+        roomTitle: "codex03",
+      }),
+    ).toBe("Runtime error: Codex stopped responding after 5m0s.");
+
+    expect(
+      formatTurnNotificationBody(t, {
+        agentName: "dev",
+        preview: "already asked a question",
+        room: { is_direct: false },
+        roomTitle: "11",
+      }),
+    ).toBe("11: already asked a question");
+
+    expect(
+      formatTurnNotificationBody(t, {
+        agentName: "codex03",
+        preview: "",
+        room: { is_direct: true },
+        roomTitle: "codex03",
+      }),
+    ).toBe("The agent turn has finished.");
   });
 });


### PR DESCRIPTION
- Hide the room name in turn-completion notifications when it repeats the agent name, such as in agent direct chats.
- Keep the room name in group-room notifications when it differs from the agent.
