### PR TITLE
fix(desktop): harden Windows channel switching

### DIFF
--- a/desktop/src/main/channelSwitchUpdate.ts
+++ b/desktop/src/main/channelSwitchUpdate.ts
@@ -252,37 +252,33 @@ export async function launchWindowsChannelInstaller(
   installerPath: string,
   updateExePath: string,
   executableName: string,
-  parentPid: number,
+  logPath: string,
 ): Promise<void> {
+  // Run the full installer immediately after graceful app shutdown starts.
+  // Squirrel terminates any remaining package processes, replaces the app
+  // root, and returns only after releasing its update lock. Relaunching after
+  // that point prevents the target version (including older stable builds)
+  // from checking for updates while the installer still owns the lock.
   const command = [
-    `$installer = ${powerShellLiteral(installerPath)}`,
-    `$updater = ${powerShellLiteral(updateExePath)}`,
-    `$executable = ${powerShellLiteral(executableName)}`,
-    `Wait-Process -Id ${parentPid} -ErrorAction SilentlyContinue`,
-    "$result = Start-Process -FilePath $installer -ArgumentList '--silent' -Wait -PassThru",
-    "Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue",
-    "if ($result.ExitCode -ne 0) { exit $result.ExitCode }",
-    "if (-not (Test-Path -LiteralPath $updater)) { exit 1 }",
-    "Start-Process -FilePath $updater -ArgumentList @('--processStart', $executable)",
-  ].join("; ");
-  const encodedCommand = Buffer.from(command, "utf16le").toString("base64");
-  const child = spawn(
-    "powershell.exe",
-    [
-      "-NoLogo",
-      "-NoProfile",
-      "-NonInteractive",
-      "-WindowStyle",
-      "Hidden",
-      "-EncodedCommand",
-      encodedCommand,
-    ],
-    {
-      detached: true,
-      stdio: "ignore",
-      windowsHide: true,
+    `> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-started`,
+    `start "" /wait "%CSGCLAW_CHANNEL_INSTALLER%" --silent`,
+    `if errorlevel 1 (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-failed) else (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-finished)`,
+    `if not exist "%CSGCLAW_CHANNEL_UPDATER%" (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo updater-missing & exit /b 1)`,
+    `start "" "%CSGCLAW_CHANNEL_UPDATER%" --processStart "%CSGCLAW_CHANNEL_EXECUTABLE%"`,
+    `>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo relaunch-requested`,
+  ].join(" & ");
+  const child = spawn("cmd.exe", ["/d", "/s", "/c", command], {
+    detached: true,
+    env: {
+      ...process.env,
+      CSGCLAW_CHANNEL_EXECUTABLE: executableName,
+      CSGCLAW_CHANNEL_INSTALLER: installerPath,
+      CSGCLAW_CHANNEL_INSTALL_LOG: logPath,
+      CSGCLAW_CHANNEL_UPDATER: updateExePath,
     },
-  );
+    stdio: "ignore",
+    windowsHide: true,
+  });
   await new Promise<void>((resolve, reject) => {
     child.once("error", reject);
     child.once("spawn", () => {
@@ -291,8 +287,4 @@ export async function launchWindowsChannelInstaller(
     });
   });
   child.unref();
-}
-
-function powerShellLiteral(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
 }

--- a/desktop/src/main/updatePolicy.test.ts
+++ b/desktop/src/main/updatePolicy.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DesktopPlatform } from "../shared/desktopEnvironment";
 import {
+  SQUIRREL_FIRST_RUN_UPDATE_DELAY_MS,
+  isSquirrelUpdateLockError,
   shouldInstallDesktopVersion,
+  squirrelFirstRunUpdateDelay,
   usesMicrosoftStoreUpdates,
 } from "./updatePolicy";
 
@@ -42,4 +45,35 @@ test("channel switches install the target latest regardless of version direction
     true,
   );
   assert.equal(shouldInstallDesktopVersion("0.5.0", "0.5.0", true), false);
