### PR TITLE
fix(sandbox): defer BoxLite availability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ CSGClaw gives you one **Manager** and a set of specialized **Workers**, so inste
 
 **Workers** — role-specific executors (frontend, backend, testing, docs, research…). Specialization keeps context clean and reduces role confusion.
 
-**Sandbox** — Worker execution is isolated by the configured sandbox provider. CSGClaw defaults to **Docker** when the provider is unset, and BoxLite remains available through explicit configuration.
+**Sandbox** — Worker execution is isolated by the configured sandbox provider. CSGClaw defaults to **Docker** when the provider is unset. The deprecated BoxLite provider remains available through explicit configuration for legacy development use.
 
 **Interface** — WebUI out of the box; Feishu, WeChat, Matrix, and other channels available as integrations.
 
@@ -122,7 +122,7 @@ The key isn't that multiple agents exist — it's that **their collaboration is 
 CSGClaw uses PicoClaw as its lightweight default Agent Runtime, keeping the Manager fast to start and cheap to run. The runtime remains pluggable, so deployments can integrate alternatives such as OpenClaw when needed.
 
 **Docker by default, sandbox-agnostic by design.**
-Isolation is non-negotiable. Docker is the default sandbox provider for broad cross-platform availability, while BoxLite remains supported for environments that prefer its lightweight local runtime. Teams can switch sandbox providers explicitly when their environment requires it.
+Isolation is non-negotiable. Docker is the default sandbox provider for broad cross-platform availability. The deprecated BoxLite provider remains supported only for explicitly configured legacy development environments.
 
 **WebUI first, channel-agnostic by design.**
 Many multi-agent systems are tightly coupled to one messaging protocol. CSGClaw ships with a built-in WebUI so you can start immediately, while keeping other channels (Feishu, WeChat, Matrix) as optional integrations — not assumptions.

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1547,7 +1547,7 @@ func TestNewAgentServiceRejectsUnsupportedSandboxProvider(t *testing.T) {
 	}
 }
 
