### PR TITLE
fix(desktop): coordinate Windows channel installer startup

### DIFF
--- a/desktop/src/main/channelSwitchUpdate.test.ts
+++ b/desktop/src/main/channelSwitchUpdate.test.ts
@@ -11,6 +11,7 @@ import {
   officialMacReleaseArchiveURL,
   parseMacChannelUpdate,
   startMacChannelUpdateFeed,
+  windowsChannelInstallerCoordinatorScript,
 } from "./channelSwitchUpdate";
 
 test("selects the target latest release from a static macOS feed", () => {
@@ -55,7 +56,11 @@ test("builds the official release archive fallback for macOS", () => {
 
 test("explains a missing signed macOS auto-update package", () => {
   assert.match(
-    missingSignedMacUpdatePackageError("release", "0.4.6", new Error("HTTP 404")).message,
+    missingSignedMacUpdatePackageError(
+      "release",
+      "0.4.6",
+      new Error("HTTP 404"),
+    ).message,
     /does not provide a signed macOS auto-update package for 0.4.6\. HTTP 404/,
   );
 });
@@ -112,4 +117,22 @@ test("downloads and verifies a complete channel installer", async () => {
   } finally {
     await fs.promises.rm(directory, { recursive: true, force: true });
   }
+});
+
+test("coordinates a Windows channel install after the parent exits", () => {
+  const script = windowsChannelInstallerCoordinatorScript();
+  const readyIndex = script.indexOf("coordinator-ready");
+  const parentWaitIndex = script.indexOf(":wait_for_parent");
+  const installerIndex = script.indexOf(
+    '"%CSGCLAW_CHANNEL_INSTALLER%" --silent',
+  );
+  const relaunchIndex = script.indexOf(
+    'start "" "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%"',
+  );
+
+  assert.ok(readyIndex >= 0);
+  assert.ok(parentWaitIndex > readyIndex);
+  assert.ok(installerIndex > parentWaitIndex);
+  assert.ok(relaunchIndex > installerIndex);
+  assert.match(script, /installer-exited code=%installerExit%/);
 });

--- a/desktop/src/main/channelSwitchUpdate.ts
+++ b/desktop/src/main/channelSwitchUpdate.ts
@@ -248,43 +248,186 @@ export async function isVerifiedArtifact(
   }
 }
 
-export async function launchWindowsChannelInstaller(
-  installerPath: string,
-  updateExePath: string,
-  executableName: string,
+const WINDOWS_COORDINATOR_READY = "coordinator-ready";
+const WINDOWS_COORDINATOR_READY_TIMEOUT_MS = 5_000;
+
+export function windowsChannelInstallerCoordinatorScript(): string {
+  return [
+    "@echo off",
+    "setlocal EnableExtensions DisableDelayedExpansion",
+    "echo coordinator-started parent-pid=%CSGCLAW_CHANNEL_PARENT_PID%",
+    `> "%CSGCLAW_CHANNEL_READY_FILE%" echo ${WINDOWS_COORDINATOR_READY}`,
+    `echo ${WINDOWS_COORDINATOR_READY}`,
+    ":wait_for_parent",
+    '"%SystemRoot%\\System32\\tasklist.exe" /FI "PID eq %CSGCLAW_CHANNEL_PARENT_PID%" /NH 2>NUL | "%SystemRoot%\\System32\\findstr.exe" /C:"%CSGCLAW_CHANNEL_PARENT_PID%" >NUL',
+    "if errorlevel 1 goto parent_exited",
+    '"%SystemRoot%\\System32\\ping.exe" 127.0.0.1 -n 2 >NUL',
+    "goto wait_for_parent",
+    ":parent_exited",
+    "echo parent-exited",
+    "echo installer-started",
+    '"%CSGCLAW_CHANNEL_INSTALLER%" --silent',
+    'set "installerExit=%ERRORLEVEL%"',
+    "echo installer-exited code=%installerExit%",
+    'if not exist "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%" goto relaunch_missing',
+    "echo relaunch-started",
+    'start "" "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%"',
+    "if errorlevel 1 goto relaunch_failed",
+    "echo relaunch-requested",
+    "exit /b %installerExit%",
+    ":relaunch_failed",
+    "echo relaunch-failed code=%ERRORLEVEL%",
+    "exit /b 1",
+    ":relaunch_missing",
+    "echo relaunch-missing",
+    "exit /b 1",
+    "",
+  ].join("\r\n");
+}
+
+async function waitForWindowsCoordinatorReady(
+  readyFilePath: string,
+  child: ReturnType<typeof spawn>,
   logPath: string,
 ): Promise<void> {
-  // Run the full installer immediately after graceful app shutdown starts.
-  // Squirrel terminates any remaining package processes, replaces the app
-  // root, and returns only after releasing its update lock. Relaunching after
-  // that point prevents the target version (including older stable builds)
-  // from checking for updates while the installer still owns the lock.
-  const command = [
-    `> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-started`,
-    `start "" /wait "%CSGCLAW_CHANNEL_INSTALLER%" --silent`,
-    `if errorlevel 1 (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-failed) else (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo installer-finished)`,
-    `if not exist "%CSGCLAW_CHANNEL_UPDATER%" (>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo updater-missing & exit /b 1)`,
-    `start "" "%CSGCLAW_CHANNEL_UPDATER%" --processStart "%CSGCLAW_CHANNEL_EXECUTABLE%"`,
-    `>> "%CSGCLAW_CHANNEL_INSTALL_LOG%" echo relaunch-requested`,
-  ].join(" & ");
-  const child = spawn("cmd.exe", ["/d", "/s", "/c", command], {
-    detached: true,
-    env: {
-      ...process.env,
-      CSGCLAW_CHANNEL_EXECUTABLE: executableName,
-      CSGCLAW_CHANNEL_INSTALLER: installerPath,
-      CSGCLAW_CHANNEL_INSTALL_LOG: logPath,
-      CSGCLAW_CHANNEL_UPDATER: updateExePath,
-    },
-    stdio: "ignore",
-    windowsHide: true,
-  });
   await new Promise<void>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("spawn", () => {
-      child.off("error", reject);
+    const deadline = Date.now() + WINDOWS_COORDINATOR_READY_TIMEOUT_MS;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      child.off("error", fail);
+      child.off("exit", exited);
+    };
+    const succeed = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
       resolve();
-    });
+    };
+    const fail = (error: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const exited = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ): void => {
+      fail(
+        new Error(
+          `Windows update coordinator exited before it became ready (code=${code ?? "none"}, signal=${signal ?? "none"}). See ${logPath}.`,
+        ),
+      );
+    };
+    const poll = async (): Promise<void> => {
+      try {
+        const marker = await fs.promises.readFile(readyFilePath, "utf8");
+        if (marker.trim() === WINDOWS_COORDINATOR_READY) {
+          succeed();
+          return;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          fail(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+      }
+      if (settled) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        fail(
+          new Error(
+            `Windows update coordinator did not become ready within ${WINDOWS_COORDINATOR_READY_TIMEOUT_MS / 1_000} seconds. See ${logPath}.`,
+          ),
+        );
+        return;
+      }
+      timer = setTimeout(() => {
+        void poll();
+      }, 50);
+    };
+
+    child.once("error", fail);
+    child.once("exit", exited);
+    void poll();
   });
+}
+
+export async function launchWindowsChannelInstaller(
+  installerPath: string,
+  rootExecutablePath: string,
+  logPath: string,
+  parentProcessId: number,
+): Promise<void> {
+  // Keep the coordinator independent from the Electron process so it can wait
+  // for the current app to exit before running the full Squirrel installer.
+  // The ready-file handshake proves that cmd.exe parsed and started the batch
+  // file; merely observing ChildProcess's spawn event does not prove that.
+  const coordinatorDirectory = path.dirname(installerPath);
+  const coordinatorPath = path.join(
+    coordinatorDirectory,
+    "channel-installer.cmd",
+  );
+  const readyFilePath = path.join(
+    coordinatorDirectory,
+    "channel-installer.ready",
+  );
+  await fs.promises.mkdir(coordinatorDirectory, { recursive: true });
+  await fs.promises.mkdir(path.dirname(logPath), { recursive: true });
+  await Promise.all([
+    fs.promises.writeFile(
+      coordinatorPath,
+      windowsChannelInstallerCoordinatorScript(),
+      { encoding: "utf8", mode: 0o600 },
+    ),
+    fs.promises.writeFile(logPath, "", { encoding: "utf8", mode: 0o600 }),
+    fs.promises.rm(readyFilePath, { force: true }),
+  ]);
+
+  const logDescriptor = fs.openSync(logPath, "a");
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(
+      process.env.ComSpec || "cmd.exe",
+      ["/d", "/q", "/s", "/c", 'call "%CSGCLAW_CHANNEL_COORDINATOR%"'],
+      {
+        detached: true,
+        env: {
+          ...process.env,
+          CSGCLAW_CHANNEL_COORDINATOR: coordinatorPath,
+          CSGCLAW_CHANNEL_INSTALLER: installerPath,
+          CSGCLAW_CHANNEL_PARENT_PID: String(parentProcessId),
+          CSGCLAW_CHANNEL_READY_FILE: readyFilePath,
+          CSGCLAW_CHANNEL_ROOT_EXECUTABLE: rootExecutablePath,
+        },
+        stdio: ["ignore", logDescriptor, logDescriptor],
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      },
+    );
+  } finally {
+    fs.closeSync(logDescriptor);
+  }
+
+  try {
+    await waitForWindowsCoordinatorReady(readyFilePath, child, logPath);
+  } catch (error) {
+    try {
+      child.kill();
+    } catch {
+      // Preserve the coordinator readiness error if the process already exited.
+    }
+    throw error;
+  }
   child.unref();
 }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -433,19 +433,22 @@ export class DesktopUpdater {
     const wasChannelSwitch = this.channelSwitchActive;
     try {
       await this.beforeInstall();
-      if (this.windowsChannelInstallerPath) {
-        const updateExePath = path.resolve(
+      if (
+        process.platform === DesktopPlatform.Windows &&
+        this.windowsChannelInstallerPath
+      ) {
+        const rootExecutablePath = path.resolve(
           path.dirname(process.execPath),
           "..",
-          "Update.exe",
+          path.basename(process.execPath),
         );
         await launchWindowsChannelInstaller(
           this.windowsChannelInstallerPath,
-          updateExePath,
-          path.basename(process.execPath),
+          rootExecutablePath,
           path.join(app.getPath("logs"), "channel-installer.log"),
+          process.pid,
         );
-        logDesktopInfo("desktop-channel-switch-windows-installer-launched", {
+        logDesktopInfo("desktop-channel-switch-windows-coordinator-ready", {
           availableVersion: this.expectedVersion,
           channel: this.effectiveUpdateChannel(),
         });

--- a/scripts/collect-desktop-diagnostics.ps1
+++ b/scripts/collect-desktop-diagnostics.ps1
@@ -19,12 +19,20 @@ $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
 $stagingDirectory = Join-Path ([IO.Path]::GetTempPath()) "csgclaw-diagnostics-$timestamp-$PID"
 $archivePath = Join-Path $OutputDirectory "csgclaw-diagnostics-$timestamp.zip"
 $collectedPaths = [Collections.Generic.List[string]]::new()
+$installationDirectory = Join-Path $env:LOCALAPPDATA "csgclaw_desktop"
 
 New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
 New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 
 try {
-    foreach ($name in @("main.log", "main.previous.log", "backend.log", "channel-installer.log")) {
+    foreach ($name in @(
+        "main.log",
+        "main.previous.log",
+        "backend.log",
+        "channel-installer.log",
+        "channel-installer.cmd",
+        "channel-installer.ready"
+    )) {
         $source = Get-ChildItem -LiteralPath $UserDataDirectory -Recurse -File -Filter $name -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
@@ -41,6 +49,16 @@ try {
             -Destination (Join-Path $stagingDirectory "squirrel-setup.log") `
             -Force
         $collectedPaths.Add($squirrelLog)
+    }
+
+    if (Test-Path -LiteralPath $installationDirectory -PathType Container) {
+        Get-ChildItem -LiteralPath $installationDirectory -File -Filter "Squirrel-*.log" -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                Copy-Item -LiteralPath $_.FullName `
+                    -Destination (Join-Path $stagingDirectory $_.Name) `
+                    -Force
+                $collectedPaths.Add($_.FullName)
+            }
     }
 
     Get-ChildItem -LiteralPath $UserDataDirectory -Recurse -File -ErrorAction SilentlyContinue |
@@ -73,7 +91,6 @@ try {
             Out-File -LiteralPath (Join-Path $stagingDirectory "process-status.txt") -Encoding UTF8
     }
 
-    $installationDirectory = Join-Path $env:LOCALAPPDATA "csgclaw_desktop"
     if (Test-Path -LiteralPath $installationDirectory -PathType Container) {
         Get-ChildItem -LiteralPath $installationDirectory -Force -ErrorAction SilentlyContinue |
             Select-Object Name, FullName, Length, LastWriteTime, Attributes |


### PR DESCRIPTION
- Add a ready handshake and parent-exit coordinator for Windows channel installers, preserve the running app when coordinator startup fails, and collect coordinator and Squirrel logs without changing the macOS updater path.