+});
+
+test("Squirrel first-run defers update checks until the installer releases its lock", () => {
+  assert.equal(
+    squirrelFirstRunUpdateDelay(DesktopPlatform.Windows, [
+      "CSGClaw.exe",
+      "--squirrel-firstrun",
+    ]),
+    SQUIRREL_FIRST_RUN_UPDATE_DELAY_MS,
+  );
+  assert.equal(
+    squirrelFirstRunUpdateDelay(DesktopPlatform.Windows, ["CSGClaw.exe"]),
+    0,
+  );
+  assert.equal(
+    squirrelFirstRunUpdateDelay(DesktopPlatform.MacOS, [
+      "CSGClaw",
+      "--squirrel-firstrun",
+    ]),
+    0,
+  );
+});
+
+test("recognizes the Squirrel global update lock error", () => {
+  assert.equal(
+    isSquirrelUpdateLockError(
+      "System.Exception: Couldn't acquire lock, is another instance running",
+    ),
+    true,
+  );
+  assert.equal(isSquirrelUpdateLockError("Desktop update feed failed"), false);
 });

--- a/desktop/src/main/updatePolicy.ts
+++ b/desktop/src/main/updatePolicy.ts
@@ -1,6 +1,8 @@
 import { DesktopPlatform } from "../shared/desktopEnvironment";
 import { compareDesktopReleaseVersions } from "../shared/releaseVersion";
 
+export const SQUIRREL_FIRST_RUN_UPDATE_DELAY_MS = 60_000;
+
 export function usesMicrosoftStoreUpdates(
   platform: NodeJS.Platform,
   windowsStore: boolean | undefined,
@@ -18,4 +20,22 @@ export function shouldInstallDesktopVersion(
     targetVersion,
   );
   return channelSwitch ? comparison !== 0 : comparison < 0;
+}
+
+export function squirrelFirstRunUpdateDelay(
+  platform: NodeJS.Platform,
+  argv: readonly string[],
+): number {
+  if (platform !== DesktopPlatform.Windows) {
+    return 0;
+  }
+  return argv.some(
+    (argument) => argument.toLowerCase() === "--squirrel-firstrun",
+  )
+    ? SQUIRREL_FIRST_RUN_UPDATE_DELAY_MS
+    : 0;
+}
+
+export function isSquirrelUpdateLockError(message: string): boolean {
+  return message.toLowerCase().includes("couldn't acquire lock");
 }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -30,12 +30,16 @@ import {
 } from "./channelSwitchUpdate";
 import { logDesktopInfo } from "./desktopLogger";
 import {
+  isSquirrelUpdateLockError,
   shouldInstallDesktopVersion,
+  squirrelFirstRunUpdateDelay,
   usesMicrosoftStoreUpdates,
 } from "./updatePolicy";
 
 const STARTUP_CHECK_DELAY_MS = 5_000;
 const PERIODIC_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const SQUIRREL_LOCK_RETRY_INTERVAL_MS = 30_000;