-func TestNewAgentServiceExplainsMissingConfiguredBoxLite(t *testing.T) {
+func TestNewAgentServiceAllowsMissingConfiguredBoxLiteAtStartup(t *testing.T) {
 	prevLookPath := sandboxprovidersTestOnlyLookPath(t, func(string) (string, error) {
 		return "", fmt.Errorf("not found")
 	})
@@ -1558,24 +1558,17 @@ func TestNewAgentServiceExplainsMissingConfiguredBoxLite(t *testing.T) {
 	})
 	defer prevStatPath()
 
-	_, err := newAgentService(config.Config{
+	t.Setenv("HOME", t.TempDir())
+
+	svc, err := newAgentService(config.Config{
 		Sandbox: config.SandboxConfig{
 			Provider: config.BoxLiteProvider,
 		},
 	}, nil)
-	if err == nil {
-		t.Fatal("newAgentService() error = nil, want actionable boxlite availability error")
+	if err != nil {
+		t.Fatalf("newAgentService() error = %v, want host-only startup to succeed", err)
 	}
-	for _, want := range []string{
-		`sandbox provider "boxlite" is configured`,
-		`no bundled boxlite binary was found`,
-		`"boxlite" is not available on PATH`,
-		`Switch [sandbox].provider to "docker"`,
-	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("newAgentService() error = %q, want substring %q", err, want)
-		}
-	}
+	defer svc.Close()
 }
 
 func TestNewAgentServiceAllowsMissingConfiguredDockerAtStartup(t *testing.T) {

--- a/docs/tech/config.md
+++ b/docs/tech/config.md
@@ -158,7 +158,7 @@ The Codex `reasoningEffortMap` passes these levels through by name.
 
 CSGClaw runs Workers through the configured sandbox provider. Supported built-in providers are:
 
-- `boxlite`: runs Workers through the local `boxlite` CLI.
+- `boxlite`: deprecated compatibility provider for legacy development environments; runs Workers through the local `boxlite` CLI when explicitly configured.
 - `docker`: runs Workers through the local Docker CLI.
 - `csghub`: runs Workers in the remote CSGHub sandbox. This is currently supported only in [AgenticHub](https://opencsg.com/agentichub).
 
@@ -188,7 +188,7 @@ provider = "boxlite"
 provider = "docker"
 ```
 
-For `provider = "boxlite"`, CSGClaw resolves the bundled sibling `boxlite` binary next to `csgclaw` first, then falls back to `PATH` if that bundle is missing. If neither exists, startup fails with an actionable error instead of silently rewriting the provider.
+For `provider = "boxlite"`, CSGClaw resolves the bundled sibling `boxlite` binary next to `csgclaw` first, then falls back to `PATH` if that bundle is missing. BoxLite is deprecated and no longer the recommended provider, but explicit legacy configurations remain supported for development use. CSGClaw does not silently rewrite them. If BoxLite is unavailable, the server and host-only runtimes still start; the first BoxLite-backed operation returns an actionable error recommending Docker.
 
 For `provider = "docker"`, Docker executable availability is checked when an operation actually opens the provider, such as creating or starting a sandbox Agent or listing local images. The server and a host-only manager can therefore start without Docker installed; the first Docker-backed operation still returns an actionable error.
 

--- a/docs/tech/config.zh.md
+++ b/docs/tech/config.zh.md
@@ -158,7 +158,7 @@ Codex 的 `reasoningEffortMap` 会按同名值透传这些档位。
 
 CSGClaw 通过配置的 sandbox provider 隔离 Worker 执行环境。当前内置支持的 provider 包括：
 
-- `boxlite`：通过本地 `boxlite` CLI 运行 Worker。
+- `boxlite`：用于旧开发环境兼容的已弃用 provider；仅在显式配置时通过本地 `boxlite` CLI 运行 Worker。
 - `docker`：通过本地 Docker CLI 运行 Worker。
 - `csghub`：在远端 CSGHub sandbox 运行 Worker（目前仅支持在 [AgenticHub](https://opencsg.com/agentichub) 里使用）。
 
@@ -188,7 +188,7 @@ provider = "boxlite"
 provider = "docker"
 ```
 
-对于 `provider = "boxlite"`，CSGClaw 会优先解析与 `csgclaw` 同 bundle 的 `boxlite`，只有 bundle 缺失时才回退到 `PATH`。如果两者都找不到，启动会直接报带操作建议的错误，而不是静默改写 provider。
+对于 `provider = "boxlite"`，CSGClaw 会优先解析与 `csgclaw` 同 bundle 的 `boxlite`，只有 bundle 缺失时才回退到 `PATH`。BoxLite 已弃用且不再是推荐 provider，但为了开发兼容，显式的旧配置仍然有效，CSGClaw 不会静默改写它。即使 BoxLite 不可用，服务和仅使用宿主机 runtime 的 manager 仍可启动；第一次 BoxLite sandbox 操作会返回带操作建议的错误并推荐切换到 Docker。
 
 对于 `provider = "docker"`，Docker 可执行文件会在真正打开 provider 的操作中检查，例如创建或启动 sandbox Agent、列出本地镜像。这样，即使未安装 Docker，服务和仅使用宿主机 runtime 的 manager 也可以正常启动；第一次 Docker sandbox 操作仍会返回带操作建议的错误。
 

--- a/internal/sandboxproviders/availability.go
+++ b/internal/sandboxproviders/availability.go
@@ -17,7 +17,7 @@ func Availability(cfg config.SandboxConfig) error {
 	switch strings.TrimSpace(cfg.Provider) {
 	case config.BoxLiteProvider:
 		if goruntime.GOOS == "windows" {
-			return fmt.Errorf("sandbox provider %q is not supported on Windows; switch [sandbox].provider to %q", config.BoxLiteProvider, config.DockerProvider)
+			return fmt.Errorf("sandbox provider %q is deprecated and is not supported on Windows; switch [sandbox].provider to %q", config.BoxLiteProvider, config.DockerProvider)
 		}
 		return ensureBoxLiteAvailable(boxlitecli.ResolvePath(""))
 	case config.DockerProvider:

--- a/internal/sandboxproviders/boxlite_provider.go
+++ b/internal/sandboxproviders/boxlite_provider.go
@@ -37,10 +37,6 @@ func StatPathForTest(fn func(string) (os.FileInfo, error)) func() {
 func init() {
 	Register(config.BoxLiteProvider, func(cfg config.SandboxConfig) (sandbox.Provider, error) {
 		resolvedPath := boxlitecli.ResolvePath("")
-		if err := Availability(config.SandboxConfig{Provider: config.BoxLiteProvider}); err != nil {
-			return nil, err
-		}
-
 		opts := []boxlitecli.ProviderOption{boxlitecli.WithPath(resolvedPath)}
 		for _, registry := range cfg.EffectiveDebianRegistries() {
 			opts = append(opts, boxlitecli.WithRegistry(registry))
@@ -59,5 +55,5 @@ func ensureBoxLiteAvailable(resolvedPath string) error {
 		return nil
 	}
 
-	return fmt.Errorf("sandbox provider %q is configured, but no bundled boxlite binary was found and %q is not available on PATH\nSwitch [sandbox].provider to %q, or install boxlite separately if your platform later supports it.", config.BoxLiteProvider, resolvedPath, config.DockerProvider)
+	return fmt.Errorf("sandbox provider %q is configured explicitly and is deprecated, but no bundled boxlite binary was found and %q is not available on PATH\nSwitch [sandbox].provider to %q, or install boxlite separately for legacy development use.", config.BoxLiteProvider, resolvedPath, config.DockerProvider)
 }

--- a/internal/sandboxproviders/boxlite_provider_test.go
+++ b/internal/sandboxproviders/boxlite_provider_test.go
@@ -52,7 +52,7 @@ func TestBoxLiteProviderFactoryUsesDefaultResolvedPath(t *testing.T) {
 	}
 }
 
-func TestBoxLiteProviderFactoryErrorsWhenBundledAndPATHFallbackAreUnavailable(t *testing.T) {
+func TestBoxLiteProviderDefersAvailabilityUntilOpen(t *testing.T) {
 	restore := stubBoxLiteAvailability(t, func(string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}, func(path string) (os.FileInfo, error) {
@@ -60,17 +60,17 @@ func TestBoxLiteProviderFactoryErrorsWhenBundledAndPATHFallbackAreUnavailable(t 
 	})
 	defer restore()
 
-	factory, ok := factories[config.BoxLiteProvider]
-	if !ok {
-		t.Fatalf("boxlite provider factory not registered")
+	provider, err := Provider(config.SandboxConfig{Provider: config.BoxLiteProvider})
+	if err != nil {
+		t.Fatalf("Provider() error = %v, want deferred availability check", err)
 	}
-
-	_, err := factory(config.SandboxConfig{Provider: config.BoxLiteProvider})
+	_, err = provider.Open(t.Context(), t.TempDir())
 	if err == nil {
-		t.Fatal("factory() error = nil, want actionable boxlite availability error")
+		t.Fatal("provider.Open() error = nil, want actionable boxlite availability error")
 	}
 	wants := []string{
 		`sandbox provider "boxlite"`,
+		`is deprecated`,
 		`"docker"`,
 	}
 	if goruntime.GOOS != "windows" {
@@ -78,11 +78,12 @@ func TestBoxLiteProviderFactoryErrorsWhenBundledAndPATHFallbackAreUnavailable(t 
 			`no bundled boxlite binary was found`,
 			`"boxlite" is not available on PATH`,
 			`Switch [sandbox].provider to "docker"`,
+			`legacy development use`,
 		)
 	}
 	for _, want := range wants {
 		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("factory() error = %q, want substring %q", err, want)
+			t.Fatalf("provider.Open() error = %q, want substring %q", err, want)
 		}
 	}
 }

--- a/internal/sandboxproviders/registry.go
+++ b/internal/sandboxproviders/registry.go
@@ -46,7 +46,7 @@ func Provider(cfg config.SandboxConfig) (sandbox.Provider, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.Provider != config.DockerProvider {
+	if cfg.Provider != config.DockerProvider && cfg.Provider != config.BoxLiteProvider {
 		return provider, nil
 	}
 	return deferredAvailabilityProvider{
@@ -55,9 +55,10 @@ func Provider(cfg config.SandboxConfig) (sandbox.Provider, error) {
 	}, nil
 }
 
-// deferredAvailabilityProvider keeps host-only runtimes usable when Docker is
-// not installed. Availability is checked at the first operation that actually
-// needs Docker instead of while the Agent service is starting.
+// deferredAvailabilityProvider keeps host-only runtimes usable when the
+// configured local sandbox CLI is not installed. Availability is checked at
+// the first operation that actually needs the sandbox instead of while the
+// Agent service is starting.
 type deferredAvailabilityProvider struct {
 	cfg      config.SandboxConfig
 	provider sandbox.Provider


### PR DESCRIPTION
- Allow CSGClaw and host-only runtimes to start when an explicitly configured BoxLite binary is unavailable.
- Check BoxLite availability only when sandbox operations are requested, while preserving legacy development configurations without silently switching providers.
- Mark BoxLite as deprecated in actionable errors and documentation, and cover deferred startup behavior including Windows compatibility.