+const SQUIRREL_LOCK_RETRY_WINDOW_MS = 15 * 60 * 1000;
 
 export class DesktopUpdater {
   private readonly channel: DesktopUpdateChannel;
@@ -48,6 +52,10 @@ export class DesktopUpdater {
   private channelSwitchActive = false;
   private macChannelFeed: LocalUpdateFeed | null = null;
   private windowsChannelInstallerPath = "";
+  private readonly updateChecksReadyAt: number;
+  private updateChecksReady: Promise<void> | null = null;
+  private readonly squirrelLockRetryUntil: number;
+  private squirrelLockRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private periodicTimer: ReturnType<typeof setInterval> | null = null;
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private status: DesktopUpdateStatus;
@@ -57,6 +65,15 @@ export class DesktopUpdater {
     private readonly beforeInstall: () => Promise<void>,
   ) {
     this.channel = inferDesktopUpdateChannel(app.getVersion());
+    const startedAt = Date.now();
+    const firstRunDelay = squirrelFirstRunUpdateDelay(
+      process.platform,
+      process.argv,
+    );
+    this.updateChecksReadyAt = startedAt + firstRunDelay;
+    this.squirrelLockRetryUntil = firstRunDelay
+      ? startedAt + SQUIRREL_LOCK_RETRY_WINDOW_MS
+      : 0;
     this.status = {
       state: "idle",
       channel: this.channel,
@@ -91,6 +108,10 @@ export class DesktopUpdater {
     if (this.periodicTimer !== null) {
       clearInterval(this.periodicTimer);
       this.periodicTimer = null;
+    }
+    if (this.squirrelLockRetryTimer !== null) {
+      clearTimeout(this.squirrelLockRetryTimer);
+      this.squirrelLockRetryTimer = null;
     }
   }
 
@@ -134,6 +155,10 @@ export class DesktopUpdater {
     if (this.checkActive) {
       return;
     }
+    if (this.squirrelLockRetryTimer !== null) {
+      this.publishStatus({ ...this.status });
+      return;
+    }
     if (usesMicrosoftStoreUpdates(process.platform, process.windowsStore)) {
       const channel = this.failChannelSwitch();
       this.updateStatus({
@@ -155,18 +180,34 @@ export class DesktopUpdater {
       });
       return;
     }
-    const updateChannel = this.effectiveUpdateChannel();
-    const updateURL = resolveUpdateURL(updateChannel);
-    const manifestURL = resolveManifestURL(updateChannel);
-    if (!app.isPackaged || !updateURL || !manifestURL) {
+    if (!app.isPackaged) {
       const channel = this.failChannelSwitch();
       this.updateStatus({
         state: "unsupported",
         channel,
         currentVersion: app.getVersion(),
-        message: app.isPackaged
-          ? "Desktop update feed or downloads manifest is not configured."
-          : "Updates are disabled in development.",
+        message: "Updates are disabled in development.",
+      });
+      return;
+    }
+    await this.waitForUpdateChecksReady();
+    if (this.downloaded) {
+      this.publishStatus({ ...this.status });
+      return;
+    }
+    if (this.checkActive) {
+      return;
+    }
+    const updateChannel = this.effectiveUpdateChannel();
+    const updateURL = resolveUpdateURL(updateChannel);
+    const manifestURL = resolveManifestURL(updateChannel);
+    if (!updateURL || !manifestURL) {
+      const channel = this.failChannelSwitch();
+      this.updateStatus({
+        state: "unsupported",
+        channel,
+        currentVersion: app.getVersion(),
+        message: "Desktop update feed or downloads manifest is not configured.",
       });
       return;
     }
@@ -220,6 +261,16 @@ export class DesktopUpdater {
       autoUpdater.checkForUpdates();
     } catch (error) {
       this.checkActive = false;
+      const message = error instanceof Error ? error.message : String(error);
+      if (this.scheduleSquirrelLockRetry(message)) {
+        this.updateStatus({
+          state: "checking",
+          channel: this.channel,
+          currentVersion: app.getVersion(),
+          availableVersion: this.expectedVersion || undefined,
+        });
+        return;
+      }
       this.installWhenDownloaded = false;
       const channel = this.failChannelSwitch();
       await this.closeMacChannelFeed();
@@ -227,7 +278,7 @@ export class DesktopUpdater {
         state: "error",
         channel,
         currentVersion: app.getVersion(),
-        message: error instanceof Error ? error.message : String(error),
+        message,
       });
       throw error;
     }
@@ -338,6 +389,15 @@ export class DesktopUpdater {
     );
     autoUpdater.on("error", (error) => {
       this.checkActive = false;
+      if (this.scheduleSquirrelLockRetry(error.message)) {
+        this.updateStatus({
+          state: "checking",
+          channel: this.channel,
+          currentVersion: app.getVersion(),
+          availableVersion: this.expectedVersion || undefined,
+        });
+        return;
+      }
       this.installWhenDownloaded = false;
       const channel = this.failChannelSwitch();
       void this.closeMacChannelFeed();
@@ -383,8 +443,12 @@ export class DesktopUpdater {
           this.windowsChannelInstallerPath,
           updateExePath,
           path.basename(process.execPath),
-          process.pid,
+          path.join(app.getPath("logs"), "channel-installer.log"),
         );
+        logDesktopInfo("desktop-channel-switch-windows-installer-launched", {
+          availableVersion: this.expectedVersion,
+          channel: this.effectiveUpdateChannel(),
+        });
         app.quit();
         return;
       }
@@ -502,6 +566,50 @@ export class DesktopUpdater {
 
   private effectiveUpdateChannel(): DesktopUpdateChannel {
     return this.targetChannel ?? this.channel;
+  }
+
+  private async waitForUpdateChecksReady(): Promise<void> {
+    const delayMs = this.updateChecksReadyAt - Date.now();
+    if (delayMs <= 0) {
+      return;
+    }
+    if (this.updateChecksReady === null) {
+      logDesktopInfo("desktop-update-check-delayed", {
+        delayMs,
+        reason: "squirrel-firstrun",
+      });
+      this.updateChecksReady = new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, delayMs);
+        timer.unref();
+      });
+    }
+    await this.updateChecksReady;
+  }
+
+  private scheduleSquirrelLockRetry(message: string): boolean {
+    if (
+      !isSquirrelUpdateLockError(message) ||
+      this.squirrelLockRetryUntil <= Date.now()
+    ) {
+      return false;
+    }
+    if (this.squirrelLockRetryTimer !== null) {
+      return true;
+    }
+    const delayMs = Math.min(
+      SQUIRREL_LOCK_RETRY_INTERVAL_MS,
+      this.squirrelLockRetryUntil - Date.now(),
+    );
+    logDesktopInfo("desktop-update-squirrel-lock-retry-scheduled", {
+      delayMs,
+      retryUntil: new Date(this.squirrelLockRetryUntil).toISOString(),
+    });
+    this.squirrelLockRetryTimer = setTimeout(() => {
+      this.squirrelLockRetryTimer = null;
+      void this.checkForUpdates().catch(() => undefined);
+    }, delayMs);
+    this.squirrelLockRetryTimer.unref();
+    return true;
   }
 }
 

--- a/scripts/collect-desktop-diagnostics.ps1
+++ b/scripts/collect-desktop-diagnostics.ps1
@@ -24,7 +24,7 @@ New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
 New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 
 try {
-    foreach ($name in @("main.log", "main.previous.log", "backend.log")) {
+    foreach ($name in @("main.log", "main.previous.log", "backend.log", "channel-installer.log")) {
         $source = Get-ChildItem -LiteralPath $UserDataDirectory -Recurse -File -Filter $name -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
@@ -33,6 +33,14 @@ try {
         }
         Copy-Item -LiteralPath $source.FullName -Destination (Join-Path $stagingDirectory $name) -Force
         $collectedPaths.Add($source.FullName)
+    }
+
+    $squirrelLog = Join-Path $env:LOCALAPPDATA "SquirrelTemp\SquirrelSetup.log"
+    if (Test-Path -LiteralPath $squirrelLog -PathType Leaf) {
+        Copy-Item -LiteralPath $squirrelLog `
+            -Destination (Join-Path $stagingDirectory "squirrel-setup.log") `
+            -Force
+        $collectedPaths.Add($squirrelLog)
     }
 
     Get-ChildItem -LiteralPath $UserDataDirectory -Recurse -File -ErrorAction SilentlyContinue |
@@ -63,6 +71,18 @@ try {
             Select-Object Id, StartTime, Path |
             Format-List |
             Out-File -LiteralPath (Join-Path $stagingDirectory "process-status.txt") -Encoding UTF8
+    }
+
+    $installationDirectory = Join-Path $env:LOCALAPPDATA "csgclaw_desktop"
+    if (Test-Path -LiteralPath $installationDirectory -PathType Container) {
+        Get-ChildItem -LiteralPath $installationDirectory -Force -ErrorAction SilentlyContinue |
+            Select-Object Name, FullName, Length, LastWriteTime, Attributes |
+            Format-List |
+            Out-File -LiteralPath (Join-Path $stagingDirectory "installation-status.txt") -Encoding UTF8
+    }
+    else {
+        "CSGClaw Squirrel installation directory was not found: $installationDirectory" |
+            Set-Content -LiteralPath (Join-Path $stagingDirectory "installation-status.txt") -Encoding UTF8
     }
 
     try {


### PR DESCRIPTION
- Make Windows channel switching reliably relaunch CSGClaw after Squirrel installation, retry transient first-run lock contention, and capture additional installer diagnostics.
