### PR TITLE
feat(agent-engine): add phase 2 orchestration and runtime provisioning

### DIFF
--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -260,9 +260,12 @@ Engine validates only that it is non-empty and length-bounded.
 It never parses Room, Thread, Channel, Binding, or Session fields from the key.
 
 `TurnID` is an opaque caller-generated identity for one `Run` request.
-The Channel Adapter or Session HTTP Adapter generates a random ID after ingress validation and deduplication, but before calling `Run`.
+The Channel Adapter generates it after ingress validation and keeps it stable for retries of the same source event, while the Session HTTP Adapter generates one response ID for its request.
 Engine validates only that it is non-empty and length-bounded, and passes it unchanged to the Runtime Adapter.
-It is not derived from `ConversationKey` or a source Message ID because those identify different lifecycles.
+It remains distinct from `ConversationKey`; a Channel Adapter may normalize a scoped source event ID into `TurnID` because that event identifies the same logical Turn across delivery retries.
+Within one Engine process, `(agentID, ConversationKey, TurnID)` is the idempotency identity.
+An in-flight retry joins the original Turn, and a completed dispatched retry replays the bounded process-local progress events and returns the cached result without submitting another Runtime Turn.
+Reusing the same identity with different normalized input or policies returns `invalid_request`.
 
 Each Adapter owns collision-free key construction:
 
@@ -272,16 +275,17 @@ Each Adapter owns collision-free key construction:
 | Feishu | App Binding, Chat, and optional Thread root |
 | Session API | Random internal key stored by the Session Binding Store |
 
-Engine permits at most one Turn or Reset for `(agentID, ConversationKey)` at a time.
+Engine permits at most one Turn or atomic control operation for `(agentID, ConversationKey)` at a time.
 Different Conversation keys may execute concurrently.
-An overlapping Run fails immediately with `conversation_busy`.
-Phase 2 does not implement admission configuration or queues.
-Future wait queues and broader concurrency limits can be added before the existing execution lease without changing Turn ownership.
+`AdmissionPolicy` selects `reject_if_busy`, `wait`, or `supersede` for a different overlapping Turn.
+`reject_if_busy` fails immediately with `conversation_busy` and remains the default for the anonymous Session API.
+`wait` waits for the current Turn or control operation before competing for admission.
+`supersede` closes admission, cancels the current Turn, waits for true Runtime cleanup, and admits the replacement without an intervening Run.
 Cancel therefore uses the Agent-scoped `ConversationKey` and `TurnID` to identify exactly one running Turn.
 Resolve additionally carries `InteractionID` to identify one pending interaction.
 
-`TurnID` lives only for the Turn lifecycle.
-It is not a Conversation key, Runtime-native conversation mapping, transcript identity, or durable Engine resource.
+`TurnID` is retained only in a bounded process-local idempotency window after the Turn lifecycle.
+It is not a Conversation key, Runtime-native conversation mapping, transcript identity, or durable Engine resource, so a process restart still requires source-side deduplication.
 `Reset` remains scoped to `ConversationKey`, and `Resolve` remains scoped to `ConversationKey` plus `InteractionID`.
 
 `ContinuationPolicy` makes Runtime mapping behavior explicit:
@@ -309,7 +313,7 @@ Incremental implementation does not narrow this contract to a string.
 The Phase 1 Session HTTP Adapter creates one text part, and the private Codex Runtime Adapter joins ordered text parts before calling the current Runtime API.
 A file part retains its public type but returns `file_unavailable` before Runtime dispatch until a later phase implements file execution.
 
-The Event Sink receives ordered, non-terminal progress for one `Run` call:
+The Event Sink receives ordered progress for a logical Turn:
 
 - Text delta.
 - Thought delta.
@@ -318,7 +322,8 @@ The Event Sink receives ordered, non-terminal progress for one `Run` call:
 - Validated output item.
 
 The sink is not an event bus, transcript store, or Channel renderer.
-Its sequence number orders events only within the current Run call.
+Every event carries `TurnID` and monotonic `Sequence`.
+The tuple `(TurnID, Sequence)` lets an Adapter deduplicate replayed envelopes after a retry.
 
 `Run` returns exactly one `TurnResult` and no second raw Runtime error.
 `Dispatched=false` means the native Turn was not submitted.
@@ -389,7 +394,7 @@ It may merge the current hidden Channel or new-Thread context into normalized te
 Engine does not model that context separately.
 
 `/new` calls `Reset` with the same `ConversationKey`.
-The Runtime Adapter atomically replaces its native conversation mapping.
+Engine closes admission in the same Conversation gate, cancels and drains any active Turn, calls the Runtime Adapter to remove its native mapping, and only then reopens admission.
 
 ### 5.3 Runtime Adapter
 
@@ -417,14 +422,15 @@ It must not fabricate direct execution through an IM or Feishu event.
 ### 6.1 Persistence
 
 Agent Engine has no durable Conversation store.
+It retains only a bounded process-local cache of dispatched Turn progress events and results for retry idempotency.
 The Agent resource implementation owns desired Runtime credentials, while each Runtime Adapter owns its materialized credential files.
 Runtime Adapters own native conversation mappings.
 Channel Adapters own transcripts and source delivery state.
 The Session Binding Store owns only the association between an external Session ID and a Conversation Key.
 
-An Engine process restart interrupts queued and running Turns.
+An Engine process restart interrupts waiting and running Turns and clears the process-local idempotency cache.
 It does not delete Runtime-native mappings.
-The design does not promise replay, exactly-once execution, or recovery of in-flight side effects.
+The design does not promise cross-restart replay, exactly-once execution, or recovery of in-flight side effects.
 
 ### 6.2 Files
 
@@ -448,14 +454,17 @@ Raw control lines never reach public text or Channel renderers.
 A blocking Runtime Permission or User Input keeps the same Turn open and uses `Resolve`.
 A detached `request_user_input` completes the current Turn and creates a later Turn after the user answers.
 Detached input does not call `Resolve`.
+Engine atomically claims a pending interaction before calling the Runtime Adapter, so only the first duplicate action can enter Runtime resolution.
+A failed Runtime resolution restores the claim to pending while the same Turn remains active; a successful resolution consumes it.
+The Channel Adapter authorizes the acting user, while Engine treats `ResponderID` as opaque audit identity and never uses it for authorization.
 
 Secret interaction answers must not enter logs or transcripts.
 Detached secret answers also must not be inserted into model continuation.
 
 ### 6.4 Concurrency and Lifecycle
 
-Phase 2 has no configurable admission limits or normalized Turn queue.
-Engine indexes the one active Turn by `(agentID, ConversationKey, TurnID)` while Runtime-native conversation mappings remain keyed by Conversation identity.
+Engine applies the request's `AdmissionPolicy` before acquiring the Agent execution lease.
+Waiting and superseding remain process-local, while Runtime-native conversation mappings remain keyed by Conversation identity.
 Channel Adapters may retain source-ingress buffering for subscription, deduplication, and acknowledgment.
 
 If a sink fails, Engine requests Runtime cancellation when possible and waits for a true Runtime terminal state before releasing admission.
@@ -517,7 +526,7 @@ Starting in Phase 2, the Agent Engine interface is the only boundary between Eng
 
 - Implement the complete `agentengine.Interface` and provide the concurrency-safe, stateful `enginetest.MemoryClient` implementing the same contract.
 - The interface is not an immutable protocol; when implementation exposes an omission or mistake, it may change through joint review, with the real Engine, Mock Client, contract tests, and affected Adapter call sites updated in the same change.
-- Implement `Agents()`, `Run`, `Cancel`, `Reset`, `Resolve`, fail-fast serialization, file input, interactions, Structured Output, event ordering, `Dispatched`, and stable errors.
+- Implement `Agents()`, `Run`, `Cancel`, atomic `Reset`, claimed `Resolve`, explicit admission policies, Turn retry idempotency, TurnID event envelopes, file input, interactions, Structured Output, `Dispatched`, and stable errors.
 - Let the Agent Engine Facade first wrap the existing Agent Service, Codex Session, brokers, Structured Output, and Runtime provisioning code instead of making internal refactoring a prerequisite for a complete Engine.
 - Coordinate Agent mutation, admission, active Turns, drain, and pinned Runtime handles through one shared Lifecycle Gate.
 - Migrate the anonymous Session API to `agentengine.Interface` while preserving its HTTP contract and zero IM entity creation.
@@ -598,8 +607,8 @@ The two Phase 2 sides can be developed and verified independently, Phase 3 owns 
 
 ### 8.4 Target Verification
 
-- Contract tests cover Run, Cancel, Reset, Resolve, event ordering, terminal results, and stable errors.
-- Tests cover one Turn, different-Conversation concurrency, fail-fast busy admission, sink failure, and cancellation behavior.
+- Contract tests cover Run, Cancel, atomic Reset, claimed Resolve, event envelopes, terminal results, and stable errors.
+- Tests cover Turn retry idempotency, different-Conversation concurrency, reject, wait, supersede, sink failure, and cancellation behavior.
 - Tests cover no MCP, local MCP, remote MCP, text input, and file input.
 - Anonymous tests verify that IM entity counts do not change and Session Binding scope is Agent-specific.
 - Channel tests verify deduplication, replay, superseding, rendering, Binding-driven Event Worker lifecycle, and idempotent reconciliation.

--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -4,11 +4,13 @@ Chinese version: [agent-engine-decoupling.zh.md](agent-engine-decoupling.zh.md)
 
 ## Status
 
-Status: **Architecture proposal; Phase 1 Session path implemented**.
+Status: **Architecture proposal; Phase 2 Engine and Mock Client baseline complete, with production Channel Adapter integration remaining in Phase 3**.
 
 The contract and Phase 1 in-process Conversation implementation are in [`internal/agentengine`](../../internal/agentengine).
-Phase 1 is wired only to the anonymous Session API and the existing Codex Runtime.
-The broader Agent, Channel, file, interaction, and lifecycle design remains incremental.
+Phase 1 connects the anonymous Session API to the existing Codex Runtime and removes anonymous Session dependence on IM entities.
+Phase 2 completes the Engine, Memory Client, Session migration, Codex Runtime Adapter behavior, and a mock-backed Feishu Adapter proof.
+It does not introduce or switch a production Channel Adapter.
+Phase 3 integrates them with an atomic switch, and Phase 4 then refactors the internal Engine components.
 That package is the source of truth for exact Go types and method signatures.
 This document explains the intended ownership, behavior, and incremental implementation plan.
 
@@ -124,6 +126,89 @@ The composition root registers Runtime Adapters and connects the interfaces to t
 A missing Runtime Adapter returns `runtime_adapter_unavailable` before creating Engine execution state or a Session Binding.
 It does not start a fallback execution path.
 
+The overview above shows dependency direction and state ownership.
+The following two views expand the same components into control-plane and data-plane interactions without introducing a second Engine execution path.
+
+#### Control Plane
+
+The control plane changes desired Agent state and coordinates Runtime lifecycle.
+In Phase 2, the Engine Agent Facade delegates persistence and lifecycle work to the existing Agent Service, so the Engine does not create a duplicate Agent store.
+
+```mermaid
+sequenceDiagram
+    participant Caller as Agent API or Internal Caller
+    participant Engine as Agent Engine Agents()
+    participant Gate as Agent Lifecycle Gate
+    participant Service as Agent Service and Store
+    participant Runtime as Runtime Adapter
+
+    Caller->>Engine: Create, Update, Start, Stop, Recreate, or Delete
+    Engine->>Service: validate complete desired Agent state
+    Service->>Gate: enter lifecycle mutation
+    Gate->>Gate: close execution admission and drain active leases
+    alt drain completes
+        Service->>Runtime: provision credentials, run InitShell, and change Runtime lifecycle
+        Runtime-->>Service: observed Runtime result
+        Service->>Service: atomically commit Agent and Runtime state
+        Service-->>Engine: updated Agent
+        Engine-->>Caller: Agent with credential values redacted
+    else caller context expires
+        Gate-->>Service: drain canceled
+        Service-->>Engine: error with prior Runtime unchanged
+        Engine-->>Caller: normalized failure
+    end
+```
+
+All existing direct Agent Service lifecycle callers use the same Gate.
+This prevents Session execution, future Channel execution, and current Agent APIs from replacing or deleting a Runtime while a Turn still holds a pinned execution lease.
+
+#### Data Plane
+
+The data plane executes one normalized Turn and returns ordered events and one terminal result.
+Binding, transcript, attachment, and delivery state remain owned by the calling Adapter and its stores.
+
+```mermaid
+sequenceDiagram
+    participant Source as Session Client or Channel
+    participant Adapter as Session or Channel Adapter
+    participant State as Binding and Transcript Owner
+    participant Engine as Agent Engine Conversations()
+    participant Gate as Agent Lifecycle Gate
+    participant Runtime as Runtime Adapter
+    participant Native as Runtime-native Conversation
+
+    Source->>Adapter: HTTP request or inbound message
+    Adapter->>State: resolve binding and optionally deduplicate and authorize files
+    Adapter->>Engine: Run(TurnID, ConversationKey, Input)
+    Engine->>Engine: fail-fast admission and register active Turn
+    Engine->>Gate: acquire pinned Agent and Runtime lease
+    Engine->>Runtime: Run normalized Turn
+    Runtime->>Native: create or resume mapping and submit native Turn
+    Native-->>Runtime: text, thought, tool, interaction, and output events
+    Runtime-->>Engine: normalized events
+    Engine-->>Adapter: sequenced EventSink events
+    Adapter->>State: update Adapter-owned transcript or delivery state
+    Adapter-->>Source: SSE or rendered Channel delivery
+    opt active Turn control
+        Adapter->>Engine: Cancel exact Turn or Resolve interaction
+        Engine->>Runtime: cancel native Turn or answer Runtime broker
+        Note over Engine,Runtime: Cancel returns only after terminal cleanup and state release
+    end
+    Native-->>Runtime: terminal completion
+    Runtime-->>Engine: terminal result after true Runtime termination
+    Engine->>Gate: release execution lease and active Turn
+    Engine-->>Adapter: one TurnResult
+    opt inactive Conversation reset
+        Adapter->>Engine: Reset(ConversationKey)
+        Engine->>Runtime: remove Runtime-native mapping
+        Runtime-->>Engine: mapping removed
+        Engine-->>Adapter: Reset result
+    end
+```
+
+The Engine owns admission, cancellation, interaction routing, event ordering, and result normalization in this flow.
+The Runtime Adapter owns only Runtime-specific mapping, protocol translation, credential materialization, `InitShell` execution, and Runtime-local file exposure.
+
 ### 3.2 Public Resource Interfaces
 
 The exact declarations remain in `internal/agentengine`.
@@ -132,44 +217,43 @@ The review surface is:
 | Resource | Operations | Purpose |
 |---|---|---|
 | `Agents()` | Create, Get, List, Update, Delete, Start, Stop, Recreate | Desired Agent configuration and Runtime lifecycle |
-| `Conversations(agentID)` | Run; Cancel, Reset, and Resolve planned | Conversation execution scoped to one Agent |
-| `ConversationRuntime` | Run; additional lifecycle operations planned | Runtime-specific direct execution behind Engine |
+| `Conversations(agentID)` | Run, Cancel, Reset, Resolve | Conversation execution scoped to one Agent |
+| `ConversationRuntime` | Run, Cancel, Reset, Resolve | Runtime-specific direct execution behind Engine |
 
-`AgentInterface` is the collection-scoped API for Agent resources, not an adapter around the current `internal/agent.Service`.
-Its implementation owns Agent persistence and Runtime lifecycle through explicit storage and Runtime dependencies.
-The current Agent Service may be refactored or replaced incrementally when this contract is implemented; it is not a dependency of the contract.
+`AgentInterface` is the collection-scoped API for Agent resources, and callers cannot depend on the current `internal/agent.Service`.
+The Phase 2 Engine Facade may wrap the current Agent Service through a private backend so it can first reuse the already verified Agent persistence and Runtime lifecycle code.
+That wrapper is only an internal Engine implementation; it does not enter the public contract or prevent Phase 4 from separating the broad Service into explicit storage, lifecycle, and Runtime components.
 Conversation execution keeps no duplicate Agent records and coordinates active Turns with lifecycle changes.
-Phase 1 is an explicit transition: the Conversation implementation may reach the current Agent Service only through one private Adapter wired by the composition root.
-That Adapter resolves the Agent's current availability and Runtime for execution without adding `ExecutionTarget` or another public interface.
-It is removed in Phase 2 when the new `AgentInterface` implementation becomes the Agent state and Runtime lifecycle owner.
+The Phase 1 Conversation implementation may reach the current Agent Service only through the private Adapter wired by the composition root.
+Phase 2 extends this boundary so the complete Engine implements `Agents()` and `Conversations()` through one private Facade instead of first rewriting the existing Agent components.
+Phase 4 then replaces the transitional Facade and consolidates the internal owners of Agent state and Runtime lifecycle while preserving external behavior.
+If the internal refactor genuinely requires a public interface change, the change remains subject to joint review and must update every implementation, the Mock Client, and the contract tests together.
 
 `AgentSpec` contains the complete desired state: name, description, instructions, role, Runtime, model, Skills, and MCP servers.
-`RuntimeSpec.Credentials` is a map of adapter-defined credential names to secret string values.
-`RuntimeSpec.InitShell` is an idempotent shell program for preparing the Runtime environment.
+`RuntimeSpec.Credentials` maps workspace-relative file paths to complete secret file contents.
+`RuntimeSpec.InitShell` is an idempotent shell program executed with the Runtime workspace as its working directory.
 Create and Update replace both fields as part of the complete desired Runtime state.
 The Go names follow the Kubernetes Go API field convention; a serialized form uses `credentials` and `initShell`.
 `Credentials` is write-only on Create and Update; every returned `Agent`, including Create, Update, Get, and List results, omits its values.
 
-The Runtime Adapter validates credential names, selects file formats and paths, writes the values into its Runtime-local state, and then runs `InitShell` in the same execution environment before reporting the Runtime ready.
-`InitShell` may prepare the Workspace or initialize an Adapter-owned Channel environment, but it receives no more privilege than the Runtime itself.
-`InitShell` may run again after Update, Recreate, or a provisioning retry, so it must be idempotent.
-Failure to materialize credentials or complete `InitShell` prevents the Agent from becoming ready.
-Credential values must not enter logs, status messages, events, transcripts, or `InitShell` itself.
+The Phase 2 Codex Runtime Adapter validates every relative path, atomically writes credential files with restrictive permissions, and removes files omitted by a complete Update.
+It runs `InitShell` only after credential files are available; a file or shell failure fails the Agent operation and restores the previous managed credential files.
+`InitShell` uses the selected workspace as `cwd` and receives the same `HOME`, per-Agent `CODEX_HOME`, model environment, and reserved-variable filtering as the Codex process; exported shell variables do not persist after the script exits.
+Credential values must not enter logs, status messages, events, transcripts, shell arguments, or `InitShell` itself.
 The Codex Adapter does not receive Feishu credentials when the host Feishu Adapter owns delivery; these fields do not change Channel ownership.
 
 `AgentStatus` contains observed lifecycle state and the current Runtime ID.
 Updating an Agent replaces its desired specification as one resource update.
 
 `ConversationInterface` does not expose CRUD methods because Engine does not persist Conversation resources.
-Phase 1 activates only `Run`.
-The planned `Cancel`, `Reset`, and `Resolve` signatures and their related request fields remain commented in the Go contract until a migrated caller needs them.
-Request cancellation currently uses `context.Context`.
+Phase 1 activates `Run` and uses `context.Context` for current request cancellation.
+Phase 2 activates `Cancel`, `Reset`, `Resolve`, and their related request fields in the same contract so Engine and Adapter implementations can align independently through the Mock Client.
 
 ### 3.3 Conversation Semantics
 
 This section describes the complete target contract.
 Phase 1 uses only `TurnID`, `ConversationKey`, text `InputPart` values, text and tool events, and a terminal result.
-Continuation policy, configurable admission, files, interactions, structured output, and explicit lifecycle methods remain later-phase design.
+Phase 2 completes continuation policy, fail-fast per-Conversation serialization, files, interactions, structured output, and explicit lifecycle methods together instead of splitting Engine capability by caller.
 
 `ConversationKey` is an opaque caller-owned identity.
 Engine validates only that it is non-empty and length-bounded.
@@ -190,8 +274,10 @@ Each Adapter owns collision-free key construction:
 
 Engine permits at most one Turn or Reset for `(agentID, ConversationKey)` at a time.
 Different Conversation keys may execute concurrently.
-Waiting admission may leave one Turn running while later Turns are queued for the same Conversation.
-Cancel therefore uses the Agent-scoped `ConversationKey` and `TurnID` to identify exactly one queued or running Turn.
+An overlapping Run fails immediately with `conversation_busy`.
+Phase 2 does not implement admission configuration or queues.
+Future wait queues and broader concurrency limits can be added before the existing execution lease without changing Turn ownership.
+Cancel therefore uses the Agent-scoped `ConversationKey` and `TurnID` to identify exactly one running Turn.
 Resolve additionally carries `InteractionID` to identify one pending interaction.
 
 `TurnID` lives only for the Turn lifecycle.
@@ -202,11 +288,6 @@ It is not a Conversation key, Runtime-native conversation mapping, transcript id
 
 - `create_or_resume` creates a missing native mapping or resumes it.
 - `require_existing` returns `conversation_not_resumable` when the mapping is missing.
-
-`ConversationAdmission` selects busy-key behavior:
-
-- `wait` queues behind the active Turn inside Engine.
-- `reject_if_busy` returns `conversation_busy` immediately.
 
 `InteractionPolicy` selects caller behavior for blocking Runtime interactions:
 
@@ -245,7 +326,7 @@ This includes Engine admission rejection and failure to create, resolve, or pers
 `Dispatched=true` means the Continuation Policy succeeded, the required mapping was durably established or resolved, and the native Turn was submitted.
 After submission, success, failure, cancellation, and timeout all retain `Dispatched=true`.
 
-Stable failure categories include invalid request, unavailable Agent, unavailable Runtime Adapter, busy Conversation, exhausted admission, missing Runtime mapping, unavailable file, unsupported interaction, and Runtime failure.
+Stable failure categories include invalid request, unavailable Agent, unavailable Runtime Adapter, busy Conversation, missing Runtime mapping, unavailable file, unsupported interaction, cancellation, and Runtime failure.
 
 ## 4. Ownership
 
@@ -259,8 +340,8 @@ Each fact has one owner:
 | Channel Adapter | Ingress, identity, binding and Channel Event Worker lifecycle, host-side Channel credentials, deduplication, hidden context, file authorization, transcript, rendering, acknowledgment | Runtime-native mapping, Engine admission |
 | Session HTTP Adapter | HTTP validation, Session Binding, SSE and error mapping | IM Room, Message, Participant, transcript |
 
-Lifecycle coordination is not part of the minimal Phase 1 Session implementation.
-After the Agent control plane is implemented, the Agent resource implementation and conversation execution share one Agent Lifecycle Gate so lifecycle changes cannot replace resources used by an active Turn.
+The minimal Phase 1 Session implementation has no lifecycle coordination.
+The complete Phase 2 Engine makes the Agent resource implementation and Conversation execution share one Agent Lifecycle Gate so lifecycle changes cannot replace resources used by an active Turn.
 The Gate remains an implementation detail and is not part of the public interfaces.
 
 ## 5. Primary Flows
@@ -373,17 +454,16 @@ Detached secret answers also must not be inserted into model continuation.
 
 ### 6.4 Concurrency and Lifecycle
 
-Server configuration owns global, per-Agent, queue-length, and queue-timeout limits.
-Engine owns the only per-Conversation execution queue.
-Channel Adapters may retain source-ingress buffering for subscription, deduplication, and acknowledgment, but must not add a second normalized Turn queue.
-Engine indexes queued and running Turns by `(agentID, ConversationKey, TurnID)` while Runtime-native conversation mappings remain keyed by Conversation identity.
+Phase 2 has no configurable admission limits or normalized Turn queue.
+Engine indexes the one active Turn by `(agentID, ConversationKey, TurnID)` while Runtime-native conversation mappings remain keyed by Conversation identity.
+Channel Adapters may retain source-ingress buffering for subscription, deduplication, and acknowledgment.
 
 If a sink fails, Engine requests Runtime cancellation when possible and waits for a true Runtime terminal state before releasing admission.
 If cancellation is unsupported, Engine continues supervising the Runtime until termination.
 
-The Agent Lifecycle Gate is a planned process-local concurrency primitive for one Agent, not a service or public interface.
-It records whether admission is open and which Turns are active while Engine continues to own the queue.
-When lifecycle coordination is implemented, it extends the existing `internal/agent.agentLifecycleGate`, which currently serializes Agent lifecycle operations, instead of introducing a second coordinator.
+The Agent Lifecycle Gate is the process-local concurrency primitive for one Agent, not a service or public interface.
+It records whether admission is open and which execution leases are active.
+Phase 2 extends the existing `internal/agent.agentLifecycleGate` instead of introducing a second coordinator.
 If its expanded responsibility later warrants a different internal name, it may be renamed without changing this public contract.
 
 Run admission and lifecycle changes serialize through the same Gate.
@@ -391,7 +471,6 @@ Run may dispatch only after it atomically confirms that the Agent is ready and r
 
 Stop, Runtime-affecting Update, Recreate, and Delete first mark the Agent unavailable and close new admission.
 New Runs return `TurnFailed` with `Dispatched=false` and `agent_unavailable`.
-Queued Turns complete as `TurnCanceled` with `Dispatched=false` and `agent_unavailable`.
 Running Turns are allowed to reach a terminal result before Runtime state changes.
 
 A configured drain timeout bounds that wait.
@@ -421,57 +500,54 @@ Agent deletion is coordinated at the application and Binding boundary: reference
 
 ## 7. Incremental Implementation
 
-### Phase 0: Review Contract
+The phases describe delivery order without artificially splitting the Agent Engine contract or implementation capabilities.
+Starting in Phase 2, the Agent Engine interface is the only boundary between Engine and Adapter development.
 
-- Keep only the standalone interfaces in `internal/agentengine`.
-- Review Agent lifecycle, conversation execution, input, event, output, interaction, and error shapes.
-- Do not wire the package into existing behavior.
+### Phase 1: Anonymous Session Path (Complete)
 
-### Phase 1: Conversations, Codex, and Anonymous Session
+- Establish the standalone `internal/agentengine` contract and in-process Conversation implementation.
+- Reuse Codex `EnsureSession`, `Prompt`, and scoped Runtime events through a private Adapter.
+- Route streaming and non-streaming anonymous Session requests through `Conversations(agentID).Run`.
+- Add the Agent-scoped Session Binding Store.
+- Remove anonymous Session persistence dependencies on IM Rooms, Messages, and Participants while preserving the existing HTTP, SSE, timeout, and error shapes.
+- Fail explicitly for unavailable Runtime Adapters without starting a fallback path.
+- Preserve Agent CRUD, built-in IM, Feishu, Team, Task, Scheduled Task, Notification, and Work behavior.
 
-- Implement `Conversations(agentID)` without implementing or migrating the `Agents()` control plane.
-- Keep existing Agent CRUD and lifecycle APIs on the current Agent Service.
-- Isolate all Conversation access to that Service behind one private Adapter; do not add `ExecutionTarget` or another public contract.
-- Activate only `Run`; keep later operations and fields commented in the Go contract.
-- Reuse the current Codex `EnsureSession`, `Prompt`, and scoped Runtime events through the private Adapter.
-- Add the minimal Agent-scoped Session Binding Store without mapping state.
-- Keep only the current fail-fast lock for the same Agent and external Session; do not add queues or configurable admission.
-- Route streaming and non-streaming anonymous Session requests through Agent Engine.
-- Adapt Session text to `InputPartText` without narrowing `TurnRequest.Input`; the private Codex Runtime Adapter rejects file parts explicitly until file execution is implemented.
-- Preserve the public API while removing anonymous IM persistence.
-- Reject unsupported Runtime Adapters before creating state.
-- Treat the private Adapter as transitional and remove it in Phase 2.
+### Phase 2: Agent Engine and Mock Baseline - Complete
 
-### Phase 2: Agents Control Plane
+- Implement the complete `agentengine.Interface` and provide the concurrency-safe, stateful `enginetest.MemoryClient` implementing the same contract.
+- The interface is not an immutable protocol; when implementation exposes an omission or mistake, it may change through joint review, with the real Engine, Mock Client, contract tests, and affected Adapter call sites updated in the same change.
+- Implement `Agents()`, `Run`, `Cancel`, `Reset`, `Resolve`, fail-fast serialization, file input, interactions, Structured Output, event ordering, `Dispatched`, and stable errors.
+- Let the Agent Engine Facade first wrap the existing Agent Service, Codex Session, brokers, Structured Output, and Runtime provisioning code instead of making internal refactoring a prerequisite for a complete Engine.
+- Coordinate Agent mutation, admission, active Turns, drain, and pinned Runtime handles through one shared Lifecycle Gate.
+- Migrate the anonymous Session API to `agentengine.Interface` while preserving its HTTP contract and zero IM entity creation.
+- Prove a test-only Feishu ingress harness through `MemoryClient`, with Feishu credentials remaining exclusively in the current Channel binding owner.
+- Keep production Channel Adapter implementation, integration, and atomic switching in Phase 3.
+- Materialize Codex `RuntimeSpec.Credentials` as workspace-relative files and run `RuntimeSpec.InitShell` after the files are available.
 
-- Implement `AgentInterface` with explicit storage and Runtime dependencies.
-- Reuse existing Agent stores, data formats, and extracted low-level Runtime code without making the broad current Agent Service a permanent backend.
-- Route existing Agent CRUD and lifecycle APIs through `Agents()` so all mutations use the Agent Lifecycle Gate.
-- Replace the Phase 1 private Adapter so `Conversations()` obtains Agent availability and Runtime selection from the new Agent implementation.
-- Migrate read-only internal callers later through narrow interfaces when they do not affect lifecycle correctness.
-- Preserve the public Agent API while making the new implementation the only Agent persistence and Runtime lifecycle owner.
+### Phase 3: Agent Engine and Adapter Integration
 
-### Phase 3: Built-in IM
+- Have the composition root inject the real Agent Engine into the Adapter already verified against the Mock Client.
+- Run joint Engine and Adapter contract, concurrency, lifecycle, and end-to-end behavior verification.
+- After verification, atomically switch the target Channel execution path to `Channel Adapter -> Agent Engine -> Runtime Adapter`.
+- Preserve existing Room, Thread, mention, file, interaction, Work, Stop, `/new`, transcript, rendering, reaction, and acknowledgment behavior.
+- At the switch, remove the corresponding old execution entry point, duplicate queue and cancellation state, and the Agent lifecycle control chain into `codexBridgeMgr`.
+- Do not run dual execution, shadow prompts, or fallback; any missing required capability blocks the switch.
 
-- Move built-in IM execution behind Agent Engine.
-- Move the built-in IM Event Worker under Binding-driven Channel ownership and remove its Agent lifecycle callbacks to `codexBridgeMgr`.
-- Preserve Channel routing, hidden context, files, interactions, Work, Stop, `/new`, transcript, and rendering.
-- Run Team, Task, Scheduled Task, Notification, and Work regression coverage.
+### Phase 4: Refactor Agent Engine Internals
 
-### Phase 4: Feishu and Additional Runtimes
+- Refactor internal Engine components while preserving external behavior; keep the public interface stable by default, but allow it to evolve through joint review when necessary.
+- Replace the Phase 2 Agent Service Facade with focused Agent resource backend, Conversation coordinator, Lifecycle Gate, Runtime Adapter registry, and Runtime Adapter components.
+- Extract reusable storage, Runtime provisioning, credential, InitShell, file exposure, interaction, and Structured Output capabilities while removing duplicate state and reverse-control dependencies.
+- Make `Agents()` the unified Engine entry point for Agent persistence and Runtime lifecycle, then incrementally migrate internal callers that still bypass it.
+- Use the Phase 2 contract tests and Phase 3 end-to-end tests to prove the refactor preserves existing CSGClaw behavior; when a reviewed interface change is required, update the Adapter and Mock Client together.
 
-- Move the supported Feishu text path behind Agent Engine.
-- Move the Feishu Event Worker under Binding-driven Channel ownership and remove its Agent lifecycle callbacks to `codexBridgeMgr`.
-- Preserve current mention, Thread, reaction, rendering, and `skip_user_input` behavior.
-- Add OpenClaw only after its direct protocol exists.
-- Design remote transport and new Channel file support separately when required.
-
-Each phase must be independently reviewable and releasable.
-A later phase must not be required to validate an earlier phase.
+Every merge must leave existing CSGClaw behavior operational.
+The two Phase 2 sides can be developed and verified independently, Phase 3 owns only integration and atomic switching, and Phase 4 changes only Engine internals.
 
 ## 8. Acceptance Criteria
 
-### 8.1 Phase 1
+### 8.1 Phase 1 (Complete)
 
 - Streaming and non-streaming Session requests use `Conversations(agentID).Run`.
 - Anonymous Session execution creates no IM entities and preserves the existing HTTP, JSON, SSE, timeout, and error shapes.
@@ -495,7 +571,8 @@ A later phase must not be required to validate an earlier phase.
 - Agent resource implementations, Agent Engine, and Runtime Adapters have no Channel Event Worker dependency and do not access IM message persistence.
 - Channel Event Workers are keyed by stable Binding identity, not Runtime ID or native Session ID.
 - Runtime-native conversation mapping has one owner.
-- After Phase 2, the `AgentInterface` implementation is the only Agent persistence and Runtime lifecycle owner, and `Conversations()` no longer depends on the current `internal/agent.Service`.
+- After Phase 2, external callers depend only on `AgentInterface`, and `Conversations()` accesses Agent availability and Runtime selection only through the internal Engine Facade.
+- After Phase 4, the `AgentInterface` implementation is the only Agent persistence and Runtime lifecycle owner, and Engine internals no longer depend on the broad `internal/agent.Service`.
 - Runtime credential file layouts and initialization remain owned by each Runtime Adapter.
 - Missing Runtime Adapters fail explicitly with no fallback path.
 - The Go contract and both language documents remain synchronized.
@@ -510,11 +587,10 @@ A later phase must not be required to validate an earlier phase.
 - Agent Stop, Recreate, and Runtime restart neither restart Channel Event Workers nor delete bindings or transcripts.
 - Agent API deletion removes or deactivates referenced bindings, stops their Event Workers, and preserves saved transcripts.
 - Codex conversations continue after Stop followed by Start.
-- Lifecycle changes close admission, cancel queued Turns, drain running Turns, and never replace a Runtime still used by an active Turn.
+- Lifecycle changes close admission, drain running Turns, and never replace a Runtime still used by an active Turn.
 - A lifecycle drain timeout leaves the current Runtime unchanged and returns a failed lifecycle operation.
 - Session Bindings are unique by `(agentID, externalSessionID)`, remain `initializing` after mapping failure, and retry the same Conversation Key after process restart.
-- Create, Runtime-affecting Update, and Recreate materialize credentials before running an idempotent `InitShell` and starting the Runtime.
-- Credential or `InitShell` failure leaves the Agent not ready, and secret values enter neither logs nor public results.
+- Codex credential files are replaced atomically with restrictive permissions, and failed `InitShell` execution fails the Agent operation while restoring previous managed credentials.
 - Create, Update, Get, and List results omit Runtime credential values.
 - Recreate and Delete report missing strict-continuation mappings honestly.
 - CSGClaw Structured Output never leaks raw control lines.
@@ -523,15 +599,17 @@ A later phase must not be required to validate an earlier phase.
 ### 8.4 Target Verification
 
 - Contract tests cover Run, Cancel, Reset, Resolve, event ordering, terminal results, and stable errors.
-- Tests cover one Turn, configured concurrency, busy admission, queue exhaustion, sink failure, and cancellation behavior.
+- Tests cover one Turn, different-Conversation concurrency, fail-fast busy admission, sink failure, and cancellation behavior.
 - Tests cover no MCP, local MCP, remote MCP, text input, and file input.
 - Anonymous tests verify that IM entity counts do not change and Session Binding scope is Agent-specific.
 - Channel tests verify deduplication, replay, superseding, rendering, Binding-driven Event Worker lifecycle, and idempotent reconciliation.
 - Lifecycle tests verify that Agent Stop, Recreate, and Runtime restart do not start or stop Channel Event Workers.
 - Agent deletion tests verify Binding cleanup, Event Worker shutdown, and transcript retention.
-- Lifecycle tests verify admission closure, queued cancellation, active Turn drain, drain timeout, lifecycle failure, and Runtime pinning.
-- Phase 2 tests verify that Agent APIs use `Agents()` and that the temporary private Adapter has been removed.
+- Lifecycle tests verify admission closure, active Turn drain, drain timeout, lifecycle failure, and Runtime pinning.
+- Phase 2 runs the same contract tests against the Mock Client and real Engine, and verifies that the Adapter can complete its behavior tests independently through the Mock Client.
+- Phase 3 joint tests verify real Engine and Adapter contract alignment, an atomic switch without dual execution or fallback, and preservation of all existing Channel behavior.
+- Phase 4 tests verify that Agent APIs use `Agents()` and the transitional Service Facade is gone; if joint review changes the public contract, the Mock Client, Adapter, and contract tests must pass together.
 - Runtime tests verify mapping creation and persistence before dispatch, strict continuation, Reset, Stop and Start, Recreate, and Delete semantics.
-- Runtime Adapter tests verify credential serialization, `InitShell` ordering, reruns, failure handling, and secret redaction.
+- Runtime Adapter tests verify credential path containment, atomic replacement, deletion, permissions, failed-`InitShell` rollback, and secret redaction.
 - Agent contract tests verify that all returned Agent values omit Runtime credentials.
 - Existing Agent, Session API, built-in IM, Feishu, Team, Task, Scheduled Task, Notification, and Work regressions pass.

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -4,11 +4,13 @@
 
 ## 状态
 
-状态：**架构提案；阶段 1 Session Path 已实现**。
+状态：**架构提案；阶段 2 的 Engine 与 Mock Client 基线已完成，生产 Channel Adapter 融合留在阶段 3**。
 
 Contract 和阶段 1 的进程内 Conversation 实现位于 [`internal/agentengine`](../../internal/agentengine)。
-阶段 1 只接入匿名 Session API 和现有 Codex Runtime。
-更完整的 Agent、Channel、File、Interaction 和生命周期设计继续按阶段实现。
+阶段 1 已把匿名 Session API 接入现有 Codex Runtime，并移除匿名 Session 对 IM Entity 的依赖。
+阶段 2 完成 Engine、Memory Client、Session 迁移、Codex Runtime Adapter 行为和基于 Mock 的飞书 Adapter 证明。
+阶段 2 不引入或切换生产 Channel Adapter。
+阶段 3 负责两侧融合与原子切换，阶段 4 再重构 Engine 内部组件。
 该 Package 是精确 Go Type 和 Method Signature 的 Source of Truth。
 本文档说明期望的 Owner、行为和增量实现计划。
 
@@ -124,6 +126,89 @@ Composition Root 注册 Runtime Adapter，并把接口连接到现有 Owner。
 缺少 Runtime Adapter 时，在创建 Engine Execution State 或 Session Binding 前返回 `runtime_adapter_unavailable`。
 它不会启动 Fallback Execution Path。
 
+上面的总览图展示 Dependency Direction 和 State Ownership。
+下面两张图把同一组组件展开为控制面和数据面交互，但不会引入第二条 Engine Execution Path。
+
+#### 控制面
+
+控制面修改 Agent 期望状态，并协调 Runtime 生命周期。
+阶段 2 中，Engine Agent Facade 把持久化和生命周期操作委托给现有 Agent Service，因此 Engine 不会创建重复的 Agent Store。
+
+```mermaid
+sequenceDiagram
+    participant Caller as Agent API 或内部调用方
+    participant Engine as Agent Engine Agents()
+    participant Gate as Agent Lifecycle Gate
+    participant Service as Agent Service 和 Store
+    participant Runtime as Runtime Adapter
+
+    Caller->>Engine: Create、Update、Start、Stop、Recreate 或 Delete
+    Engine->>Service: 校验完整 Agent 期望状态
+    Service->>Gate: 进入生命周期变更
+    Gate->>Gate: 关闭执行准入并等待 Active Lease 结束
+    alt Drain 完成
+        Service->>Runtime: 物化 Credential、执行 InitShell 并变更 Runtime 生命周期
+        Runtime-->>Service: 返回观察到的 Runtime 结果
+        Service->>Service: 原子提交 Agent 和 Runtime 状态
+        Service-->>Engine: 返回更新后的 Agent
+        Engine-->>Caller: 返回已隐去 Credential Value 的 Agent
+    else 调用方 Context 到期
+        Gate-->>Service: Drain 取消
+        Service-->>Engine: 返回错误并保持原 Runtime 不变
+        Engine-->>Caller: 返回归一化错误
+    end
+```
+
+所有现有的 Agent Service 直接生命周期调用方都使用同一个 Gate。
+这样可以防止 Session 执行、未来 Channel 执行和当前 Agent API 在 Turn 仍持有固定 Execution Lease 时替换或删除 Runtime。
+
+#### 数据面
+
+数据面执行一个归一化 Turn，并返回有序 Event 和唯一 Terminal Result。
+Binding、Transcript、Attachment 和 Delivery State 继续由调用它的 Adapter 及其 Store 管理。
+
+```mermaid
+sequenceDiagram
+    participant Source as Session Client 或 Channel
+    participant Adapter as Session 或 Channel Adapter
+    participant State as Binding 和 Transcript Owner
+    participant Engine as Agent Engine Conversations()
+    participant Gate as Agent Lifecycle Gate
+    participant Runtime as Runtime Adapter
+    participant Native as Runtime-native Conversation
+
+    Source->>Adapter: HTTP Request 或 Inbound Message
+    Adapter->>State: 解析 Binding，并按需去重和授权 File
+    Adapter->>Engine: Run(TurnID, ConversationKey, Input)
+    Engine->>Engine: Fail-fast 准入并注册 Active Turn
+    Engine->>Gate: 获取固定 Agent 和 Runtime Lease
+    Engine->>Runtime: 执行归一化 Turn
+    Runtime->>Native: 创建或恢复 Mapping 并提交 Native Turn
+    Native-->>Runtime: Text、Thought、Tool、Interaction 和 Output Event
+    Runtime-->>Engine: 返回归一化 Event
+    Engine-->>Adapter: 返回有 Sequence 的 EventSink Event
+    Adapter->>State: 更新 Adapter 所有的 Transcript 或 Delivery State
+    Adapter-->>Source: 返回 SSE 或渲染后的 Channel Delivery
+    opt Active Turn 控制
+        Adapter->>Engine: Cancel 精确 Turn 或 Resolve Interaction
+        Engine->>Runtime: 取消 Native Turn 或回答 Runtime Broker
+        Note over Engine,Runtime: Cancel 仅在 Terminal Cleanup 和状态释放后返回
+    end
+    Native-->>Runtime: Terminal Completion
+    Runtime-->>Engine: 在 Runtime 真正结束后返回 Terminal Result
+    Engine->>Gate: 释放 Execution Lease 和 Active Turn
+    Engine-->>Adapter: 返回唯一 TurnResult
+    opt 非活跃 Conversation Reset
+        Adapter->>Engine: Reset(ConversationKey)
+        Engine->>Runtime: 删除 Runtime-native Mapping
+        Runtime-->>Engine: Mapping 已删除
+        Engine-->>Adapter: 返回 Reset 结果
+    end
+```
+
+Engine 在这条流程中管理 Admission、Cancellation、Interaction Routing、Event Ordering 和 Result Normalization。
+Runtime Adapter 只管理 Runtime 特有的 Mapping、Protocol Translation、Credential Materialization、`InitShell` 执行和 Runtime-local File Exposure。
+
 ### 3.2 公共 Resource Interface
 
 精确声明保留在 `internal/agentengine`。
@@ -132,44 +217,43 @@ Composition Root 注册 Runtime Adapter，并把接口连接到现有 Owner。
 | Resource | 操作 | 用途 |
 |---|---|---|
 | `Agents()` | Create、Get、List、Update、Delete、Start、Stop、Recreate | Agent 期望配置和 Runtime 生命周期 |
-| `Conversations(agentID)` | Run；计划支持 Cancel、Reset 和 Resolve | 限定到一个 Agent 的 Conversation 执行 |
-| `ConversationRuntime` | Run；计划支持其他生命周期操作 | Engine 后面的 Runtime 特有直接执行 |
+| `Conversations(agentID)` | Run、Cancel、Reset、Resolve | 限定到一个 Agent 的 Conversation 执行 |
+| `ConversationRuntime` | Run、Cancel、Reset、Resolve | Engine 后面的 Runtime 特有直接执行 |
 
-`AgentInterface` 是 Agent Resource 的 Collection-scoped API，不是当前 `internal/agent.Service` 的 Adapter。
-它的实现通过明确的 Storage 和 Runtime Dependency 拥有 Agent 持久化及 Runtime 生命周期。
-实现该 Contract 时，可以渐进重构或替换当前 Agent Service；当前 Service 不是 Contract 的依赖。
+`AgentInterface` 是 Agent Resource 的 Collection-scoped API，调用方不能依赖当前 `internal/agent.Service`。
+阶段 2 的 Engine Facade 可以通过私有 Backend 包装当前 Agent Service，以优先复用已经验证的 Agent 持久化和 Runtime 生命周期代码。
+该包装只是 Engine 内部实现，不进入公共 Contract，也不阻止阶段 4 把宽泛的 Service 拆成明确的 Storage、Lifecycle 和 Runtime 组件。
 Conversation Execution 不保存重复的 Agent Record，并协调 Active Turn 和生命周期变更。
-阶段 1 是明确的过渡状态：Conversation 实现只能通过 Composition Root 注入的一个私有 Adapter 访问当前 Agent Service。
-该 Adapter 为执行解析 Agent 当前的可用性和 Runtime，不引入 `ExecutionTarget` 或其他公共 Interface。
-阶段 2 中新的 `AgentInterface` 实现成为 Agent State 和 Runtime 生命周期 Owner 后，删除该 Adapter。
+阶段 1 的 Conversation 实现只能通过 Composition Root 注入的私有 Adapter 访问当前 Agent Service。
+阶段 2 扩展这个边界，让完整 Engine 通过同一个私有 Facade 实现 `Agents()` 和 `Conversations()`，而不是先重写现有 Agent 组件。
+阶段 4 再在保持外部行为的前提下替换临时 Facade，并收敛 Agent State 与 Runtime 生命周期的内部 Owner。
+如果内部重构确实需要调整公共 Interface，该调整继续通过共同 Review 完成，并同步所有实现、Mock Client 和 Contract Test。
 
 `AgentSpec` 包含完整期望状态：Name、Description、Instructions、Role、Runtime、Model、Skills 和 MCP Server。
-`RuntimeSpec.Credentials` 是 Adapter 定义的 Credential Name 到 Secret String Value 的 Map。
-`RuntimeSpec.InitShell` 是准备 Runtime 环境的幂等 Shell Program。
+`RuntimeSpec.Credentials` 是 Workspace 相对文件路径到完整 Secret File Content 的 Map。
+`RuntimeSpec.InitShell` 是以 Runtime Workspace 为工作目录执行的幂等 Shell Program。
 Create 和 Update 把这两个 Field 作为完整 Runtime 期望状态的一部分进行替换。
 Go Name 遵循 Kubernetes Go API Field Convention；序列化形式使用 `credentials` 和 `initShell`。
 `Credentials` 在 Create 和 Update 中是 Write-only；Create、Update、Get 和 List 返回的所有 `Agent` 都省略其 Value。
 
-Runtime Adapter 校验 Credential Name，选择 File Format 和 Path，把 Value 写入自己的 Runtime-local State，然后在报告 Runtime Ready 前，在同一个执行环境中运行 `InitShell`。
-`InitShell` 可以准备 Workspace 或初始化 Adapter 自己拥有的 Channel 环境，但其权限不能高于 Runtime 本身。
-Update、Recreate 或 Provisioning Retry 后可能再次运行 `InitShell`，因此它必须幂等。
-Credential 物化或 `InitShell` 执行失败时，Agent 不能进入 Ready。
-Credential Value 不能进入 Log、Status Message、Event、Transcript 或 `InitShell` 本身。
+阶段 2 的 Codex Runtime Adapter 验证每个相对路径，以严格权限原子写入 Credential File，并删除完整 Update 中省略的旧 File。
+它仅在 Credential File 可用后运行 `InitShell`；File 或 Shell 失败会让 Agent Operation 失败，并恢复此前受管理的 Credential File。
+`InitShell` 使用选定的 Workspace 作为 `cwd`，并接收与 Codex Process 相同的 `HOME`、Agent 专属 `CODEX_HOME`、Model Environment 和 Reserved Variable Filter；Shell Export 在脚本退出后不会继续生效。
+Credential Value 不能进入 Log、Status Message、Event、Transcript、Shell Argument 或 `InitShell` 本身。
 Host Feishu Adapter 负责 Delivery 时，Codex Adapter 不接收 Feishu Credential；这两个 Field 不改变 Channel Ownership。
 
 `AgentStatus` 包含观察到的生命周期状态和当前 Runtime ID。
 更新 Agent 时，把完整期望 Specification 作为一个 Resource Update 替换。
 
 `ConversationInterface` 不暴露 CRUD Method，因为 Engine 不持久化 Conversation Resource。
-阶段 1 只启用 `Run`。
-计划中的 `Cancel`、`Reset`、`Resolve` Signature 和相关 Request Field 继续以注释形式保留在 Go Contract 中，等迁移后的调用方真正需要时再启用。
-当前 Request Cancellation 使用 `context.Context`。
+阶段 1 已启用 `Run`，并使用 `context.Context` 处理当前 Request Cancellation。
+阶段 2 在同一个 Contract 中启用 `Cancel`、`Reset`、`Resolve` 及其相关 Request Field，使 Engine 和 Adapter 可以独立实现并通过 Mock Client 对齐行为。
 
 ### 3.3 Conversation 语义
 
 本节描述完整的目标 Contract。
 阶段 1 只使用 `TurnID`、`ConversationKey`、Text `InputPart`、Text 和 Tool Event，以及终态 Result。
-Continuation Policy、可配置 Admission、File、Interaction、Structured Output 和显式生命周期 Method 留到后续阶段。
+阶段 2 一次补齐 Continuation Policy、按 Conversation 快速失败的串行化、File、Interaction、Structured Output 和显式生命周期 Method，不再按调用方拆分 Engine 能力。
 
 `ConversationKey` 是调用方拥有的不透明 Identity。
 Engine 只校验其非空且长度有界。
@@ -190,8 +274,10 @@ Engine 只校验其非空且长度有界，并原样传递给 Runtime Adapter。
 
 Engine 同时只允许 `(agentID, ConversationKey)` 存在一个 Turn 或 Reset。
 不同 Conversation Key 可以并发执行。
-等待 Admission 时，同一个 Conversation 可以有一个正在运行的 Turn 和后续排队的 Turn。
-因此 Cancel 使用按 Agent 限定的 `ConversationKey` 和 `TurnID` 精确标识一个排队中或运行中的 Turn。
+重叠 Run 立即返回 `conversation_busy`。
+阶段 2 不实现 Admission 配置或 Queue。
+未来的等待队列和更宽泛的并发限制可以放在现有 Execution Lease 之前，而不改变 Turn Owner。
+因此 Cancel 使用按 Agent 限定的 `ConversationKey` 和 `TurnID` 精确标识一个运行中的 Turn。
 Resolve 额外携带 `InteractionID` 来标识一个 Pending Interaction。
 
 `TurnID` 只存在于该 Turn 的生命周期内。
@@ -202,11 +288,6 @@ Resolve 额外携带 `InteractionID` 来标识一个 Pending Interaction。
 
 - `create_or_resume` 创建缺失的原生 Mapping，或恢复已有 Mapping。
 - `require_existing` 在 Mapping 缺失时返回 `conversation_not_resumable`。
-
-`ConversationAdmission` 选择 Busy Key 行为：
-
-- `wait` 在 Engine 内排在活动 Turn 后面。
-- `reject_if_busy` 立即返回 `conversation_busy`。
 
 `InteractionPolicy` 选择调用方如何处理 Blocking Runtime Interaction：
 
@@ -245,7 +326,7 @@ Sink 不是 Event Bus、Transcript Store 或 Channel Renderer。
 `Dispatched=true` 表示 Continuation Policy 已成功满足，必要的 Mapping 已经持久化或解析，并且原生 Turn 已提交。
 提交后，成功、失败、取消和超时都保持 `Dispatched=true`。
 
-稳定失败类别包括无效请求、Agent 不可用、Runtime Adapter 不可用、Conversation Busy、Admission 已满、Runtime Mapping 缺失、File 不可用、不支持 Interaction 和 Runtime 失败。
+稳定失败类别包括无效请求、Agent 不可用、Runtime Adapter 不可用、Conversation Busy、Runtime Mapping 缺失、File 不可用、不支持 Interaction、取消和 Runtime 失败。
 
 ## 4. Owner
 
@@ -259,8 +340,8 @@ Sink 不是 Event Bus、Transcript Store 或 Channel Renderer。
 | Channel Adapter | Ingress、Identity、Binding 和 Channel Event Worker 生命周期、Host 侧 Channel Credential、Deduplication、Hidden Context、File Authorization、Transcript、Rendering、Ack | Runtime 原生 Mapping、Engine Admission |
 | Session HTTP Adapter | HTTP Validation、Session Binding、SSE 和 Error Mapping | IM Room、Message、Participant、Transcript |
 
-生命周期协调不属于最小阶段 1 Session 实现。
-Agent Control Plane 实现后，Agent Resource 实现和 Conversation Execution 共享一个 Agent Lifecycle Gate，确保生命周期变更不会替换活动 Turn 正在使用的资源。
+阶段 1 的最小 Session 实现没有生命周期协调。
+阶段 2 的完整 Engine 让 Agent Resource 实现和 Conversation Execution 共享一个 Agent Lifecycle Gate，确保生命周期变更不会替换活动 Turn 正在使用的资源。
 Gate 保持为实现细节，不进入公共 Interface。
 
 ## 5. 主要流程
@@ -373,17 +454,16 @@ Detached Secret Answer 也不能插入模型续接。
 
 ### 6.4 并发和生命周期
 
-Server Config 是全局、每 Agent、Queue Length 和 Queue Timeout Limit 的 Owner。
-Engine 拥有唯一的每 Conversation 执行队列。
-Channel Adapter 可以为 Subscription、Deduplication 和 Ack 保留 Source Ingress Buffer，但不能增加第二套规范化 Turn Queue。
-Engine 使用 `(agentID, ConversationKey, TurnID)` 索引排队中和运行中的 Turn，Runtime 原生 Conversation Mapping 仍按 Conversation Identity 建立索引。
+阶段 2 没有可配置 Admission Limit 或规范化 Turn Queue。
+Engine 使用 `(agentID, ConversationKey, TurnID)` 索引唯一的 Active Turn，Runtime 原生 Conversation Mapping 仍按 Conversation Identity 建立索引。
+Channel Adapter 可以为 Subscription、Deduplication 和 Ack 保留 Source Ingress Buffer。
 
 Sink 失败时，Engine 在可能时请求 Runtime Cancel，并等待 Runtime 真实终态后才释放 Admission。
 Runtime 不支持 Cancel 时，Engine 继续监督到终态。
 
-Agent Lifecycle Gate 是计划中的每 Agent 进程内并发控制原语，不是 Service 或公共 Interface。
-它记录 Admission 是否开放以及哪些 Turn 正在运行，Queue 仍然由 Engine 拥有。
-实现生命周期协调时，扩展现有的 `internal/agent.agentLifecycleGate`；它目前只负责串行化 Agent 生命周期操作，不再引入第二个 Coordinator。
+Agent Lifecycle Gate 是每 Agent 的进程内并发控制原语，不是 Service 或公共 Interface。
+它记录 Admission 是否开放以及哪些 Execution Lease 正在运行。
+阶段 2 扩展现有的 `internal/agent.agentLifecycleGate`，不引入第二个 Coordinator。
 如果扩展后的职责以后需要更合适的内部名称，可以重命名，但不改变该公共 Contract。
 
 Run Admission 和生命周期变更通过同一个 Gate 串行化。
@@ -391,7 +471,6 @@ Run 只有在原子地确认 Agent Ready，并使用选定的内部 Runtime Hand
 
 Stop、影响 Runtime 的 Update、Recreate 和 Delete 首先把 Agent 标记为不可用，并关闭新 Admission。
 新的 Run 返回 `TurnFailed`、`Dispatched=false` 和 `agent_unavailable`。
-排队中的 Turn 返回 `TurnCanceled`、`Dispatched=false` 和 `agent_unavailable`。
 运行中的 Turn 在 Runtime State 变更前可以执行到终态。
 
 配置的 Drain Timeout 限制等待时间。
@@ -421,57 +500,54 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 
 ## 7. 增量实现
 
-### 阶段 0：评审 Contract
+阶段只描述交付顺序，不把 Agent Engine Contract 或实现能力人为切碎。
+从阶段 2 开始，Agent Engine Interface 是 Engine 与 Adapter 之间唯一的中介线。
 
-- `internal/agentengine` 只保留独立 Interface。
-- 评审 Agent Lifecycle、Conversation Execution、Input、Event、Output、Interaction 和 Error Shape。
-- 不把该 Package 接入现有行为。
+### 阶段 1：匿名 Session Path（已完成）
 
-### 阶段 1：Conversations、Codex 和匿名 Session
+- 建立独立的 `internal/agentengine` Contract 和进程内 Conversation 实现。
+- 通过私有 Adapter 复用 Codex 的 `EnsureSession`、`Prompt` 和 Scoped Runtime Event。
+- 让 Streaming 和 Non-streaming 匿名 Session Request 通过 `Conversations(agentID).Run` 执行。
+- 增加 Agent-scoped Session Binding Store。
+- 删除匿名 Session 对 IM Room、Message 和 Participant 的持久化依赖，同时保留现有 HTTP、SSE、Timeout 和 Error Shape。
+- 对不受支持的 Runtime Adapter 明确失败，不启动 Fallback Path。
+- 保持 Agent CRUD、内置 IM、飞书、Team、Task、Scheduled Task、Notification 和 Work 行为不变。
 
-- 实现 `Conversations(agentID)`，不实现或迁移 `Agents()` Control Plane。
-- 现有 Agent CRUD 和生命周期 API 继续使用当前 Agent Service。
-- Conversation 只能通过一个私有 Adapter 访问该 Service；不增加 `ExecutionTarget` 或其他公共 Contract。
-- 只启用 `Run`；后续 Operation 和 Field 继续以注释形式保留在 Go Contract 中。
-- 通过私有 Adapter 复用当前 Codex 的 `EnsureSession`、`Prompt` 和 Scoped Runtime Event。
-- 增加最小的 Agent-scoped Session Binding Store，不增加 Mapping State。
-- 只保留当前同一 Agent 和外部 Session 的快速失败 Lock；不增加 Queue 或可配置 Admission。
-- 让 Streaming 和 Non-streaming 匿名 Session Request 通过 Agent Engine 执行。
-- 把 Session Text 适配为 `InputPartText`，不缩窄 `TurnRequest.Input`；私有 Codex Runtime Adapter 在实现 File Execution 前明确拒绝 File Part。
-- 保留公共 API，同时删除匿名 IM 持久化。
-- 在创建 State 前拒绝不受支持的 Runtime Adapter。
-- 把私有 Adapter 视为过渡实现，并在阶段 2 删除。
+### 阶段 2：Agent Engine 与 Mock 基线 - 已完成
 
-### 阶段 2：Agents Control Plane
+- 实现完整 `agentengine.Interface`，并提供实现同一 Contract 的并发安全、有状态 `enginetest.MemoryClient`。
+- Interface 不是不可修改的冻结协议；实现中发现遗漏或错误时，可以通过共同 Review 调整，并在同一次变更中同步真实 Engine、Mock Client、Contract Test 和受影响的 Adapter 调用代码。
+- 实现 `Agents()`、`Run`、`Cancel`、`Reset`、`Resolve`、快速失败串行化、File Input、Interaction、Structured Output、Event 顺序、`Dispatched` 和稳定 Error。
+- Agent Engine Facade 优先包装现有 Agent Service、Codex Session、Broker、Structured Output 和 Runtime Provision 代码，不把内部重构作为完成 Engine 的前置条件。
+- Agent Engine 通过共享 Lifecycle Gate 协调 Agent Mutation、Admission、Active Turn、Drain 和固定 Runtime Handle。
+- 把匿名 Session API 迁移到 `agentengine.Interface`，同时保留其 HTTP Contract 和零 IM Entity 创建。
+- 通过 `MemoryClient` 证明 Test-only 飞书 Ingress Harness，并让飞书 Credential 只存在于当前 Channel Binding Owner。
+- 生产 Channel Adapter 的实现、融合和原子切换保留在阶段 3。
+- 将 Codex `RuntimeSpec.Credentials` 物化为 Workspace 相对文件，并在 File 可用后运行 `RuntimeSpec.InitShell`。
 
-- 使用明确的 Storage 和 Runtime Dependency 实现 `AgentInterface`。
-- 复用现有 Agent Store、Data Format 和抽取后的底层 Runtime Code，不让职责宽泛的当前 Agent Service 成为永久 Backend。
-- 让现有 Agent CRUD 和生命周期 API 通过 `Agents()`，使所有变更都使用 Agent Lifecycle Gate。
-- 替换阶段 1 的私有 Adapter，使 `Conversations()` 从新的 Agent 实现获取 Agent 可用性和 Runtime 选择。
-- 不影响生命周期正确性的只读内部调用方，可以后续再通过窄 Interface 迁移。
-- 保留公共 Agent API，并让新实现成为唯一的 Agent 持久化和 Runtime 生命周期 Owner。
+### 阶段 3：Agent Engine 与 Adapter 融合
 
-### 阶段 3：内置 IM
+- Composition Root 把真实 Agent Engine 注入已通过 Mock Client 验证的 Adapter。
+- 运行 Engine 与 Adapter 的联合 Contract、并发、生命周期和端到端行为验证。
+- 验证通过后，把目标 Channel 的执行路径原子切换为 `Channel Adapter -> Agent Engine -> Runtime Adapter`。
+- 保留现有 Room、Thread、Mention、File、Interaction、Work、Stop、`/new`、Transcript、Rendering、Reaction 和 Ack 行为。
+- 切换时删除对应的旧执行入口、重复队列、重复取消状态和 Agent 生命周期到 `codexBridgeMgr` 的控制链。
+- 不运行双执行、Shadow Prompt 或 Fallback；任一必需能力缺失都阻止切换。
 
-- 把内置 IM 执行迁移到 Agent Engine 后面。
-- 把内置 IM Event Worker 迁移到 Binding 驱动的 Channel Owner，并删除它到 `codexBridgeMgr` 的 Agent 生命周期回调。
-- 保留 Channel Routing、Hidden Context、File、Interaction、Work、Stop、`/new`、Transcript 和 Rendering。
-- 运行 Team、Task、Scheduled Task、Notification 和 Work 回归测试。
+### 阶段 4：重构 Agent Engine 内部组件
 
-### 阶段 4：飞书和更多 Runtime
+- 在外部行为保持不变的前提下重构 Engine 内部组件；公共 Interface 默认保持稳定，确有必要时仍可通过共同 Review 演进。
+- 把阶段 2 的 Agent Service Facade 收敛为职责明确的 Agent Resource Backend、Conversation Coordinator、Lifecycle Gate、Runtime Adapter Registry 和 Runtime Adapter。
+- 抽取可复用的 Storage、Runtime Provision、Credential、InitShell、File Exposure、Interaction 和 Structured Output 能力，删除重复状态与反向控制依赖。
+- 让 `Agents()` 成为 Agent 持久化和 Runtime 生命周期的统一 Engine 入口，并逐步迁移仍然绕过该入口的内部调用方。
+- 使用阶段 2 的 Contract Test 和阶段 3 的端到端测试证明重构不改变 CSGClaw 现有行为；如果 Interface 发生经 Review 的调整，则同步更新 Adapter 和 Mock Client。
 
-- 把受支持的飞书 Text Path 迁移到 Agent Engine 后面。
-- 把飞书 Event Worker 迁移到 Binding 驱动的 Channel Owner，并删除它到 `codexBridgeMgr` 的 Agent 生命周期回调。
-- 保留当前 Mention、Thread、Reaction、Rendering 和 `skip_user_input` 行为。
-- 只有 Direct Protocol 存在后才增加 OpenClaw。
-- 真正需要时再单独设计远程传输和新 Channel File 支持。
-
-每个阶段必须可以独立评审和发布。
-后续阶段不能成为验证前一阶段的前置条件。
+每次合入都必须保持 CSGClaw 现有行为可用。
+阶段 2 的两侧可以独立开发和验证，阶段 3 只负责融合与原子切换，阶段 4 只改变 Engine 内部结构。
 
 ## 8. 验收标准
 
-### 8.1 阶段 1
+### 8.1 阶段 1（已完成）
 
 - Streaming 和 Non-streaming Session Request 都使用 `Conversations(agentID).Run`。
 - 匿名 Session Execution 不创建 IM Entity，并保留现有 HTTP、JSON、SSE、Timeout 和 Error Shape。
@@ -495,7 +571,8 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 - Agent Resource 实现、Agent Engine 和 Runtime Adapter 不依赖 Channel Event Worker，也不访问 IM Message 持久化。
 - Channel Event Worker 按稳定的 Binding Identity 建立索引，不使用 Runtime ID 或原生 Session ID。
 - Runtime 原生 Conversation Mapping 只有一个 Owner。
-- 阶段 2 完成后，`AgentInterface` 实现是唯一的 Agent 持久化和 Runtime 生命周期 Owner，`Conversations()` 不再依赖当前 `internal/agent.Service`。
+- 阶段 2 完成后，外部调用方只依赖 `AgentInterface`，`Conversations()` 只通过 Engine 内部 Facade 访问 Agent 可用性和 Runtime 选择。
+- 阶段 4 完成后，`AgentInterface` 实现是唯一的 Agent 持久化和 Runtime 生命周期 Owner，并且 Engine 内部不再依赖宽泛的 `internal/agent.Service`。
 - Runtime Credential File Layout 和初始化由各 Runtime Adapter 负责。
 - 缺少 Runtime Adapter 时明确失败，不启动 Fallback Path。
 - Go Contract 和两种语言文档保持同步。
@@ -510,11 +587,10 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 - Agent Stop、Recreate 和 Runtime Restart 既不重启 Channel Event Worker，也不删除 Binding 或 Transcript。
 - Agent API 删除会删除或停用关联 Binding、停止对应 Event Worker，并保留已保存的 Transcript。
 - Codex Conversation 在 Stop 后再次 Start 时可以继续。
-- 生命周期变更关闭 Admission、取消排队中的 Turn、Drain 运行中的 Turn，并且不会替换活动 Turn 正在使用的 Runtime。
+- 生命周期变更关闭 Admission、Drain 运行中的 Turn，并且不会替换活动 Turn 正在使用的 Runtime。
 - Lifecycle Drain Timeout 保持当前 Runtime 不变，并返回失败的生命周期操作。
 - Session Binding 按 `(agentID, externalSessionID)` 唯一，Mapping 失败后保持 `initializing`，进程重启后使用相同的 Conversation Key 重试。
-- Create、影响 Runtime 的 Update 和 Recreate 在运行幂等 `InitShell` 并启动 Runtime 前先物化 Credential。
-- Credential 或 `InitShell` 失败时 Agent 不会 Ready，Secret Value 不进入 Log 或公开 Result。
+- Codex Credential File 以严格权限原子替换；`InitShell` 执行失败会让 Agent Operation 失败，并恢复此前受管理的 Credential。
 - Create、Update、Get 和 List Result 省略 Runtime Credential Value。
 - Recreate 和 Delete 如实报告严格续接 Mapping 缺失。
 - CSGClaw Structured Output 不泄漏原始控制行。
@@ -523,15 +599,17 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 ### 8.4 目标验证
 
 - Contract Test 覆盖 Run、Cancel、Reset、Resolve、Event 顺序、终态 Result 和稳定 Error。
-- 测试覆盖单 Turn、配置并发、Busy Admission、Queue Exhaustion、Sink Failure 和 Cancel 行为。
+- 测试覆盖单 Turn、不同 Conversation 并发、快速失败 Busy Admission、Sink Failure 和 Cancel 行为。
 - 测试覆盖无 MCP、本地 MCP、远程 MCP、Text Input 和 File Input。
 - 匿名测试验证 IM Entity 数量不变，并且 Session Binding Scope 按 Agent 隔离。
 - Channel 测试验证 Deduplication、Replay、Superseding、Rendering、Binding 驱动的 Event Worker 生命周期和幂等协调。
 - Lifecycle 测试验证 Agent Stop、Recreate 和 Runtime Restart 不启动或停止 Channel Event Worker。
 - Agent 删除测试验证 Binding 清理、Event Worker 停止和 Transcript 保留。
-- Lifecycle 测试验证 Admission 关闭、Queued Turn 取消、Active Turn Drain、Drain Timeout、Lifecycle Failure 和 Runtime Pinning。
-- 阶段 2 测试验证 Agent API 使用 `Agents()`，并且临时私有 Adapter 已删除。
+- Lifecycle 测试验证 Admission 关闭、Active Turn Drain、Drain Timeout、Lifecycle Failure 和 Runtime Pinning。
+- 阶段 2 使用同一套 Contract Test 验证 Mock Client 和真实 Engine，并验证 Adapter 可以只通过 Mock Client 独立完成行为测试。
+- 阶段 3 联合测试验证真实 Engine 与 Adapter 的契约一致、原子切换没有双执行或 Fallback，并保留所有现有 Channel 行为。
+- 阶段 4 测试验证 Agent API 使用 `Agents()`、临时 Service Facade 已删除；如公共 Contract 经 Review 调整，Mock Client、Adapter 和 Contract Test 必须同步通过。
 - Runtime 测试验证分派前完成 Mapping 创建和持久化、严格续接、Reset、Stop 和 Start、Recreate 和 Delete 语义。
-- Runtime Adapter 测试验证 Credential 序列化、`InitShell` 顺序、重跑、失败处理和 Secret Redaction。
+- Runtime Adapter 测试验证 Credential Path Containment、原子替换、删除、权限、`InitShell` 失败回滚和 Secret Redaction。
 - Agent Contract 测试验证所有返回的 Agent Value 都省略 Runtime Credential。
 - 现有 Agent、Session API、内置 IM、飞书、Team、Task、Scheduled Task、Notification 和 Work 回归测试通过。

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -260,9 +260,12 @@ Engine 只校验其非空且长度有界。
 它不会解析 Key 中的 Room、Thread、Channel、Binding 或 Session 字段。
 
 `TurnID` 是调用方为一次 `Run` Request 生成的不透明 Identity。
-Channel Adapter 或 Session HTTP Adapter 在完成 Ingress Validation 和 Deduplication 后、调用 `Run` 前生成随机 ID。
+Channel Adapter 在完成 Ingress Validation 后生成该值，并让同一个 Source Event 的重试保持稳定；Session HTTP Adapter 则为其 Request 生成一个 Response ID。
 Engine 只校验其非空且长度有界，并原样传递给 Runtime Adapter。
-它不从 `ConversationKey` 或 Source Message ID 派生，因为这些值标识不同的生命周期。
+它与 `ConversationKey` 保持不同；Channel Adapter 可以把限定 Scope 的 Source Event ID 规范化为 `TurnID`，因为该 Event 在 Delivery Retry 间标识同一个逻辑 Turn。
+在一个 Engine 进程内，`(agentID, ConversationKey, TurnID)` 是幂等 Identity。
+进行中的重试加入原 Turn，已完成且已分派的重试回放有界的进程内 Progress Event 并返回缓存 Result，不会再次提交 Runtime Turn。
+使用相同 Identity 但不同的规范化 Input 或 Policy 会返回 `invalid_request`。
 
 每个 Adapter 负责构造无碰撞 Key：
 
@@ -272,16 +275,17 @@ Engine 只校验其非空且长度有界，并原样传递给 Runtime Adapter。
 | 飞书 | App Binding、Chat 和可选 Thread Root |
 | Session API | Session Binding Store 保存的随机内部 Key |
 
-Engine 同时只允许 `(agentID, ConversationKey)` 存在一个 Turn 或 Reset。
+Engine 同时只允许 `(agentID, ConversationKey)` 存在一个 Turn 或原子 Control Operation。
 不同 Conversation Key 可以并发执行。
-重叠 Run 立即返回 `conversation_busy`。
-阶段 2 不实现 Admission 配置或 Queue。
-未来的等待队列和更宽泛的并发限制可以放在现有 Execution Lease 之前，而不改变 Turn Owner。
+`AdmissionPolicy` 为不同的重叠 Turn 选择 `reject_if_busy`、`wait` 或 `supersede`。
+`reject_if_busy` 立即返回 `conversation_busy`，并继续作为匿名 Session API 的默认策略。
+`wait` 等待当前 Turn 或 Control Operation 完成后再竞争 Admission。
+`supersede` 关闭 Admission、取消当前 Turn、等待 Runtime 真实清理完成，并且不留新 Run 插入的窗口直接准入替代 Turn。
 因此 Cancel 使用按 Agent 限定的 `ConversationKey` 和 `TurnID` 精确标识一个运行中的 Turn。
 Resolve 额外携带 `InteractionID` 来标识一个 Pending Interaction。
 
-`TurnID` 只存在于该 Turn 的生命周期内。
-它不是 Conversation Key、Runtime 原生 Conversation Mapping、Transcript Identity 或持久化 Engine Resource。
+Turn 生命周期结束后，`TurnID` 只在有界的进程内幂等窗口中保留。
+它不是 Conversation Key、Runtime 原生 Conversation Mapping、Transcript Identity 或持久化 Engine Resource，因此进程重启后仍依赖 Source 侧去重。
 `Reset` 仍按 `ConversationKey` 限定，`Resolve` 仍按 `ConversationKey` 和 `InteractionID` 限定。
 
 `ContinuationPolicy` 明确 Runtime Mapping 行为：
@@ -309,7 +313,7 @@ File Part 包含一个调用方已授权的 `InputFile`。
 阶段 1 的 Session HTTP Adapter 创建一个 Text Part，私有 Codex Runtime Adapter 则在调用当前 Runtime API 前按顺序合并 Text Part。
 File Part 保留公共 Type，但在后续阶段实现 File Execution 前，会在 Runtime Dispatch 前返回 `file_unavailable`。
 
-Event Sink 接收一次 `Run` 调用内有序且非终态的进度：
+Event Sink 接收一个逻辑 Turn 的有序进度：
 
 - Text Delta。
 - Thought Delta。
@@ -318,7 +322,8 @@ Event Sink 接收一次 `Run` 调用内有序且非终态的进度：
 - 已验证的 Output Item。
 
 Sink 不是 Event Bus、Transcript Store 或 Channel Renderer。
-它的 Sequence Number 只对当前 Run 调用内的 Event 排序。
+每个 Event 都携带 `TurnID` 和单调递增的 `Sequence`。
+Adapter 可以使用 `(TurnID, Sequence)` 对重试后回放的 Envelope 去重。
 
 `Run` 只返回一个 `TurnResult`，没有第二套裸 Runtime Error。
 `Dispatched=false` 表示原生 Turn 尚未提交。
@@ -389,7 +394,7 @@ Channel Adapter 保留 Mention、Thread Context、Skill、Participant Work、Sto
 Engine 不单独建模该 Context。
 
 `/new` 使用同一个 `ConversationKey` 调用 `Reset`。
-Runtime Adapter 原子替换原生 Conversation Mapping。
+Engine 在同一个 Conversation Gate 内关闭 Admission、取消并 Drain 活动 Turn、调用 Runtime Adapter 删除原生 Mapping，然后才重新开放 Admission。
 
 ### 5.3 Runtime Adapter
 
@@ -417,14 +422,15 @@ Reset 为同一个 `ConversationKey` 替换该 Mapping。
 ### 6.1 持久化
 
 Agent Engine 没有持久化 Conversation Store。
+它只保留有界的进程内已分派 Turn Progress Event 和 Result Cache，用于重试幂等。
 Agent Resource 实现拥有期望的 Runtime Credential，每个 Runtime Adapter 拥有自己物化出的 Credential File。
 Runtime Adapter 拥有原生 Conversation Mapping。
 Channel Adapter 拥有 Transcript 和 Source Delivery State。
 Session Binding Store 只拥有外部 Session ID 和 Conversation Key 之间的关联。
 
-Engine 进程重启会中断排队中和运行中的 Turn。
+Engine 进程重启会中断等待中和运行中的 Turn，并清空进程内幂等 Cache。
 它不会删除 Runtime 原生 Mapping。
-设计不承诺 Replay、Exactly-once Execution 或 In-flight Side Effect 恢复。
+设计不承诺跨重启 Replay、Exactly-once Execution 或 In-flight Side Effect 恢复。
 
 ### 6.2 文件
 
@@ -448,14 +454,17 @@ Runtime Adapter 决定如何 Mount、Copy 或暴露 File，并保留 Path、Syml
 Blocking Runtime Permission 或 User Input 保持同一个 Turn 打开，并使用 `Resolve`。
 Detached `request_user_input` 完成当前 Turn，并在用户回答后创建后续 Turn。
 Detached Input 不调用 `Resolve`。
+Engine 在调用 Runtime Adapter 前原子 Claim Pending Interaction，因此重复 Action 只有第一个能够进入 Runtime Resolution。
+Runtime Resolution 失败时，只要同一个 Turn 仍处于 Active，就把 Claim 恢复为 Pending；成功时则消费该 Interaction。
+Channel Adapter 授权操作用户，Engine 只把 `ResponderID` 当作不透明的审计 Identity，绝不使用它做授权。
 
 Secret Interaction Answer 不能进入 Log 或 Transcript。
 Detached Secret Answer 也不能插入模型续接。
 
 ### 6.4 并发和生命周期
 
-阶段 2 没有可配置 Admission Limit 或规范化 Turn Queue。
-Engine 使用 `(agentID, ConversationKey, TurnID)` 索引唯一的 Active Turn，Runtime 原生 Conversation Mapping 仍按 Conversation Identity 建立索引。
+Engine 在获取 Agent Execution Lease 前应用 Request 的 `AdmissionPolicy`。
+等待和 Supersede 保持为进程内状态，Runtime 原生 Conversation Mapping 仍按 Conversation Identity 建立索引。
 Channel Adapter 可以为 Subscription、Deduplication 和 Ack 保留 Source Ingress Buffer。
 
 Sink 失败时，Engine 在可能时请求 Runtime Cancel，并等待 Runtime 真实终态后才释放 Admission。
@@ -517,7 +526,7 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 
 - 实现完整 `agentengine.Interface`，并提供实现同一 Contract 的并发安全、有状态 `enginetest.MemoryClient`。
 - Interface 不是不可修改的冻结协议；实现中发现遗漏或错误时，可以通过共同 Review 调整，并在同一次变更中同步真实 Engine、Mock Client、Contract Test 和受影响的 Adapter 调用代码。
-- 实现 `Agents()`、`Run`、`Cancel`、`Reset`、`Resolve`、快速失败串行化、File Input、Interaction、Structured Output、Event 顺序、`Dispatched` 和稳定 Error。
+- 实现 `Agents()`、`Run`、`Cancel`、原子 `Reset`、Claimed `Resolve`、显式 Admission Policy、Turn 重试幂等、TurnID Event Envelope、File Input、Interaction、Structured Output、`Dispatched` 和稳定 Error。
 - Agent Engine Facade 优先包装现有 Agent Service、Codex Session、Broker、Structured Output 和 Runtime Provision 代码，不把内部重构作为完成 Engine 的前置条件。
 - Agent Engine 通过共享 Lifecycle Gate 协调 Agent Mutation、Admission、Active Turn、Drain 和固定 Runtime Handle。
 - 把匿名 Session API 迁移到 `agentengine.Interface`，同时保留其 HTTP Contract 和零 IM Entity 创建。
@@ -598,8 +607,8 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 
 ### 8.4 目标验证
 
-- Contract Test 覆盖 Run、Cancel、Reset、Resolve、Event 顺序、终态 Result 和稳定 Error。
-- 测试覆盖单 Turn、不同 Conversation 并发、快速失败 Busy Admission、Sink Failure 和 Cancel 行为。
+- Contract Test 覆盖 Run、Cancel、原子 Reset、Claimed Resolve、Event Envelope、终态 Result 和稳定 Error。
+- 测试覆盖 Turn 重试幂等、不同 Conversation 并发、Reject、Wait、Supersede、Sink Failure 和 Cancel 行为。
 - 测试覆盖无 MCP、本地 MCP、远程 MCP、Text Input 和 File Input。
 - 匿名测试验证 IM Entity 数量不变，并且 Session Binding Scope 按 Agent 隔离。
 - Channel 测试验证 Deduplication、Replay、Superseding、Rendering、Binding 驱动的 Event Worker 生命周期和幂等协调。

--- a/internal/agent/lifecycle_coordination.go
+++ b/internal/agent/lifecycle_coordination.go
@@ -4,10 +4,21 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+
+	agentruntime "csgclaw/internal/runtime"
 )
 
+// agentLifecycleGate is the single coordinator for lifecycle mutation and
+// execution admission for one Agent. A future admission controller can wait or
+// enforce broader limits before AcquireExecution without changing this gate.
 type agentLifecycleGate struct {
 	token chan struct{}
+
+	mu              sync.Mutex
+	admissionClosed bool
+	active          int
+	drained         chan struct{}
 }
 
 type agentLifecycleLease struct {
@@ -18,10 +29,95 @@ type agentLifecycleLease struct {
 
 type agentLifecycleLeaseContextKey struct{}
 
+// ExecutionLease pins the Agent snapshot and concrete Runtime selected before
+// dispatch. Release must be called after true Runtime termination.
+type ExecutionLease struct {
+	Agent   Agent
+	Runtime agentruntime.Runtime
+
+	once    sync.Once
+	release func()
+}
+
+// Release returns this execution lease to the shared lifecycle gate.
+func (l *ExecutionLease) Release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		if l.release != nil {
+			l.release()
+		}
+	})
+}
+
 func newAgentLifecycleGate() *agentLifecycleGate {
-	gate := &agentLifecycleGate{token: make(chan struct{}, 1)}
+	gate := &agentLifecycleGate{token: make(chan struct{}, 1), drained: make(chan struct{})}
+	close(gate.drained)
 	gate.token <- struct{}{}
 	return gate
+}
+
+func (s *Service) lifecycleGate(agentID string) *agentLifecycleGate {
+	s.agentLifecycleMu.Lock()
+	defer s.agentLifecycleMu.Unlock()
+	if s.agentLifecycleGates == nil {
+		s.agentLifecycleGates = make(map[string]*agentLifecycleGate)
+	}
+	gate := s.agentLifecycleGates[agentID]
+	if gate == nil {
+		gate = newAgentLifecycleGate()
+		s.agentLifecycleGates[agentID] = gate
+	}
+	return gate
+}
+
+// AcquireExecution admits one active execution and returns a pinned Agent and
+// Runtime handle. Lifecycle mutations close admission and drain all such leases
+// through this same gate.
+func (s *Service) AcquireExecution(ctx context.Context, agentID string) (*ExecutionLease, error) {
+	if s == nil {
+		return nil, fmt.Errorf("agent service is required")
+	}
+	agentID = canonicalAgentID(strings.TrimSpace(agentID))
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	gate := s.lifecycleGate(agentID)
+	gate.mu.Lock()
+	if gate.admissionClosed {
+		gate.mu.Unlock()
+		return nil, fmt.Errorf("agent %q lifecycle change is in progress", agentID)
+	}
+	selected, ok := s.Agent(agentID)
+	if !ok {
+		gate.mu.Unlock()
+		return nil, fmt.Errorf("agent %q not found", agentID)
+	}
+	runtimeImpl, err := s.runtimeForKind(strings.TrimSpace(selected.RuntimeKind))
+	if err != nil {
+		gate.mu.Unlock()
+		return nil, err
+	}
+	if gate.active == 0 {
+		gate.drained = make(chan struct{})
+	}
+	gate.active++
+	gate.mu.Unlock()
+
+	return &ExecutionLease{Agent: selected, Runtime: runtimeImpl, release: func() {
+		gate.mu.Lock()
+		if gate.active > 0 {
+			gate.active--
+			if gate.active == 0 {
+				close(gate.drained)
+			}
+		}
+		gate.mu.Unlock()
+	}}, nil
 }
 
 func (s *Service) acquireAgentLifecycle(ctx context.Context, agentID string) (context.Context, func(), error) {
@@ -39,28 +135,49 @@ func (s *Service) acquireAgentLifecycle(ctx context.Context, agentID string) (co
 		return ctx, func() {}, nil
 	}
 
-	s.agentLifecycleMu.Lock()
-	if s.agentLifecycleGates == nil {
-		s.agentLifecycleGates = make(map[string]*agentLifecycleGate)
-	}
-	gate := s.agentLifecycleGates[agentID]
-	if gate == nil {
-		gate = newAgentLifecycleGate()
-		s.agentLifecycleGates[agentID] = gate
-	}
-	s.agentLifecycleMu.Unlock()
-
+	gate := s.lifecycleGate(agentID)
 	select {
 	case <-ctx.Done():
 		return ctx, nil, ctx.Err()
 	case <-gate.token:
 	}
 
+	gate.mu.Lock()
+	gate.admissionClosed = true
+	drained := gate.drained
+	gate.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		gate.mu.Lock()
+		gate.admissionClosed = false
+		gate.mu.Unlock()
+		gate.token <- struct{}{}
+		return ctx, nil, ctx.Err()
+	case <-drained:
+	}
+
 	parent, _ := ctx.Value(agentLifecycleLeaseContextKey{}).(*agentLifecycleLease)
 	lease := &agentLifecycleLease{service: s, agentID: agentID, parent: parent}
 	return context.WithValue(ctx, agentLifecycleLeaseContextKey{}, lease), func() {
+		gate.mu.Lock()
+		gate.admissionClosed = false
+		gate.mu.Unlock()
 		gate.token <- struct{}{}
 	}, nil
+}
+
+// WithAgentLifecycle runs one compound lifecycle mutation while admission is
+// closed and active executions are drained.
+func (s *Service) WithAgentLifecycle(ctx context.Context, agentID string, operation func(context.Context) error) error {
+	if operation == nil {
+		return fmt.Errorf("lifecycle operation is required")
+	}
+	ctx, release, err := s.acquireAgentLifecycle(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return operation(ctx)
 }
 
 func holdsAgentLifecycle(ctx context.Context, service *Service, agentID string) bool {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -46,6 +47,34 @@ type Agent struct {
 	// lifecycle state is durable, while readiness may change between probes.
 	Availability   *RuntimeAvailability `json:"-"`
 	StartupPending bool                 `json:"-"`
+
+	runtimeCredentials runtimeCredentials
+	runtimeInitShell   string
+}
+
+type runtimeCredentials map[string]string
+
+func (runtimeCredentials) String() string { return "[redacted]" }
+
+// String deliberately renders only non-secret identity and lifecycle fields.
+func (a Agent) String() string {
+	return fmt.Sprintf("Agent{ID:%q Name:%q RuntimeKind:%q RuntimeID:%q Status:%q}", a.ID, a.Name, a.RuntimeKind, a.RuntimeID, a.Status)
+}
+
+// RuntimeProvision returns a defensive copy of Runtime-owned provisioning
+// state that is intentionally excluded from Agent JSON responses.
+func (a Agent) RuntimeProvision() (map[string]string, string) {
+	return cloneStringMap(map[string]string(a.runtimeCredentials)), a.runtimeInitShell
+}
+
+// SetRuntimeProvision replaces Runtime-owned provisioning state without
+// exposing credential values through the Agent JSON representation.
+func (a *Agent) SetRuntimeProvision(credentials map[string]string, initShell string) {
+	if a == nil {
+		return
+	}
+	a.runtimeCredentials = runtimeCredentials(cloneStringMap(credentials))
+	a.runtimeInitShell = initShell
 }
 
 // AgentMetadata is the persisted identity and capability metadata for an agent.
@@ -191,26 +220,28 @@ func (a *Agent) UnmarshalJSON(data []byte) error {
 }
 
 type CreateAgentSpec struct {
-	ID                   string         `json:"id,omitempty"`
-	Name                 string         `json:"name"`
-	Description          string         `json:"description,omitempty"`
-	Instructions         string         `json:"instructions,omitempty"`
-	Image                string         `json:"image,omitempty"`
-	Avatar               string         `json:"-"`
-	RuntimeKind          string         `json:"-"`
-	RuntimeName          string         `json:"runtime_name,omitempty"`
-	SandboxEnabled       bool           `json:"sandbox_enabled,omitempty"`
-	FromTemplate         string         `json:"from_template,omitempty"`
-	TemplateInstructions string         `json:"-"`
-	Role                 string         `json:"role,omitempty"`
-	Status               string         `json:"status,omitempty"`
-	CreatedAt            time.Time      `json:"created_at,omitempty"`
-	UpdatedAt            time.Time      `json:"updated_at,omitempty"`
-	Profile              string         `json:"profile,omitempty"`
-	RuntimeOptions       map[string]any `json:"runtime_options,omitempty"`
-	MCPServers           map[string]any `json:"mcpServers,omitempty"`
-	MCPServersSet        bool           `json:"-"`
-	AgentProfile         AgentProfile   `json:"agent_profile,omitempty"`
+	ID                   string            `json:"id,omitempty"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description,omitempty"`
+	Instructions         string            `json:"instructions,omitempty"`
+	Image                string            `json:"image,omitempty"`
+	Avatar               string            `json:"-"`
+	RuntimeKind          string            `json:"-"`
+	RuntimeName          string            `json:"runtime_name,omitempty"`
+	SandboxEnabled       bool              `json:"sandbox_enabled,omitempty"`
+	FromTemplate         string            `json:"from_template,omitempty"`
+	TemplateInstructions string            `json:"-"`
+	Role                 string            `json:"role,omitempty"`
+	Status               string            `json:"status,omitempty"`
+	CreatedAt            time.Time         `json:"created_at,omitempty"`
+	UpdatedAt            time.Time         `json:"updated_at,omitempty"`
+	Profile              string            `json:"profile,omitempty"`
+	RuntimeOptions       map[string]any    `json:"runtime_options,omitempty"`
+	MCPServers           map[string]any    `json:"mcpServers,omitempty"`
+	MCPServersSet        bool              `json:"-"`
+	RuntimeCredentials   map[string]string `json:"-"`
+	RuntimeInitShell     string            `json:"-"`
+	AgentProfile         AgentProfile      `json:"agent_profile,omitempty"`
 }
 
 func (s CreateAgentSpec) RuntimeConfig() agentruntime.RuntimeConfig {
@@ -404,21 +435,23 @@ func (s *CreateAgentSpec) UnmarshalJSON(data []byte) error {
 }
 
 type UpdateRequest struct {
-	Name                      *string         `json:"name,omitempty"`
-	Description               *string         `json:"description,omitempty"`
-	Instructions              *string         `json:"instructions,omitempty"`
-	Image                     *string         `json:"image,omitempty"`
-	Avatar                    *string         `json:"-"`
-	Profile                   *string         `json:"profile,omitempty"`
-	RuntimeKind               string          `json:"-"`
-	RuntimeName               string          `json:"-"`
-	SandboxEnabled            *bool           `json:"-"`
-	RuntimeSelectionRequested bool            `json:"-"`
-	RuntimeOptions            *map[string]any `json:"runtime_options,omitempty"`
-	MCPServers                *map[string]any `json:"mcpServers,omitempty"`
-	MCPServersSet             bool            `json:"-"`
-	AgentProfile              *AgentProfile   `json:"agent_profile,omitempty"`
-	FieldMask                 []string        `json:"field_mask,omitempty"`
+	Name                      *string            `json:"name,omitempty"`
+	Description               *string            `json:"description,omitempty"`
+	Instructions              *string            `json:"instructions,omitempty"`
+	Image                     *string            `json:"image,omitempty"`
+	Avatar                    *string            `json:"-"`
+	Profile                   *string            `json:"profile,omitempty"`
+	RuntimeKind               string             `json:"-"`
+	RuntimeName               string             `json:"-"`
+	SandboxEnabled            *bool              `json:"-"`
+	RuntimeSelectionRequested bool               `json:"-"`
+	RuntimeOptions            *map[string]any    `json:"runtime_options,omitempty"`
+	MCPServers                *map[string]any    `json:"mcpServers,omitempty"`
+	MCPServersSet             bool               `json:"-"`
+	RuntimeCredentials        *map[string]string `json:"-"`
+	RuntimeInitShell          *string            `json:"-"`
+	AgentProfile              *AgentProfile      `json:"agent_profile,omitempty"`
+	FieldMask                 []string           `json:"field_mask,omitempty"`
 }
 
 func (r *UpdateRequest) UnmarshalJSON(data []byte) error {
@@ -641,6 +674,7 @@ func cloneAgent(src *Agent) *Agent {
 	dst.DetectionResults = append([]ProfileDetectionResult(nil), src.DetectionResults...)
 	dst.RuntimeOptions = utils.CloneAnyMap(src.RuntimeOptions)
 	dst.MCPServers = cloneMCPServers(src.MCPServers)
+	dst.runtimeCredentials = runtimeCredentials(cloneStringMap(map[string]string(src.runtimeCredentials)))
 	dst.Availability = cloneRuntimeAvailability(src.Availability)
 	return &dst
 }

--- a/internal/agent/runtime_provision_test.go
+++ b/internal/agent/runtime_provision_test.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeProvisionStatePersistsWithoutEnteringAgentJSON(t *testing.T) {
+	item := Agent{ID: "agent-a", Name: "alice", Role: RoleWorker, RuntimeKind: RuntimeKindCodex}
+	item.SetRuntimeProvision(map[string]string{"secrets/token": "persisted-secret"}, "test -f secrets/token")
+
+	raw, err := json.Marshal(newPersistedAgent(item))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "persisted-secret") || !strings.Contains(string(raw), "runtime_init_shell") {
+		t.Fatalf("persisted Agent omitted Runtime provisioning state: %s", raw)
+	}
+	var stored persistedAgent
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatal(err)
+	}
+	loaded := stored.toAgent()
+	credentials, initShell := loaded.RuntimeProvision()
+	if credentials["secrets/token"] != "persisted-secret" || initShell != "test -f secrets/token" {
+		t.Fatalf("loaded Runtime provisioning = %#v, %q", credentials, initShell)
+	}
+	credentials["secrets/token"] = "mutated"
+	got, _ := loaded.RuntimeProvision()
+	if got["secrets/token"] != "persisted-secret" {
+		t.Fatalf("RuntimeProvision returned mutable credentials: %#v", got)
+	}
+
+	public, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(public), "persisted-secret") || strings.Contains(string(public), "test -f secrets/token") {
+		t.Fatalf("Agent JSON leaked Runtime provisioning state: %s", public)
+	}
+	if rendered := fmt.Sprintf("%+v", loaded); strings.Contains(rendered, "persisted-secret") {
+		t.Fatalf("formatted Agent leaked Runtime credentials: %s", rendered)
+	}
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -583,10 +583,29 @@ func (s *Service) ensureCodexManager(ctx context.Context, forceRecreate bool) (A
 	}
 
 	existing, _ := s.Agent(ManagerUserID)
+	managerCredentials, managerInitShell := existing.RuntimeProvision()
 	if err := s.validateMCPServers(ctx, RuntimeKindCodex, mcpServersSnapshotForAgent(managerMCPServers)); err != nil {
 		return Agent{}, err
 	}
 	legacyCleanupKeys := s.legacyManagerSandboxCleanupKeys()
+	runtimeAgent := s.newCodexManagerAgent(managerDisplayName, managerDescription, managerInstructions, managerAvatar, managerCreatedAt, "", agentruntime.StateCreated, string(agentruntime.StateCreated), startProfile, detectionResults)
+	applyManagerMCPServers(&runtimeAgent, managerMCPServers)
+	runtimeAgent.SetRuntimeProvision(managerCredentials, managerInitShell)
+	runtimeProfile := s.runtimeProfileForAgentWithProfile(runtimeAgent, s.hydrateProfileFromCatalog(startProfile))
+	provisionReq := agentruntime.ProvisionRequest{
+		RuntimeID:           runtimeIDForAgentID(ManagerUserID),
+		AgentID:             ManagerUserID,
+		ParticipantID:       ManagerParticipantID,
+		AgentName:           managerDisplayName,
+		Profile:             runtimeProfile,
+		MCPServers:          cloneMCPServers(runtimeAgent.MCPServers),
+		Credentials:         managerCredentials,
+		PreviousCredentials: sortedStringKeys(managerCredentials),
+		InitShell:           managerInitShell,
+	}
+	if err := s.provisionRuntime(ctx, runtimeImpl, RuntimeKindCodex, provisionReq); err != nil {
+		return Agent{}, fmt.Errorf("provision manager runtime: %w", err)
+	}
 	if forceRecreate {
 		// Stop every channel bridge before deleting the Codex runtime. Bridge
 		// workers can otherwise access or restore the session while its runtime
@@ -597,21 +616,6 @@ func (s *Service) ensureCodexManager(ctx context.Context, forceRecreate bool) (A
 				return Agent{}, fmt.Errorf("remove existing manager runtime: %w", err)
 			}
 		}
-	}
-
-	runtimeAgent := s.newCodexManagerAgent(managerDisplayName, managerDescription, managerInstructions, managerAvatar, managerCreatedAt, "", agentruntime.StateCreated, string(agentruntime.StateCreated), startProfile, detectionResults)
-	applyManagerMCPServers(&runtimeAgent, managerMCPServers)
-	runtimeProfile := s.runtimeProfileForAgentWithProfile(runtimeAgent, s.hydrateProfileFromCatalog(startProfile))
-	provisionReq := agentruntime.ProvisionRequest{
-		RuntimeID:     runtimeIDForAgentID(ManagerUserID),
-		AgentID:       ManagerUserID,
-		ParticipantID: ManagerParticipantID,
-		AgentName:     managerDisplayName,
-		Profile:       runtimeProfile,
-		MCPServers:    cloneMCPServers(runtimeAgent.MCPServers),
-	}
-	if err := s.provisionRuntime(ctx, runtimeImpl, RuntimeKindCodex, provisionReq); err != nil {
-		return Agent{}, fmt.Errorf("provision manager runtime: %w", err)
 	}
 	if _, err := s.persistManagerAgent(ctx, runtimeAgent, false); err != nil {
 		return Agent{}, err
@@ -639,6 +643,7 @@ func (s *Service) ensureCodexManager(ctx context.Context, forceRecreate bool) (A
 	}
 	manager := s.newCodexManagerAgent(managerDisplayName, managerDescription, managerInstructions, managerAvatar, managerCreatedAt, info.HandleID, info.State, string(info.State), startProfile, detectionResults)
 	applyManagerMCPServers(&manager, managerMCPServers)
+	manager.SetRuntimeProvision(managerCredentials, managerInitShell)
 	manager.AgentProfile.EnvRestartRequired = false
 	manager.AgentProfile.ImageUpgradeRequired = false
 	if !info.CreatedAt.IsZero() {
@@ -2391,6 +2396,8 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		Profile:              runtimeProfile,
 		RuntimeOptions:       utils.CloneAnyMap(spec.RuntimeOptions),
 		MCPServers:           cloneMCPServers(spec.MCPServers),
+		Credentials:          cloneStringMap(spec.RuntimeCredentials),
+		InitShell:            spec.RuntimeInitShell,
 		WorkspaceOverlay:     strings.TrimSpace(spec.FromTemplate),
 	}); err != nil {
 		return Agent{}, fmt.Errorf("provision worker runtime: %w", err)
@@ -2414,14 +2421,14 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		defer func() {
 			_ = s.closeBox(box)
 		}()
-		return s.persistCreatedWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers, agentruntime.Info{
+		return s.persistCreatedWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers, spec.RuntimeCredentials, spec.RuntimeInitShell, agentruntime.Info{
 			HandleID:  strings.TrimSpace(info.ID),
 			State:     agentruntime.State(info.State),
 			CreatedAt: info.CreatedAt.UTC(),
 		})
 	}
 	if runtimeKind == RuntimeKindCodex {
-		if err := s.persistStartingWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers); err != nil {
+		if err := s.persistStartingWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers, spec.RuntimeCredentials, spec.RuntimeInitShell); err != nil {
 			return Agent{}, err
 		}
 		defer func() {
@@ -2446,10 +2453,10 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		CreatedAt: time.Now().UTC(),
 	}
 
-	return s.persistCreatedWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers, info)
+	return s.persistCreatedWorker(ctx, id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxed, resolvedProfile, spec.RuntimeOptions, spec.MCPServers, spec.RuntimeCredentials, spec.RuntimeInitShell, info)
 }
 
-func (s *Service) persistStartingWorker(ctx context.Context, id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, runtimeOptions map[string]any, mcpServers map[string]any) error {
+func (s *Service) persistStartingWorker(ctx context.Context, id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, runtimeOptions map[string]any, mcpServers map[string]any, runtimeCredentials map[string]string, runtimeInitShell string) error {
 	s.mu.Lock()
 
 	if _, _, ok := s.agentByIDLocked(id); ok {
@@ -2461,7 +2468,7 @@ func (s *Service) persistStartingWorker(ctx context.Context, id, name, descripti
 		return fmt.Errorf("agent name %q already exists", name)
 	}
 
-	worker := newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxEnabled, profile, runtimeOptions, mcpServers, agentruntime.Info{
+	worker := newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxEnabled, profile, runtimeOptions, mcpServers, runtimeCredentials, runtimeInitShell, agentruntime.Info{
 		State:     agentruntime.StateCreated,
 		CreatedAt: time.Now().UTC(),
 	})
@@ -2489,7 +2496,7 @@ func (s *Service) removeStartingWorker(ctx context.Context, id string) error {
 	return err
 }
 
-func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, createRuntimeExt map[string]any, mcpServers map[string]any, info agentruntime.Info) (Agent, error) {
+func (s *Service) persistCreatedWorker(ctx context.Context, id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, createRuntimeExt map[string]any, mcpServers map[string]any, runtimeCredentials map[string]string, runtimeInitShell string, info agentruntime.Info) (Agent, error) {
 	s.mu.Lock()
 
 	if existing, _, ok := s.agentByIDLocked(id); ok && !isStartingWorker(existing) {
@@ -2501,7 +2508,7 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 		return Agent{}, fmt.Errorf("agent name %q already exists", name)
 	}
 
-	worker := newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxEnabled, profile, createRuntimeExt, mcpServers, info)
+	worker := newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName, sandboxEnabled, profile, createRuntimeExt, mcpServers, runtimeCredentials, runtimeInitShell, info)
 	s.clearRuntimeAvailabilityLocked(worker.ID)
 	s.agents[worker.ID] = worker
 	s.syncRuntimeRecordLocked(worker)
@@ -2522,7 +2529,7 @@ func (s *Service) persistCreatedWorker(ctx context.Context, id, name, descriptio
 	return created, nil
 }
 
-func newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, runtimeOptions map[string]any, mcpServers map[string]any, info agentruntime.Info) Agent {
+func newWorkerAgent(id, name, description, instructions, image, avatar, runtimeKind, runtimeName string, sandboxEnabled bool, profile AgentProfile, runtimeOptions map[string]any, mcpServers map[string]any, runtimeCredentials map[string]string, runtimeInitShell string, info agentruntime.Info) Agent {
 	createdAt := info.CreatedAt.UTC()
 	if info.CreatedAt.IsZero() {
 		createdAt = time.Now().UTC()
@@ -2539,7 +2546,7 @@ func newWorkerAgent(id, name, description, instructions, image, avatar, runtimeK
 	runtimeCfg, _ := agentruntime.RuntimeConfigFromSelection(runtimeKind, runtimeName, sandboxEnabled)
 	resolvedRuntimeKind := runtimeCfg.LegacyKind()
 	resolvedRuntimeName := runtimeCfg.Name
-	return Agent{
+	worker := Agent{
 		ID:              id,
 		Name:            name,
 		RuntimeID:       runtimeIDForAgentID(id),
@@ -2561,6 +2568,8 @@ func newWorkerAgent(id, name, description, instructions, image, avatar, runtimeK
 		ProfileComplete: prof.ProfileComplete,
 		Role:            RoleWorker,
 	}
+	worker.SetRuntimeProvision(runtimeCredentials, runtimeInitShell)
+	return worker
 }
 
 func isStartingWorker(a Agent) bool {
@@ -2605,19 +2614,28 @@ func (s *Service) provisionRuntime(ctx context.Context, rt agentruntime.Runtime,
 }
 
 func (s *Service) provisionRuntimeForAgent(ctx context.Context, rt agentruntime.Runtime, got Agent, workspaceOverlay string) error {
+	credentials, _ := got.RuntimeProvision()
+	return s.provisionRuntimeForAgentWithPrevious(ctx, rt, got, sortedStringKeys(credentials), workspaceOverlay)
+}
+
+func (s *Service) provisionRuntimeForAgentWithPrevious(ctx context.Context, rt agentruntime.Runtime, got Agent, previousCredentials []string, workspaceOverlay string) error {
 	if s == nil || rt == nil {
 		return nil
 	}
+	credentials, initShell := got.RuntimeProvision()
 	return s.provisionRuntime(ctx, rt, strings.TrimSpace(got.RuntimeKind), agentruntime.ProvisionRequest{
-		RuntimeID:        normalizeRuntimeID(got.RuntimeID, got.ID),
-		AgentID:          strings.TrimSpace(got.ID),
-		ParticipantID:    participantIDForAgent(got.Name, got.ID),
-		AgentName:        strings.TrimSpace(got.Name),
-		Instructions:     strings.TrimSpace(got.Instructions),
-		Profile:          s.runtimeProfileForAgent(got),
-		RuntimeOptions:   utils.CloneAnyMap(got.RuntimeOptions),
-		MCPServers:       cloneMCPServers(got.MCPServers),
-		WorkspaceOverlay: strings.TrimSpace(workspaceOverlay),
+		RuntimeID:           normalizeRuntimeID(got.RuntimeID, got.ID),
+		AgentID:             strings.TrimSpace(got.ID),
+		ParticipantID:       participantIDForAgent(got.Name, got.ID),
+		AgentName:           strings.TrimSpace(got.Name),
+		Instructions:        strings.TrimSpace(got.Instructions),
+		Profile:             s.runtimeProfileForAgent(got),
+		RuntimeOptions:      utils.CloneAnyMap(got.RuntimeOptions),
+		MCPServers:          cloneMCPServers(got.MCPServers),
+		Credentials:         credentials,
+		PreviousCredentials: append([]string(nil), previousCredentials...),
+		InitShell:           initShell,
+		WorkspaceOverlay:    strings.TrimSpace(workspaceOverlay),
 	})
 }
 
@@ -2627,6 +2645,15 @@ func participantIDForAgent(agentName, agentID string) string {
 		return ManagerParticipantID
 	}
 	return participantIDFromAgentID(agentID)
+}
+
+func sortedStringKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func ParticipantIDForAgent(agentName, agentID string) string {

--- a/internal/agent/service_profiles.go
+++ b/internal/agent/service_profiles.go
@@ -311,6 +311,11 @@ func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Age
 	if s == nil {
 		return Agent{}, fmt.Errorf("agent service is required")
 	}
+	ctx, release, err := s.acquireAgentLifecycle(ctx, id)
+	if err != nil {
+		return Agent{}, err
+	}
+	defer release()
 	if updateIncludesMCPServers(req) {
 		s.mcpServersMu.Lock()
 		defer s.mcpServersMu.Unlock()
@@ -356,6 +361,9 @@ func (s *Service) update(ctx context.Context, id string, req UpdateRequest) (Age
 	instructionsUpdated := updateRequested("instructions", req.Instructions != nil)
 	runtimeOptionsUpdated := updateRequested("runtime_options", req.RuntimeOptions != nil)
 	mcpServersUpdated := updateRequested("mcpservers", req.MCPServersSet)
+	runtimeCredentialsUpdated := updateRequested("runtime_credentials", req.RuntimeCredentials != nil)
+	runtimeInitShellUpdated := updateRequested("runtime_init_shell", req.RuntimeInitShell != nil)
+	runtimeProvisionUpdated := runtimeCredentialsUpdated || runtimeInitShellUpdated
 	if mcpServersUpdated && !req.MCPServersSet {
 		s.mu.Unlock()
 		return Agent{}, fmt.Errorf("field_mask includes mcpServers but request is missing mcpServers")
@@ -420,6 +428,22 @@ func (s *Service) update(ctx context.Context, id string, req UpdateRequest) (Age
 			return Agent{}, fmt.Errorf("field_mask includes profile but request is missing profile")
 		}
 		current.Profile = strings.TrimSpace(*req.Profile)
+	}
+	if runtimeCredentialsUpdated {
+		if req.RuntimeCredentials == nil {
+			s.mu.Unlock()
+			return Agent{}, fmt.Errorf("field_mask includes runtime_credentials but request is missing credentials")
+		}
+		_, initShell := current.RuntimeProvision()
+		current.SetRuntimeProvision(*req.RuntimeCredentials, initShell)
+	}
+	if runtimeInitShellUpdated {
+		if req.RuntimeInitShell == nil {
+			s.mu.Unlock()
+			return Agent{}, fmt.Errorf("field_mask includes runtime_init_shell but request is missing initShell")
+		}
+		credentials, _ := current.RuntimeProvision()
+		current.SetRuntimeProvision(credentials, *req.RuntimeInitShell)
 	}
 	agentProfileUpdated := updateRequested("agent_profile", req.AgentProfile != nil)
 	if !hasFieldMask && !agentProfileUpdated && strings.TrimSpace(current.Profile) != "" {
@@ -532,6 +556,23 @@ func (s *Service) update(ctx context.Context, id string, req UpdateRequest) (Age
 	if runtimeAffectingUpdate && current.ProfileComplete {
 		s.profileDefaults = profileDefaultsSnapshot(current.AgentProfile)
 		s.detectionResults = nil
+	}
+	if runtimeProvisionUpdated {
+		previousCredentials, _ := previous.RuntimeProvision()
+		runtimeImpl, err := s.runtimeForKind(runtimeKind)
+		if err != nil {
+			s.mu.Unlock()
+			return Agent{}, err
+		}
+		s.mu.Unlock()
+		if err := s.provisionRuntimeForAgentWithPrevious(ctx, runtimeImpl, current, sortedStringKeys(previousCredentials), ""); err != nil {
+			return Agent{}, fmt.Errorf("provision Runtime credentials and initShell: %w", err)
+		}
+		s.mu.Lock()
+		if _, key, ok = s.agentByIDLocked(id); !ok {
+			s.mu.Unlock()
+			return Agent{}, fmt.Errorf("agent %q not found", id)
+		}
 	}
 	current.UpdatedAt = time.Now().UTC()
 	s.agents[key] = current
@@ -1235,12 +1276,6 @@ func (s *Service) recreate(ctx context.Context, id string, imageFor func(context
 		return recreated, nil
 	}
 
-	deleteHandle := runtimeHandleForAgent(got)
-	deleteErr := runtimeImpl.Delete(ctx, deleteHandle)
-	if deleteErr != nil && !sandbox.IsNotFound(deleteErr) {
-		return Agent{}, fmt.Errorf("remove existing agent box: %w", deleteErr)
-	}
-
 	runtimeProfile := s.runtimeProfileForKind(runtimeKind, got.ID, got.Name, got.Description, profile)
 	createSpec := agentruntime.Spec{
 		RuntimeID: normalizeRuntimeID(got.RuntimeID, got.ID),
@@ -1252,18 +1287,38 @@ func (s *Service) recreate(ctx context.Context, id string, imageFor func(context
 	if err := s.refreshGatewayTemplateSkills(got.ID, runtimeKind, recreateTemplateRole(got)); err != nil {
 		return Agent{}, fmt.Errorf("refresh gateway template skills: %w", err)
 	}
-	if err := s.provisionRuntime(ctx, runtimeImpl, runtimeKind, agentruntime.ProvisionRequest{
-		RuntimeID:            createSpec.RuntimeID,
-		AgentID:              createSpec.AgentID,
-		ParticipantID:        participantIDForAgent(createSpec.AgentName, createSpec.AgentID),
-		AgentName:            createSpec.AgentName,
-		Instructions:         strings.TrimSpace(got.Instructions),
-		TemplateInstructions: preservedInstructions,
-		Profile:              runtimeProfile,
-		RuntimeOptions:       utils.CloneAnyMap(got.RuntimeOptions),
-		MCPServers:           cloneMCPServers(got.MCPServers),
-	}); err != nil {
-		return Agent{}, fmt.Errorf("provision agent runtime: %w", err)
+	runtimeCredentials, runtimeInitShell := got.RuntimeProvision()
+	provision := func() error {
+		return s.provisionRuntime(ctx, runtimeImpl, runtimeKind, agentruntime.ProvisionRequest{
+			RuntimeID:            createSpec.RuntimeID,
+			AgentID:              createSpec.AgentID,
+			ParticipantID:        participantIDForAgent(createSpec.AgentName, createSpec.AgentID),
+			AgentName:            createSpec.AgentName,
+			Instructions:         strings.TrimSpace(got.Instructions),
+			TemplateInstructions: preservedInstructions,
+			Profile:              runtimeProfile,
+			RuntimeOptions:       utils.CloneAnyMap(got.RuntimeOptions),
+			MCPServers:           cloneMCPServers(got.MCPServers),
+			Credentials:          runtimeCredentials,
+			PreviousCredentials:  sortedStringKeys(runtimeCredentials),
+			InitShell:            runtimeInitShell,
+		})
+	}
+	provisionBeforeDelete := strings.EqualFold(runtimeKind, RuntimeKindCodex)
+	if provisionBeforeDelete {
+		if err := provision(); err != nil {
+			return Agent{}, fmt.Errorf("provision agent runtime: %w", err)
+		}
+	}
+	deleteHandle := runtimeHandleForAgent(got)
+	deleteErr := runtimeImpl.Delete(ctx, deleteHandle)
+	if deleteErr != nil && !sandbox.IsNotFound(deleteErr) {
+		return Agent{}, fmt.Errorf("remove existing agent box: %w", deleteErr)
+	}
+	if !provisionBeforeDelete {
+		if err := provision(); err != nil {
+			return Agent{}, fmt.Errorf("provision agent runtime: %w", err)
+		}
 	}
 	handle, err := runtimeImpl.New(ctx, createSpec)
 	if err != nil {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -2952,6 +2952,9 @@ func TestCreateWorkerProvisionsRuntimeBeforeNew(t *testing.T) {
 				if req.WorkspaceOverlay != "" {
 					t.Fatalf("Provision() workspace overlay = %q, want empty", req.WorkspaceOverlay)
 				}
+				if req.Credentials["secrets/token"] != "runtime-secret" || req.InitShell != "test -f secrets/token" {
+					t.Fatalf("Provision() Runtime provisioning = %#v, %q", req.Credentials, req.InitShell)
+				}
 				return nil
 			},
 			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
@@ -2965,9 +2968,11 @@ func TestCreateWorkerProvisionsRuntimeBeforeNew(t *testing.T) {
 	}
 
 	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{
-		ID:          "u-alice",
-		Name:        "alice",
-		RuntimeKind: RuntimeKindCodex,
+		ID:                 "u-alice",
+		Name:               "alice",
+		RuntimeKind:        RuntimeKindCodex,
+		RuntimeCredentials: map[string]string{"secrets/token": "runtime-secret"},
+		RuntimeInitShell:   "test -f secrets/token",
 		AgentProfile: AgentProfile{
 			Name:            "alice",
 			Provider:        ProviderAPI,
@@ -3346,7 +3351,7 @@ func TestRecreateWaitsForConcurrentStartOfSameAgent(t *testing.T) {
 	}
 }
 
-func TestRecreateProvisionsRuntimeBeforeNew(t *testing.T) {
+func TestRecreateProvisionsRuntimeBeforeDeleteAndNew(t *testing.T) {
 	var callOrder []string
 	svc, err := NewService(
 		config.ModelConfig{},
@@ -3381,6 +3386,9 @@ func TestRecreateProvisionsRuntimeBeforeNew(t *testing.T) {
 				if req.WorkspaceOverlay != "" {
 					t.Fatalf("Provision() workspace overlay = %q, want empty", req.WorkspaceOverlay)
 				}
+				if req.Credentials["secrets/token"] != "runtime-secret" || req.InitShell != "test -f secrets/token" {
+					t.Fatalf("Provision() Runtime provisioning paths = %#v, initShell = %q", sortedStringKeys(req.Credentials), req.InitShell)
+				}
 				return nil
 			},
 			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
@@ -3413,13 +3421,66 @@ func TestRecreateProvisionsRuntimeBeforeNew(t *testing.T) {
 		},
 		ProfileComplete: true,
 	}
+	provisionedAgent := svc.agents["u-alice"]
+	provisionedAgent.SetRuntimeProvision(map[string]string{"secrets/token": "runtime-secret"}, "test -f secrets/token")
+	svc.agents["u-alice"] = provisionedAgent
 
 	_, err = svc.Recreate(context.Background(), "u-alice")
 	if err != nil {
 		t.Fatalf("Recreate() error = %v", err)
 	}
-	if got, want := strings.Join(callOrder, ","), "delete,provision,new"; got != want {
+	if got, want := strings.Join(callOrder, ","), "provision,delete,new"; got != want {
 		t.Fatalf("call order = %q, want %q", got, want)
+	}
+}
+
+func TestRecreateGatewayDeletesBeforeProvisionAndNew(t *testing.T) {
+	var callOrder []string
+	statePath := filepath.Join(t.TempDir(), "agents.json")
+	svc, err := NewService(
+		config.ModelConfig{},
+		config.ServerConfig{ListenAddr: "0.0.0.0:18080", AccessToken: "shared-token"},
+		"manager-image:test",
+		statePath,
+		WithRuntime(fakeAgentRuntime{
+			kind: RuntimeKindOpenClawSandbox,
+			del: func(context.Context, agentruntime.Handle) error {
+				callOrder = append(callOrder, "delete")
+				return nil
+			},
+			provision: func(context.Context, agentruntime.ProvisionRequest) error {
+				callOrder = append(callOrder, "provision")
+				return nil
+			},
+			new: func(_ context.Context, spec agentruntime.Spec) (agentruntime.Handle, error) {
+				callOrder = append(callOrder, "new")
+				return agentruntime.Handle{RuntimeID: spec.RuntimeID, HandleID: "openclaw-new"}, nil
+			},
+			info: func(_ context.Context, handle agentruntime.Handle) (agentruntime.Info, error) {
+				return agentruntime.Info{HandleID: handle.HandleID, State: agentruntime.StateRunning}, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.agents["agent-alice"] = Agent{
+		ID: "agent-alice", Name: "alice", Role: RoleWorker,
+		RuntimeID: "rt-agent-alice", RuntimeKind: RuntimeKindOpenClawSandbox,
+		RuntimeName: RuntimeNameOpenClaw, SandboxEnabled: true,
+		Image: "openclaw:test", BoxID: "openclaw-old", Status: string(agentruntime.StateRunning),
+		AgentProfile: AgentProfile{
+			Name: "alice", Provider: ProviderAPI, BaseURL: "https://api.example/v1",
+			APIKey: "api-key", ModelID: "model-a", ProfileComplete: true,
+		},
+		ProfileComplete: true,
+	}
+
+	if _, err := svc.Recreate(context.Background(), "agent-alice"); err != nil {
+		t.Fatalf("Recreate() error = %v", err)
+	}
+	if got, want := strings.Join(callOrder, ","), "delete,provision,new"; got != want {
+		t.Fatalf("gateway call order = %q, want %q", got, want)
 	}
 }
 
@@ -4201,16 +4262,26 @@ func TestEnsureBootstrapManagerPreservesLatestManagerMCPServersDuringStart(t *te
 
 	<-newStarted
 	updateConfig := utils.CloneAnyMap(newMCPServers)
-	if _, err := svc.Update(context.Background(), ManagerUserID, UpdateRequest{
-		MCPServers:    &updateConfig,
-		MCPServersSet: true,
-	}); err != nil {
-		t.Fatalf("Update(manager MCPServers) error = %v", err)
+	updateErrCh := make(chan error, 1)
+	go func() {
+		_, updateErr := svc.Update(context.Background(), ManagerUserID, UpdateRequest{
+			MCPServers:    &updateConfig,
+			MCPServersSet: true,
+		})
+		updateErrCh <- updateErr
+	}()
+	select {
+	case updateErr := <-updateErrCh:
+		t.Fatalf("Update(manager MCPServers) returned before start drained: %v", updateErr)
+	case <-time.After(20 * time.Millisecond):
 	}
 	close(releaseNew)
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("EnsureBootstrapManager() error = %v", err)
+	}
+	if err := <-updateErrCh; err != nil {
+		t.Fatalf("Update(manager MCPServers) error = %v", err)
 	}
 	manager, ok := svc.Agent(ManagerUserID)
 	if !ok {
@@ -4220,11 +4291,8 @@ func TestEnsureBootstrapManagerPreservesLatestManagerMCPServersDuringStart(t *te
 	if manager.MCPServers["old"] != nil {
 		t.Fatalf("manager MCPServers = %#v, want latest config without old server", manager.MCPServers)
 	}
-	if !manager.AgentProfile.EnvRestartRequired {
-		t.Fatal("manager EnvRestartRequired = false, want true after MCP update during start")
-	}
-	if len(reconciledConfigs) < 2 {
-		t.Fatalf("MCP reconcile calls = %d, want update and post-start reconcile", len(reconciledConfigs))
+	if len(reconciledConfigs) < 1 {
+		t.Fatal("MCP reconcile was not called")
 	}
 	if got := reconcileHandles[len(reconcileHandles)-1]; got != "codex-manager-session" {
 		t.Fatalf("last MCP reconcile handle = %q, want codex-manager-session", got)

--- a/internal/agent/skills.go
+++ b/internal/agent/skills.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -107,6 +108,115 @@ func (s *Service) DeleteSkill(agentID, skillName string) error {
 		return err
 	}
 	return skilllocal.Delete(targetRoot, skillName)
+}
+
+// Skills returns the installed skill names for one Agent.
+func (s *Service) Skills(agentID string) ([]string, error) {
+	agentID = strings.TrimSpace(agentID)
+	got, ok := s.agentSnapshot(agentID)
+	if !ok {
+		return nil, fmt.Errorf("agent %q not found", agentID)
+	}
+	targetRoot, err := s.agentSkillsRoot(got.ID, got.RuntimeKind)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(targetRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read agent skills root %q: %w", targetRoot, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := skilllocal.ResolveDir(targetRoot, entry.Name()); err == nil {
+			names = append(names, entry.Name())
+		}
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// ReplaceSkills validates and stages the complete desired skill set before an
+// atomic directory replacement under the shared lifecycle gate.
+func (s *Service) ReplaceSkills(ctx context.Context, agentID string, skillNames []string) error {
+	ctx, release, err := s.acquireAgentLifecycle(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	got, ok := s.agentSnapshot(agentID)
+	if !ok {
+		return fmt.Errorf("agent %q not found", strings.TrimSpace(agentID))
+	}
+	targetRoot, err := s.agentSkillsRoot(got.ID, got.RuntimeKind)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(targetRoot)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create agent workspace %q: %w", parent, err)
+	}
+	stageRoot, err := os.MkdirTemp(parent, ".skills-stage-")
+	if err != nil {
+		return fmt.Errorf("create staged skills directory: %w", err)
+	}
+	defer os.RemoveAll(stageRoot)
+
+	globalRoot, err := skilllocal.SkillsRoot()
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(skillNames))
+	for _, rawName := range skillNames {
+		name, err := skilllocal.NormalizeName(rawName)
+		if err != nil {
+			return err
+		}
+		if _, exists := seen[name]; exists {
+			return fmt.Errorf("duplicate skill name %q", name)
+		}
+		seen[name] = struct{}{}
+		srcFS, srcRoot, err := resolveAgentSkillSource(globalRoot, name)
+		if err != nil {
+			if errors.Is(err, skilllocal.ErrSkillInvalid) {
+				return fmt.Errorf("%w: %s", ErrAgentSkillInvalid, name)
+			}
+			return err
+		}
+		if err := copyWorkspaceFS(srcFS, srcRoot, filepath.Join(stageRoot, name), "skill", true); err != nil {
+			return fmt.Errorf("stage skill %q: %w", name, err)
+		}
+	}
+
+	backupRoot := targetRoot + ".replace-backup"
+	if err := os.RemoveAll(backupRoot); err != nil {
+		return fmt.Errorf("remove stale skill backup: %w", err)
+	}
+	targetExists := false
+	if _, err := os.Stat(targetRoot); err == nil {
+		targetExists = true
+		if err := os.Rename(targetRoot, backupRoot); err != nil {
+			return fmt.Errorf("backup current skills: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat current skills: %w", err)
+	}
+	if err := os.Rename(stageRoot, targetRoot); err != nil {
+		if targetExists {
+			_ = os.Rename(backupRoot, targetRoot)
+		}
+		return fmt.Errorf("activate staged skills: %w", err)
+	}
+	if err := os.RemoveAll(backupRoot); err != nil {
+		return fmt.Errorf("remove previous skills: %w", err)
+	}
+	return nil
 }
 
 func resolveAgentSkillSource(root, name string) (fs.FS, string, error) {

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -66,30 +66,32 @@ type legacyWorker struct {
 }
 
 type persistedAgent struct {
-	ID               string                   `json:"id"`
-	Name             string                   `json:"name"`
-	Description      string                   `json:"description,omitempty"`
-	Instructions     string                   `json:"instructions,omitempty"`
-	RuntimeID        string                   `json:"runtime_id,omitempty"`
-	RuntimeKind      string                   `json:"runtime_kind,omitempty"`
-	Image            string                   `json:"image,omitempty"`
-	Avatar           string                   `json:"avatar,omitempty"`
-	BoxID            string                   `json:"box_id,omitempty"`
-	Runtime          *RuntimeRecord           `json:"runtime,omitempty"`
-	RuntimeOptions   map[string]any           `json:"-"`
-	MCPServers       map[string]any           `json:"-"`
-	Role             string                   `json:"role"`
-	Status           string                   `json:"status,omitempty"`
-	CreatedAt        time.Time                `json:"created_at"`
-	UpdatedAt        time.Time                `json:"updated_at,omitempty"`
-	Profile          AgentProfile             `json:"model_config,omitempty"`
-	ProfileSelector  string                   `json:"-"`
-	Provider         string                   `json:"provider,omitempty"`
-	ModelID          string                   `json:"model_id,omitempty"`
-	ReasoningEffort  string                   `json:"reasoning_effort,omitempty"`
-	AgentProfile     AgentProfile             `json:"agent_profile,omitempty"`
-	ProfileComplete  bool                     `json:"profile_complete"`
-	DetectionResults []ProfileDetectionResult `json:"detection_results,omitempty"`
+	ID                 string                   `json:"id"`
+	Name               string                   `json:"name"`
+	Description        string                   `json:"description,omitempty"`
+	Instructions       string                   `json:"instructions,omitempty"`
+	RuntimeID          string                   `json:"runtime_id,omitempty"`
+	RuntimeKind        string                   `json:"runtime_kind,omitempty"`
+	Image              string                   `json:"image,omitempty"`
+	Avatar             string                   `json:"avatar,omitempty"`
+	BoxID              string                   `json:"box_id,omitempty"`
+	Runtime            *RuntimeRecord           `json:"runtime,omitempty"`
+	RuntimeOptions     map[string]any           `json:"-"`
+	MCPServers         map[string]any           `json:"-"`
+	RuntimeCredentials map[string]string        `json:"-"`
+	RuntimeInitShell   string                   `json:"-"`
+	Role               string                   `json:"role"`
+	Status             string                   `json:"status,omitempty"`
+	CreatedAt          time.Time                `json:"created_at"`
+	UpdatedAt          time.Time                `json:"updated_at,omitempty"`
+	Profile            AgentProfile             `json:"model_config,omitempty"`
+	ProfileSelector    string                   `json:"-"`
+	Provider           string                   `json:"provider,omitempty"`
+	ModelID            string                   `json:"model_id,omitempty"`
+	ReasoningEffort    string                   `json:"reasoning_effort,omitempty"`
+	AgentProfile       AgentProfile             `json:"agent_profile,omitempty"`
+	ProfileComplete    bool                     `json:"profile_complete"`
+	DetectionResults   []ProfileDetectionResult `json:"detection_results,omitempty"`
 }
 
 func (a persistedAgent) MarshalJSON() ([]byte, error) {
@@ -136,6 +138,12 @@ func (a persistedAgent) MarshalJSON() ([]byte, error) {
 	if a.MCPServers != nil {
 		out["mcpServers"] = a.MCPServers
 	}
+	if a.RuntimeCredentials != nil {
+		out["runtime_credentials"] = a.RuntimeCredentials
+	}
+	if a.RuntimeInitShell != "" {
+		out["runtime_init_shell"] = a.RuntimeInitShell
+	}
 	if len(a.DetectionResults) > 0 {
 		out["detection_results"] = a.DetectionResults
 	}
@@ -146,10 +154,12 @@ func (a *persistedAgent) UnmarshalJSON(data []byte) error {
 	type persistedAgentAlias persistedAgent
 	type persistedAgentJSON struct {
 		persistedAgentAlias
-		ModelConfig    json.RawMessage `json:"model_config"`
-		Profile        json.RawMessage `json:"profile"`
-		RuntimeOptions map[string]any  `json:"runtime_options"`
-		MCPServers     map[string]any  `json:"mcpServers"`
+		ModelConfig        json.RawMessage   `json:"model_config"`
+		Profile            json.RawMessage   `json:"profile"`
+		RuntimeOptions     map[string]any    `json:"runtime_options"`
+		MCPServers         map[string]any    `json:"mcpServers"`
+		RuntimeCredentials map[string]string `json:"runtime_credentials"`
+		RuntimeInitShell   string            `json:"runtime_init_shell"`
 	}
 	var decoded persistedAgentJSON
 	if err := json.Unmarshal(data, &decoded); err != nil {
@@ -158,6 +168,8 @@ func (a *persistedAgent) UnmarshalJSON(data []byte) error {
 	*a = persistedAgent(decoded.persistedAgentAlias)
 	a.RuntimeOptions = utils.CloneAnyMap(decoded.RuntimeOptions)
 	a.MCPServers = cloneMCPServers(decoded.MCPServers)
+	a.RuntimeCredentials = cloneStringMap(decoded.RuntimeCredentials)
+	a.RuntimeInitShell = decoded.RuntimeInitShell
 	profilePayload := decoded.ModelConfig
 	if len(profilePayload) == 0 || string(profilePayload) == "null" {
 		profilePayload = decoded.Profile
@@ -211,19 +223,21 @@ func newPersistedAgent(a Agent) persistedAgent {
 		updatedAt = a.CreatedAt.UTC()
 	}
 	return persistedAgent{
-		ID:               a.ID,
-		Name:             a.Name,
-		Description:      a.Description,
-		Instructions:     a.Instructions,
-		Image:            a.Image,
-		Runtime:          compactPersistedRuntime(runtimeRecordForAgent(a), topRX),
-		RuntimeOptions:   topRX,
-		MCPServers:       cloneMCPServers(a.MCPServers),
-		Role:             a.Role,
-		CreatedAt:        a.CreatedAt,
-		UpdatedAt:        updatedAt,
-		Profile:          ap,
-		DetectionResults: append([]ProfileDetectionResult(nil), a.DetectionResults...),
+		ID:                 a.ID,
+		Name:               a.Name,
+		Description:        a.Description,
+		Instructions:       a.Instructions,
+		Image:              a.Image,
+		Runtime:            compactPersistedRuntime(runtimeRecordForAgent(a), topRX),
+		RuntimeOptions:     topRX,
+		MCPServers:         cloneMCPServers(a.MCPServers),
+		RuntimeCredentials: cloneStringMap(map[string]string(a.runtimeCredentials)),
+		RuntimeInitShell:   a.runtimeInitShell,
+		Role:               a.Role,
+		CreatedAt:          a.CreatedAt,
+		UpdatedAt:          updatedAt,
+		Profile:            ap,
+		DetectionResults:   append([]ProfileDetectionResult(nil), a.DetectionResults...),
 	}
 }
 
@@ -301,6 +315,7 @@ func (a persistedAgent) toAgent() Agent {
 		ProfileComplete:  a.ProfileComplete,
 		DetectionResults: append([]ProfileDetectionResult(nil), a.DetectionResults...),
 	}
+	ag.SetRuntimeProvision(a.RuntimeCredentials, a.RuntimeInitShell)
 	return ag
 }
 

--- a/internal/agentengine/agent.go
+++ b/internal/agentengine/agent.go
@@ -77,13 +77,13 @@ type RuntimeSpec struct {
 	Sandboxed bool
 	Image     string
 
-	// Credentials contains adapter-specific secrets to materialize in the
-	// Runtime environment. It is write-only on Create and Update: returned Agent
-	// values omit it, and its values must not be logged.
+	// Credentials maps Runtime-workspace-relative file paths to complete secret
+	// file contents. It is write-only on Create and Update: returned Agent values
+	// omit it, and its values must not be logged.
 	Credentials map[string]string
 
-	// InitShell is an idempotent shell program run in the Runtime environment
-	// after credentials are materialized and before the Runtime starts.
+	// InitShell is an idempotent shell program run with the Runtime workspace as
+	// its working directory after credentials are materialized.
 	InitShell string
 
 	Options map[string]any

--- a/internal/agentengine/agent_facade.go
+++ b/internal/agentengine/agent_facade.go
@@ -1,0 +1,348 @@
+package agentengine
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	"csgclaw/internal/agent"
+	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/utils"
+)
+
+type unavailableAgents struct{}
+
+func (unavailableAgents) Create(context.Context, AgentSpec) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Get(context.Context, string) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) List(context.Context) ([]Agent, error) {
+	return nil, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Update(context.Context, string, AgentSpec) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Delete(context.Context, string) error {
+	return &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Start(context.Context, string) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Stop(context.Context, string) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+func (unavailableAgents) Recreate(context.Context, string) (Agent, error) {
+	return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+}
+
+type agentFacade struct {
+	service *agent.Service
+}
+
+func (f agentFacade) Create(ctx context.Context, spec AgentSpec) (Agent, error) {
+	spec = normalizeAgentSpec(spec)
+	if err := validateAgentSpec(spec); err != nil {
+		return Agent{}, err
+	}
+	createdByCall := true
+	if spec.Role == AgentRoleManager {
+		_, existed := f.service.Agent(agent.ManagerUserID)
+		createdByCall = !existed
+	}
+	created, err := f.service.Create(ctx, agent.CreateRequest{Spec: createAgentSpec(spec)})
+	if err != nil {
+		return Agent{}, err
+	}
+	if spec.Role == AgentRoleManager {
+		created, err = f.service.Update(ctx, created.ID, updateAgentRequestForRole(spec, spec.Role))
+		if err != nil {
+			return Agent{}, err
+		}
+	}
+	if err := f.service.ReplaceSkills(ctx, created.ID, spec.Skills); err != nil {
+		if createdByCall {
+			_ = f.service.Delete(context.Background(), created.ID)
+		}
+		return Agent{}, err
+	}
+	return f.convert(created)
+}
+
+func (f agentFacade) Get(ctx context.Context, agentID string) (Agent, error) {
+	if f.service == nil {
+		return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+	}
+	agentID = strings.TrimSpace(agentID)
+	selected, ok := f.service.Agent(agentID)
+	if !ok {
+		selected, ok = f.service.AgentByName(agentID)
+	}
+	if !ok {
+		return Agent{}, &TurnError{Code: ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q not found", agentID)}
+	}
+	return f.convert(selected)
+}
+
+func (f agentFacade) List(ctx context.Context) ([]Agent, error) {
+	if f.service == nil {
+		return nil, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is unavailable"}
+	}
+	items := f.service.ListContext(ctx)
+	out := make([]Agent, 0, len(items))
+	for _, item := range items {
+		converted, err := f.convert(item)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, converted)
+	}
+	return out, nil
+}
+
+func (f agentFacade) Update(ctx context.Context, agentID string, spec AgentSpec) (Agent, error) {
+	spec = normalizeAgentSpec(spec)
+	if err := validateAgentSpec(spec); err != nil {
+		return Agent{}, err
+	}
+	var updated agent.Agent
+	err := f.service.WithAgentLifecycle(ctx, agentID, func(lifecycleCtx context.Context) error {
+		previous, ok := f.service.Agent(agentID)
+		if !ok {
+			return fmt.Errorf("agent %q not found", agentID)
+		}
+		previousRole := AgentRoleWorker
+		if strings.EqualFold(strings.TrimSpace(previous.Role), agent.RoleManager) {
+			previousRole = AgentRoleManager
+		}
+		if spec.Role != previousRole {
+			return &TurnError{Code: ErrorInvalidRequest, Message: "agent role changes are not supported"}
+		}
+		previousSkills, err := f.service.Skills(agentID)
+		if err != nil {
+			return err
+		}
+		currentRuntime := previous.RuntimeConfig()
+		desiredRuntime := createAgentSpec(spec).RuntimeConfig()
+		replacesRuntime := currentRuntime != desiredRuntime
+		if err := f.service.ReplaceSkills(lifecycleCtx, agentID, spec.Skills); err != nil {
+			return err
+		}
+		if replacesRuntime {
+			replacement := createAgentSpec(spec)
+			replacement.ID = previous.ID
+			updated, err = f.service.Create(lifecycleCtx, agent.CreateRequest{Spec: replacement, Replace: true})
+		} else {
+			updated, err = f.service.Update(lifecycleCtx, agentID, updateAgentRequestForRole(spec, AgentRole(previous.Role)))
+		}
+		if err != nil {
+			_ = f.service.ReplaceSkills(lifecycleCtx, agentID, previousSkills)
+			return err
+		}
+		if replacesRuntime {
+			if err := f.service.ReplaceSkills(lifecycleCtx, agentID, spec.Skills); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return Agent{}, err
+	}
+	return f.convert(updated)
+}
+
+func (f agentFacade) Delete(ctx context.Context, agentID string) error {
+	return f.service.Delete(ctx, agentID)
+}
+
+func (f agentFacade) Start(ctx context.Context, agentID string) (Agent, error) {
+	selected, err := f.service.Start(ctx, agentID)
+	if err != nil {
+		return Agent{}, err
+	}
+	return f.convert(selected)
+}
+
+func (f agentFacade) Stop(ctx context.Context, agentID string) (Agent, error) {
+	selected, err := f.service.Stop(ctx, agentID)
+	if err != nil {
+		return Agent{}, err
+	}
+	return f.convert(selected)
+}
+
+func (f agentFacade) Recreate(ctx context.Context, agentID string) (Agent, error) {
+	selected, err := f.service.Recreate(ctx, agentID)
+	if err != nil {
+		return Agent{}, err
+	}
+	return f.convert(selected)
+}
+
+func validateAgentSpec(spec AgentSpec) error {
+	if strings.TrimSpace(spec.Name) == "" || strings.TrimSpace(spec.Runtime.Adapter) == "" {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent name and Runtime adapter are required"}
+	}
+	if (len(spec.Runtime.Credentials) > 0 || strings.TrimSpace(spec.Runtime.InitShell) != "") && !strings.EqualFold(strings.TrimSpace(spec.Runtime.Adapter), agent.RuntimeNameCodex) {
+		return &TurnError{Code: ErrorUnsupportedRuntimeProvision, Message: "Runtime credentials and initShell are supported only by the Codex Runtime Adapter"}
+	}
+	if spec.Role != AgentRoleWorker && spec.Role != AgentRoleManager {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent role must be worker or manager"}
+	}
+	return nil
+}
+
+func normalizeAgentSpec(spec AgentSpec) AgentSpec {
+	if strings.TrimSpace(string(spec.Role)) == "" {
+		spec.Role = AgentRoleWorker
+	}
+	spec.Role = AgentRole(strings.ToLower(strings.TrimSpace(string(spec.Role))))
+	spec.Runtime.Adapter = strings.ToLower(strings.TrimSpace(spec.Runtime.Adapter))
+	return spec
+}
+
+func createAgentSpec(spec AgentSpec) agent.CreateAgentSpec {
+	result := agent.CreateAgentSpec{
+		Name:               strings.TrimSpace(spec.Name),
+		Description:        strings.TrimSpace(spec.Description),
+		Instructions:       strings.TrimSpace(spec.Instructions),
+		Image:              strings.TrimSpace(spec.Runtime.Image),
+		Role:               string(spec.Role),
+		RuntimeOptions:     utils.CloneAnyMap(spec.Runtime.Options),
+		MCPServers:         mcpToService(spec.MCPServers),
+		MCPServersSet:      true,
+		RuntimeCredentials: maps.Clone(spec.Runtime.Credentials),
+		RuntimeInitShell:   spec.Runtime.InitShell,
+		AgentProfile:       modelToService(spec.Model),
+	}
+	result.SetRuntimeConfig(agentruntime.RuntimeConfig{Name: strings.TrimSpace(spec.Runtime.Adapter), Sandboxed: spec.Runtime.Sandboxed})
+	return result
+}
+
+func updateAgentRequest(spec AgentSpec) agent.UpdateRequest {
+	name := strings.TrimSpace(spec.Name)
+	description := strings.TrimSpace(spec.Description)
+	instructions := strings.TrimSpace(spec.Instructions)
+	image := strings.TrimSpace(spec.Runtime.Image)
+	sandboxed := spec.Runtime.Sandboxed
+	runtimeOptions := utils.CloneAnyMap(spec.Runtime.Options)
+	mcp := mcpToService(spec.MCPServers)
+	credentials := maps.Clone(spec.Runtime.Credentials)
+	initShell := spec.Runtime.InitShell
+	profile := modelToService(spec.Model)
+	return agent.UpdateRequest{
+		Name:                      &name,
+		Description:               &description,
+		Instructions:              &instructions,
+		Image:                     &image,
+		RuntimeName:               strings.TrimSpace(spec.Runtime.Adapter),
+		SandboxEnabled:            &sandboxed,
+		RuntimeSelectionRequested: true,
+		RuntimeOptions:            &runtimeOptions,
+		MCPServers:                &mcp,
+		MCPServersSet:             true,
+		RuntimeCredentials:        &credentials,
+		RuntimeInitShell:          &initShell,
+		AgentProfile:              &profile,
+		FieldMask: []string{
+			"name", "description", "instructions", "image", "runtime", "runtime_options", "mcpservers", "runtime_credentials", "runtime_init_shell", "agent_profile",
+		},
+	}
+}
+
+func updateAgentRequestForRole(spec AgentSpec, role AgentRole) agent.UpdateRequest {
+	request := updateAgentRequest(spec)
+	if role != AgentRoleManager {
+		return request
+	}
+	request.RuntimeOptions = nil
+	fields := request.FieldMask[:0]
+	for _, field := range request.FieldMask {
+		if field != "runtime_options" {
+			fields = append(fields, field)
+		}
+	}
+	request.FieldMask = fields
+	return request
+}
+
+func modelToService(spec ModelSpec) agent.AgentProfile {
+	return agent.AgentProfile{
+		ModelProviderID: strings.TrimSpace(spec.ProviderID),
+		ModelID:         strings.TrimSpace(spec.ModelID),
+		ReasoningEffort: strings.TrimSpace(spec.ReasoningEffort),
+		EnableFastMode:  spec.FastMode,
+		RequestOptions:  utils.CloneAnyMap(spec.Options),
+		ProfileComplete: strings.TrimSpace(spec.ProviderID) != "" && strings.TrimSpace(spec.ModelID) != "",
+	}
+}
+
+func mcpToService(input map[string]MCPServerConfig) map[string]any {
+	out := make(map[string]any, len(input))
+	for name, config := range input {
+		out[name] = utils.CloneAnyMap(map[string]any(config))
+	}
+	return out
+}
+
+func (f agentFacade) convert(selected agent.Agent) (Agent, error) {
+	skills, err := f.service.Skills(selected.ID)
+	if err != nil {
+		return Agent{}, err
+	}
+	mcp := make(map[string]MCPServerConfig, len(selected.MCPServers))
+	for name, raw := range selected.MCPServers {
+		config, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		mcp[name] = MCPServerConfig(utils.CloneAnyMap(config))
+	}
+	state := AgentState(strings.ToLower(strings.TrimSpace(selected.Status)))
+	_, runtimeInitShell := selected.RuntimeProvision()
+	role := AgentRoleWorker
+	if strings.EqualFold(strings.TrimSpace(selected.Role), agent.RoleManager) {
+		role = AgentRoleManager
+	}
+	runtimeAdapter := strings.TrimSpace(selected.RuntimeName)
+	if runtimeAdapter == "" {
+		runtimeAdapter = selected.RuntimeConfig().Name
+	}
+	ready := state == AgentStateRunning &&
+		(selected.Availability == nil || selected.Availability.State == agent.RuntimeAvailabilityReady || selected.Availability.State == agent.RuntimeAvailabilityNotApplicable)
+	return Agent{
+		ID: selected.ID,
+		Spec: AgentSpec{
+			Name:         selected.Name,
+			Description:  selected.Description,
+			Instructions: selected.Instructions,
+			Role:         role,
+			Runtime: RuntimeSpec{
+				Adapter:   runtimeAdapter,
+				Sandboxed: selected.SandboxEnabled,
+				Image:     selected.Image,
+				Options:   utils.CloneAnyMap(selected.RuntimeOptions),
+				InitShell: runtimeInitShell,
+			},
+			Model: ModelSpec{
+				ProviderID:      selected.AgentProfile.ModelProviderID,
+				ModelID:         selected.AgentProfile.ModelID,
+				ReasoningEffort: selected.AgentProfile.ReasoningEffort,
+				FastMode:        selected.AgentProfile.EnableFastMode,
+				Options:         utils.CloneAnyMap(selected.AgentProfile.RequestOptions),
+			},
+			Skills:     append([]string(nil), skills...),
+			MCPServers: mcp,
+		},
+		Status: AgentStatus{
+			State:     state,
+			RuntimeID: selected.RuntimeID,
+			Ready:     ready,
+		},
+		CreatedAt: selected.CreatedAt,
+		UpdatedAt: selected.UpdatedAt,
+	}, nil
+}

--- a/internal/agentengine/conversation.go
+++ b/internal/agentengine/conversation.go
@@ -29,6 +29,16 @@ type ConversationKey string
 // TurnID is an opaque, caller-generated identity for one Run request.
 type TurnID string
 
+// AdmissionPolicy controls how Run behaves when the Conversation already has
+// an active Turn or atomic control operation.
+type AdmissionPolicy string
+
+const (
+	AdmissionRejectIfBusy AdmissionPolicy = "reject_if_busy"
+	AdmissionWait         AdmissionPolicy = "wait"
+	AdmissionSupersede    AdmissionPolicy = "supersede"
+)
+
 // ContinuationPolicy controls whether a missing Runtime-native conversation may
 // be created.
 type ContinuationPolicy string
@@ -79,6 +89,7 @@ type TurnRequest struct {
 	ID              TurnID
 	ConversationKey ConversationKey
 	Input           []InputPart
+	Admission       AdmissionPolicy
 	Continuation    ContinuationPolicy
 	Interaction     InteractionPolicy
 }
@@ -96,9 +107,10 @@ const (
 	TurnEventOutputItem         TurnEventKind = "output_item"
 )
 
-// TurnEvent contains one normalized Runtime event. Sequence starts at one and
-// increases monotonically for each Run.
+// TurnEvent is the replay-safe envelope for one normalized Runtime event.
+// Sequence starts at one and increases monotonically for each TurnID.
 type TurnEvent struct {
+	TurnID      TurnID
 	Sequence    uint64
 	Kind        TurnEventKind
 	Text        string

--- a/internal/agentengine/conversation.go
+++ b/internal/agentengine/conversation.go
@@ -3,22 +3,12 @@ package agentengine
 import "context"
 
 // ConversationInterface executes conversations for the Agent selected by
-// Conversations. Phase 1 intentionally exposes only the operation used by the
-// Session API.
+// Conversations.
 type ConversationInterface interface {
 	Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult
-
-	// Run cancellation is intentionally context-based. Enable Cancel only when
-	// an independent caller must address and cancel an active turn by
-	// ConversationKey and TurnID; do not add it while callers can cancel their
-	// own Run context.
-	// Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error
-
-	// Later phases can enable these operations when a migrated caller needs
-	// them. They stay visible here instead of being implemented as misleading
-	// no-op methods.
-	// Reset(ctx context.Context, key ConversationKey) error
-	// Resolve(ctx context.Context, resolution InteractionResolution) error
+	Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error
+	Reset(ctx context.Context, key ConversationKey) error
+	Resolve(ctx context.Context, resolution InteractionResolution) error
 }
 
 // EventSink receives ordered progress for one turn.
@@ -39,6 +29,24 @@ type ConversationKey string
 // TurnID is an opaque, caller-generated identity for one Run request.
 type TurnID string
 
+// ContinuationPolicy controls whether a missing Runtime-native conversation may
+// be created.
+type ContinuationPolicy string
+
+const (
+	ContinuationCreateOrResume  ContinuationPolicy = "create_or_resume"
+	ContinuationRequireExisting ContinuationPolicy = "require_existing"
+)
+
+// InteractionPolicy controls how blocking Runtime interactions are handled.
+type InteractionPolicy string
+
+const (
+	InteractionResolve       InteractionPolicy = "resolve"
+	InteractionReject        InteractionPolicy = "reject"
+	InteractionSkipUserInput InteractionPolicy = "skip_user_input"
+)
+
 // InputPartKind identifies one normalized turn input.
 type InputPartKind string
 
@@ -48,8 +56,6 @@ const (
 )
 
 // InputPart is text or a caller-authorized file.
-// Text parts set Text and leave File nil.
-// File parts set File and leave Text empty.
 type InputPart struct {
 	Kind InputPartKind
 	Text string
@@ -57,8 +63,8 @@ type InputPart struct {
 }
 
 // InputFile is a caller-authorized file source.
-// The Engine treats SourcePath as opaque; the Runtime Adapter decides how to
-// mount, copy, or expose it.
+// Engine validates only this neutral shape. Runtime Adapters own file access,
+// copying, and Runtime-specific input conversion.
 type InputFile struct {
 	ID         string
 	SourcePath string
@@ -69,40 +75,41 @@ type InputFile struct {
 }
 
 // TurnRequest contains conversation identity and caller-normalized input.
-// File sources have already been authorized and resolved outside Engine.
 type TurnRequest struct {
 	ID              TurnID
 	ConversationKey ConversationKey
 	Input           []InputPart
-
-	// Deferred until a caller needs them:
-	// Continuation ContinuationPolicy
-	// Admission    ConversationAdmission
-	// Interaction  InteractionPolicy
+	Continuation    ContinuationPolicy
+	Interaction     InteractionPolicy
 }
 
 // TurnEventKind identifies progress emitted during a turn.
 type TurnEventKind string
 
 const (
-	TurnEventTextDelta      TurnEventKind = "text_delta"
-	TurnEventToolCallStart  TurnEventKind = "tool_call_start"
-	TurnEventToolCallUpdate TurnEventKind = "tool_call_update"
+	TurnEventTextDelta          TurnEventKind = "text_delta"
+	TurnEventThoughtDelta       TurnEventKind = "thought_delta"
+	TurnEventToolCallStart      TurnEventKind = "tool_call_start"
+	TurnEventToolCallUpdate     TurnEventKind = "tool_call_update"
+	TurnEventActivityUpdate     TurnEventKind = "activity_update"
+	TurnEventInteractionRequest TurnEventKind = "interaction_request"
+	TurnEventOutputItem         TurnEventKind = "output_item"
 )
 
-// TurnEvent contains either a text delta or a tool activity.
+// TurnEvent contains one normalized Runtime event. Sequence starts at one and
+// increases monotonically for each Run.
 type TurnEvent struct {
-	Kind TurnEventKind
-	Text string
-	Tool *ToolActivity
-
-	// Deferred until Channel migration:
-	// Thought     string
-	// Interaction *InteractionRequest
-	// Output      *OutputItem
+	Sequence    uint64
+	Kind        TurnEventKind
+	Text        string
+	Thought     string
+	Tool        *ToolActivity
+	Activity    *ActivityUpdate
+	Interaction *InteractionRequest
+	Output      *OutputItem
 }
 
-// ToolActivity contains the fields required by the Session SSE renderer.
+// ToolActivity contains normalized tool progress.
 type ToolActivity struct {
 	ID            string
 	Kind          string
@@ -111,6 +118,60 @@ type ToolActivity struct {
 	InputSummary  string
 	OutputSummary string
 	Payload       any
+}
+
+// ActivityUpdate carries Runtime-neutral progress not represented by a tool.
+type ActivityUpdate struct {
+	ID      string
+	Kind    string
+	Title   string
+	Status  string
+	Payload any
+}
+
+// InteractionKind identifies a blocking Runtime request.
+type InteractionKind string
+
+const (
+	InteractionPermission InteractionKind = "permission"
+	InteractionUserInput  InteractionKind = "user_input"
+)
+
+// InteractionRequest is one pending interaction addressable through Resolve.
+type InteractionRequest struct {
+	ID      string
+	Kind    InteractionKind
+	Title   string
+	Payload any
+}
+
+// InteractionResolution resolves exactly one pending interaction.
+type InteractionResolution struct {
+	ConversationKey ConversationKey
+	InteractionID   string
+	OptionID        string
+	Answers         map[string]InteractionAnswer
+	ResponderID     string
+}
+
+// InteractionAnswer is a normalized answer for one Runtime question.
+type InteractionAnswer struct {
+	Values  []string
+	Skipped bool
+}
+
+// OutputItemKind identifies a detached, non-blocking output record.
+type OutputItemKind string
+
+const (
+	OutputItemRequestUserInput OutputItemKind = "request_user_input"
+	OutputItemResourceLink     OutputItemKind = "resource_link"
+)
+
+// OutputItem contains an already validated Runtime output record.
+type OutputItem struct {
+	Kind    OutputItemKind
+	Payload any
 }
 
 // TurnStatus is the terminal state of one turn.
@@ -122,21 +183,24 @@ const (
 	TurnCanceled  TurnStatus = "canceled"
 )
 
-// ErrorCode is a stable failure category used by callers for transport
-// mapping.
+// ErrorCode is a stable failure category used by callers for transport mapping.
 type ErrorCode string
 
 const (
-	ErrorInvalidRequest            ErrorCode = "invalid_request"
-	ErrorAgentUnavailable          ErrorCode = "agent_unavailable"
-	ErrorRuntimeAdapterUnavailable ErrorCode = "runtime_adapter_unavailable"
-	ErrorConversationBusy          ErrorCode = "conversation_busy"
-	ErrorFileUnavailable           ErrorCode = "file_unavailable"
-	ErrorInteractionUnsupported    ErrorCode = "interaction_unsupported"
-	ErrorRuntimeFailed             ErrorCode = "runtime_failed"
+	ErrorInvalidRequest              ErrorCode = "invalid_request"
+	ErrorAgentUnavailable            ErrorCode = "agent_unavailable"
+	ErrorRuntimeAdapterUnavailable   ErrorCode = "runtime_adapter_unavailable"
+	ErrorConversationBusy            ErrorCode = "conversation_busy"
+	ErrorConversationNotResumable    ErrorCode = "conversation_not_resumable"
+	ErrorFileUnavailable             ErrorCode = "file_unavailable"
+	ErrorInteractionNotFound         ErrorCode = "interaction_not_found"
+	ErrorInteractionUnsupported      ErrorCode = "interaction_unsupported"
+	ErrorCanceled                    ErrorCode = "canceled"
+	ErrorRuntimeFailed               ErrorCode = "runtime_failed"
+	ErrorUnsupportedRuntimeProvision ErrorCode = "unsupported_runtime_provisioning"
 )
 
-// TurnError is the normalized failure carried by TurnResult.
+// TurnError is a normalized failure returned by Engine operations.
 type TurnError struct {
 	Code    ErrorCode
 	Message string
@@ -149,12 +213,26 @@ func (e *TurnError) Error() string {
 	return e.Message
 }
 
+// ErrorCodeOf returns the stable Engine code carried by err.
+func ErrorCodeOf(err error) ErrorCode {
+	for err != nil {
+		if turnErr, ok := err.(*TurnError); ok {
+			return turnErr.Code
+		}
+		type unwrapper interface{ Unwrap() error }
+		next, ok := err.(unwrapper)
+		if !ok {
+			break
+		}
+		err = next.Unwrap()
+	}
+	return ""
+}
+
 // TurnResult is the terminal outcome of one turn.
 type TurnResult struct {
-	Status TurnStatus
-	Output string
-	Error  *TurnError
-
-	// Deferred until strict continuation is implemented:
-	// Dispatched bool
+	Status     TurnStatus
+	Output     string
+	Dispatched bool
+	Error      *TurnError
 }

--- a/internal/agentengine/engine.go
+++ b/internal/agentengine/engine.go
@@ -3,9 +3,12 @@ package agentengine
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 )
+
+const maxCompletedTurns = 1024
 
 type conversationRuntimeResolver interface {
 	conversationRuntime(ctx context.Context, agentID string) (conversationRuntimeAdapter, func(), *TurnError)
@@ -18,14 +21,17 @@ type conversationRuntimeAdapter interface {
 }
 
 // Engine owns normalized Agent operations, conversation admission, active Turn
-// identity, pending interactions, and ordered event delivery.
+// identity, pending interactions, replay-safe event delivery, and terminal
+// result idempotency.
 type Engine struct {
 	agents   AgentInterface
 	runtimes conversationRuntimeResolver
 
-	mu        sync.Mutex
-	active    map[conversationIdentity]*activeTurn
-	resetting map[conversationIdentity]struct{}
+	mu             sync.Mutex
+	active         map[conversationIdentity]*activeTurn
+	controls       map[conversationIdentity]*conversationControl
+	completed      map[turnIdentity]completedTurn
+	completedOrder []turnIdentity
 }
 
 type conversationIdentity struct {
@@ -33,13 +39,43 @@ type conversationIdentity struct {
 	key     ConversationKey
 }
 
+type turnIdentity struct {
+	conversationIdentity
+	id TurnID
+}
+
+type conversationControl struct {
+	done chan struct{}
+}
+
+type interactionState uint8
+
+const (
+	interactionPending interactionState = iota
+	interactionResolving
+)
+
+type pendingInteraction struct {
+	request InteractionRequest
+	state   interactionState
+}
+
 type activeTurn struct {
-	id           TurnID
+	request      TurnRequest
+	ctx          context.Context
 	cancel       context.CancelFunc
 	done         chan struct{}
 	runtime      conversationRuntimeAdapter
-	interactions map[string]InteractionRequest
+	interactions map[string]*pendingInteraction
 	sequence     uint64
+	events       []TurnEvent
+	result       TurnResult
+}
+
+type completedTurn struct {
+	request TurnRequest
+	events  []TurnEvent
+	result  TurnResult
 }
 
 func (e *Engine) Agents() AgentInterface {
@@ -64,10 +100,14 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	}
 	request.ConversationKey = ConversationKey(strings.TrimSpace(string(request.ConversationKey)))
 	request.ID = TurnID(strings.TrimSpace(string(request.ID)))
+	request.Admission = normalizedAdmission(request.Admission)
 	request.Continuation = normalizedContinuation(request.Continuation)
 	request.Interaction = normalizedInteraction(request.Interaction)
 	if c == nil || c.engine == nil || c.engine.runtimes == nil || c.agentID == "" || request.ID == "" || request.ConversationKey == "" || len(request.Input) == 0 {
 		return failedResult(ErrorInvalidRequest, "agent ID, turn ID, conversation key, and input are required")
+	}
+	if request.Admission != AdmissionRejectIfBusy && request.Admission != AdmissionWait && request.Admission != AdmissionSupersede {
+		return failedResult(ErrorInvalidRequest, fmt.Sprintf("unsupported admission policy %q", request.Admission))
 	}
 	if request.Continuation != ContinuationCreateOrResume && request.Continuation != ContinuationRequireExisting {
 		return failedResult(ErrorInvalidRequest, fmt.Sprintf("unsupported continuation policy %q", request.Continuation))
@@ -82,75 +122,60 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 		return resultFromContext(ctx, err)
 	}
 
-	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(ctx, c.agentID)
+	identity := conversationIdentity{agentID: c.agentID, key: request.ConversationKey}
+	turn, replay, existing, admissionResult := c.engine.admit(ctx, identity, request)
+	if replay != nil {
+		return replayCompleted(ctx, sink, *replay)
+	}
+	if existing != nil {
+		return awaitActiveTurn(ctx, sink, existing)
+	}
+	if admissionResult != nil {
+		return *admissionResult
+	}
+
+	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(turn.ctx, c.agentID)
 	if resolveErr != nil {
-		return TurnResult{Status: TurnFailed, Error: resolveErr}
+		result := TurnResult{Status: TurnFailed, Error: resolveErr}
+		turn.cancel()
+		c.engine.complete(identity, turn, result)
+		return result
 	}
 	if releaseRuntime == nil {
 		releaseRuntime = func() {}
 	}
-
-	runCtx, cancel := context.WithCancel(ctx)
-	identity := conversationIdentity{agentID: c.agentID, key: request.ConversationKey}
-	turn := &activeTurn{
-		id:           request.ID,
-		cancel:       cancel,
-		done:         make(chan struct{}),
-		runtime:      runtimeAdapter,
-		interactions: make(map[string]InteractionRequest),
-	}
-	if !c.engine.register(identity, turn) {
-		cancel()
-		releaseRuntime()
-		return failedResult(ErrorConversationBusy, "conversation already has an active turn")
-	}
-	defer func() {
-		c.engine.release(identity, turn)
-		releaseRuntime()
-		close(turn.done)
-	}()
+	c.engine.setRuntime(identity, turn, runtimeAdapter)
 
 	orderedSink := EventSinkFunc(func(eventCtx context.Context, event TurnEvent) error {
-		c.engine.mu.Lock()
-		turn.sequence++
-		event.Sequence = turn.sequence
-		if event.Interaction != nil {
-			interaction := *event.Interaction
-			interaction.ID = strings.TrimSpace(interaction.ID)
-			if interaction.ID != "" {
-				turn.interactions[interaction.ID] = interaction
-				event.Interaction = &interaction
-			}
-		}
-		c.engine.mu.Unlock()
-		return emitTurnEvent(eventCtx, sink, event)
+		return c.engine.recordAndEmit(eventCtx, turn, sink, event)
 	})
-	return runtimeAdapter.Run(runCtx, request, orderedSink)
+	result := runtimeAdapter.Run(turn.ctx, request, orderedSink)
+	turn.cancel()
+	releaseRuntime()
+	c.engine.complete(identity, turn, result)
+	return result
 }
 
 func (c *conversations) Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if c == nil || c.engine == nil || c.agentID == "" || strings.TrimSpace(string(key)) == "" || strings.TrimSpace(string(turnID)) == "" {
+	key = ConversationKey(strings.TrimSpace(string(key)))
+	turnID = TurnID(strings.TrimSpace(string(turnID)))
+	if c == nil || c.engine == nil || c.agentID == "" || key == "" || turnID == "" {
 		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID, conversation key, and turn ID are required"}
 	}
-	identity := conversationIdentity{agentID: c.agentID, key: ConversationKey(strings.TrimSpace(string(key)))}
+	identity := conversationIdentity{agentID: c.agentID, key: key}
 	c.engine.mu.Lock()
 	turn := c.engine.active[identity]
-	if turn == nil || turn.id != TurnID(strings.TrimSpace(string(turnID))) {
+	if turn == nil || turn.request.ID != turnID {
 		c.engine.mu.Unlock()
 		return nil
 	}
 	turn.cancel()
 	done := turn.done
 	c.engine.mu.Unlock()
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return waitForCompletion(ctx, done)
 }
 
 func (c *conversations) Reset(ctx context.Context, key ConversationKey) error {
@@ -162,10 +187,16 @@ func (c *conversations) Reset(ctx context.Context, key ConversationKey) error {
 		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and conversation key are required"}
 	}
 	identity := conversationIdentity{agentID: c.agentID, key: key}
-	if !c.engine.beginReset(identity) {
-		return &TurnError{Code: ErrorConversationBusy, Message: "conversation already has an active turn"}
+	control, active, ok := c.engine.beginControl(identity, true)
+	if !ok {
+		return &TurnError{Code: ErrorConversationBusy, Message: "conversation already has a control operation"}
 	}
-	defer c.engine.endReset(identity)
+	defer c.engine.endControl(identity, control)
+	if active != nil {
+		if err := waitForCompletion(ctx, active.done); err != nil {
+			return err
+		}
+	}
 	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(ctx, c.agentID)
 	if resolveErr != nil {
 		return resolveErr
@@ -185,78 +216,333 @@ func (c *conversations) Resolve(ctx context.Context, resolution InteractionResol
 	}
 	resolution.ConversationKey = ConversationKey(strings.TrimSpace(string(resolution.ConversationKey)))
 	resolution.InteractionID = strings.TrimSpace(resolution.InteractionID)
+	resolution.ResponderID = strings.TrimSpace(resolution.ResponderID)
 	if c == nil || c.engine == nil || c.agentID == "" || resolution.ConversationKey == "" || resolution.InteractionID == "" {
 		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID, conversation key, and interaction ID are required"}
 	}
 	identity := conversationIdentity{agentID: c.agentID, key: resolution.ConversationKey}
 	c.engine.mu.Lock()
 	turn := c.engine.active[identity]
-	request, ok := InteractionRequest{}, false
+	var pending *pendingInteraction
 	if turn != nil {
-		request, ok = turn.interactions[resolution.InteractionID]
+		pending = turn.interactions[resolution.InteractionID]
 	}
-	c.engine.mu.Unlock()
-	if !ok {
+	if pending == nil || pending.state != interactionPending || turn.runtime == nil {
+		c.engine.mu.Unlock()
 		return &TurnError{Code: ErrorInteractionNotFound, Message: "pending interaction was not found"}
 	}
-	if err := turn.runtime.Resolve(ctx, request, resolution); err != nil {
+	pending.state = interactionResolving
+	request := pending.request
+	runtimeAdapter := turn.runtime
+	c.engine.mu.Unlock()
+
+	if err := runtimeAdapter.Resolve(ctx, request, resolution); err != nil {
+		c.engine.mu.Lock()
+		if current := c.engine.active[identity]; current == turn {
+			if currentPending := turn.interactions[resolution.InteractionID]; currentPending == pending && currentPending.state == interactionResolving {
+				currentPending.state = interactionPending
+			}
+		}
+		c.engine.mu.Unlock()
 		return err
 	}
 	c.engine.mu.Lock()
 	if current := c.engine.active[identity]; current == turn {
-		delete(turn.interactions, resolution.InteractionID)
+		if currentPending := turn.interactions[resolution.InteractionID]; currentPending == pending {
+			delete(turn.interactions, resolution.InteractionID)
+		}
 	}
 	c.engine.mu.Unlock()
 	return nil
 }
 
-func (e *Engine) register(identity conversationIdentity, turn *activeTurn) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+func (e *Engine) admit(ctx context.Context, identity conversationIdentity, request TurnRequest) (*activeTurn, *completedTurn, *activeTurn, *TurnResult) {
+	for {
+		e.mu.Lock()
+		e.ensureState()
+		turnKey := turnIdentity{conversationIdentity: identity, id: request.ID}
+		if completed, ok := e.completed[turnKey]; ok {
+			if !sameTurnRequest(completed.request, request) {
+				e.mu.Unlock()
+				result := failedResult(ErrorInvalidRequest, "turn ID was already used with a different request")
+				return nil, nil, nil, &result
+			}
+			copy := cloneCompletedTurn(completed)
+			e.mu.Unlock()
+			return nil, &copy, nil, nil
+		}
+		if current := e.active[identity]; current != nil && current.request.ID == request.ID {
+			if !sameTurnRequest(current.request, request) {
+				e.mu.Unlock()
+				result := failedResult(ErrorInvalidRequest, "turn ID is active with a different request")
+				return nil, nil, nil, &result
+			}
+			e.mu.Unlock()
+			return nil, nil, current, nil
+		}
+		control := e.controls[identity]
+		current := e.active[identity]
+		if control == nil && current == nil {
+			turn := newActiveTurn(ctx, request)
+			e.active[identity] = turn
+			e.mu.Unlock()
+			return turn, nil, nil, nil
+		}
+		switch request.Admission {
+		case AdmissionRejectIfBusy:
+			e.mu.Unlock()
+			result := failedResult(ErrorConversationBusy, "conversation already has an active turn or control operation")
+			return nil, nil, nil, &result
+		case AdmissionWait:
+			done := controlDone(control, current)
+			e.mu.Unlock()
+			if err := waitForCompletion(ctx, done); err != nil {
+				result := resultFromContext(ctx, err)
+				return nil, nil, nil, &result
+			}
+		case AdmissionSupersede:
+			if control != nil {
+				done := control.done
+				e.mu.Unlock()
+				if err := waitForCompletion(ctx, done); err != nil {
+					result := resultFromContext(ctx, err)
+					return nil, nil, nil, &result
+				}
+				continue
+			}
+			owned := &conversationControl{done: make(chan struct{})}
+			e.controls[identity] = owned
+			current.cancel()
+			done := current.done
+			e.mu.Unlock()
+			if err := waitForCompletion(ctx, done); err != nil {
+				e.endControl(identity, owned)
+				result := resultFromContext(ctx, err)
+				return nil, nil, nil, &result
+			}
+			turn := newActiveTurn(ctx, request)
+			if !e.promoteControl(identity, owned, turn) {
+				turn.cancel()
+				result := failedResult(ErrorConversationBusy, "conversation admission changed while superseding")
+				return nil, nil, nil, &result
+			}
+			return turn, nil, nil, nil
+		}
+	}
+}
+
+func newActiveTurn(ctx context.Context, request TurnRequest) *activeTurn {
+	runCtx, cancel := context.WithCancel(ctx)
+	return &activeTurn{
+		request:      cloneTurnRequest(request),
+		ctx:          runCtx,
+		cancel:       cancel,
+		done:         make(chan struct{}),
+		interactions: make(map[string]*pendingInteraction),
+	}
+}
+
+func (e *Engine) ensureState() {
 	if e.active == nil {
 		e.active = make(map[conversationIdentity]*activeTurn)
 	}
-	if e.resetting == nil {
-		e.resetting = make(map[conversationIdentity]struct{})
+	if e.controls == nil {
+		e.controls = make(map[conversationIdentity]*conversationControl)
 	}
-	if e.active[identity] != nil {
-		return false
+	if e.completed == nil {
+		e.completed = make(map[turnIdentity]completedTurn)
 	}
-	if _, resetting := e.resetting[identity]; resetting {
+}
+
+func (e *Engine) setRuntime(identity conversationIdentity, turn *activeTurn, runtimeAdapter conversationRuntimeAdapter) {
+	e.mu.Lock()
+	if e.active[identity] == turn {
+		turn.runtime = runtimeAdapter
+	}
+	e.mu.Unlock()
+}
+
+func (e *Engine) beginControl(identity conversationIdentity, cancelActive bool) (*conversationControl, *activeTurn, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ensureState()
+	if e.controls[identity] != nil {
+		return nil, nil, false
+	}
+	control := &conversationControl{done: make(chan struct{})}
+	e.controls[identity] = control
+	active := e.active[identity]
+	if cancelActive && active != nil {
+		active.cancel()
+	}
+	return control, active, true
+}
+
+func (e *Engine) promoteControl(identity conversationIdentity, control *conversationControl, turn *activeTurn) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.controls[identity] != control || e.active[identity] != nil {
 		return false
 	}
 	e.active[identity] = turn
+	delete(e.controls, identity)
+	close(control.done)
 	return true
 }
 
-func (e *Engine) release(identity conversationIdentity, turn *activeTurn) {
+func (e *Engine) endControl(identity conversationIdentity, control *conversationControl) {
+	e.mu.Lock()
+	if e.controls[identity] == control {
+		delete(e.controls, identity)
+		close(control.done)
+	}
+	e.mu.Unlock()
+}
+
+func (e *Engine) recordAndEmit(ctx context.Context, turn *activeTurn, sink EventSink, event TurnEvent) error {
+	e.mu.Lock()
+	turn.sequence++
+	event.TurnID = turn.request.ID
+	event.Sequence = turn.sequence
+	if event.Interaction != nil {
+		interaction := *event.Interaction
+		interaction.ID = strings.TrimSpace(interaction.ID)
+		if interaction.ID != "" {
+			turn.interactions[interaction.ID] = &pendingInteraction{request: interaction, state: interactionPending}
+			event.Interaction = &interaction
+		}
+	}
+	turn.events = append(turn.events, cloneTurnEvent(event))
+	e.mu.Unlock()
+	return emitTurnEvent(ctx, sink, cloneTurnEvent(event))
+}
+
+func (e *Engine) complete(identity conversationIdentity, turn *activeTurn, result TurnResult) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	turn.result = cloneTurnResult(result)
 	if e.active[identity] == turn {
 		delete(e.active, identity)
 	}
+	if result.Dispatched {
+		e.ensureState()
+		key := turnIdentity{conversationIdentity: identity, id: turn.request.ID}
+		e.completed[key] = completedTurn{request: cloneTurnRequest(turn.request), events: cloneTurnEvents(turn.events), result: cloneTurnResult(result)}
+		e.completedOrder = append(e.completedOrder, key)
+		if len(e.completedOrder) > maxCompletedTurns {
+			oldest := e.completedOrder[0]
+			e.completedOrder = e.completedOrder[1:]
+			delete(e.completed, oldest)
+		}
+	}
+	close(turn.done)
 }
 
-func (e *Engine) beginReset(identity conversationIdentity) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.resetting == nil {
-		e.resetting = make(map[conversationIdentity]struct{})
+func awaitActiveTurn(ctx context.Context, sink EventSink, turn *activeTurn) TurnResult {
+	if err := waitForCompletion(ctx, turn.done); err != nil {
+		return resultFromContext(ctx, err)
 	}
-	if e.active[identity] != nil {
-		return false
-	}
-	if _, exists := e.resetting[identity]; exists {
-		return false
-	}
-	e.resetting[identity] = struct{}{}
-	return true
+	events := cloneTurnEvents(turn.events)
+	result := cloneTurnResult(turn.result)
+	return replayEvents(ctx, sink, events, result)
 }
 
-func (e *Engine) endReset(identity conversationIdentity) {
-	e.mu.Lock()
-	delete(e.resetting, identity)
-	e.mu.Unlock()
+func replayCompleted(ctx context.Context, sink EventSink, completed completedTurn) TurnResult {
+	return replayEvents(ctx, sink, completed.events, completed.result)
+}
+
+func replayEvents(ctx context.Context, sink EventSink, events []TurnEvent, result TurnResult) TurnResult {
+	for _, event := range events {
+		if err := emitTurnEvent(ctx, sink, cloneTurnEvent(event)); err != nil {
+			failed := failedResult(ErrorRuntimeFailed, err.Error())
+			failed.Dispatched = result.Dispatched
+			return failed
+		}
+	}
+	return cloneTurnResult(result)
+}
+
+func waitForCompletion(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func controlDone(control *conversationControl, turn *activeTurn) <-chan struct{} {
+	if control != nil {
+		return control.done
+	}
+	return turn.done
+}
+
+func sameTurnRequest(left, right TurnRequest) bool {
+	left.Admission = ""
+	right.Admission = ""
+	return reflect.DeepEqual(left, right)
+}
+
+func cloneCompletedTurn(input completedTurn) completedTurn {
+	input.request = cloneTurnRequest(input.request)
+	input.events = cloneTurnEvents(input.events)
+	input.result = cloneTurnResult(input.result)
+	return input
+}
+
+func cloneTurnRequest(input TurnRequest) TurnRequest {
+	input.Input = append([]InputPart(nil), input.Input...)
+	for index := range input.Input {
+		if input.Input[index].File != nil {
+			fileCopy := *input.Input[index].File
+			input.Input[index].File = &fileCopy
+		}
+	}
+	return input
+}
+
+func cloneTurnEvents(input []TurnEvent) []TurnEvent {
+	output := make([]TurnEvent, len(input))
+	for index, event := range input {
+		output[index] = cloneTurnEvent(event)
+	}
+	return output
+}
+
+func cloneTurnEvent(input TurnEvent) TurnEvent {
+	if input.Tool != nil {
+		copy := *input.Tool
+		input.Tool = &copy
+	}
+	if input.Activity != nil {
+		copy := *input.Activity
+		input.Activity = &copy
+	}
+	if input.Interaction != nil {
+		copy := *input.Interaction
+		input.Interaction = &copy
+	}
+	if input.Output != nil {
+		copy := *input.Output
+		input.Output = &copy
+	}
+	return input
+}
+
+func cloneTurnResult(input TurnResult) TurnResult {
+	if input.Error != nil {
+		errorCopy := *input.Error
+		input.Error = &errorCopy
+	}
+	return input
+}
+
+func normalizedAdmission(policy AdmissionPolicy) AdmissionPolicy {
+	if strings.TrimSpace(string(policy)) == "" {
+		return AdmissionRejectIfBusy
+	}
+	return AdmissionPolicy(strings.TrimSpace(strings.ToLower(string(policy))))
 }
 
 func normalizedContinuation(policy ContinuationPolicy) ContinuationPolicy {

--- a/internal/agentengine/engine.go
+++ b/internal/agentengine/engine.go
@@ -4,20 +4,49 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 type conversationRuntimeResolver interface {
-	conversationRuntime(agentID string) (conversationRuntimeAdapter, *TurnError)
+	conversationRuntime(ctx context.Context, agentID string) (conversationRuntimeAdapter, func(), *TurnError)
 }
 
 type conversationRuntimeAdapter interface {
 	Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult
+	Reset(ctx context.Context, key ConversationKey) *TurnError
+	Resolve(ctx context.Context, request InteractionRequest, resolution InteractionResolution) *TurnError
 }
 
-// Engine is the Phase 1 in-process Conversation implementation.
-// Agent CRUD and lifecycle remain owned by the existing Agent Service.
+// Engine owns normalized Agent operations, conversation admission, active Turn
+// identity, pending interactions, and ordered event delivery.
 type Engine struct {
+	agents   AgentInterface
 	runtimes conversationRuntimeResolver
+
+	mu        sync.Mutex
+	active    map[conversationIdentity]*activeTurn
+	resetting map[conversationIdentity]struct{}
+}
+
+type conversationIdentity struct {
+	agentID string
+	key     ConversationKey
+}
+
+type activeTurn struct {
+	id           TurnID
+	cancel       context.CancelFunc
+	done         chan struct{}
+	runtime      conversationRuntimeAdapter
+	interactions map[string]InteractionRequest
+	sequence     uint64
+}
+
+func (e *Engine) Agents() AgentInterface {
+	if e == nil || e.agents == nil {
+		return unavailableAgents{}
+	}
+	return e.agents
 }
 
 func (e *Engine) Conversations(agentID string) ConversationInterface {
@@ -35,33 +64,228 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	}
 	request.ConversationKey = ConversationKey(strings.TrimSpace(string(request.ConversationKey)))
 	request.ID = TurnID(strings.TrimSpace(string(request.ID)))
+	request.Continuation = normalizedContinuation(request.Continuation)
+	request.Interaction = normalizedInteraction(request.Interaction)
 	if c == nil || c.engine == nil || c.engine.runtimes == nil || c.agentID == "" || request.ID == "" || request.ConversationKey == "" || len(request.Input) == 0 {
 		return failedResult(ErrorInvalidRequest, "agent ID, turn ID, conversation key, and input are required")
+	}
+	if request.Continuation != ContinuationCreateOrResume && request.Continuation != ContinuationRequireExisting {
+		return failedResult(ErrorInvalidRequest, fmt.Sprintf("unsupported continuation policy %q", request.Continuation))
+	}
+	if request.Interaction != InteractionResolve && request.Interaction != InteractionReject && request.Interaction != InteractionSkipUserInput {
+		return failedResult(ErrorInvalidRequest, fmt.Sprintf("unsupported interaction policy %q", request.Interaction))
 	}
 	if err := validateInput(request.Input); err != nil {
 		return TurnResult{Status: TurnFailed, Error: err}
 	}
-
-	runtimeAdapter, err := c.engine.runtimes.conversationRuntime(c.agentID)
-	if err != nil {
-		return TurnResult{Status: TurnFailed, Error: err}
+	if err := ctx.Err(); err != nil {
+		return resultFromContext(ctx, err)
 	}
-	return runtimeAdapter.Run(ctx, request, sink)
+
+	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(ctx, c.agentID)
+	if resolveErr != nil {
+		return TurnResult{Status: TurnFailed, Error: resolveErr}
+	}
+	if releaseRuntime == nil {
+		releaseRuntime = func() {}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	identity := conversationIdentity{agentID: c.agentID, key: request.ConversationKey}
+	turn := &activeTurn{
+		id:           request.ID,
+		cancel:       cancel,
+		done:         make(chan struct{}),
+		runtime:      runtimeAdapter,
+		interactions: make(map[string]InteractionRequest),
+	}
+	if !c.engine.register(identity, turn) {
+		cancel()
+		releaseRuntime()
+		return failedResult(ErrorConversationBusy, "conversation already has an active turn")
+	}
+	defer func() {
+		c.engine.release(identity, turn)
+		releaseRuntime()
+		close(turn.done)
+	}()
+
+	orderedSink := EventSinkFunc(func(eventCtx context.Context, event TurnEvent) error {
+		c.engine.mu.Lock()
+		turn.sequence++
+		event.Sequence = turn.sequence
+		if event.Interaction != nil {
+			interaction := *event.Interaction
+			interaction.ID = strings.TrimSpace(interaction.ID)
+			if interaction.ID != "" {
+				turn.interactions[interaction.ID] = interaction
+				event.Interaction = &interaction
+			}
+		}
+		c.engine.mu.Unlock()
+		return emitTurnEvent(eventCtx, sink, event)
+	})
+	return runtimeAdapter.Run(runCtx, request, orderedSink)
+}
+
+func (c *conversations) Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c == nil || c.engine == nil || c.agentID == "" || strings.TrimSpace(string(key)) == "" || strings.TrimSpace(string(turnID)) == "" {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID, conversation key, and turn ID are required"}
+	}
+	identity := conversationIdentity{agentID: c.agentID, key: ConversationKey(strings.TrimSpace(string(key)))}
+	c.engine.mu.Lock()
+	turn := c.engine.active[identity]
+	if turn == nil || turn.id != TurnID(strings.TrimSpace(string(turnID))) {
+		c.engine.mu.Unlock()
+		return nil
+	}
+	turn.cancel()
+	done := turn.done
+	c.engine.mu.Unlock()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *conversations) Reset(ctx context.Context, key ConversationKey) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	key = ConversationKey(strings.TrimSpace(string(key)))
+	if c == nil || c.engine == nil || c.engine.runtimes == nil || c.agentID == "" || key == "" {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and conversation key are required"}
+	}
+	identity := conversationIdentity{agentID: c.agentID, key: key}
+	if !c.engine.beginReset(identity) {
+		return &TurnError{Code: ErrorConversationBusy, Message: "conversation already has an active turn"}
+	}
+	defer c.engine.endReset(identity)
+	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(ctx, c.agentID)
+	if resolveErr != nil {
+		return resolveErr
+	}
+	if releaseRuntime != nil {
+		defer releaseRuntime()
+	}
+	if err := runtimeAdapter.Reset(ctx, key); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *conversations) Resolve(ctx context.Context, resolution InteractionResolution) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolution.ConversationKey = ConversationKey(strings.TrimSpace(string(resolution.ConversationKey)))
+	resolution.InteractionID = strings.TrimSpace(resolution.InteractionID)
+	if c == nil || c.engine == nil || c.agentID == "" || resolution.ConversationKey == "" || resolution.InteractionID == "" {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID, conversation key, and interaction ID are required"}
+	}
+	identity := conversationIdentity{agentID: c.agentID, key: resolution.ConversationKey}
+	c.engine.mu.Lock()
+	turn := c.engine.active[identity]
+	request, ok := InteractionRequest{}, false
+	if turn != nil {
+		request, ok = turn.interactions[resolution.InteractionID]
+	}
+	c.engine.mu.Unlock()
+	if !ok {
+		return &TurnError{Code: ErrorInteractionNotFound, Message: "pending interaction was not found"}
+	}
+	if err := turn.runtime.Resolve(ctx, request, resolution); err != nil {
+		return err
+	}
+	c.engine.mu.Lock()
+	if current := c.engine.active[identity]; current == turn {
+		delete(turn.interactions, resolution.InteractionID)
+	}
+	c.engine.mu.Unlock()
+	return nil
+}
+
+func (e *Engine) register(identity conversationIdentity, turn *activeTurn) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.active == nil {
+		e.active = make(map[conversationIdentity]*activeTurn)
+	}
+	if e.resetting == nil {
+		e.resetting = make(map[conversationIdentity]struct{})
+	}
+	if e.active[identity] != nil {
+		return false
+	}
+	if _, resetting := e.resetting[identity]; resetting {
+		return false
+	}
+	e.active[identity] = turn
+	return true
+}
+
+func (e *Engine) release(identity conversationIdentity, turn *activeTurn) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.active[identity] == turn {
+		delete(e.active, identity)
+	}
+}
+
+func (e *Engine) beginReset(identity conversationIdentity) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.resetting == nil {
+		e.resetting = make(map[conversationIdentity]struct{})
+	}
+	if e.active[identity] != nil {
+		return false
+	}
+	if _, exists := e.resetting[identity]; exists {
+		return false
+	}
+	e.resetting[identity] = struct{}{}
+	return true
+}
+
+func (e *Engine) endReset(identity conversationIdentity) {
+	e.mu.Lock()
+	delete(e.resetting, identity)
+	e.mu.Unlock()
+}
+
+func normalizedContinuation(policy ContinuationPolicy) ContinuationPolicy {
+	if strings.TrimSpace(string(policy)) == "" {
+		return ContinuationCreateOrResume
+	}
+	return ContinuationPolicy(strings.TrimSpace(strings.ToLower(string(policy))))
+}
+
+func normalizedInteraction(policy InteractionPolicy) InteractionPolicy {
+	if strings.TrimSpace(string(policy)) == "" {
+		return InteractionResolve
+	}
+	return InteractionPolicy(strings.TrimSpace(strings.ToLower(string(policy))))
 }
 
 func validateInput(input []InputPart) *TurnError {
 	for _, part := range input {
 		switch part.Kind {
 		case InputPartText:
-			if part.File != nil {
-				return &TurnError{Code: ErrorInvalidRequest, Message: "text input must not include a file"}
-			}
-			if strings.TrimSpace(part.Text) == "" {
-				return &TurnError{Code: ErrorInvalidRequest, Message: "text input must not be empty"}
+			if part.File != nil || strings.TrimSpace(part.Text) == "" {
+				return &TurnError{Code: ErrorInvalidRequest, Message: "text input must contain only non-empty text"}
 			}
 		case InputPartFile:
 			if part.File == nil || strings.TrimSpace(part.Text) != "" {
 				return &TurnError{Code: ErrorInvalidRequest, Message: "file input must include only a file"}
+			}
+			if strings.TrimSpace(part.File.ID) == "" || strings.TrimSpace(part.File.SourcePath) == "" || strings.TrimSpace(part.File.Name) == "" || strings.TrimSpace(part.File.MediaType) == "" || part.File.SizeBytes < 0 || len(strings.TrimSpace(part.File.SHA256)) != 64 {
+				return &TurnError{Code: ErrorInvalidRequest, Message: "file ID, source path, name, media type, non-negative size, and SHA-256 are required"}
 			}
 		default:
 			return &TurnError{Code: ErrorInvalidRequest, Message: fmt.Sprintf("unsupported input kind %q", part.Kind)}

--- a/internal/agentengine/engine_test.go
+++ b/internal/agentengine/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -825,6 +826,133 @@ func TestConversationResetRemovesStrictContinuationMapping(t *testing.T) {
 	}, nil)
 	if strict.Error == nil || strict.Error.Code != ErrorConversationNotResumable || strict.Dispatched {
 		t.Fatalf("strict result = %+v", strict)
+	}
+}
+
+type directConversationResolver struct {
+	runtime conversationRuntimeAdapter
+}
+
+func (r directConversationResolver) conversationRuntime(context.Context, string) (conversationRuntimeAdapter, func(), *TurnError) {
+	return r.runtime, func() {}, nil
+}
+
+type interactionClaimRuntime struct {
+	finishRun chan struct{}
+	resolve   func(context.Context, InteractionRequest, InteractionResolution) *TurnError
+}
+
+func (r *interactionClaimRuntime) Run(ctx context.Context, _ TurnRequest, sink EventSink) TurnResult {
+	if err := sink.Emit(ctx, TurnEvent{
+		Kind:        TurnEventInteractionRequest,
+		Interaction: &InteractionRequest{ID: "question-1", Kind: InteractionUserInput},
+	}); err != nil {
+		return TurnResult{Status: TurnFailed, Dispatched: true, Error: &TurnError{Code: ErrorRuntimeFailed, Message: err.Error()}}
+	}
+	<-r.finishRun
+	return TurnResult{Status: TurnSucceeded, Dispatched: true}
+}
+
+func (*interactionClaimRuntime) Reset(context.Context, ConversationKey) *TurnError {
+	return nil
+}
+
+func (r *interactionClaimRuntime) Resolve(ctx context.Context, request InteractionRequest, resolution InteractionResolution) *TurnError {
+	return r.resolve(ctx, request, resolution)
+}
+
+func TestConversationResolveClaimsInteractionBeforeRuntimeCall(t *testing.T) {
+	resolveStarted := make(chan struct{})
+	releaseResolve := make(chan struct{})
+	var resolveCalls atomic.Int32
+	runtimeAdapter := &interactionClaimRuntime{
+		finishRun: make(chan struct{}),
+		resolve: func(context.Context, InteractionRequest, InteractionResolution) *TurnError {
+			if resolveCalls.Add(1) == 1 {
+				close(resolveStarted)
+				<-releaseResolve
+			}
+			return nil
+		},
+	}
+	engine := &Engine{runtimes: directConversationResolver{runtime: runtimeAdapter}}
+	interactionReady := make(chan struct{})
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Interaction: InteractionResolve, Input: textInput("hello"),
+		}, EventSinkFunc(func(_ context.Context, event TurnEvent) error {
+			if event.Interaction != nil {
+				close(interactionReady)
+			}
+			return nil
+		}))
+	}()
+	<-interactionReady
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- engine.Conversations("agent-a").Resolve(context.Background(), InteractionResolution{
+			ConversationKey: "conversation-1", InteractionID: "question-1", ResponderID: "feishu:user-1",
+		})
+	}()
+	<-resolveStarted
+	second := engine.Conversations("agent-a").Resolve(context.Background(), InteractionResolution{
+		ConversationKey: "conversation-1", InteractionID: "question-1", ResponderID: "feishu:user-1",
+	})
+	if ErrorCodeOf(second) != ErrorInteractionNotFound {
+		t.Fatalf("duplicate Resolve error = %v", second)
+	}
+	if calls := resolveCalls.Load(); calls != 1 {
+		t.Fatalf("Runtime Resolve calls = %d, want 1", calls)
+	}
+	close(releaseResolve)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	close(runtimeAdapter.finishRun)
+	if result := <-runDone; result.Status != TurnSucceeded {
+		t.Fatalf("Run() = %+v", result)
+	}
+}
+
+func TestConversationResolveRestoresClaimAfterRuntimeFailure(t *testing.T) {
+	var resolveCalls atomic.Int32
+	runtimeAdapter := &interactionClaimRuntime{
+		finishRun: make(chan struct{}),
+		resolve: func(context.Context, InteractionRequest, InteractionResolution) *TurnError {
+			if resolveCalls.Add(1) == 1 {
+				return &TurnError{Code: ErrorRuntimeFailed, Message: "temporary failure"}
+			}
+			return nil
+		},
+	}
+	engine := &Engine{runtimes: directConversationResolver{runtime: runtimeAdapter}}
+	interactionReady := make(chan struct{})
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Interaction: InteractionResolve, Input: textInput("hello"),
+		}, EventSinkFunc(func(_ context.Context, event TurnEvent) error {
+			if event.Interaction != nil {
+				close(interactionReady)
+			}
+			return nil
+		}))
+	}()
+	<-interactionReady
+	resolution := InteractionResolution{ConversationKey: "conversation-1", InteractionID: "question-1", ResponderID: "feishu:user-1"}
+	if err := engine.Conversations("agent-a").Resolve(context.Background(), resolution); ErrorCodeOf(err) != ErrorRuntimeFailed {
+		t.Fatalf("first Resolve error = %v", err)
+	}
+	if err := engine.Conversations("agent-a").Resolve(context.Background(), resolution); err != nil {
+		t.Fatalf("retried Resolve error = %v", err)
+	}
+	if calls := resolveCalls.Load(); calls != 2 {
+		t.Fatalf("Runtime Resolve calls = %d, want 2", calls)
+	}
+	close(runtimeAdapter.finishRun)
+	if result := <-runDone; result.Status != TurnSucceeded {
+		t.Fatalf("Run() = %+v", result)
 	}
 }
 

--- a/internal/agentengine/engine_test.go
+++ b/internal/agentengine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,17 +16,33 @@ import (
 	"csgclaw/internal/agent"
 	"csgclaw/internal/config"
 	"csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/codex"
 )
 
 type fakeConversationRuntime struct {
 	mu              sync.Mutex
 	subscribers     []chan activity.RuntimeEvent
 	conversationKey string
+	conversations   map[string]string
+	workspace       string
+	permission      *codex.MemoryPermissionBroker
+	userInput       *codex.MemoryUserInputBroker
+	turnID          string
+	promptBlocks    []codex.PromptContentBlock
 	prompt          func(context.Context, string, string, string) error
+	provision       func(context.Context, runtime.ProvisionRequest) error
+	state           runtime.State
+	closeEvents     bool
+	deleteCalls     int
 }
 
-func (*fakeConversationRuntime) Kind() string                 { return runtime.KindCodex }
-func (*fakeConversationRuntime) Layout(string) runtime.Layout { return runtime.Layout{} }
+func (*fakeConversationRuntime) Kind() string { return runtime.KindCodex }
+func (*fakeConversationRuntime) Layout(root string) runtime.Layout {
+	return runtime.Layout{
+		WorkspaceRoot: filepath.Join(root, "workspace"),
+		SkillsRoot:    filepath.Join(root, "workspace", ".agents", "skills"),
+	}
+}
 func (*fakeConversationRuntime) New(_ context.Context, spec runtime.Spec) (runtime.Handle, error) {
 	return runtime.Handle{RuntimeID: spec.RuntimeID}, nil
 }
@@ -35,25 +52,101 @@ func (*fakeConversationRuntime) Start(context.Context, runtime.Handle) (runtime.
 func (*fakeConversationRuntime) Stop(context.Context, runtime.Handle) (runtime.State, error) {
 	return runtime.StateStopped, nil
 }
-func (*fakeConversationRuntime) Delete(context.Context, runtime.Handle) error { return nil }
-func (*fakeConversationRuntime) State(context.Context, runtime.Handle) (runtime.State, error) {
+func (f *fakeConversationRuntime) Delete(context.Context, runtime.Handle) error {
+	f.deleteCalls++
+	return nil
+}
+func (f *fakeConversationRuntime) State(context.Context, runtime.Handle) (runtime.State, error) {
+	if f.state != "" {
+		return f.state, nil
+	}
 	return runtime.StateRunning, nil
 }
-func (*fakeConversationRuntime) Info(context.Context, runtime.Handle) (runtime.Info, error) {
+func (f *fakeConversationRuntime) Info(context.Context, runtime.Handle) (runtime.Info, error) {
+	if f.state != "" {
+		return runtime.Info{State: f.state}, nil
+	}
 	return runtime.Info{State: runtime.StateRunning}, nil
 }
-func (f *fakeConversationRuntime) EnsureSession(_ context.Context, _, conversationKey string) (string, error) {
-	f.conversationKey = conversationKey
-	return "codex-thread", nil
+func (*fakeConversationRuntime) ValidateMCPServers(context.Context, runtime.MCPServersSnapshot) error {
+	return nil
 }
-func (f *fakeConversationRuntime) Prompt(ctx context.Context, runtimeID, sessionID, prompt string) error {
-	if f.prompt != nil {
-		return f.prompt(ctx, runtimeID, sessionID, prompt)
+func (*fakeConversationRuntime) MCPServersRestartRequired(runtime.MCPServersChange) (bool, error) {
+	return false, nil
+}
+func (*fakeConversationRuntime) ReconcileMCPServers(context.Context, runtime.Handle, runtime.MCPServersChange) error {
+	return nil
+}
+func (f *fakeConversationRuntime) Provision(ctx context.Context, request runtime.ProvisionRequest) error {
+	if f.provision != nil {
+		return f.provision(ctx, request)
 	}
 	return nil
 }
+func (f *fakeConversationRuntime) EnsureSession(_ context.Context, _, conversationKey string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.conversationKey = conversationKey
+	if f.conversations == nil {
+		f.conversations = make(map[string]string)
+	}
+	f.conversations[conversationKey] = "codex-thread"
+	return "codex-thread", nil
+}
+func (f *fakeConversationRuntime) ExistingSession(_ context.Context, _, conversationKey string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sessionID := f.conversations[conversationKey]
+	return sessionID, sessionID != "", nil
+}
+func (f *fakeConversationRuntime) PromptTurn(ctx context.Context, runtimeID, sessionID, turnID string, blocks []codex.PromptContentBlock, accepted func()) error {
+	f.mu.Lock()
+	f.turnID = turnID
+	f.promptBlocks = append([]codex.PromptContentBlock(nil), blocks...)
+	f.mu.Unlock()
+	if accepted != nil {
+		accepted()
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Text != nil {
+			parts = append(parts, block.Text.Text)
+		} else if block.LocalImage != nil {
+			parts = append(parts, block.LocalImage.Path)
+		}
+	}
+	if f.prompt != nil {
+		return f.prompt(ctx, runtimeID, sessionID, strings.Join(parts, "\n\n"))
+	}
+	return nil
+}
+func (f *fakeConversationRuntime) ResetConversation(_ context.Context, _, conversationKey string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.conversations, conversationKey)
+	return nil
+}
+func (f *fakeConversationRuntime) WorkspaceDir(string) (string, error) {
+	return f.workspace, nil
+}
+func (f *fakeConversationRuntime) PermissionBroker() codex.PermissionBroker {
+	if f.permission == nil {
+		f.permission = codex.NewPermissionBroker(nil)
+	}
+	return f.permission
+}
+func (f *fakeConversationRuntime) UserInputBroker() codex.UserInputBroker {
+	if f.userInput == nil {
+		f.userInput = codex.NewUserInputBroker(nil)
+	}
+	return f.userInput
+}
 func (f *fakeConversationRuntime) SubscribeSession(_, _ string) (<-chan activity.RuntimeEvent, func()) {
 	ch := make(chan activity.RuntimeEvent, 8)
+	if f.closeEvents {
+		close(ch)
+		return ch, func() {}
+	}
 	f.mu.Lock()
 	f.subscribers = append(f.subscribers, ch)
 	f.mu.Unlock()
@@ -68,12 +161,137 @@ func (f *fakeConversationRuntime) SubscribeSession(_, _ string) (<-chan activity
 		}
 	}
 }
+
+func TestConversationRunWaitsForPromptAfterEventSubscriptionCloses(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{closeEvents: true}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runtimeImpl.prompt = func(context.Context, string, string, string) error {
+		close(started)
+		<-release
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	done := make(chan TurnResult, 1)
+	go func() {
+		done <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+		}, nil)
+	}()
+	<-started
+	select {
+	case result := <-done:
+		t.Fatalf("Run returned before PromptTurn completed: %+v", result)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if result := <-done; result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorRuntimeFailed || !result.Dispatched {
+		t.Fatalf("Run() = %+v", result)
+	}
+}
 func (f *fakeConversationRuntime) publish(event activity.RuntimeEvent) {
 	f.mu.Lock()
 	subscribers := append([]chan activity.RuntimeEvent(nil), f.subscribers...)
 	f.mu.Unlock()
 	for _, subscriber := range subscribers {
 		subscriber <- event
+	}
+}
+
+func TestEngineAgentsFacadeMapsAndRedactsCompleteState(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{state: runtime.StateStopped}
+	service := newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Description: "desc", Instructions: "instructions", Role: agent.RoleWorker,
+		RuntimeKind: agent.RuntimeKindCodex, RuntimeName: agent.RuntimeNameCodex, RuntimeID: "runtime-a",
+		Status: string(runtime.StateStopped), RuntimeOptions: map[string]any{"approval": "never"},
+		MCPServers: map[string]any{"docs": map[string]any{"command": "docs-server"}},
+		AgentProfile: agent.AgentProfile{
+			ModelProviderID: "provider-a", ModelID: "gpt-test", ReasoningEffort: "high",
+			EnableFastMode: true, RequestOptions: map[string]any{"temperature": 0.1}, APIKey: "must-not-leak",
+		},
+	}}, runtimeImpl)
+	engine := New(service)
+	got, err := engine.Agents().Get(context.Background(), "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "agent-a" || got.Spec.Runtime.Adapter != agent.RuntimeNameCodex ||
+		got.Spec.Model.ProviderID != "provider-a" || got.Spec.Model.ModelID != "gpt-test" ||
+		got.Spec.MCPServers["docs"]["command"] != "docs-server" || got.Status.State != AgentStateStopped {
+		t.Fatalf("Agent = %+v", got)
+	}
+	if got.Spec.Runtime.Credentials != nil {
+		t.Fatalf("Runtime credentials leaked: %+v", got.Spec.Runtime.Credentials)
+	}
+	updated, err := engine.Agents().Update(context.Background(), got.ID, AgentSpec{
+		Name: "A2", Description: "updated", Instructions: "new instructions", Role: AgentRoleWorker,
+		Runtime: RuntimeSpec{Adapter: agent.RuntimeNameCodex, Options: map[string]any{"approval": "never"}},
+		Model:   ModelSpec{ProviderID: "provider-a", ModelID: "gpt-test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.Name != "A2" || updated.Spec.MCPServers["docs"] != nil || len(updated.Spec.MCPServers) != 0 {
+		t.Fatalf("updated Agent = %+v", updated)
+	}
+	runtimeImpl.provision = func(_ context.Context, request runtime.ProvisionRequest) error {
+		if request.Credentials["secrets/token"] != "secret" || request.InitShell != "test -f secrets/token" {
+			t.Fatalf("Provision() request = %+v", request)
+		}
+		return nil
+	}
+	provisioned, err := engine.Agents().Update(context.Background(), got.ID, AgentSpec{
+		Name: "A2", Role: AgentRoleWorker,
+		Runtime: RuntimeSpec{Adapter: agent.RuntimeNameCodex, Credentials: map[string]string{"secrets/token": "secret"}, InitShell: "test -f secrets/token"},
+		Model:   ModelSpec{ProviderID: "provider-a", ModelID: "gpt-test"},
+	})
+	if err != nil || provisioned.Spec.Runtime.Credentials != nil || provisioned.Spec.Runtime.InitShell != "test -f secrets/token" {
+		t.Fatalf("provisioned Agent = %+v, %v", provisioned, err)
+	}
+	runtimeImpl.provision = func(context.Context, runtime.ProvisionRequest) error { return errors.New("init failed") }
+	if _, err := engine.Agents().Update(context.Background(), got.ID, AgentSpec{
+		Name: "A2", Role: AgentRoleWorker,
+		Runtime: RuntimeSpec{Adapter: agent.RuntimeNameCodex, Credentials: map[string]string{"secrets/token": "replacement"}, InitShell: "exit 1"},
+		Model:   ModelSpec{ProviderID: "provider-a", ModelID: "gpt-test"},
+	}); err == nil || !strings.Contains(err.Error(), "init failed") {
+		t.Fatalf("failed provisioning error = %v", err)
+	}
+	unchanged, err := engine.Agents().Get(context.Background(), got.ID)
+	if err != nil || unchanged.Spec.Runtime.InitShell != "test -f secrets/token" {
+		t.Fatalf("Agent changed after failed provisioning: %+v, %v", unchanged, err)
+	}
+}
+
+func TestEngineCreateManagerSkillFailurePreservesExistingManager(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{state: runtime.StateRunning}
+	service := newTestAgentService(t, []agent.Agent{{
+		ID: agent.ManagerUserID, Name: agent.ManagerName, Role: agent.RoleManager,
+		RuntimeKind: agent.RuntimeKindCodex, RuntimeName: agent.RuntimeNameCodex,
+		RuntimeID: "runtime-manager", BoxID: "manager-session", Status: string(runtime.StateRunning),
+		AgentProfile: agent.AgentProfile{
+			ModelProviderID: "provider-a", ModelID: "model-a", ProfileComplete: true,
+		},
+		ProfileComplete: true,
+	}}, runtimeImpl)
+	engine := New(service)
+	_, err := engine.Agents().Create(context.Background(), AgentSpec{
+		Name: agent.ManagerName, Role: AgentRoleManager,
+		Runtime: RuntimeSpec{Adapter: agent.RuntimeNameCodex},
+		Model:   ModelSpec{ProviderID: "provider-a", ModelID: "model-a"},
+		Skills:  []string{"definitely-missing-skill"},
+	})
+	if err == nil {
+		t.Fatal("Create(manager) error = nil, want missing Skill failure")
+	}
+	manager, ok := service.Agent(agent.ManagerUserID)
+	if !ok || manager.RuntimeID == "" {
+		t.Fatalf("existing manager was removed: %+v, %t", manager, ok)
+	}
+	if runtimeImpl.deleteCalls != 0 {
+		t.Fatalf("existing manager Runtime delete calls = %d", runtimeImpl.deleteCalls)
 	}
 }
 
@@ -155,9 +373,63 @@ func TestConversationRunRejectsUnsupportedInteraction(t *testing.T) {
 		return ctx.Err()
 	}
 	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
-		ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+		ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"), Interaction: InteractionReject,
 	}, nil)
 	if result.Error == nil || result.Error.Code != ErrorInteractionUnsupported {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestConversationResolveAddressesPendingUserInput(t *testing.T) {
+	broker := codex.NewUserInputBroker(nil)
+	runtimeImpl := &fakeConversationRuntime{userInput: broker}
+	resolved := make(chan struct{})
+	broker.AddDetachedHandler(func(codex.DetachedUserInputResolution) {
+		close(resolved)
+	})
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		snapshot, err := broker.CreateDetached(codex.PendingUserInputRequest{
+			Execution: activity.ExecutionRef{RuntimeID: runtimeID, SessionID: sessionID},
+			Questions: []activity.UserInputQuestionSnapshot{{
+				ID: "choice", Header: "Choice", Question: "Continue?",
+				Options: []activity.UserInputOptionSnapshot{{Label: "Yes"}, {Label: "No"}},
+			}},
+		}, codex.DetachedUserInputContext{Channel: "test", RoomID: "room"})
+		if err != nil {
+			return err
+		}
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventUserInputRequest,
+			UserInputID: snapshot.ID, Payload: snapshot,
+		})
+		<-resolved
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	interactionID := make(chan string, 1)
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"), Interaction: InteractionResolve,
+		}, EventSinkFunc(func(_ context.Context, event TurnEvent) error {
+			if event.Interaction != nil {
+				interactionID <- event.Interaction.ID
+			}
+			return nil
+		}))
+	}()
+	id := <-interactionID
+	if err := engine.Conversations("agent-a").Resolve(context.Background(), InteractionResolution{
+		ConversationKey: "conversation-1", InteractionID: id, ResponderID: "tester",
+		Answers: map[string]InteractionAnswer{"choice": {Values: []string{"Yes"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if result := <-runDone; result.Status != TurnSucceeded || !result.Dispatched {
 		t.Fatalf("result = %+v", result)
 	}
 }
@@ -170,7 +442,9 @@ func TestConversationRunPropagatesContextCancellation(t *testing.T) {
 	}}, runtimeImpl))
 	cleanupStarted := make(chan struct{})
 	releaseCleanup := make(chan struct{})
+	promptStarted := make(chan struct{})
 	runtimeImpl.prompt = func(ctx context.Context, _, _, _ string) error {
+		close(promptStarted)
 		<-ctx.Done()
 		close(cleanupStarted)
 		<-releaseCleanup
@@ -183,6 +457,7 @@ func TestConversationRunPropagatesContextCancellation(t *testing.T) {
 			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
 		}, nil)
 	}()
+	<-promptStarted
 	cancel()
 	<-cleanupStarted
 	select {
@@ -239,8 +514,51 @@ func TestConversationRunWaitsForRuntimeCleanupAfterSinkFailure(t *testing.T) {
 	}
 }
 
-func TestConversationRunRejectsFileInputUntilCodexSupportsIt(t *testing.T) {
+func TestConversationRunRetainsDispatchedWhenFailureRacesAcceptance(t *testing.T) {
 	runtimeImpl := &fakeConversationRuntime{}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID,
+			Kind: activity.RuntimeEventPromptFailed, Error: "runtime failed after acceptance",
+		})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	for index := range 100 {
+		result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID:              TurnID(fmt.Sprintf("turn-%d", index)),
+			ConversationKey: ConversationKey(fmt.Sprintf("conversation-%d", index)),
+			Input:           textInput("hello"),
+		}, nil)
+		if result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorRuntimeFailed || !result.Dispatched {
+			t.Fatalf("Run(%d) = %+v", index, result)
+		}
+	}
+}
+
+func TestConversationRunCopiesCodexFileInput(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "report.txt")
+	content := []byte("report")
+	if err := os.WriteFile(sourcePath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
+	var runtimePath string
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, prompt string) error {
+		runtimePath = strings.TrimSpace(strings.TrimPrefix(prompt, "Attached file \"report.txt\" is available in the Runtime workspace at "))
+		info, err := os.Stat(runtimePath)
+		if err != nil {
+			t.Fatalf("stat Runtime-local file: %v", err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("Runtime-local file mode = %o, want 600", info.Mode().Perm())
+		}
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
 	engine := New(newTestAgentService(t, []agent.Agent{{
 		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
 		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
@@ -251,14 +569,340 @@ func TestConversationRunRejectsFileInputUntilCodexSupportsIt(t *testing.T) {
 		ConversationKey: "conversation-1",
 		Input: []InputPart{{
 			Kind: InputPartFile,
-			File: &InputFile{ID: "file-1", SourcePath: "/authorized/report.pdf", Name: "report.pdf"},
+			File: &InputFile{
+				ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain",
+				SizeBytes: int64(len(content)), SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917",
+			},
 		}},
 	}, nil)
-	if result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorFileUnavailable {
+	if result.Status != TurnSucceeded || result.Error != nil || !result.Dispatched {
 		t.Fatalf("result = %+v", result)
 	}
-	if runtimeImpl.conversationKey != "" {
-		t.Fatalf("runtime was called for unsupported file input: %q", runtimeImpl.conversationKey)
+	if runtimeImpl.conversationKey != "conversation-1" {
+		t.Fatalf("runtime conversation key = %q", runtimeImpl.conversationKey)
+	}
+	if runtimePath == "" {
+		t.Fatal("Runtime-local path was not passed to Codex")
+	}
+	if _, err := os.Stat(runtimePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Runtime-local copy still exists after termination: %v", err)
+	}
+}
+
+func TestConversationRunRejectsUnsafeOrInvalidFileBeforeDispatch(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(sourcePath, []byte("report"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(t.TempDir(), "report-link.txt")
+	if err := os.Symlink(sourcePath, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+	for _, testCase := range []struct {
+		name string
+		file InputFile
+	}{
+		{
+			name: "symlink",
+			file: InputFile{ID: "file-1", SourcePath: symlinkPath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 6, SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917"},
+		},
+		{
+			name: "hash mismatch",
+			file: InputFile{ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 6, SHA256: strings.Repeat("0", 64)},
+		},
+		{
+			name: "size mismatch",
+			file: InputFile{ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 7, SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
+			engine := New(newTestAgentService(t, []agent.Agent{{
+				ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+				RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+			}}, runtimeImpl))
+			result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+				ID: "turn-1", ConversationKey: "conversation-1",
+				Input: []InputPart{{Kind: InputPartFile, File: &testCase.file}},
+			}, nil)
+			if result.Error == nil || result.Error.Code != ErrorFileUnavailable || result.Dispatched {
+				t.Fatalf("result = %+v", result)
+			}
+			if runtimeImpl.conversationKey != "" {
+				t.Fatalf("Runtime mapping was touched before file validation: %q", runtimeImpl.conversationKey)
+			}
+		})
+	}
+}
+
+func TestConversationRunRejectsRuntimeInputDestinationSymlink(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, ".csgclaw")); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(root, "report.txt")
+	content := []byte("report")
+	if err := os.WriteFile(sourcePath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-1", ConversationKey: "conversation-1",
+		Input: []InputPart{{Kind: InputPartFile, File: &InputFile{
+			ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain",
+			SizeBytes: int64(len(content)), SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917",
+		}}},
+	}, nil)
+	if result.Error == nil || result.Error.Code != ErrorFileUnavailable || result.Dispatched {
+		t.Fatalf("Run() = %+v", result)
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("outside destination changed: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestCodexInputPreservesOrderedTextImageAndFileBlocks(t *testing.T) {
+	root := t.TempDir()
+	imagePath := filepath.Join(root, "image.png")
+	filePath := filepath.Join(root, "notes.txt")
+	if err := os.WriteFile(imagePath, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte("notes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "caller-turn", ConversationKey: "conversation-1",
+		Input: []InputPart{
+			{Kind: InputPartText, Text: "before"},
+			{Kind: InputPartFile, File: &InputFile{ID: "image", SourcePath: imagePath, Name: "image.png", MediaType: "image/png", SizeBytes: 5, SHA256: "6105d6cc76af400325e94d588ce511be5bfdbb73b437dc51eca43917d7a43e3d"}},
+			{Kind: InputPartFile, File: &InputFile{ID: "notes", SourcePath: filePath, Name: "notes.txt", MediaType: "text/plain", SizeBytes: 5, SHA256: "ab5aa97074c454a0632057e704220d9a6678fbf773a0a5806fc09b8173b07309"}},
+			{Kind: InputPartText, Text: "after"},
+		},
+	}, nil)
+	if result.Status != TurnSucceeded {
+		t.Fatalf("result = %+v", result)
+	}
+	runtimeImpl.mu.Lock()
+	defer runtimeImpl.mu.Unlock()
+	if runtimeImpl.turnID != "caller-turn" {
+		t.Fatalf("clientUserMessageId = %q", runtimeImpl.turnID)
+	}
+	blocks := runtimeImpl.promptBlocks
+	if len(blocks) != 4 || blocks[0].Text == nil || blocks[0].Text.Text != "before" ||
+		blocks[1].LocalImage == nil || blocks[2].Text == nil || !strings.Contains(blocks[2].Text.Text, "notes.txt") ||
+		blocks[3].Text == nil || blocks[3].Text.Text != "after" {
+		t.Fatalf("prompt blocks = %#v", blocks)
+	}
+}
+
+func TestConversationRunRejectsSameConversationOverlap(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		once.Do(func() { close(started) })
+		<-release
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	firstDone := make(chan TurnResult, 1)
+	go func() {
+		firstDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("first"),
+		}, nil)
+	}()
+	<-started
+	second := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-2", ConversationKey: "conversation-1", Input: textInput("second"),
+	}, nil)
+	if second.Error == nil || second.Error.Code != ErrorConversationBusy || second.Dispatched {
+		t.Fatalf("overlap result = %+v", second)
+	}
+	close(release)
+	if result := <-firstDone; result.Status != TurnSucceeded {
+		t.Fatalf("first result = %+v", result)
+	}
+}
+
+func TestConversationCancelIsExactAndWaitsForCleanup(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	started := make(chan struct{})
+	cleanupStarted := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	runtimeImpl.prompt = func(ctx context.Context, _, _, _ string) error {
+		close(started)
+		<-ctx.Done()
+		close(cleanupStarted)
+		<-releaseCleanup
+		return ctx.Err()
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+		}, nil)
+	}()
+	<-started
+	if err := engine.Conversations("agent-a").Cancel(context.Background(), "conversation-1", "other-turn"); err != nil {
+		t.Fatal(err)
+	}
+	cancelDone := make(chan error, 1)
+	go func() {
+		cancelDone <- engine.Conversations("agent-a").Cancel(context.Background(), "conversation-1", "turn-1")
+	}()
+	<-cleanupStarted
+	select {
+	case err := <-cancelDone:
+		t.Fatalf("Cancel returned before cleanup: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseCleanup)
+	if err := <-cancelDone; err != nil {
+		t.Fatal(err)
+	}
+	if result := <-runDone; result.Status != TurnCanceled || result.Error == nil || result.Error.Code != ErrorCanceled {
+		t.Fatalf("result = %+v", result)
+	}
+	if err := engine.Conversations("agent-a").Cancel(context.Background(), "conversation-1", "turn-1"); err != nil {
+		t.Fatalf("idempotent Cancel error = %v", err)
+	}
+}
+
+func TestConversationResetRemovesStrictContinuationMapping(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	conversations := engine.Conversations("agent-a")
+	first := conversations.Run(context.Background(), TurnRequest{
+		ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+	}, nil)
+	if first.Status != TurnSucceeded {
+		t.Fatalf("first result = %+v", first)
+	}
+	if err := conversations.Reset(context.Background(), "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	strict := conversations.Run(context.Background(), TurnRequest{
+		ID: "turn-2", ConversationKey: "conversation-1", Input: textInput("hello"), Continuation: ContinuationRequireExisting,
+	}, nil)
+	if strict.Error == nil || strict.Error.Code != ErrorConversationNotResumable || strict.Dispatched {
+		t.Fatalf("strict result = %+v", strict)
+	}
+}
+
+func TestAgentStopDrainsActiveEngineTurn(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		close(started)
+		<-release
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	service := newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl)
+	engine := New(service)
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+		}, nil)
+	}()
+	<-started
+	stopDone := make(chan error, 1)
+	go func() {
+		_, err := service.Stop(context.Background(), "agent-a")
+		stopDone <- err
+	}()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned before active Turn drained: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if result := <-runDone; result.Status != TurnSucceeded {
+		t.Fatalf("run result = %+v", result)
+	}
+	if err := <-stopDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentLifecycleDrainTimeoutLeavesRuntimeUnchanged(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		close(started)
+		<-release
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	service := newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl)
+	engine := New(service)
+	runDone := make(chan TurnResult, 1)
+	go func() {
+		runDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-1", ConversationKey: "conversation-1", Input: textInput("hello"),
+		}, nil)
+	}()
+	<-started
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := service.Stop(stopCtx, "agent-a"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop error = %v", err)
+	}
+	selected, ok := service.Agent("agent-a")
+	if !ok || selected.RuntimeID != "runtime-a" || selected.Status != string(runtime.StateRunning) {
+		t.Fatalf("Agent changed after drain timeout: %+v, %t", selected, ok)
+	}
+	close(release)
+	if result := <-runDone; result.Status != TurnSucceeded {
+		t.Fatalf("result = %+v", result)
 	}
 }
 

--- a/internal/agentengine/enginetest/contract.go
+++ b/internal/agentengine/enginetest/contract.go
@@ -1,0 +1,487 @@
+package enginetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"csgclaw/internal/activity"
+	"csgclaw/internal/agentengine"
+)
+
+// InterfaceFactory creates one isolated Engine implementation with seeded
+// Agents and programmable Turn behavior.
+type InterfaceFactory func(testing.TB, []agentengine.Agent, TurnBehavior) agentengine.Interface
+
+// RunInterfaceContract runs the same public Agent Engine behavior checks
+// against any Interface implementation.
+func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
+	t.Helper()
+	t.Run("agent lifecycle and secret handling", func(t *testing.T) {
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateStopped, "codex")}, nil)
+		agents := client.Agents()
+		created, err := agents.Create(context.Background(), agentengine.AgentSpec{
+			Name: "created", Role: agentengine.AgentRoleWorker,
+			Runtime: agentengine.RuntimeSpec{Adapter: "openclaw", Sandboxed: true, Image: "contract-openclaw:latest"},
+			Model:   agentengine.ModelSpec{ProviderID: "provider-a", ModelID: "model-a"},
+		})
+		if err != nil || created.ID == "" || created.Spec.Runtime.Credentials != nil {
+			t.Fatalf("Create() = %+v, %v", created, err)
+		}
+
+		got, err := agents.Get(context.Background(), "agent-a")
+		if err != nil || got.Spec.Runtime.Credentials != nil || got.Status.State != agentengine.AgentStateStopped {
+			t.Fatalf("Get() = %+v, %v", got, err)
+		}
+		listed, err := agents.List(context.Background())
+		if err != nil || len(listed) != 2 {
+			t.Fatalf("List() = %+v, %v", listed, err)
+		}
+		for _, item := range listed {
+			if item.Spec.Runtime.Credentials != nil {
+				t.Fatalf("List() leaked credentials: %+v", item)
+			}
+		}
+
+		updatedSpec := got.Spec
+		updatedSpec.Name = "updated"
+		updatedSpec.Description = "updated description"
+		updatedSpec.Skills = []string{"skill-creator"}
+		updatedSpec.Runtime.Credentials = map[string]string{"secrets/token.txt": "contract-secret"}
+		updatedSpec.Runtime.InitShell = "test -f secrets/token.txt"
+		updatedSpec.MCPServers = map[string]agentengine.MCPServerConfig{
+			"local":  {"command": "local-server"},
+			"remote": {"url": "https://mcp.example.test"},
+		}
+		updated, err := agents.Update(context.Background(), got.ID, updatedSpec)
+		if err != nil || updated.Spec.Name != "updated" || updated.Spec.Description != "updated description" || len(updated.Spec.MCPServers) != 2 || len(updated.Spec.Skills) != 1 || updated.Spec.Skills[0] != "skill-creator" || updated.Spec.Runtime.Credentials != nil || updated.Spec.Runtime.InitShell != "test -f secrets/token.txt" {
+			t.Fatalf("Update() = %+v, %v", updated, err)
+		}
+		replacement := updated.Spec
+		replacement.Skills = []string{"skill-installer"}
+		replacement.Runtime.Credentials = map[string]string{"secrets/token.txt": "contract-secret"}
+		replaced, err := agents.Update(context.Background(), got.ID, replacement)
+		if err != nil || len(replaced.Spec.Skills) != 1 || replaced.Spec.Skills[0] != "skill-installer" {
+			t.Fatalf("complete Skill replacement = %+v, %v", replaced, err)
+		}
+
+		started, err := agents.Start(context.Background(), got.ID)
+		if err != nil || started.Status.State != agentengine.AgentStateRunning || !started.Status.Ready {
+			t.Fatalf("Start() = %+v, %v", started, err)
+		}
+		stopped, err := agents.Stop(context.Background(), got.ID)
+		if err != nil || stopped.Status.State != agentengine.AgentStateStopped || stopped.Status.Ready {
+			t.Fatalf("Stop() = %+v, %v", stopped, err)
+		}
+		recreated, err := agents.Recreate(context.Background(), got.ID)
+		if err != nil || recreated.ID != got.ID || recreated.Status.State == "" || recreated.Status.RuntimeID == "" || recreated.Spec.Runtime.Credentials != nil {
+			t.Fatalf("Recreate() = %+v, %v", recreated, err)
+		}
+		if err := agents.Delete(context.Background(), got.ID); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		if _, err := agents.Get(context.Background(), got.ID); agentengine.ErrorCodeOf(err) != agentengine.ErrorAgentUnavailable {
+			t.Fatalf("Get(deleted) error = %v", err)
+		}
+	})
+
+	t.Run("run events result and recording", func(t *testing.T) {
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			events := []agentengine.TurnEvent{
+				{Kind: agentengine.TurnEventThoughtDelta, Thought: "thinking"},
+				{Kind: agentengine.TurnEventToolCallStart, Tool: &agentengine.ToolActivity{ID: "tool-1", Kind: "exec_command", InputSummary: "pwd"}},
+				{Kind: agentengine.TurnEventActivityUpdate, Activity: &agentengine.ActivityUpdate{ID: "plan-1", Kind: "plan_update", Status: "running"}},
+				{Kind: agentengine.TurnEventOutputItem, Output: &agentengine.OutputItem{Kind: agentengine.OutputItemResourceLink, Payload: activity.ResourceLink{Name: "report", URI: "file:///report"}}},
+				{Kind: agentengine.TurnEventTextDelta, Text: "answer"},
+			}
+			for _, event := range events {
+				if err := sink.Emit(ctx, event); err != nil {
+					return contractFailure(agentengine.ErrorRuntimeFailed, err)
+				}
+			}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		var events []agentengine.TurnEvent
+		result := client.Conversations("agent-a").Run(context.Background(), contractTurn("turn-1", "conversation-1"), agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+			events = append(events, event)
+			return nil
+		}))
+		if result.Status != agentengine.TurnSucceeded || result.Output != "answer" || !result.Dispatched || result.Error != nil {
+			t.Fatalf("Run() = %+v", result)
+		}
+		if len(events) != 5 {
+			t.Fatalf("events = %+v", events)
+		}
+		for index, event := range events {
+			if event.Sequence != uint64(index+1) {
+				t.Fatalf("event %d sequence = %d", index, event.Sequence)
+			}
+		}
+		if events[0].Thought != "thinking" || events[1].Tool == nil || events[2].Activity == nil || events[3].Output == nil || events[4].Text != "answer" {
+			t.Fatalf("normalized events = %+v", events)
+		}
+	})
+
+	t.Run("agent role changes are rejected", func(t *testing.T) {
+		worker := contractAgent("agent-worker", agentengine.AgentStateStopped, "codex")
+		manager := contractAgent("agent-manager", agentengine.AgentStateStopped, "codex")
+		manager.Spec.Role = agentengine.AgentRoleManager
+		client := factory(t, []agentengine.Agent{worker, manager}, nil)
+		workerUpdate, err := client.Agents().Get(context.Background(), worker.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workerUpdate.Spec.Role = agentengine.AgentRoleManager
+		if _, err := client.Agents().Update(context.Background(), worker.ID, workerUpdate.Spec); agentengine.ErrorCodeOf(err) != agentengine.ErrorInvalidRequest {
+			t.Fatalf("worker-to-manager Update error = %v", err)
+		}
+		managerUpdate, err := client.Agents().Get(context.Background(), manager.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		managerUpdate.Spec.Role = agentengine.AgentRoleWorker
+		if _, err := client.Agents().Update(context.Background(), manager.ID, managerUpdate.Spec); agentengine.ErrorCodeOf(err) != agentengine.ErrorInvalidRequest {
+			t.Fatalf("manager-to-worker Update error = %v", err)
+		}
+	})
+
+	t.Run("conversation admission and concurrency", func(t *testing.T) {
+		started := make(chan agentengine.ConversationKey, 2)
+		release := make(chan struct{})
+		behavior := func(_ context.Context, _ string, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+			started <- request.ConversationKey
+			<-release
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		firstDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			firstDone <- conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		<-started
+		overlap := conversations.Run(context.Background(), contractTurn("turn-2", "conversation-1"), nil)
+		if overlap.Error == nil || overlap.Error.Code != agentengine.ErrorConversationBusy || overlap.Dispatched {
+			t.Fatalf("overlap = %+v", overlap)
+		}
+		secondDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			secondDone <- conversations.Run(context.Background(), contractTurn("turn-3", "conversation-2"), nil)
+		}()
+		<-started
+		close(release)
+		if (<-firstDone).Status != agentengine.TurnSucceeded || (<-secondDone).Status != agentengine.TurnSucceeded {
+			t.Fatal("different conversations did not complete")
+		}
+	})
+
+	t.Run("exact cancellation waits for cleanup", func(t *testing.T) {
+		started := make(chan struct{})
+		cleanupStarted := make(chan struct{})
+		releaseCleanup := make(chan struct{})
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+			close(started)
+			<-ctx.Done()
+			close(cleanupStarted)
+			<-releaseCleanup
+			return agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: ctx.Err().Error()}}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		runDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			runDone <- conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		<-started
+		if err := conversations.Cancel(context.Background(), "conversation-1", "other-turn"); err != nil {
+			t.Fatalf("Cancel(other) error = %v", err)
+		}
+		cancelDone := make(chan error, 1)
+		go func() { cancelDone <- conversations.Cancel(context.Background(), "conversation-1", "turn-1") }()
+		<-cleanupStarted
+		select {
+		case err := <-cancelDone:
+			t.Fatalf("Cancel returned before cleanup: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(releaseCleanup)
+		if err := <-cancelDone; err != nil {
+			t.Fatal(err)
+		}
+		result := <-runDone
+		if result.Status != agentengine.TurnCanceled || result.Error == nil || result.Error.Code != agentengine.ErrorCanceled || !result.Dispatched {
+			t.Fatalf("canceled result = %+v", result)
+		}
+		if err := conversations.Cancel(context.Background(), "conversation-1", "turn-1"); err != nil {
+			t.Fatalf("idempotent Cancel error = %v", err)
+		}
+	})
+
+	t.Run("agent mutations drain active turns", func(t *testing.T) {
+		operations := map[string]func(context.Context, agentengine.AgentInterface, agentengine.Agent) error{
+			"stop": func(ctx context.Context, agents agentengine.AgentInterface, item agentengine.Agent) error {
+				_, err := agents.Stop(ctx, item.ID)
+				return err
+			},
+			"update": func(ctx context.Context, agents agentengine.AgentInterface, item agentengine.Agent) error {
+				item.Spec.Description = "updated after drain"
+				_, err := agents.Update(ctx, item.ID, item.Spec)
+				return err
+			},
+			"recreate": func(ctx context.Context, agents agentengine.AgentInterface, item agentengine.Agent) error {
+				_, err := agents.Recreate(ctx, item.ID)
+				return err
+			},
+			"delete": func(ctx context.Context, agents agentengine.AgentInterface, item agentengine.Agent) error {
+				return agents.Delete(ctx, item.ID)
+			},
+		}
+		for name, operation := range operations {
+			operation := operation
+			t.Run(name, func(t *testing.T) {
+				started := make(chan struct{})
+				release := make(chan struct{})
+				behavior := func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+					close(started)
+					<-release
+					return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+				}
+				seed := contractAgent("agent-a", agentengine.AgentStateRunning, "codex")
+				client := factory(t, []agentengine.Agent{seed}, behavior)
+				current, err := client.Agents().Get(context.Background(), seed.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				runDone := make(chan agentengine.TurnResult, 1)
+				go func() {
+					runDone <- client.Conversations(seed.ID).Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+				}()
+				<-started
+				operationDone := make(chan error, 1)
+				go func() { operationDone <- operation(context.Background(), client.Agents(), current) }()
+				select {
+				case err := <-operationDone:
+					t.Fatalf("operation returned before active Turn drained: %v", err)
+				case <-time.After(20 * time.Millisecond):
+				}
+				close(release)
+				if result := <-runDone; result.Status != agentengine.TurnSucceeded {
+					t.Fatalf("Run() = %+v", result)
+				}
+				if err := <-operationDone; err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	})
+
+	t.Run("lifecycle drain timeout preserves the running agent", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		behavior := func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+			close(started)
+			<-release
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		seed := contractAgent("agent-a", agentengine.AgentStateRunning, "codex")
+		client := factory(t, []agentengine.Agent{seed}, behavior)
+		runDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			runDone <- client.Conversations(seed.ID).Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		<-started
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		if _, err := client.Agents().Stop(ctx, seed.ID); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+		got, err := client.Agents().Get(context.Background(), seed.ID)
+		if err != nil || got.Status.State != agentengine.AgentStateRunning || got.Status.RuntimeID != seed.Status.RuntimeID {
+			t.Fatalf("Agent changed after timeout: %+v, %v", got, err)
+		}
+		close(release)
+		if result := <-runDone; result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("Run() = %+v", result)
+		}
+	})
+
+	t.Run("reset removes strict continuation mapping", func(t *testing.T) {
+		behavior := func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		if result := conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil); result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("first Run() = %+v", result)
+		}
+		if err := conversations.Reset(context.Background(), "conversation-1"); err != nil {
+			t.Fatal(err)
+		}
+		strict := contractTurn("turn-2", "conversation-1")
+		strict.Continuation = agentengine.ContinuationRequireExisting
+		result := conversations.Run(context.Background(), strict, nil)
+		if result.Error == nil || result.Error.Code != agentengine.ErrorConversationNotResumable || result.Dispatched {
+			t.Fatalf("strict Run() = %+v", result)
+		}
+	})
+
+	t.Run("interaction resolution", func(t *testing.T) {
+		resolved := make(chan struct{})
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventInteractionRequest, Interaction: &agentengine.InteractionRequest{ID: "question-1", Kind: agentengine.InteractionUserInput, Title: "Continue?"}}); err != nil {
+				return contractFailure(agentengine.ErrorRuntimeFailed, err)
+			}
+			<-resolved
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		interactionID := make(chan string, 1)
+		runDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			request := contractTurn("turn-1", "conversation-1")
+			request.Interaction = agentengine.InteractionResolve
+			runDone <- conversations.Run(context.Background(), request, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+				if event.Interaction != nil {
+					interactionID <- event.Interaction.ID
+				}
+				return nil
+			}))
+		}()
+		id := <-interactionID
+		if err := conversations.Resolve(context.Background(), agentengine.InteractionResolution{
+			ConversationKey: "conversation-1", InteractionID: id, ResponderID: "tester",
+			Answers: map[string]agentengine.InteractionAnswer{"choice": {Values: []string{"Yes"}}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		close(resolved)
+		if result := <-runDone; result.Status != agentengine.TurnSucceeded || !result.Dispatched {
+			t.Fatalf("Run() = %+v", result)
+		}
+	})
+
+	t.Run("interaction policies", func(t *testing.T) {
+		interaction := agentengine.TurnEvent{Kind: agentengine.TurnEventInteractionRequest, Interaction: &agentengine.InteractionRequest{ID: "question-1", Kind: agentengine.InteractionUserInput}}
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			if err := sink.Emit(ctx, interaction); err != nil {
+				return contractFailure(agentengine.ErrorRuntimeFailed, err)
+			}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		reject := contractTurn("turn-reject", "conversation-reject")
+		reject.Interaction = agentengine.InteractionReject
+		result := client.Conversations("agent-a").Run(context.Background(), reject, nil)
+		if result.Status != agentengine.TurnFailed || result.Error == nil || result.Error.Code != agentengine.ErrorInteractionUnsupported || !result.Dispatched {
+			t.Fatalf("reject Run() = %+v", result)
+		}
+
+		var emitted []agentengine.TurnEvent
+		skip := contractTurn("turn-skip", "conversation-skip")
+		skip.Interaction = agentengine.InteractionSkipUserInput
+		result = client.Conversations("agent-a").Run(context.Background(), skip, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+			emitted = append(emitted, event)
+			return nil
+		}))
+		if result.Status != agentengine.TurnSucceeded || result.Error != nil || !result.Dispatched {
+			t.Fatalf("skip Run() = %+v", result)
+		}
+		for _, event := range emitted {
+			if event.Interaction != nil {
+				t.Fatalf("skip_user_input exposed interaction: %+v", emitted)
+			}
+		}
+	})
+
+	t.Run("sink failure terminates the turn", func(t *testing.T) {
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "partial"}); err != nil {
+				return contractFailure(agentengine.ErrorRuntimeFailed, err)
+			}
+			<-ctx.Done()
+			return agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: ctx.Err().Error()}}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		result := client.Conversations("agent-a").Run(context.Background(), contractTurn("turn-1", "conversation-1"), agentengine.EventSinkFunc(func(context.Context, agentengine.TurnEvent) error {
+			return errors.New("sink closed")
+		}))
+		if result.Status != agentengine.TurnFailed || result.Error == nil || result.Error.Code != agentengine.ErrorRuntimeFailed || !result.Dispatched {
+			t.Fatalf("Run() = %+v", result)
+		}
+	})
+
+	t.Run("stable validation and availability errors", func(t *testing.T) {
+		client := factory(t, []agentengine.Agent{
+			contractAgent("agent-running", agentengine.AgentStateRunning, "codex"),
+			contractAgent("agent-stopped", agentengine.AgentStateStopped, "codex"),
+			contractAgent("agent-unsupported", agentengine.AgentStateRunning, "openclaw_sandbox"),
+		}, nil)
+		invalid := client.Conversations("agent-running").Run(context.Background(), agentengine.TurnRequest{}, nil)
+		if invalid.Error == nil || invalid.Error.Code != agentengine.ErrorInvalidRequest || invalid.Dispatched {
+			t.Fatalf("invalid Run() = %+v", invalid)
+		}
+		invalidFile := contractTurn("turn-invalid-file", "conversation-invalid-file")
+		invalidFile.Input = []agentengine.InputPart{{Kind: agentengine.InputPartFile, File: &agentengine.InputFile{ID: "file"}}}
+		if result := client.Conversations("agent-running").Run(context.Background(), invalidFile, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
+			t.Fatalf("invalid file Run() = %+v", result)
+		}
+		invalidContinuation := contractTurn("turn-invalid-continuation", "conversation-invalid-continuation")
+		invalidContinuation.Continuation = agentengine.ContinuationPolicy("future")
+		if result := client.Conversations("agent-running").Run(context.Background(), invalidContinuation, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
+			t.Fatalf("invalid continuation Run() = %+v", result)
+		}
+		invalidInteraction := contractTurn("turn-invalid-interaction", "conversation-invalid-interaction")
+		invalidInteraction.Interaction = agentengine.InteractionPolicy("future")
+		if result := client.Conversations("agent-running").Run(context.Background(), invalidInteraction, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
+			t.Fatalf("invalid interaction Run() = %+v", result)
+		}
+		canceledContext, cancel := context.WithCancel(context.Background())
+		cancel()
+		canceled := client.Conversations("agent-running").Run(canceledContext, contractTurn("turn-canceled", "conversation-canceled"), nil)
+		if canceled.Status != agentengine.TurnCanceled || canceled.Error == nil || canceled.Error.Code != agentengine.ErrorCanceled || canceled.Dispatched {
+			t.Fatalf("pre-canceled Run() = %+v", canceled)
+		}
+		unavailable := client.Conversations("agent-stopped").Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		if unavailable.Error == nil || unavailable.Error.Code != agentengine.ErrorAgentUnavailable || unavailable.Dispatched {
+			t.Fatalf("unavailable Run() = %+v", unavailable)
+		}
+		unsupported := client.Conversations("agent-unsupported").Run(context.Background(), contractTurn("turn-2", "conversation-1"), nil)
+		if unsupported.Error == nil || unsupported.Error.Code != agentengine.ErrorRuntimeAdapterUnavailable || unsupported.Dispatched {
+			t.Fatalf("unsupported Run() = %+v", unsupported)
+		}
+		unsupportedAgent, err := client.Agents().Get(context.Background(), "agent-unsupported")
+		if err != nil {
+			t.Fatal(err)
+		}
+		unsupportedAgent.Spec.Runtime.Credentials = map[string]string{"secret.txt": "secret"}
+		if _, err := client.Agents().Update(context.Background(), unsupportedAgent.ID, unsupportedAgent.Spec); agentengine.ErrorCodeOf(err) != agentengine.ErrorUnsupportedRuntimeProvision {
+			t.Fatalf("unsupported provisioning error = %v", err)
+		}
+	})
+}
+
+func contractAgent(id string, state agentengine.AgentState, adapter string) agentengine.Agent {
+	return agentengine.Agent{
+		ID: id,
+		Spec: agentengine.AgentSpec{
+			Name: id, Role: agentengine.AgentRoleWorker,
+			Runtime: agentengine.RuntimeSpec{Adapter: adapter, Credentials: map[string]string{"seed": "must-not-leak"}},
+			Model:   agentengine.ModelSpec{ProviderID: "provider-a", ModelID: "model-a"},
+		},
+		Status: agentengine.AgentStatus{State: state, RuntimeID: "runtime-" + id, Ready: state == agentengine.AgentStateRunning},
+	}
+}
+
+func contractTurn(id agentengine.TurnID, key agentengine.ConversationKey) agentengine.TurnRequest {
+	return agentengine.TurnRequest{
+		ID: id, ConversationKey: key,
+		Input: []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: "hello"}},
+	}
+}
+
+func contractFailure(code agentengine.ErrorCode, err error) agentengine.TurnResult {
+	return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: true, Error: &agentengine.TurnError{Code: code, Message: err.Error()}}
+}

--- a/internal/agentengine/enginetest/contract.go
+++ b/internal/agentengine/enginetest/contract.go
@@ -115,8 +115,8 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 			t.Fatalf("events = %+v", events)
 		}
 		for index, event := range events {
-			if event.Sequence != uint64(index+1) {
-				t.Fatalf("event %d sequence = %d", index, event.Sequence)
+			if event.TurnID != "turn-1" || event.Sequence != uint64(index+1) {
+				t.Fatalf("event %d envelope = %+v", index, event)
 			}
 		}
 		if events[0].Thought != "thinking" || events[1].Tool == nil || events[2].Activity == nil || events[3].Output == nil || events[4].Text != "answer" {
@@ -174,6 +174,164 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		close(release)
 		if (<-firstDone).Status != agentengine.TurnSucceeded || (<-secondDone).Status != agentengine.TurnSucceeded {
 			t.Fatal("different conversations did not complete")
+		}
+	})
+
+	t.Run("turn retries are idempotent", func(t *testing.T) {
+		var executions int
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			executions++
+			if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "answer"}); err != nil {
+				return contractFailure(agentengine.ErrorRuntimeFailed, err)
+			}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		request := contractTurn("turn-1", "conversation-1")
+		var firstEvents []agentengine.TurnEvent
+		first := client.Conversations("agent-a").Run(context.Background(), request, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+			firstEvents = append(firstEvents, event)
+			return nil
+		}))
+		var retriedEvents []agentengine.TurnEvent
+		retried := client.Conversations("agent-a").Run(context.Background(), request, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+			retriedEvents = append(retriedEvents, event)
+			return nil
+		}))
+		if executions != 1 {
+			t.Fatalf("Runtime executions = %d, want 1", executions)
+		}
+		if first.Status != agentengine.TurnSucceeded || retried != first {
+			t.Fatalf("first = %+v, retried = %+v", first, retried)
+		}
+		if len(retriedEvents) != len(firstEvents) {
+			t.Fatalf("first events = %+v, retried events = %+v", firstEvents, retriedEvents)
+		}
+		for index := range firstEvents {
+			if retriedEvents[index].Sequence != firstEvents[index].Sequence || retriedEvents[index].Kind != firstEvents[index].Kind {
+				t.Fatalf("event %d first = %+v, retried = %+v", index, firstEvents[index], retriedEvents[index])
+			}
+		}
+		conflict := request
+		conflict.Input = []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: "different"}}
+		if result := client.Conversations("agent-a").Run(context.Background(), conflict, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || executions != 1 {
+			t.Fatalf("conflicting retry = %+v, executions = %d", result, executions)
+		}
+	})
+
+	t.Run("in-flight turn retries coalesce", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var executions int
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+			executions++
+			close(started)
+			if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "answer"}); err != nil {
+				return contractFailure(agentengine.ErrorRuntimeFailed, err)
+			}
+			<-release
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		request := contractTurn("turn-1", "conversation-1")
+		firstDone := make(chan agentengine.TurnResult, 1)
+		secondDone := make(chan agentengine.TurnResult, 1)
+		go func() { firstDone <- client.Conversations("agent-a").Run(context.Background(), request, nil) }()
+		<-started
+		go func() { secondDone <- client.Conversations("agent-a").Run(context.Background(), request, nil) }()
+		select {
+		case result := <-secondDone:
+			t.Fatalf("retry returned before the original Turn completed: %+v", result)
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(release)
+		first := <-firstDone
+		second := <-secondDone
+		if executions != 1 || first.Status != agentengine.TurnSucceeded || second.Status != agentengine.TurnSucceeded || second.Output != first.Output {
+			t.Fatalf("executions = %d, first = %+v, second = %+v", executions, first, second)
+		}
+	})
+
+	t.Run("admission wait serializes turns", func(t *testing.T) {
+		started := make(chan agentengine.TurnID, 2)
+		releaseFirst := make(chan struct{})
+		behavior := func(_ context.Context, _ string, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+			started <- request.ID
+			if request.ID == "turn-1" {
+				<-releaseFirst
+			}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		firstDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			firstDone <- conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		if id := <-started; id != "turn-1" {
+			t.Fatalf("first started Turn = %q", id)
+		}
+		waitRequest := contractTurn("turn-2", "conversation-1")
+		waitRequest.Admission = agentengine.AdmissionWait
+		secondDone := make(chan agentengine.TurnResult, 1)
+		go func() { secondDone <- conversations.Run(context.Background(), waitRequest, nil) }()
+		select {
+		case id := <-started:
+			t.Fatalf("waiting Turn started early: %q", id)
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(releaseFirst)
+		if result := <-firstDone; result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("first Run() = %+v", result)
+		}
+		if id := <-started; id != "turn-2" {
+			t.Fatalf("second started Turn = %q", id)
+		}
+		if result := <-secondDone; result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("second Run() = %+v", result)
+		}
+	})
+
+	t.Run("admission supersede cancels before replacement", func(t *testing.T) {
+		firstStarted := make(chan struct{})
+		cleanupStarted := make(chan struct{})
+		releaseCleanup := make(chan struct{})
+		secondStarted := make(chan struct{})
+		behavior := func(ctx context.Context, _ string, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+			if request.ID == "turn-1" {
+				close(firstStarted)
+				<-ctx.Done()
+				close(cleanupStarted)
+				<-releaseCleanup
+				return agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: ctx.Err().Error()}}
+			}
+			close(secondStarted)
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		firstDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			firstDone <- conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		<-firstStarted
+		replacement := contractTurn("turn-2", "conversation-1")
+		replacement.Admission = agentengine.AdmissionSupersede
+		secondDone := make(chan agentengine.TurnResult, 1)
+		go func() { secondDone <- conversations.Run(context.Background(), replacement, nil) }()
+		<-cleanupStarted
+		select {
+		case <-secondStarted:
+			t.Fatal("replacement started before superseded Turn cleanup")
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(releaseCleanup)
+		if result := <-firstDone; result.Status != agentengine.TurnCanceled {
+			t.Fatalf("superseded Run() = %+v", result)
+		}
+		<-secondStarted
+		if result := <-secondDone; result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("replacement Run() = %+v", result)
 		}
 	})
 
@@ -327,6 +485,69 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		}
 	})
 
+	t.Run("reset atomically cancels an active turn", func(t *testing.T) {
+		started := make(chan struct{})
+		cleanupStarted := make(chan struct{})
+		releaseCleanup := make(chan struct{})
+		forceRelease := make(chan struct{})
+		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+			close(started)
+			select {
+			case <-ctx.Done():
+				close(cleanupStarted)
+				<-releaseCleanup
+				return agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: ctx.Err().Error()}}
+			case <-forceRelease:
+				return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+			}
+		}
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		conversations := client.Conversations("agent-a")
+		runDone := make(chan agentengine.TurnResult, 1)
+		go func() {
+			runDone <- conversations.Run(context.Background(), contractTurn("turn-1", "conversation-1"), nil)
+		}()
+		<-started
+		resetDone := make(chan error, 1)
+		go func() { resetDone <- conversations.Reset(context.Background(), "conversation-1") }()
+		select {
+		case <-cleanupStarted:
+		case err := <-resetDone:
+			close(forceRelease)
+			<-runDone
+			t.Fatalf("Reset returned before canceling the active Turn: %v", err)
+		case <-time.After(time.Second):
+			close(forceRelease)
+			<-runDone
+			t.Fatal("Reset did not cancel the active Turn")
+		}
+		if result := conversations.Run(context.Background(), contractTurn("turn-blocked", "conversation-1"), nil); result.Error == nil || result.Error.Code != agentengine.ErrorConversationBusy || result.Dispatched {
+			close(releaseCleanup)
+			<-runDone
+			<-resetDone
+			t.Fatalf("Run during Reset = %+v", result)
+		}
+		select {
+		case err := <-resetDone:
+			close(releaseCleanup)
+			<-runDone
+			t.Fatalf("Reset returned before Turn cleanup: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(releaseCleanup)
+		if result := <-runDone; result.Status != agentengine.TurnCanceled {
+			t.Fatalf("Run() = %+v", result)
+		}
+		if err := <-resetDone; err != nil {
+			t.Fatal(err)
+		}
+		strict := contractTurn("turn-2", "conversation-1")
+		strict.Continuation = agentengine.ContinuationRequireExisting
+		if result := conversations.Run(context.Background(), strict, nil); result.Error == nil || result.Error.Code != agentengine.ErrorConversationNotResumable || result.Dispatched {
+			t.Fatalf("strict Run() = %+v", result)
+		}
+	})
+
 	t.Run("interaction resolution", func(t *testing.T) {
 		resolved := make(chan struct{})
 		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
@@ -432,6 +653,11 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		invalidContinuation.Continuation = agentengine.ContinuationPolicy("future")
 		if result := client.Conversations("agent-running").Run(context.Background(), invalidContinuation, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
 			t.Fatalf("invalid continuation Run() = %+v", result)
+		}
+		invalidAdmission := contractTurn("turn-invalid-admission", "conversation-invalid-admission")
+		invalidAdmission.Admission = agentengine.AdmissionPolicy("future")
+		if result := client.Conversations("agent-running").Run(context.Background(), invalidAdmission, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
+			t.Fatalf("invalid admission Run() = %+v", result)
 		}
 		invalidInteraction := contractTurn("turn-invalid-interaction", "conversation-invalid-interaction")
 		invalidInteraction.Interaction = agentengine.InteractionPolicy("future")

--- a/internal/agentengine/enginetest/contract_test.go
+++ b/internal/agentengine/enginetest/contract_test.go
@@ -1,0 +1,15 @@
+package enginetest
+
+import (
+	"testing"
+
+	"csgclaw/internal/agentengine"
+)
+
+func TestMemoryClientInterfaceContract(t *testing.T) {
+	RunInterfaceContract(t, func(_ testing.TB, agents []agentengine.Agent, behavior TurnBehavior) agentengine.Interface {
+		client := NewMemoryClient(agents...)
+		client.SetTurnBehavior(behavior)
+		return client
+	})
+}

--- a/internal/agentengine/enginetest/feishu_adapter_test.go
+++ b/internal/agentengine/enginetest/feishu_adapter_test.go
@@ -1,0 +1,74 @@
+package enginetest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel/feishu"
+)
+
+// feishuAdapterHarness is deliberately test-only. It accepts only the Engine
+// contract and the existing channel credential owner.
+type feishuAdapterHarness struct {
+	engine      agentengine.Interface
+	credentials feishu.AgentCredentialProvider
+}
+
+func (h feishuAdapterHarness) Ingress(ctx context.Context, agentID string, key agentengine.ConversationKey, text string) agentengine.TurnResult {
+	_, app, ok := h.credentials.BotConfigForAgent(agentID)
+	if !ok || strings.TrimSpace(app.AppID) == "" || strings.TrimSpace(app.AppSecret) == "" {
+		return agentengine.TurnResult{Status: agentengine.TurnFailed, Error: &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "Feishu binding is unavailable"}}
+	}
+	return h.engine.Conversations(agentID).Run(ctx, agentengine.TurnRequest{
+		ID: "feishu-turn", ConversationKey: key,
+		Input: []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: text}},
+	}, nil)
+}
+
+type feishuCredentialStub struct {
+	app feishu.AppConfig
+}
+
+func (p feishuCredentialStub) BotConfigForAgent(string) (string, feishu.AppConfig, bool) {
+	return "participant-feishu", p.app, true
+}
+
+func TestFeishuAdapterHarnessUsesEngineWithoutLeakingChannelSecrets(t *testing.T) {
+	seed := runningAgent("agent-feishu")
+	client := NewMemoryClient(seed)
+	client.SetTurnBehavior(func(_ context.Context, _ string, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: request.Input[0].Text, Dispatched: true}
+	})
+	const appID = "cli_feishu_only"
+	const appSecret = "feishu-secret-only"
+	harness := feishuAdapterHarness{
+		engine:      client,
+		credentials: feishuCredentialStub{app: feishu.AppConfig{AppID: appID, AppSecret: appSecret}},
+	}
+	result := harness.Ingress(context.Background(), seed.ID, "chat-1", "hello from Feishu")
+	if result.Status != agentengine.TurnSucceeded {
+		t.Fatalf("result = %+v", result)
+	}
+	calls := client.Calls()
+	if len(calls) != 1 || calls[0].AgentID != seed.ID || calls[0].Request.ConversationKey != "chat-1" {
+		t.Fatalf("Engine calls = %+v", calls)
+	}
+	agentItem, err := client.Agents().Get(context.Background(), seed.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(struct {
+		Agent  agentengine.Agent
+		Calls  []TurnCall
+		Result agentengine.TurnResult
+	}{Agent: agentItem, Calls: calls, Result: result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), appID) || strings.Contains(string(encoded), appSecret) {
+		t.Fatalf("Feishu channel credentials leaked into Engine data: %s", encoded)
+	}
+}

--- a/internal/agentengine/enginetest/feishu_adapter_test.go
+++ b/internal/agentengine/enginetest/feishu_adapter_test.go
@@ -17,13 +17,14 @@ type feishuAdapterHarness struct {
 	credentials feishu.AgentCredentialProvider
 }
 
-func (h feishuAdapterHarness) Ingress(ctx context.Context, agentID string, key agentengine.ConversationKey, text string) agentengine.TurnResult {
+func (h feishuAdapterHarness) Ingress(ctx context.Context, agentID string, key agentengine.ConversationKey, eventID, text string) agentengine.TurnResult {
 	_, app, ok := h.credentials.BotConfigForAgent(agentID)
 	if !ok || strings.TrimSpace(app.AppID) == "" || strings.TrimSpace(app.AppSecret) == "" {
 		return agentengine.TurnResult{Status: agentengine.TurnFailed, Error: &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "Feishu binding is unavailable"}}
 	}
 	return h.engine.Conversations(agentID).Run(ctx, agentengine.TurnRequest{
-		ID: "feishu-turn", ConversationKey: key,
+		ID: agentengine.TurnID(eventID), ConversationKey: key,
+		Admission: agentengine.AdmissionSupersede, Interaction: agentengine.InteractionSkipUserInput,
 		Input: []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: text}},
 	}, nil)
 }
@@ -48,12 +49,16 @@ func TestFeishuAdapterHarnessUsesEngineWithoutLeakingChannelSecrets(t *testing.T
 		engine:      client,
 		credentials: feishuCredentialStub{app: feishu.AppConfig{AppID: appID, AppSecret: appSecret}},
 	}
-	result := harness.Ingress(context.Background(), seed.ID, "chat-1", "hello from Feishu")
+	result := harness.Ingress(context.Background(), seed.ID, "chat-1", "event-1", "hello from Feishu")
 	if result.Status != agentengine.TurnSucceeded {
 		t.Fatalf("result = %+v", result)
 	}
+	retried := harness.Ingress(context.Background(), seed.ID, "chat-1", "event-1", "hello from Feishu")
+	if retried.Status != agentengine.TurnSucceeded || retried.Output != result.Output {
+		t.Fatalf("retried result = %+v", retried)
+	}
 	calls := client.Calls()
-	if len(calls) != 1 || calls[0].AgentID != seed.ID || calls[0].Request.ConversationKey != "chat-1" {
+	if len(calls) != 1 || calls[0].AgentID != seed.ID || calls[0].Request.ConversationKey != "chat-1" || calls[0].Request.ID != "event-1" || calls[0].Request.Admission != agentengine.AdmissionSupersede {
 		t.Fatalf("Engine calls = %+v", calls)
 	}
 	agentItem, err := client.Agents().Get(context.Background(), seed.ID)

--- a/internal/agentengine/enginetest/memory_client.go
+++ b/internal/agentengine/enginetest/memory_client.go
@@ -1,0 +1,608 @@
+// Package enginetest provides contract-compatible Agent Engine test clients.
+package enginetest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"csgclaw/internal/agentengine"
+)
+
+// TurnBehavior programs one MemoryClient Run.
+type TurnBehavior func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult
+
+// TurnCall records one admitted Run and its ordered events and result.
+type TurnCall struct {
+	AgentID string
+	Request agentengine.TurnRequest
+	Events  []agentengine.TurnEvent
+	Result  agentengine.TurnResult
+}
+
+// Resolution records one successful Resolve.
+type Resolution struct {
+	AgentID string
+	Value   agentengine.InteractionResolution
+}
+
+// MemoryClient is a concurrency-safe, stateful implementation of the same
+// Interface used by production adapters.
+type MemoryClient struct {
+	mu sync.Mutex
+
+	agents        map[string]agentengine.Agent
+	provisions    map[string]memoryProvision
+	conversations map[memoryConversation]string
+	active        map[memoryConversation]*memoryTurn
+	behavior      TurnBehavior
+	calls         []TurnCall
+	resolutions   []Resolution
+	nextAgentID   atomic.Uint64
+}
+
+type memoryProvision struct {
+	credentials map[string]string
+	initShell   string
+}
+
+type memoryConversation struct {
+	agentID string
+	key     agentengine.ConversationKey
+}
+
+type memoryTurn struct {
+	id           agentengine.TurnID
+	cancel       context.CancelFunc
+	done         chan struct{}
+	interactions map[string]agentengine.InteractionRequest
+}
+
+var errMemoryInteractionRejected = errors.New("memory interaction rejected")
+
+// NewMemoryClient creates a client with defensively copied seeded Agents.
+func NewMemoryClient(agents ...agentengine.Agent) *MemoryClient {
+	client := &MemoryClient{
+		agents:        make(map[string]agentengine.Agent),
+		provisions:    make(map[string]memoryProvision),
+		conversations: make(map[memoryConversation]string),
+		active:        make(map[memoryConversation]*memoryTurn),
+	}
+	for _, item := range agents {
+		client.provisions[item.ID] = memoryProvision{credentials: cloneStringMap(item.Spec.Runtime.Credentials), initShell: item.Spec.Runtime.InitShell}
+		item = cloneAgent(item)
+		item.Spec.Runtime.Credentials = nil
+		client.agents[item.ID] = item
+	}
+	return client
+}
+
+// SetTurnBehavior replaces the programmable Run behavior.
+func (c *MemoryClient) SetTurnBehavior(behavior TurnBehavior) {
+	c.mu.Lock()
+	c.behavior = behavior
+	c.mu.Unlock()
+}
+
+// Calls returns defensive copies of all admitted Runs.
+func (c *MemoryClient) Calls() []TurnCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]TurnCall, len(c.calls))
+	for index := range c.calls {
+		out[index] = cloneCall(c.calls[index])
+	}
+	return out
+}
+
+// Resolutions returns defensive copies of successful resolutions.
+func (c *MemoryClient) Resolutions() []Resolution {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := append([]Resolution(nil), c.resolutions...)
+	for index := range out {
+		out[index].Value = cloneResolution(out[index].Value)
+	}
+	return out
+}
+
+func (c *MemoryClient) Agents() agentengine.AgentInterface {
+	return &memoryAgents{client: c}
+}
+
+func (c *MemoryClient) Conversations(agentID string) agentengine.ConversationInterface {
+	return &memoryConversations{client: c, agentID: strings.TrimSpace(agentID)}
+}
+
+type memoryAgents struct {
+	client *MemoryClient
+}
+
+func (a *memoryAgents) Create(_ context.Context, spec agentengine.AgentSpec) (agentengine.Agent, error) {
+	spec = normalizeSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return agentengine.Agent{}, err
+	}
+	id := fmt.Sprintf("memory-agent-%d", a.client.nextAgentID.Add(1))
+	now := time.Now().UTC()
+	item := agentengine.Agent{ID: id, Spec: cloneSpec(spec), Status: agentengine.AgentStatus{State: agentengine.AgentStateStopped}, CreatedAt: now, UpdatedAt: now}
+	item.Spec.Runtime.Credentials = nil
+	a.client.mu.Lock()
+	a.client.agents[id] = item
+	a.client.provisions[id] = memoryProvision{credentials: cloneStringMap(spec.Runtime.Credentials), initShell: spec.Runtime.InitShell}
+	a.client.mu.Unlock()
+	return cloneAgent(item), nil
+}
+
+func (a *memoryAgents) Get(_ context.Context, agentID string) (agentengine.Agent, error) {
+	a.client.mu.Lock()
+	defer a.client.mu.Unlock()
+	item, ok := a.client.agents[strings.TrimSpace(agentID)]
+	if !ok {
+		for _, candidate := range a.client.agents {
+			if strings.EqualFold(candidate.Spec.Name, strings.TrimSpace(agentID)) {
+				item, ok = candidate, true
+				break
+			}
+		}
+	}
+	if !ok {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q not found", agentID)}
+	}
+	return cloneAgent(item), nil
+}
+
+func (a *memoryAgents) List(context.Context) ([]agentengine.Agent, error) {
+	a.client.mu.Lock()
+	defer a.client.mu.Unlock()
+	out := make([]agentengine.Agent, 0, len(a.client.agents))
+	for _, item := range a.client.agents {
+		out = append(out, cloneAgent(item))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (a *memoryAgents) Update(ctx context.Context, agentID string, spec agentengine.AgentSpec) (agentengine.Agent, error) {
+	spec = normalizeSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return agentengine.Agent{}, err
+	}
+	if err := a.waitForAgent(ctx, agentID); err != nil {
+		return agentengine.Agent{}, err
+	}
+	a.client.mu.Lock()
+	defer a.client.mu.Unlock()
+	item, ok := a.client.agents[strings.TrimSpace(agentID)]
+	if !ok {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q not found", agentID)}
+	}
+	if item.Spec.Role != spec.Role {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorInvalidRequest, Message: "agent role changes are not supported"}
+	}
+	item.Spec = cloneSpec(spec)
+	item.Spec.Runtime.Credentials = nil
+	item.UpdatedAt = time.Now().UTC()
+	a.client.agents[item.ID] = item
+	a.client.provisions[item.ID] = memoryProvision{credentials: cloneStringMap(spec.Runtime.Credentials), initShell: spec.Runtime.InitShell}
+	return cloneAgent(item), nil
+}
+
+func (a *memoryAgents) Delete(ctx context.Context, agentID string) error {
+	if err := a.waitForAgent(ctx, agentID); err != nil {
+		return err
+	}
+	a.client.mu.Lock()
+	delete(a.client.agents, strings.TrimSpace(agentID))
+	delete(a.client.provisions, strings.TrimSpace(agentID))
+	for key := range a.client.conversations {
+		if key.agentID == strings.TrimSpace(agentID) {
+			delete(a.client.conversations, key)
+		}
+	}
+	a.client.mu.Unlock()
+	return nil
+}
+
+func (a *memoryAgents) Start(_ context.Context, agentID string) (agentengine.Agent, error) {
+	return a.setState(agentID, agentengine.AgentStateRunning, true)
+}
+
+func (a *memoryAgents) Stop(ctx context.Context, agentID string) (agentengine.Agent, error) {
+	if err := a.waitForAgent(ctx, agentID); err != nil {
+		return agentengine.Agent{}, err
+	}
+	return a.setState(agentID, agentengine.AgentStateStopped, false)
+}
+
+func (a *memoryAgents) Recreate(ctx context.Context, agentID string) (agentengine.Agent, error) {
+	if err := a.waitForAgent(ctx, agentID); err != nil {
+		return agentengine.Agent{}, err
+	}
+	return a.setState(agentID, agentengine.AgentStateRunning, true)
+}
+
+func (a *memoryAgents) setState(agentID string, state agentengine.AgentState, ready bool) (agentengine.Agent, error) {
+	a.client.mu.Lock()
+	defer a.client.mu.Unlock()
+	item, ok := a.client.agents[strings.TrimSpace(agentID)]
+	if !ok {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q not found", agentID)}
+	}
+	item.Status.State = state
+	item.Status.Ready = ready
+	if ready && item.Status.RuntimeID == "" {
+		item.Status.RuntimeID = "memory-" + item.ID
+	}
+	item.UpdatedAt = time.Now().UTC()
+	a.client.agents[item.ID] = item
+	return cloneAgent(item), nil
+}
+
+func (a *memoryAgents) waitForAgent(ctx context.Context, agentID string) error {
+	for {
+		a.client.mu.Lock()
+		var pending []*memoryTurn
+		for key, turn := range a.client.active {
+			if key.agentID == strings.TrimSpace(agentID) {
+				pending = append(pending, turn)
+			}
+		}
+		a.client.mu.Unlock()
+		if len(pending) == 0 {
+			return nil
+		}
+		select {
+		case <-pending[0].done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+type memoryConversations struct {
+	client  *MemoryClient
+	agentID string
+}
+
+func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request.ID = agentengine.TurnID(strings.TrimSpace(string(request.ID)))
+	request.ConversationKey = agentengine.ConversationKey(strings.TrimSpace(string(request.ConversationKey)))
+	request.Continuation = agentengine.ContinuationPolicy(strings.TrimSpace(strings.ToLower(string(request.Continuation))))
+	request.Interaction = agentengine.InteractionPolicy(strings.TrimSpace(strings.ToLower(string(request.Interaction))))
+	if c.agentID == "" || request.ID == "" || request.ConversationKey == "" || len(request.Input) == 0 {
+		return failed(agentengine.ErrorInvalidRequest, "agent ID, turn ID, conversation key, and input are required")
+	}
+	for _, part := range request.Input {
+		if part.Kind == agentengine.InputPartText && (strings.TrimSpace(part.Text) == "" || part.File != nil) {
+			return failed(agentengine.ErrorInvalidRequest, "text input must contain only non-empty text")
+		}
+		if part.Kind == agentengine.InputPartFile && (part.File == nil || strings.TrimSpace(part.Text) != "") {
+			return failed(agentengine.ErrorInvalidRequest, "file input must include only a file")
+		}
+		if part.Kind == agentengine.InputPartFile && (strings.TrimSpace(part.File.ID) == "" || strings.TrimSpace(part.File.SourcePath) == "" || strings.TrimSpace(part.File.Name) == "" || strings.TrimSpace(part.File.MediaType) == "" || part.File.SizeBytes < 0 || len(strings.TrimSpace(part.File.SHA256)) != 64) {
+			return failed(agentengine.ErrorInvalidRequest, "file ID, source path, name, media type, non-negative size, and SHA-256 are required")
+		}
+		if part.Kind != agentengine.InputPartText && part.Kind != agentengine.InputPartFile {
+			return failed(agentengine.ErrorInvalidRequest, "unsupported input kind")
+		}
+	}
+	if request.Continuation == "" {
+		request.Continuation = agentengine.ContinuationCreateOrResume
+	}
+	if request.Interaction == "" {
+		request.Interaction = agentengine.InteractionResolve
+	}
+	if request.Continuation != agentengine.ContinuationCreateOrResume && request.Continuation != agentengine.ContinuationRequireExisting {
+		return failed(agentengine.ErrorInvalidRequest, fmt.Sprintf("unsupported continuation policy %q", request.Continuation))
+	}
+	if request.Interaction != agentengine.InteractionResolve && request.Interaction != agentengine.InteractionReject && request.Interaction != agentengine.InteractionSkipUserInput {
+		return failed(agentengine.ErrorInvalidRequest, fmt.Sprintf("unsupported interaction policy %q", request.Interaction))
+	}
+	if err := ctx.Err(); err != nil {
+		return agentengine.TurnResult{Status: agentengine.TurnCanceled, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: err.Error()}}
+	}
+	key := memoryConversation{agentID: c.agentID, key: request.ConversationKey}
+	runCtx, cancel := context.WithCancel(ctx)
+	turn := &memoryTurn{id: request.ID, cancel: cancel, done: make(chan struct{}), interactions: make(map[string]agentengine.InteractionRequest)}
+
+	c.client.mu.Lock()
+	agentItem, exists := c.client.agents[c.agentID]
+	if !exists || agentItem.Status.State != agentengine.AgentStateRunning {
+		c.client.mu.Unlock()
+		cancel()
+		return failed(agentengine.ErrorAgentUnavailable, "agent is unavailable")
+	}
+	if !strings.EqualFold(strings.TrimSpace(agentItem.Spec.Runtime.Adapter), "codex") {
+		c.client.mu.Unlock()
+		cancel()
+		return failed(agentengine.ErrorRuntimeAdapterUnavailable, fmt.Sprintf("runtime adapter %q is unavailable", agentItem.Spec.Runtime.Adapter))
+	}
+	if c.client.active[key] != nil {
+		c.client.mu.Unlock()
+		cancel()
+		return failed(agentengine.ErrorConversationBusy, "conversation already has an active turn")
+	}
+	if request.Continuation == agentengine.ContinuationRequireExisting && c.client.conversations[key] == "" {
+		c.client.mu.Unlock()
+		cancel()
+		return failed(agentengine.ErrorConversationNotResumable, "conversation has no Runtime-native mapping")
+	}
+	if c.client.conversations[key] == "" {
+		c.client.conversations[key] = "memory-conversation"
+	}
+	c.client.active[key] = turn
+	behavior := c.client.behavior
+	callIndex := len(c.client.calls)
+	c.client.calls = append(c.client.calls, TurnCall{AgentID: c.agentID, Request: cloneRequest(request)})
+	c.client.mu.Unlock()
+
+	sequence := uint64(0)
+	var policyMu sync.Mutex
+	var policyResult *agentengine.TurnResult
+	recordingSink := agentengine.EventSinkFunc(func(eventCtx context.Context, event agentengine.TurnEvent) error {
+		if event.Interaction != nil {
+			switch request.Interaction {
+			case agentengine.InteractionReject:
+				result := failed(agentengine.ErrorInteractionUnsupported, "Runtime interaction is not supported by this caller")
+				result.Dispatched = true
+				policyMu.Lock()
+				policyResult = &result
+				policyMu.Unlock()
+				cancel()
+				return errMemoryInteractionRejected
+			case agentengine.InteractionSkipUserInput:
+				c.client.mu.Lock()
+				c.client.resolutions = append(c.client.resolutions, Resolution{AgentID: c.agentID, Value: agentengine.InteractionResolution{
+					ConversationKey: request.ConversationKey,
+					InteractionID:   event.Interaction.ID,
+					ResponderID:     "agent-engine",
+				}})
+				c.client.mu.Unlock()
+				return nil
+			default:
+				c.client.mu.Lock()
+				turn.interactions[event.Interaction.ID] = *event.Interaction
+				c.client.mu.Unlock()
+			}
+		}
+		sequence++
+		event.Sequence = sequence
+		c.client.mu.Lock()
+		c.client.calls[callIndex].Events = append(c.client.calls[callIndex].Events, event)
+		c.client.mu.Unlock()
+		if sink != nil {
+			return sink.Emit(eventCtx, event)
+		}
+		return nil
+	})
+
+	result := agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+	if behavior != nil {
+		result = behavior(runCtx, c.agentID, cloneRequest(request), recordingSink)
+	}
+	if runCtx.Err() != nil && result.Status == agentengine.TurnSucceeded {
+		result = agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: result.Dispatched, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: runCtx.Err().Error()}}
+	}
+	policyMu.Lock()
+	if policyResult != nil {
+		result = *policyResult
+	}
+	policyMu.Unlock()
+	cancel()
+	c.client.mu.Lock()
+	c.client.calls[callIndex].Result = result
+	delete(c.client.active, key)
+	c.client.mu.Unlock()
+	close(turn.done)
+	return result
+}
+
+func (c *memoryConversations) Cancel(ctx context.Context, key agentengine.ConversationKey, turnID agentengine.TurnID) error {
+	c.client.mu.Lock()
+	turn := c.client.active[memoryConversation{agentID: c.agentID, key: key}]
+	if turn == nil || turn.id != turnID {
+		c.client.mu.Unlock()
+		return nil
+	}
+	turn.cancel()
+	done := turn.done
+	c.client.mu.Unlock()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *memoryConversations) Reset(_ context.Context, key agentengine.ConversationKey) error {
+	identity := memoryConversation{agentID: c.agentID, key: key}
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+	if c.client.active[identity] != nil {
+		return &agentengine.TurnError{Code: agentengine.ErrorConversationBusy, Message: "conversation already has an active turn"}
+	}
+	delete(c.client.conversations, identity)
+	return nil
+}
+
+func (c *memoryConversations) Resolve(_ context.Context, resolution agentengine.InteractionResolution) error {
+	identity := memoryConversation{agentID: c.agentID, key: resolution.ConversationKey}
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+	turn := c.client.active[identity]
+	if turn == nil {
+		return &agentengine.TurnError{Code: agentengine.ErrorInteractionNotFound, Message: "pending interaction was not found"}
+	}
+	if _, ok := turn.interactions[resolution.InteractionID]; !ok {
+		return &agentengine.TurnError{Code: agentengine.ErrorInteractionNotFound, Message: "pending interaction was not found"}
+	}
+	delete(turn.interactions, resolution.InteractionID)
+	c.client.resolutions = append(c.client.resolutions, Resolution{AgentID: c.agentID, Value: cloneResolution(resolution)})
+	return nil
+}
+
+func validateSpec(spec agentengine.AgentSpec) error {
+	if strings.TrimSpace(spec.Name) == "" || strings.TrimSpace(spec.Runtime.Adapter) == "" {
+		return &agentengine.TurnError{Code: agentengine.ErrorInvalidRequest, Message: "agent name and Runtime adapter are required"}
+	}
+	if (len(spec.Runtime.Credentials) > 0 || strings.TrimSpace(spec.Runtime.InitShell) != "") && !strings.EqualFold(strings.TrimSpace(spec.Runtime.Adapter), "codex") {
+		return &agentengine.TurnError{Code: agentengine.ErrorUnsupportedRuntimeProvision, Message: "Runtime credentials and initShell are supported only by Codex"}
+	}
+	if spec.Role != agentengine.AgentRoleWorker && spec.Role != agentengine.AgentRoleManager {
+		return &agentengine.TurnError{Code: agentengine.ErrorInvalidRequest, Message: "agent role must be worker or manager"}
+	}
+	return nil
+}
+
+func normalizeSpec(spec agentengine.AgentSpec) agentengine.AgentSpec {
+	if strings.TrimSpace(string(spec.Role)) == "" {
+		spec.Role = agentengine.AgentRoleWorker
+	}
+	spec.Role = agentengine.AgentRole(strings.ToLower(strings.TrimSpace(string(spec.Role))))
+	spec.Runtime.Adapter = strings.ToLower(strings.TrimSpace(spec.Runtime.Adapter))
+	return spec
+}
+
+func failed(code agentengine.ErrorCode, message string) agentengine.TurnResult {
+	return agentengine.TurnResult{Status: agentengine.TurnFailed, Error: &agentengine.TurnError{Code: code, Message: message}}
+}
+
+func cloneAgent(input agentengine.Agent) agentengine.Agent {
+	input.Spec = cloneSpec(input.Spec)
+	input.Spec.Runtime.Credentials = nil
+	return input
+}
+
+func cloneSpec(input agentengine.AgentSpec) agentengine.AgentSpec {
+	input.Skills = append([]string(nil), input.Skills...)
+	input.Runtime.Credentials = cloneStringMap(input.Runtime.Credentials)
+	input.Runtime.Options = cloneAnyMap(input.Runtime.Options)
+	input.Model.Options = cloneAnyMap(input.Model.Options)
+	servers := input.MCPServers
+	input.MCPServers = make(map[string]agentengine.MCPServerConfig, len(servers))
+	for name, config := range servers {
+		input.MCPServers[name] = agentengine.MCPServerConfig(cloneAnyMap(map[string]any(config)))
+	}
+	return input
+}
+
+func cloneRequest(input agentengine.TurnRequest) agentengine.TurnRequest {
+	input.Input = append([]agentengine.InputPart(nil), input.Input...)
+	for index := range input.Input {
+		if input.Input[index].File != nil {
+			fileCopy := *input.Input[index].File
+			input.Input[index].File = &fileCopy
+		}
+	}
+	return input
+}
+
+func cloneResolution(input agentengine.InteractionResolution) agentengine.InteractionResolution {
+	input.Answers = make(map[string]agentengine.InteractionAnswer, len(input.Answers))
+	for key, answer := range input.Answers {
+		answer.Values = append([]string(nil), answer.Values...)
+		input.Answers[key] = answer
+	}
+	return input
+}
+
+func cloneCall(input TurnCall) TurnCall {
+	input.Request = cloneRequest(input.Request)
+	events := make([]agentengine.TurnEvent, len(input.Events))
+	for index, event := range input.Events {
+		event.Tool = cloneTool(event.Tool)
+		event.Activity = cloneActivity(event.Activity)
+		event.Interaction = cloneInteraction(event.Interaction)
+		event.Output = cloneOutput(event.Output)
+		events[index] = event
+	}
+	input.Events = events
+	return input
+}
+
+func cloneTool(input *agentengine.ToolActivity) *agentengine.ToolActivity {
+	if input == nil {
+		return nil
+	}
+	out := *input
+	out.Payload = cloneAny(input.Payload)
+	return &out
+}
+
+func cloneActivity(input *agentengine.ActivityUpdate) *agentengine.ActivityUpdate {
+	if input == nil {
+		return nil
+	}
+	out := *input
+	out.Payload = cloneAny(input.Payload)
+	return &out
+}
+
+func cloneInteraction(input *agentengine.InteractionRequest) *agentengine.InteractionRequest {
+	if input == nil {
+		return nil
+	}
+	out := *input
+	out.Payload = cloneAny(input.Payload)
+	return &out
+}
+
+func cloneOutput(input *agentengine.OutputItem) *agentengine.OutputItem {
+	if input == nil {
+		return nil
+	}
+	out := *input
+	out.Payload = cloneAny(input.Payload)
+	return &out
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = cloneAny(value)
+	}
+	return out
+}
+
+func cloneAny(input any) any {
+	switch value := input.(type) {
+	case map[string]any:
+		return cloneAnyMap(value)
+	case []any:
+		out := make([]any, len(value))
+		for index := range value {
+			out[index] = cloneAny(value[index])
+		}
+		return out
+	case []string:
+		return append([]string(nil), value...)
+	default:
+		return value
+	}
+}
+
+var _ agentengine.Interface = (*MemoryClient)(nil)

--- a/internal/agentengine/enginetest/memory_client.go
+++ b/internal/agentengine/enginetest/memory_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -36,14 +37,17 @@ type Resolution struct {
 type MemoryClient struct {
 	mu sync.Mutex
 
-	agents        map[string]agentengine.Agent
-	provisions    map[string]memoryProvision
-	conversations map[memoryConversation]string
-	active        map[memoryConversation]*memoryTurn
-	behavior      TurnBehavior
-	calls         []TurnCall
-	resolutions   []Resolution
-	nextAgentID   atomic.Uint64
+	agents         map[string]agentengine.Agent
+	provisions     map[string]memoryProvision
+	conversations  map[memoryConversation]string
+	active         map[memoryConversation]*memoryTurn
+	controls       map[memoryConversation]*memoryControl
+	completed      map[memoryTurnIdentity]memoryCompletedTurn
+	completedOrder []memoryTurnIdentity
+	behavior       TurnBehavior
+	calls          []TurnCall
+	resolutions    []Resolution
+	nextAgentID    atomic.Uint64
 }
 
 type memoryProvision struct {
@@ -57,11 +61,38 @@ type memoryConversation struct {
 }
 
 type memoryTurn struct {
-	id           agentengine.TurnID
+	request      agentengine.TurnRequest
+	ctx          context.Context
 	cancel       context.CancelFunc
 	done         chan struct{}
-	interactions map[string]agentengine.InteractionRequest
+	interactions map[string]*memoryInteraction
+	sequence     uint64
+	events       []agentengine.TurnEvent
+	result       agentengine.TurnResult
+	callIndex    int
 }
+
+type memoryControl struct {
+	done chan struct{}
+}
+
+type memoryTurnIdentity struct {
+	memoryConversation
+	id agentengine.TurnID
+}
+
+type memoryCompletedTurn struct {
+	request agentengine.TurnRequest
+	events  []agentengine.TurnEvent
+	result  agentengine.TurnResult
+}
+
+type memoryInteraction struct {
+	request   agentengine.InteractionRequest
+	resolving bool
+}
+
+const maxMemoryCompletedTurns = 1024
 
 var errMemoryInteractionRejected = errors.New("memory interaction rejected")
 
@@ -72,6 +103,8 @@ func NewMemoryClient(agents ...agentengine.Agent) *MemoryClient {
 		provisions:    make(map[string]memoryProvision),
 		conversations: make(map[memoryConversation]string),
 		active:        make(map[memoryConversation]*memoryTurn),
+		controls:      make(map[memoryConversation]*memoryControl),
+		completed:     make(map[memoryTurnIdentity]memoryCompletedTurn),
 	}
 	for _, item := range agents {
 		client.provisions[item.ID] = memoryProvision{credentials: cloneStringMap(item.Spec.Runtime.Credentials), initShell: item.Spec.Runtime.InitShell}
@@ -276,6 +309,7 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 	}
 	request.ID = agentengine.TurnID(strings.TrimSpace(string(request.ID)))
 	request.ConversationKey = agentengine.ConversationKey(strings.TrimSpace(string(request.ConversationKey)))
+	request.Admission = agentengine.AdmissionPolicy(strings.TrimSpace(strings.ToLower(string(request.Admission))))
 	request.Continuation = agentengine.ContinuationPolicy(strings.TrimSpace(strings.ToLower(string(request.Continuation))))
 	request.Interaction = agentengine.InteractionPolicy(strings.TrimSpace(strings.ToLower(string(request.Interaction))))
 	if c.agentID == "" || request.ID == "" || request.ConversationKey == "" || len(request.Input) == 0 {
@@ -301,6 +335,12 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 	if request.Interaction == "" {
 		request.Interaction = agentengine.InteractionResolve
 	}
+	if request.Admission == "" {
+		request.Admission = agentengine.AdmissionRejectIfBusy
+	}
+	if request.Admission != agentengine.AdmissionRejectIfBusy && request.Admission != agentengine.AdmissionWait && request.Admission != agentengine.AdmissionSupersede {
+		return failed(agentengine.ErrorInvalidRequest, fmt.Sprintf("unsupported admission policy %q", request.Admission))
+	}
 	if request.Continuation != agentengine.ContinuationCreateOrResume && request.Continuation != agentengine.ContinuationRequireExisting {
 		return failed(agentengine.ErrorInvalidRequest, fmt.Sprintf("unsupported continuation policy %q", request.Continuation))
 	}
@@ -311,41 +351,51 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 		return agentengine.TurnResult{Status: agentengine.TurnCanceled, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: err.Error()}}
 	}
 	key := memoryConversation{agentID: c.agentID, key: request.ConversationKey}
-	runCtx, cancel := context.WithCancel(ctx)
-	turn := &memoryTurn{id: request.ID, cancel: cancel, done: make(chan struct{}), interactions: make(map[string]agentengine.InteractionRequest)}
+	turn, completed, existing, admissionResult := c.admit(ctx, key, request)
+	if completed != nil {
+		return replayMemoryEvents(ctx, sink, completed.events, completed.result)
+	}
+	if existing != nil {
+		if err := waitMemory(ctx, existing.done); err != nil {
+			return memoryContextResult(ctx, err)
+		}
+		return replayMemoryEvents(ctx, sink, existing.events, existing.result)
+	}
+	if admissionResult != nil {
+		return *admissionResult
+	}
 
 	c.client.mu.Lock()
 	agentItem, exists := c.client.agents[c.agentID]
 	if !exists || agentItem.Status.State != agentengine.AgentStateRunning {
 		c.client.mu.Unlock()
-		cancel()
-		return failed(agentengine.ErrorAgentUnavailable, "agent is unavailable")
+		result := failed(agentengine.ErrorAgentUnavailable, "agent is unavailable")
+		turn.cancel()
+		c.completeMemoryTurn(key, turn, result)
+		return result
 	}
 	if !strings.EqualFold(strings.TrimSpace(agentItem.Spec.Runtime.Adapter), "codex") {
 		c.client.mu.Unlock()
-		cancel()
-		return failed(agentengine.ErrorRuntimeAdapterUnavailable, fmt.Sprintf("runtime adapter %q is unavailable", agentItem.Spec.Runtime.Adapter))
-	}
-	if c.client.active[key] != nil {
-		c.client.mu.Unlock()
-		cancel()
-		return failed(agentengine.ErrorConversationBusy, "conversation already has an active turn")
+		result := failed(agentengine.ErrorRuntimeAdapterUnavailable, fmt.Sprintf("runtime adapter %q is unavailable", agentItem.Spec.Runtime.Adapter))
+		turn.cancel()
+		c.completeMemoryTurn(key, turn, result)
+		return result
 	}
 	if request.Continuation == agentengine.ContinuationRequireExisting && c.client.conversations[key] == "" {
 		c.client.mu.Unlock()
-		cancel()
-		return failed(agentengine.ErrorConversationNotResumable, "conversation has no Runtime-native mapping")
+		result := failed(agentengine.ErrorConversationNotResumable, "conversation has no Runtime-native mapping")
+		turn.cancel()
+		c.completeMemoryTurn(key, turn, result)
+		return result
 	}
 	if c.client.conversations[key] == "" {
 		c.client.conversations[key] = "memory-conversation"
 	}
-	c.client.active[key] = turn
 	behavior := c.client.behavior
-	callIndex := len(c.client.calls)
+	turn.callIndex = len(c.client.calls)
 	c.client.calls = append(c.client.calls, TurnCall{AgentID: c.agentID, Request: cloneRequest(request)})
 	c.client.mu.Unlock()
 
-	sequence := uint64(0)
 	var policyMu sync.Mutex
 	var policyResult *agentengine.TurnResult
 	recordingSink := agentengine.EventSinkFunc(func(eventCtx context.Context, event agentengine.TurnEvent) error {
@@ -357,7 +407,7 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 				policyMu.Lock()
 				policyResult = &result
 				policyMu.Unlock()
-				cancel()
+				turn.cancel()
 				return errMemoryInteractionRejected
 			case agentengine.InteractionSkipUserInput:
 				c.client.mu.Lock()
@@ -369,47 +419,35 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 				c.client.mu.Unlock()
 				return nil
 			default:
-				c.client.mu.Lock()
-				turn.interactions[event.Interaction.ID] = *event.Interaction
-				c.client.mu.Unlock()
+				// The common recorder below atomically publishes the pending interaction.
 			}
 		}
-		sequence++
-		event.Sequence = sequence
-		c.client.mu.Lock()
-		c.client.calls[callIndex].Events = append(c.client.calls[callIndex].Events, event)
-		c.client.mu.Unlock()
-		if sink != nil {
-			return sink.Emit(eventCtx, event)
-		}
-		return nil
+		return c.recordMemoryEvent(eventCtx, turn, sink, event)
 	})
 
 	result := agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
 	if behavior != nil {
-		result = behavior(runCtx, c.agentID, cloneRequest(request), recordingSink)
+		result = behavior(turn.ctx, c.agentID, cloneRequest(request), recordingSink)
 	}
-	if runCtx.Err() != nil && result.Status == agentengine.TurnSucceeded {
-		result = agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: result.Dispatched, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: runCtx.Err().Error()}}
+	if turn.ctx.Err() != nil && result.Status == agentengine.TurnSucceeded {
+		result = agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: result.Dispatched, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: turn.ctx.Err().Error()}}
 	}
 	policyMu.Lock()
 	if policyResult != nil {
 		result = *policyResult
 	}
 	policyMu.Unlock()
-	cancel()
-	c.client.mu.Lock()
-	c.client.calls[callIndex].Result = result
-	delete(c.client.active, key)
-	c.client.mu.Unlock()
-	close(turn.done)
+	turn.cancel()
+	c.completeMemoryTurn(key, turn, result)
 	return result
 }
 
 func (c *memoryConversations) Cancel(ctx context.Context, key agentengine.ConversationKey, turnID agentengine.TurnID) error {
+	key = agentengine.ConversationKey(strings.TrimSpace(string(key)))
+	turnID = agentengine.TurnID(strings.TrimSpace(string(turnID)))
 	c.client.mu.Lock()
 	turn := c.client.active[memoryConversation{agentID: c.agentID, key: key}]
-	if turn == nil || turn.id != turnID {
+	if turn == nil || turn.request.ID != turnID {
 		c.client.mu.Unlock()
 		return nil
 	}
@@ -424,31 +462,278 @@ func (c *memoryConversations) Cancel(ctx context.Context, key agentengine.Conver
 	}
 }
 
-func (c *memoryConversations) Reset(_ context.Context, key agentengine.ConversationKey) error {
-	identity := memoryConversation{agentID: c.agentID, key: key}
-	c.client.mu.Lock()
-	defer c.client.mu.Unlock()
-	if c.client.active[identity] != nil {
-		return &agentengine.TurnError{Code: agentengine.ErrorConversationBusy, Message: "conversation already has an active turn"}
+func (c *memoryConversations) Reset(ctx context.Context, key agentengine.ConversationKey) error {
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	key = agentengine.ConversationKey(strings.TrimSpace(string(key)))
+	if c.agentID == "" || key == "" {
+		return &agentengine.TurnError{Code: agentengine.ErrorInvalidRequest, Message: "agent ID and conversation key are required"}
+	}
+	identity := memoryConversation{agentID: c.agentID, key: key}
+	control, active, ok := c.beginMemoryControl(identity)
+	if !ok {
+		return &agentengine.TurnError{Code: agentengine.ErrorConversationBusy, Message: "conversation already has a control operation"}
+	}
+	defer c.endMemoryControl(identity, control)
+	if active != nil {
+		if err := waitMemory(ctx, active.done); err != nil {
+			return err
+		}
+	}
+	c.client.mu.Lock()
 	delete(c.client.conversations, identity)
+	c.client.mu.Unlock()
 	return nil
 }
 
 func (c *memoryConversations) Resolve(_ context.Context, resolution agentengine.InteractionResolution) error {
+	resolution.ConversationKey = agentengine.ConversationKey(strings.TrimSpace(string(resolution.ConversationKey)))
+	resolution.InteractionID = strings.TrimSpace(resolution.InteractionID)
+	resolution.ResponderID = strings.TrimSpace(resolution.ResponderID)
 	identity := memoryConversation{agentID: c.agentID, key: resolution.ConversationKey}
 	c.client.mu.Lock()
-	defer c.client.mu.Unlock()
 	turn := c.client.active[identity]
 	if turn == nil {
+		c.client.mu.Unlock()
 		return &agentengine.TurnError{Code: agentengine.ErrorInteractionNotFound, Message: "pending interaction was not found"}
 	}
-	if _, ok := turn.interactions[resolution.InteractionID]; !ok {
+	pending := turn.interactions[resolution.InteractionID]
+	if pending == nil || pending.resolving {
+		c.client.mu.Unlock()
 		return &agentengine.TurnError{Code: agentengine.ErrorInteractionNotFound, Message: "pending interaction was not found"}
 	}
+	pending.resolving = true
 	delete(turn.interactions, resolution.InteractionID)
 	c.client.resolutions = append(c.client.resolutions, Resolution{AgentID: c.agentID, Value: cloneResolution(resolution)})
+	c.client.mu.Unlock()
 	return nil
+}
+
+func (c *memoryConversations) admit(ctx context.Context, identity memoryConversation, request agentengine.TurnRequest) (*memoryTurn, *memoryCompletedTurn, *memoryTurn, *agentengine.TurnResult) {
+	for {
+		c.client.mu.Lock()
+		turnKey := memoryTurnIdentity{memoryConversation: identity, id: request.ID}
+		if completed, ok := c.client.completed[turnKey]; ok {
+			if !sameMemoryRequest(completed.request, request) {
+				c.client.mu.Unlock()
+				result := failed(agentengine.ErrorInvalidRequest, "turn ID was already used with a different request")
+				return nil, nil, nil, &result
+			}
+			copy := cloneMemoryCompleted(completed)
+			c.client.mu.Unlock()
+			return nil, &copy, nil, nil
+		}
+		if current := c.client.active[identity]; current != nil && current.request.ID == request.ID {
+			if !sameMemoryRequest(current.request, request) {
+				c.client.mu.Unlock()
+				result := failed(agentengine.ErrorInvalidRequest, "turn ID is active with a different request")
+				return nil, nil, nil, &result
+			}
+			c.client.mu.Unlock()
+			return nil, nil, current, nil
+		}
+		control := c.client.controls[identity]
+		current := c.client.active[identity]
+		if control == nil && current == nil {
+			turn := newMemoryTurn(ctx, request)
+			c.client.active[identity] = turn
+			c.client.mu.Unlock()
+			return turn, nil, nil, nil
+		}
+		switch request.Admission {
+		case agentengine.AdmissionRejectIfBusy:
+			c.client.mu.Unlock()
+			result := failed(agentengine.ErrorConversationBusy, "conversation already has an active turn or control operation")
+			return nil, nil, nil, &result
+		case agentengine.AdmissionWait:
+			done := memoryControlDone(control, current)
+			c.client.mu.Unlock()
+			if err := waitMemory(ctx, done); err != nil {
+				result := memoryContextResult(ctx, err)
+				return nil, nil, nil, &result
+			}
+		case agentengine.AdmissionSupersede:
+			if control != nil {
+				done := control.done
+				c.client.mu.Unlock()
+				if err := waitMemory(ctx, done); err != nil {
+					result := memoryContextResult(ctx, err)
+					return nil, nil, nil, &result
+				}
+				continue
+			}
+			owned := &memoryControl{done: make(chan struct{})}
+			c.client.controls[identity] = owned
+			current.cancel()
+			done := current.done
+			c.client.mu.Unlock()
+			if err := waitMemory(ctx, done); err != nil {
+				c.endMemoryControl(identity, owned)
+				result := memoryContextResult(ctx, err)
+				return nil, nil, nil, &result
+			}
+			turn := newMemoryTurn(ctx, request)
+			if !c.promoteMemoryControl(identity, owned, turn) {
+				turn.cancel()
+				result := failed(agentengine.ErrorConversationBusy, "conversation admission changed while superseding")
+				return nil, nil, nil, &result
+			}
+			return turn, nil, nil, nil
+		}
+	}
+}
+
+func newMemoryTurn(ctx context.Context, request agentengine.TurnRequest) *memoryTurn {
+	runCtx, cancel := context.WithCancel(ctx)
+	return &memoryTurn{
+		request:      cloneRequest(request),
+		ctx:          runCtx,
+		cancel:       cancel,
+		done:         make(chan struct{}),
+		interactions: make(map[string]*memoryInteraction),
+		callIndex:    -1,
+	}
+}
+
+func (c *memoryConversations) beginMemoryControl(identity memoryConversation) (*memoryControl, *memoryTurn, bool) {
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+	if c.client.controls[identity] != nil {
+		return nil, nil, false
+	}
+	control := &memoryControl{done: make(chan struct{})}
+	c.client.controls[identity] = control
+	active := c.client.active[identity]
+	if active != nil {
+		active.cancel()
+	}
+	return control, active, true
+}
+
+func (c *memoryConversations) promoteMemoryControl(identity memoryConversation, control *memoryControl, turn *memoryTurn) bool {
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+	if c.client.controls[identity] != control || c.client.active[identity] != nil {
+		return false
+	}
+	c.client.active[identity] = turn
+	delete(c.client.controls, identity)
+	close(control.done)
+	return true
+}
+
+func (c *memoryConversations) endMemoryControl(identity memoryConversation, control *memoryControl) {
+	c.client.mu.Lock()
+	if c.client.controls[identity] == control {
+		delete(c.client.controls, identity)
+		close(control.done)
+	}
+	c.client.mu.Unlock()
+}
+
+func (c *memoryConversations) recordMemoryEvent(ctx context.Context, turn *memoryTurn, sink agentengine.EventSink, event agentengine.TurnEvent) error {
+	c.client.mu.Lock()
+	turn.sequence++
+	event.TurnID = turn.request.ID
+	event.Sequence = turn.sequence
+	if event.Interaction != nil {
+		interaction := *event.Interaction
+		interaction.ID = strings.TrimSpace(interaction.ID)
+		if interaction.ID != "" {
+			turn.interactions[interaction.ID] = &memoryInteraction{request: interaction}
+			event.Interaction = &interaction
+		}
+	}
+	turn.events = append(turn.events, cloneEvent(event))
+	if turn.callIndex >= 0 {
+		c.client.calls[turn.callIndex].Events = append(c.client.calls[turn.callIndex].Events, cloneEvent(event))
+	}
+	c.client.mu.Unlock()
+	if sink == nil {
+		return nil
+	}
+	return sink.Emit(ctx, cloneEvent(event))
+}
+
+func (c *memoryConversations) completeMemoryTurn(identity memoryConversation, turn *memoryTurn, result agentengine.TurnResult) {
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+	turn.result = cloneMemoryResult(result)
+	if turn.callIndex >= 0 {
+		c.client.calls[turn.callIndex].Result = cloneMemoryResult(result)
+	}
+	if c.client.active[identity] == turn {
+		delete(c.client.active, identity)
+	}
+	if result.Dispatched {
+		key := memoryTurnIdentity{memoryConversation: identity, id: turn.request.ID}
+		c.client.completed[key] = memoryCompletedTurn{request: cloneRequest(turn.request), events: cloneEvents(turn.events), result: cloneMemoryResult(result)}
+		c.client.completedOrder = append(c.client.completedOrder, key)
+		if len(c.client.completedOrder) > maxMemoryCompletedTurns {
+			oldest := c.client.completedOrder[0]
+			c.client.completedOrder = c.client.completedOrder[1:]
+			delete(c.client.completed, oldest)
+		}
+	}
+	close(turn.done)
+}
+
+func replayMemoryEvents(ctx context.Context, sink agentengine.EventSink, events []agentengine.TurnEvent, result agentengine.TurnResult) agentengine.TurnResult {
+	for _, event := range events {
+		if sink != nil {
+			if err := sink.Emit(ctx, cloneEvent(event)); err != nil {
+				failedResult := failed(agentengine.ErrorRuntimeFailed, err.Error())
+				failedResult.Dispatched = result.Dispatched
+				return failedResult
+			}
+		}
+	}
+	return cloneMemoryResult(result)
+}
+
+func waitMemory(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func memoryControlDone(control *memoryControl, turn *memoryTurn) <-chan struct{} {
+	if control != nil {
+		return control.done
+	}
+	return turn.done
+}
+
+func memoryContextResult(ctx context.Context, err error) agentengine.TurnResult {
+	if err == nil {
+		err = ctx.Err()
+	}
+	return agentengine.TurnResult{Status: agentengine.TurnCanceled, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: err.Error()}}
+}
+
+func sameMemoryRequest(left, right agentengine.TurnRequest) bool {
+	left.Admission = ""
+	right.Admission = ""
+	return reflect.DeepEqual(left, right)
+}
+
+func cloneMemoryCompleted(input memoryCompletedTurn) memoryCompletedTurn {
+	input.request = cloneRequest(input.request)
+	input.events = cloneEvents(input.events)
+	input.result = cloneMemoryResult(input.result)
+	return input
+}
+
+func cloneMemoryResult(input agentengine.TurnResult) agentengine.TurnResult {
+	if input.Error != nil {
+		errorCopy := *input.Error
+		input.Error = &errorCopy
+	}
+	return input
 }
 
 func validateSpec(spec agentengine.AgentSpec) error {
@@ -518,16 +803,24 @@ func cloneResolution(input agentengine.InteractionResolution) agentengine.Intera
 
 func cloneCall(input TurnCall) TurnCall {
 	input.Request = cloneRequest(input.Request)
-	events := make([]agentengine.TurnEvent, len(input.Events))
-	for index, event := range input.Events {
-		event.Tool = cloneTool(event.Tool)
-		event.Activity = cloneActivity(event.Activity)
-		event.Interaction = cloneInteraction(event.Interaction)
-		event.Output = cloneOutput(event.Output)
-		events[index] = event
-	}
-	input.Events = events
+	input.Events = cloneEvents(input.Events)
 	return input
+}
+
+func cloneEvents(input []agentengine.TurnEvent) []agentengine.TurnEvent {
+	output := make([]agentengine.TurnEvent, len(input))
+	for index, event := range input {
+		output[index] = cloneEvent(event)
+	}
+	return output
+}
+
+func cloneEvent(event agentengine.TurnEvent) agentengine.TurnEvent {
+	event.Tool = cloneTool(event.Tool)
+	event.Activity = cloneActivity(event.Activity)
+	event.Interaction = cloneInteraction(event.Interaction)
+	event.Output = cloneOutput(event.Output)
+	return event
 }
 
 func cloneTool(input *agentengine.ToolActivity) *agentengine.ToolActivity {

--- a/internal/agentengine/enginetest/memory_client_test.go
+++ b/internal/agentengine/enginetest/memory_client_test.go
@@ -1,0 +1,184 @@
+package enginetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"csgclaw/internal/agentengine"
+)
+
+func runningAgent(id string) agentengine.Agent {
+	return agentengine.Agent{
+		ID: id,
+		Spec: agentengine.AgentSpec{
+			Name:    id,
+			Role:    agentengine.AgentRoleWorker,
+			Runtime: agentengine.RuntimeSpec{Adapter: "codex"},
+		},
+		Status: agentengine.AgentStatus{State: agentengine.AgentStateRunning, RuntimeID: "runtime-" + id, Ready: true},
+	}
+}
+
+func TestMemoryClientAgentLifecycleAndSecretRedaction(t *testing.T) {
+	client := NewMemoryClient()
+	created, err := client.Agents().Create(context.Background(), agentengine.AgentSpec{
+		Name:       "worker",
+		Role:       agentengine.AgentRoleWorker,
+		Runtime:    agentengine.RuntimeSpec{Adapter: "codex", Options: map[string]any{"mode": "fast"}},
+		Skills:     []string{"review"},
+		MCPServers: map[string]agentengine.MCPServerConfig{"tools": {"command": "tool"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := client.Agents().Start(context.Background(), created.ID)
+	if err != nil || started.Status.State != agentengine.AgentStateRunning {
+		t.Fatalf("Start() = %+v, %v", started, err)
+	}
+	started.Spec.Skills[0] = "mutated"
+	got, err := client.Agents().Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.Skills[0] != "review" || got.Spec.Runtime.Credentials != nil {
+		t.Fatalf("Get() leaked mutation or credentials: %+v", got)
+	}
+	provisioned, err := client.Agents().Update(context.Background(), created.ID, agentengine.AgentSpec{
+		Name:    "worker",
+		Runtime: agentengine.RuntimeSpec{Adapter: "codex", Credentials: map[string]string{"secrets/token": "secret"}, InitShell: "test -f secrets/token"},
+	})
+	if err != nil || provisioned.Spec.Runtime.Credentials != nil || provisioned.Spec.Runtime.InitShell != "test -f secrets/token" {
+		t.Fatalf("provisioned Update = %+v, %v", provisioned, err)
+	}
+	if _, err := client.Agents().Update(context.Background(), created.ID, agentengine.AgentSpec{
+		Name:    "worker",
+		Runtime: agentengine.RuntimeSpec{Adapter: "openclaw", Credentials: map[string]string{"token": "secret"}},
+	}); !hasCode(err, agentengine.ErrorUnsupportedRuntimeProvision) {
+		t.Fatalf("unsupported credential Update error = %v", err)
+	}
+}
+
+func TestMemoryClientConversationContract(t *testing.T) {
+	client := NewMemoryClient(runningAgent("agent-a"))
+	started := make(chan agentengine.ConversationKey, 2)
+	release := make(chan struct{})
+	client.SetTurnBehavior(func(ctx context.Context, _ string, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		started <- request.ConversationKey
+		if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "one"}); err != nil {
+			return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()}}
+		}
+		<-release
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "one", Dispatched: true}
+	})
+	firstDone := make(chan agentengine.TurnResult, 1)
+	go func() {
+		firstDone <- client.Conversations("agent-a").Run(context.Background(), turnRequest("turn-1", "conversation-1"), nil)
+	}()
+	<-started
+	overlap := client.Conversations("agent-a").Run(context.Background(), turnRequest("turn-2", "conversation-1"), nil)
+	if overlap.Error == nil || overlap.Error.Code != agentengine.ErrorConversationBusy || overlap.Dispatched {
+		t.Fatalf("overlap = %+v", overlap)
+	}
+	secondDone := make(chan agentengine.TurnResult, 1)
+	go func() {
+		secondDone <- client.Conversations("agent-a").Run(context.Background(), turnRequest("turn-3", "conversation-2"), nil)
+	}()
+	<-started
+	close(release)
+	if (<-firstDone).Status != agentengine.TurnSucceeded || (<-secondDone).Status != agentengine.TurnSucceeded {
+		t.Fatal("different conversations did not complete")
+	}
+	calls := client.Calls()
+	if len(calls) != 2 || len(calls[0].Events) != 1 || calls[0].Events[0].Sequence != 1 {
+		t.Fatalf("calls = %+v", calls)
+	}
+}
+
+func TestMemoryClientCancelResetAndResolve(t *testing.T) {
+	client := NewMemoryClient(runningAgent("agent-a"))
+	started := make(chan struct{})
+	cleanup := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	client.SetTurnBehavior(func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		if err := sink.Emit(ctx, agentengine.TurnEvent{
+			Kind:        agentengine.TurnEventInteractionRequest,
+			Interaction: &agentengine.InteractionRequest{ID: "question-1", Kind: agentengine.InteractionUserInput},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		close(started)
+		<-ctx.Done()
+		close(cleanup)
+		<-releaseCleanup
+		return agentengine.TurnResult{Status: agentengine.TurnCanceled, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorCanceled, Message: ctx.Err().Error()}}
+	})
+	done := make(chan agentengine.TurnResult, 1)
+	go func() {
+		done <- client.Conversations("agent-a").Run(context.Background(), turnRequest("turn-1", "conversation-1"), nil)
+	}()
+	<-started
+	if err := client.Conversations("agent-a").Resolve(context.Background(), agentengine.InteractionResolution{
+		ConversationKey: "conversation-1", InteractionID: "question-1", ResponderID: "tester",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(client.Resolutions()) != 1 {
+		t.Fatalf("resolutions = %+v", client.Resolutions())
+	}
+	if err := client.Conversations("agent-a").Reset(context.Background(), "conversation-1"); !hasCode(err, agentengine.ErrorConversationBusy) {
+		t.Fatalf("Reset(active) error = %v", err)
+	}
+	cancelDone := make(chan error, 1)
+	go func() {
+		cancelDone <- client.Conversations("agent-a").Cancel(context.Background(), "conversation-1", "turn-1")
+	}()
+	<-cleanup
+	select {
+	case err := <-cancelDone:
+		t.Fatalf("Cancel returned before cleanup: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseCleanup)
+	if err := <-cancelDone; err != nil {
+		t.Fatal(err)
+	}
+	if (<-done).Status != agentengine.TurnCanceled {
+		t.Fatal("turn was not canceled")
+	}
+	if err := client.Conversations("agent-a").Reset(context.Background(), "conversation-1"); err != nil {
+		t.Fatal(err)
+	}
+	strict := turnRequest("turn-2", "conversation-1")
+	strict.Continuation = agentengine.ContinuationRequireExisting
+	if result := client.Conversations("agent-a").Run(context.Background(), strict, nil); result.Error == nil || result.Error.Code != agentengine.ErrorConversationNotResumable {
+		t.Fatalf("strict result = %+v", result)
+	}
+}
+
+func TestMemoryClientSinkFailureRecordsFailure(t *testing.T) {
+	client := NewMemoryClient(runningAgent("agent-a"))
+	client.SetTurnBehavior(func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "partial"})
+		return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()}}
+	})
+	result := client.Conversations("agent-a").Run(context.Background(), turnRequest("turn-1", "conversation-1"), agentengine.EventSinkFunc(func(context.Context, agentengine.TurnEvent) error {
+		return errors.New("sink closed")
+	}))
+	if result.Error == nil || result.Error.Code != agentengine.ErrorRuntimeFailed {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func turnRequest(turnID agentengine.TurnID, key agentengine.ConversationKey) agentengine.TurnRequest {
+	return agentengine.TurnRequest{
+		ID: turnID, ConversationKey: key,
+		Input: []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: "hello"}},
+	}
+}
+
+func hasCode(err error, code agentengine.ErrorCode) bool {
+	var turnErr *agentengine.TurnError
+	return errors.As(err, &turnErr) && turnErr.Code == code
+}

--- a/internal/agentengine/enginetest/memory_client_test.go
+++ b/internal/agentengine/enginetest/memory_client_test.go
@@ -124,30 +124,25 @@ func TestMemoryClientCancelResetAndResolve(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if len(client.Resolutions()) != 1 {
-		t.Fatalf("resolutions = %+v", client.Resolutions())
+	resolutions := client.Resolutions()
+	if len(resolutions) != 1 || resolutions[0].Value.ResponderID != "tester" {
+		t.Fatalf("resolutions = %+v", resolutions)
 	}
-	if err := client.Conversations("agent-a").Reset(context.Background(), "conversation-1"); !hasCode(err, agentengine.ErrorConversationBusy) {
-		t.Fatalf("Reset(active) error = %v", err)
-	}
-	cancelDone := make(chan error, 1)
+	resetDone := make(chan error, 1)
 	go func() {
-		cancelDone <- client.Conversations("agent-a").Cancel(context.Background(), "conversation-1", "turn-1")
+		resetDone <- client.Conversations("agent-a").Reset(context.Background(), "conversation-1")
 	}()
 	<-cleanup
 	select {
-	case err := <-cancelDone:
-		t.Fatalf("Cancel returned before cleanup: %v", err)
+	case err := <-resetDone:
+		t.Fatalf("Reset returned before cleanup: %v", err)
 	case <-time.After(20 * time.Millisecond):
 	}
 	close(releaseCleanup)
-	if err := <-cancelDone; err != nil {
-		t.Fatal(err)
-	}
 	if (<-done).Status != agentengine.TurnCanceled {
 		t.Fatal("turn was not canceled")
 	}
-	if err := client.Conversations("agent-a").Reset(context.Background(), "conversation-1"); err != nil {
+	if err := <-resetDone; err != nil {
 		t.Fatal(err)
 	}
 	strict := turnRequest("turn-2", "conversation-1")

--- a/internal/agentengine/interface_contract_test.go
+++ b/internal/agentengine/interface_contract_test.go
@@ -1,0 +1,340 @@
+package agentengine_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"csgclaw/internal/activity"
+	"csgclaw/internal/agent"
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/agentengine/enginetest"
+	"csgclaw/internal/config"
+	"csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/codex"
+)
+
+func TestRealEngineInterfaceContract(t *testing.T) {
+	enginetest.RunInterfaceContract(t, newRealContractEngine)
+}
+
+type contractRuntime struct {
+	kind string
+
+	mu            sync.Mutex
+	states        map[string]runtime.State
+	conversations map[string]string
+	sessionKeys   map[string]agentengine.ConversationKey
+	subscribers   []chan activity.RuntimeEvent
+	behavior      enginetest.TurnBehavior
+	workspace     string
+	permission    *codex.MemoryPermissionBroker
+	userInput     *codex.MemoryUserInputBroker
+}
+
+func newContractRuntime(kind, workspace string, behavior enginetest.TurnBehavior) *contractRuntime {
+	return &contractRuntime{
+		kind: kind, states: make(map[string]runtime.State), conversations: make(map[string]string),
+		sessionKeys: make(map[string]agentengine.ConversationKey), behavior: behavior, workspace: workspace,
+		permission: codex.NewPermissionBroker(nil), userInput: codex.NewUserInputBroker(nil),
+	}
+}
+
+func (r *contractRuntime) Kind() string { return r.kind }
+
+func (r *contractRuntime) Layout(root string) runtime.Layout {
+	return runtime.Layout{
+		WorkspaceRoot: filepath.Join(root, "workspace"),
+		SkillsRoot:    filepath.Join(root, "workspace", ".agents", "skills"),
+	}
+}
+
+func (r *contractRuntime) New(_ context.Context, spec runtime.Spec) (runtime.Handle, error) {
+	runtimeID := strings.TrimSpace(spec.RuntimeID)
+	if runtimeID == "" {
+		runtimeID = "runtime-" + strings.TrimSpace(spec.AgentID)
+	}
+	r.mu.Lock()
+	r.states[runtimeID] = runtime.StateCreated
+	r.mu.Unlock()
+	return runtime.Handle{RuntimeID: runtimeID}, nil
+}
+
+func (r *contractRuntime) Start(_ context.Context, handle runtime.Handle) (runtime.State, error) {
+	r.setState(handle.RuntimeID, runtime.StateRunning)
+	return runtime.StateRunning, nil
+}
+
+func (r *contractRuntime) Stop(_ context.Context, handle runtime.Handle) (runtime.State, error) {
+	r.setState(handle.RuntimeID, runtime.StateStopped)
+	return runtime.StateStopped, nil
+}
+
+func (r *contractRuntime) Delete(_ context.Context, handle runtime.Handle) error {
+	r.mu.Lock()
+	delete(r.states, handle.RuntimeID)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *contractRuntime) State(_ context.Context, handle runtime.Handle) (runtime.State, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state := r.states[handle.RuntimeID]
+	if state == "" {
+		state = runtime.StateStopped
+	}
+	return state, nil
+}
+
+func (r *contractRuntime) Info(ctx context.Context, handle runtime.Handle) (runtime.Info, error) {
+	state, err := r.State(ctx, handle)
+	return runtime.Info{HandleID: handle.RuntimeID, State: state}, err
+}
+
+func (*contractRuntime) ValidateMCPServers(context.Context, runtime.MCPServersSnapshot) error {
+	return nil
+}
+
+func (*contractRuntime) MCPServersRestartRequired(runtime.MCPServersChange) (bool, error) {
+	return false, nil
+}
+
+func (*contractRuntime) ReconcileMCPServers(context.Context, runtime.Handle, runtime.MCPServersChange) error {
+	return nil
+}
+
+func (r *contractRuntime) EnsureSession(_ context.Context, _ string, conversationKey string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if sessionID := r.conversations[conversationKey]; sessionID != "" {
+		return sessionID, nil
+	}
+	sessionID := "contract-session-" + conversationKey
+	r.conversations[conversationKey] = sessionID
+	r.sessionKeys[sessionID] = agentengine.ConversationKey(conversationKey)
+	return sessionID, nil
+}
+
+func (r *contractRuntime) ExistingSession(_ context.Context, _ string, conversationKey string) (string, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sessionID := r.conversations[conversationKey]
+	return sessionID, sessionID != "", nil
+}
+
+func (r *contractRuntime) PromptTurn(ctx context.Context, runtimeID, sessionID, turnID string, blocks []codex.PromptContentBlock, accepted func()) error {
+	if accepted != nil {
+		accepted()
+	}
+	r.mu.Lock()
+	key := r.sessionKeys[sessionID]
+	behavior := r.behavior
+	r.mu.Unlock()
+	request := agentengine.TurnRequest{ID: agentengine.TurnID(turnID), ConversationKey: key}
+	for _, block := range blocks {
+		if block.Text != nil {
+			request.Input = append(request.Input, agentengine.InputPart{Kind: agentengine.InputPartText, Text: block.Text.Text})
+		}
+	}
+	result := agentengine.TurnResult{Status: agentengine.TurnSucceeded, Dispatched: true}
+	if behavior != nil {
+		result = behavior(ctx, "agent-a", request, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
+			return r.publishTurnEvent(runtimeID, sessionID, event)
+		}))
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if result.Status == agentengine.TurnFailed {
+		message := "contract Runtime failed"
+		if result.Error != nil && strings.TrimSpace(result.Error.Message) != "" {
+			message = result.Error.Message
+		}
+		r.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptFailed, Error: message})
+		return nil
+	}
+	r.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+	return nil
+}
+
+func (r *contractRuntime) ResetConversation(_ context.Context, _ string, conversationKey string) error {
+	r.mu.Lock()
+	sessionID := r.conversations[conversationKey]
+	delete(r.conversations, conversationKey)
+	delete(r.sessionKeys, sessionID)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *contractRuntime) WorkspaceDir(string) (string, error) { return r.workspace, nil }
+
+func (r *contractRuntime) PermissionBroker() codex.PermissionBroker { return r.permission }
+
+func (r *contractRuntime) UserInputBroker() codex.UserInputBroker { return r.userInput }
+
+func (r *contractRuntime) SubscribeSession(_, _ string) (<-chan activity.RuntimeEvent, func()) {
+	stream := make(chan activity.RuntimeEvent, 16)
+	r.mu.Lock()
+	r.subscribers = append(r.subscribers, stream)
+	r.mu.Unlock()
+	return stream, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for index, candidate := range r.subscribers {
+			if candidate == stream {
+				r.subscribers = append(r.subscribers[:index], r.subscribers[index+1:]...)
+				return
+			}
+		}
+	}
+}
+
+func (r *contractRuntime) publishTurnEvent(runtimeID, sessionID string, event agentengine.TurnEvent) error {
+	runtimeEvent := activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID}
+	switch event.Kind {
+	case agentengine.TurnEventTextDelta:
+		runtimeEvent.Kind = activity.RuntimeEventTextDelta
+		runtimeEvent.Text = event.Text
+		runtimeEvent.Payload = map[string]any{"phase": "final_answer"}
+	case agentengine.TurnEventThoughtDelta:
+		runtimeEvent.Kind = activity.RuntimeEventThoughtDelta
+		runtimeEvent.Text = event.Thought
+	case agentengine.TurnEventToolCallStart, agentengine.TurnEventToolCallUpdate:
+		if event.Tool == nil {
+			return fmt.Errorf("tool event is missing tool data")
+		}
+		if event.Kind == agentengine.TurnEventToolCallStart {
+			runtimeEvent.Kind = activity.RuntimeEventToolCallStart
+		} else {
+			runtimeEvent.Kind = activity.RuntimeEventToolCallUpdate
+		}
+		runtimeEvent.ToolCallID = event.Tool.ID
+		runtimeEvent.ToolKind = event.Tool.Kind
+		runtimeEvent.ToolTitle = event.Tool.Title
+		runtimeEvent.ToolStatus = event.Tool.Status
+		runtimeEvent.ToolInputSummary = event.Tool.InputSummary
+		runtimeEvent.ToolOutputSummary = event.Tool.OutputSummary
+		runtimeEvent.Payload = event.Tool.Payload
+	case agentengine.TurnEventActivityUpdate:
+		if event.Activity == nil {
+			return fmt.Errorf("activity event is missing activity data")
+		}
+		runtimeEvent.Kind = activity.RuntimeEventPlanUpdate
+		runtimeEvent.ActionID = event.Activity.ID
+		runtimeEvent.ActionStatus = event.Activity.Status
+		runtimeEvent.Payload = event.Activity.Payload
+	case agentengine.TurnEventOutputItem:
+		if event.Output == nil {
+			return fmt.Errorf("output event is missing output data")
+		}
+		artifact := activity.StructuredOutputArtifact{}
+		switch event.Output.Kind {
+		case agentengine.OutputItemResourceLink:
+			link, ok := event.Output.Payload.(activity.ResourceLink)
+			if !ok {
+				return fmt.Errorf("resource link output has invalid payload")
+			}
+			artifact.ResourceLinks = []activity.ResourceLink{link}
+		case agentengine.OutputItemRequestUserInput:
+			request, ok := event.Output.Payload.(activity.RequestUserInputArgs)
+			if !ok {
+				return fmt.Errorf("request user input output has invalid payload")
+			}
+			artifact.RequestUserInput = &request
+		default:
+			return fmt.Errorf("unsupported output kind %q", event.Output.Kind)
+		}
+		runtimeEvent.Kind = activity.RuntimeEventStructuredOutput
+		runtimeEvent.Payload = artifact
+	case agentengine.TurnEventInteractionRequest:
+		if event.Interaction == nil || event.Interaction.Kind != agentengine.InteractionUserInput {
+			return fmt.Errorf("unsupported contract interaction")
+		}
+		snapshot, err := r.userInput.CreateDetached(codex.PendingUserInputRequest{
+			Execution: activity.ExecutionRef{RuntimeID: runtimeID, SessionID: sessionID},
+			Questions: []activity.UserInputQuestionSnapshot{{
+				ID: "choice", Header: "Choice", Question: "Continue?",
+				Options: []activity.UserInputOptionSnapshot{{Label: "Yes"}, {Label: "No"}},
+			}},
+		}, codex.DetachedUserInputContext{Channel: "contract", RoomID: "contract"})
+		if err != nil {
+			return err
+		}
+		runtimeEvent.Kind = activity.RuntimeEventUserInputRequest
+		runtimeEvent.UserInputID = snapshot.ID
+		runtimeEvent.Payload = snapshot
+	default:
+		return fmt.Errorf("unsupported contract event %q", event.Kind)
+	}
+	r.publish(runtimeEvent)
+	return nil
+}
+
+func (r *contractRuntime) publish(event activity.RuntimeEvent) {
+	r.mu.Lock()
+	streams := append([]chan activity.RuntimeEvent(nil), r.subscribers...)
+	r.mu.Unlock()
+	for _, stream := range streams {
+		stream <- event
+	}
+}
+
+func (r *contractRuntime) setState(runtimeID string, state runtime.State) {
+	r.mu.Lock()
+	r.states[runtimeID] = state
+	r.mu.Unlock()
+}
+
+func newRealContractEngine(t testing.TB, seeded []agentengine.Agent, behavior enginetest.TurnBehavior) agentengine.Interface {
+	t.Helper()
+	root := t.TempDir()
+	codexRuntime := newContractRuntime(runtime.KindCodex, filepath.Join(root, "workspace"), behavior)
+	openClawRuntime := newContractRuntime(runtime.KindOpenClawSandbox, filepath.Join(root, "openclaw-workspace"), behavior)
+	stored := make([]agent.Agent, 0, len(seeded))
+	for _, item := range seeded {
+		runtimeKind := strings.TrimSpace(item.Spec.Runtime.Adapter)
+		runtimeName := runtimeKind
+		if runtimeKind == "" || runtimeKind == "codex" {
+			runtimeKind = agent.RuntimeKindCodex
+			runtimeName = agent.RuntimeNameCodex
+		}
+		stored = append(stored, agent.Agent{
+			ID: item.ID, Name: item.Spec.Name, Description: item.Spec.Description, Instructions: item.Spec.Instructions,
+			Role: string(item.Spec.Role), RuntimeKind: runtimeKind, RuntimeName: runtimeName,
+			RuntimeID: item.Status.RuntimeID, BoxID: item.Status.RuntimeID, Status: string(item.Status.State), RuntimeOptions: item.Spec.Runtime.Options,
+			AgentProfile: agent.AgentProfile{
+				ModelProviderID: item.Spec.Model.ProviderID, ModelID: item.Spec.Model.ModelID,
+				ReasoningEffort: item.Spec.Model.ReasoningEffort, EnableFastMode: item.Spec.Model.FastMode,
+				RequestOptions: item.Spec.Model.Options,
+			},
+		})
+		if runtimeKind == agent.RuntimeKindCodex {
+			codexRuntime.setState(item.Status.RuntimeID, runtime.State(item.Status.State))
+		} else {
+			openClawRuntime.setState(item.Status.RuntimeID, runtime.State(item.Status.State))
+		}
+	}
+	statePath := filepath.Join(root, "agents.json")
+	data, err := json.Marshal(map[string]any{"agents": stored})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	service, err := agent.NewService(
+		config.ModelConfig{}, config.ServerConfig{}, "manager:test", statePath,
+		agent.WithRuntime(codexRuntime), agent.WithRuntime(openClawRuntime),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	return agentengine.New(service)
+}

--- a/internal/agentengine/runtime_adapter.go
+++ b/internal/agentengine/runtime_adapter.go
@@ -2,54 +2,74 @@ package agentengine
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"csgclaw/internal/activity"
 	"csgclaw/internal/agent"
 	"csgclaw/internal/runtime"
+	"csgclaw/internal/runtime/codex"
 )
-
-var errInteractiveTurnUnsupported = errors.New("interactive approval and user-input requests are not supported for anonymous streamed sessions")
 
 type agentServiceAdapter struct {
 	service *agent.Service
 }
 
-// New wires the transitional Agent Service-backed Runtime resolver into the
-// runtime-neutral Engine core.
+// New wires the existing Agent Service through private Engine facades.
 func New(service *agent.Service) *Engine {
-	return &Engine{runtimes: agentServiceAdapter{service: service}}
+	adapter := agentServiceAdapter{service: service}
+	return &Engine{agents: agentFacade{service: service}, runtimes: adapter}
 }
 
-func (a agentServiceAdapter) conversationRuntime(agentID string) (conversationRuntimeAdapter, *TurnError) {
+func (a agentServiceAdapter) conversationRuntime(ctx context.Context, agentID string) (conversationRuntimeAdapter, func(), *TurnError) {
 	if a.service == nil {
-		return nil, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is required"}
+		return nil, nil, &TurnError{Code: ErrorAgentUnavailable, Message: "agent service is required"}
 	}
-	selected, ok := a.service.Agent(agentID)
-	if !ok || !strings.EqualFold(strings.TrimSpace(selected.Status), string(runtime.StateRunning)) || strings.TrimSpace(selected.RuntimeID) == "" {
-		return nil, &TurnError{Code: ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q is unavailable", agentID)}
+	lease, err := a.service.AcquireExecution(ctx, agentID)
+	if err != nil {
+		return nil, nil, &TurnError{Code: ErrorAgentUnavailable, Message: err.Error()}
+	}
+	release := lease.Release
+	selected := lease.Agent
+	if !strings.EqualFold(strings.TrimSpace(selected.Status), string(runtime.StateRunning)) || strings.TrimSpace(selected.RuntimeID) == "" {
+		release()
+		return nil, nil, &TurnError{Code: ErrorAgentUnavailable, Message: fmt.Sprintf("agent %q is unavailable", agentID)}
 	}
 	if !strings.EqualFold(strings.TrimSpace(selected.RuntimeKind), agent.RuntimeKindCodex) {
-		return nil, &TurnError{Code: ErrorRuntimeAdapterUnavailable, Message: fmt.Sprintf("runtime adapter %q is unavailable", selected.RuntimeKind)}
+		release()
+		return nil, nil, &TurnError{Code: ErrorRuntimeAdapterUnavailable, Message: fmt.Sprintf("runtime adapter %q is unavailable", selected.RuntimeKind)}
 	}
-
-	runtimeImpl, err := a.service.Runtime(selected.RuntimeKind)
-	if err != nil {
-		return nil, &TurnError{Code: ErrorRuntimeAdapterUnavailable, Message: err.Error()}
-	}
-	codex, ok := runtimeImpl.(codexConversationRuntime)
+	codexRuntime, ok := lease.Runtime.(codexConversationRuntime)
 	if !ok {
-		return nil, &TurnError{Code: ErrorRuntimeAdapterUnavailable, Message: "Codex runtime does not support direct conversations"}
+		release()
+		return nil, nil, &TurnError{Code: ErrorRuntimeAdapterUnavailable, Message: "Codex runtime does not support direct conversations"}
 	}
-	return codexRuntimeAdapter{runtimeID: selected.RuntimeID, runtime: codex}, nil
+	return &codexRuntimeAdapter{runtimeID: selected.RuntimeID, runtime: codexRuntime}, release, nil
 }
 
 type codexConversationRuntime interface {
 	EnsureSession(ctx context.Context, runtimeID, conversationKey string) (string, error)
-	Prompt(ctx context.Context, runtimeID, sessionID, prompt string) error
+	ExistingSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error)
+	PromptTurn(ctx context.Context, runtimeID, sessionID, turnID string, blocks []codex.PromptContentBlock, accepted func()) error
 	SubscribeSession(runtimeID, sessionID string) (<-chan activity.RuntimeEvent, func())
+	ResetConversation(ctx context.Context, runtimeID, conversationKey string) error
+	WorkspaceDir(runtimeID string) (string, error)
+	PermissionBroker() codex.PermissionBroker
+	UserInputBroker() codex.UserInputBroker
+}
+
+type directUserInputResponder interface {
+	RespondDirect(context.Context, string, string, activity.RequestUserInputResponse) (activity.UserInputSnapshot, error)
 }
 
 type codexRuntimeAdapter struct {
@@ -57,106 +77,417 @@ type codexRuntimeAdapter struct {
 	runtime   codexConversationRuntime
 }
 
-func (a codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult {
-	prompt, inputErr := a.prepareInput(request.Input)
+func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult {
+	blocks, cleanup, inputErr := a.prepareInput(request.ID, request.Input)
 	if inputErr != nil {
 		return TurnResult{Status: TurnFailed, Error: inputErr}
 	}
+	defer cleanup()
 
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	sessionID, err := a.runtime.EnsureSession(runCtx, a.runtimeID, string(request.ConversationKey))
-	if err != nil {
-		return resultFromContext(runCtx, fmt.Errorf("ensure Codex conversation: %w", err))
+	sessionID, sessionErr := a.session(runCtx, request)
+	if sessionErr != nil {
+		return TurnResult{Status: TurnFailed, Error: sessionErr}
 	}
 	events, unsubscribe := a.runtime.SubscribeSession(a.runtimeID, sessionID)
 	defer unsubscribe()
 
+	accepted := make(chan struct{})
+	var dispatchedState atomic.Bool
 	promptDone := make(chan error, 1)
 	go func() {
-		promptDone <- a.runtime.Prompt(runCtx, a.runtimeID, sessionID, prompt)
+		promptDone <- a.runtime.PromptTurn(runCtx, a.runtimeID, sessionID, string(request.ID), blocks, func() {
+			if dispatchedState.CompareAndSwap(false, true) {
+				close(accepted)
+			}
+		})
 	}()
 
-	var output strings.Builder
+	dispatched := false
 	promptReturned := false
+	runtimeDone := false
+	eventStreamClosed := false
+	var output strings.Builder
 	stopPrompt := func(result TurnResult) TurnResult {
 		cancel()
 		if !promptReturned {
 			<-promptDone
 			promptReturned = true
 		}
+		result.Dispatched = dispatchedState.Load()
 		return result
 	}
-	runtimeDone := false
 	for {
 		if runtimeDone && promptReturned {
-			return TurnResult{Status: TurnSucceeded, Output: output.String()}
+			if eventStreamClosed {
+				result := failedResult(ErrorRuntimeFailed, "Runtime event stream closed before prompt completion")
+				result.Dispatched = dispatched
+				return result
+			}
+			return TurnResult{Status: TurnSucceeded, Output: output.String(), Dispatched: dispatched}
 		}
 		select {
+		case <-accepted:
+			dispatched = dispatchedState.Load()
+			accepted = nil
 		case <-runCtx.Done():
 			return stopPrompt(resultFromContext(runCtx, runCtx.Err()))
 		case err := <-promptDone:
 			promptReturned = true
+			dispatched = dispatchedState.Load()
 			if err != nil {
-				return resultFromContext(runCtx, err)
+				result := resultFromContext(runCtx, err)
+				result.Dispatched = dispatched
+				return result
 			}
 		case event, ok := <-events:
 			if !ok {
 				runtimeDone = true
+				eventStreamClosed = true
+				events = nil
 				continue
 			}
 			if strings.TrimSpace(event.RuntimeID) != strings.TrimSpace(a.runtimeID) || strings.TrimSpace(event.SessionID) != strings.TrimSpace(sessionID) {
 				continue
 			}
-			switch event.Kind {
-			case activity.RuntimeEventPromptFailed:
-				message := strings.TrimSpace(event.Error)
-				if message == "" {
-					message = "agent turn ended without a final response"
-				}
-				return stopPrompt(failedResult(ErrorRuntimeFailed, message))
-			case activity.RuntimeEventActionRequest, activity.RuntimeEventUserInputRequest:
-				return stopPrompt(failedResult(ErrorInteractionUnsupported, errInteractiveTurnUnsupported.Error()))
-			case activity.RuntimeEventStructuredOutput:
-				artifact, ok := event.Payload.(activity.StructuredOutputArtifact)
-				if ok && artifact.RequestUserInput != nil {
-					return stopPrompt(failedResult(ErrorInteractionUnsupported, errInteractiveTurnUnsupported.Error()))
-				}
-			case activity.RuntimeEventTextDelta:
-				phase := runtimeEventPhase(event)
-				if phase != "" && phase != "final_answer" {
-					continue
-				}
-				if err := emitTurnEvent(runCtx, sink, TurnEvent{Kind: TurnEventTextDelta, Text: event.Text}); err != nil {
-					return stopPrompt(resultFromContext(runCtx, err))
-				}
-				_, _ = output.WriteString(event.Text)
-			case activity.RuntimeEventToolCallStart:
-				if err := emitTurnEvent(runCtx, sink, TurnEvent{Kind: TurnEventToolCallStart, Tool: toolActivity(event)}); err != nil {
-					return stopPrompt(resultFromContext(runCtx, err))
-				}
-			case activity.RuntimeEventToolCallUpdate:
-				if err := emitTurnEvent(runCtx, sink, TurnEvent{Kind: TurnEventToolCallUpdate, Tool: toolActivity(event)}); err != nil {
-					return stopPrompt(resultFromContext(runCtx, err))
-				}
-			case activity.RuntimeEventPromptCompleted:
+			if result := a.handleEvent(runCtx, request, sink, event, &output); result != nil {
+				return stopPrompt(*result)
+			}
+			if event.Kind == activity.RuntimeEventPromptCompleted {
 				runtimeDone = true
 			}
 		}
 	}
 }
 
-func (a codexRuntimeAdapter) prepareInput(input []InputPart) (string, *TurnError) {
-	text := make([]string, 0, len(input))
+func (a *codexRuntimeAdapter) session(ctx context.Context, request TurnRequest) (string, *TurnError) {
+	if request.Continuation == ContinuationRequireExisting {
+		sessionID, ok, err := a.runtime.ExistingSession(ctx, a.runtimeID, string(request.ConversationKey))
+		if err != nil {
+			return "", &TurnError{Code: ErrorRuntimeFailed, Message: err.Error()}
+		}
+		if !ok {
+			return "", &TurnError{Code: ErrorConversationNotResumable, Message: "conversation has no Runtime-native mapping"}
+		}
+		return sessionID, nil
+	}
+	sessionID, err := a.runtime.EnsureSession(ctx, a.runtimeID, string(request.ConversationKey))
+	if err != nil {
+		return "", &TurnError{Code: ErrorRuntimeFailed, Message: fmt.Sprintf("ensure Codex conversation: %v", err)}
+	}
+	return sessionID, nil
+}
+
+func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnRequest, sink EventSink, event activity.RuntimeEvent, output *strings.Builder) *TurnResult {
+	emit := func(turnEvent TurnEvent) *TurnResult {
+		if err := emitTurnEvent(ctx, sink, turnEvent); err != nil {
+			result := resultFromContext(ctx, err)
+			return &result
+		}
+		return nil
+	}
+	switch event.Kind {
+	case activity.RuntimeEventPromptFailed:
+		message := strings.TrimSpace(event.Error)
+		if message == "" {
+			message = "agent turn ended without a final response"
+		}
+		result := failedResult(ErrorRuntimeFailed, message)
+		return &result
+	case activity.RuntimeEventActionRequest:
+		return a.handleInteraction(ctx, request.Interaction, permissionInteraction(event), sink)
+	case activity.RuntimeEventUserInputRequest:
+		return a.handleInteraction(ctx, request.Interaction, userInputInteraction(event), sink)
+	case activity.RuntimeEventStructuredOutput:
+		artifact, ok := event.Payload.(activity.StructuredOutputArtifact)
+		if !ok {
+			result := failedResult(ErrorRuntimeFailed, "Codex returned invalid structured output")
+			return &result
+		}
+		if artifact.RequestUserInput != nil {
+			if result := emit(TurnEvent{Kind: TurnEventOutputItem, Output: &OutputItem{Kind: OutputItemRequestUserInput, Payload: *artifact.RequestUserInput}}); result != nil {
+				return result
+			}
+		}
+		for _, link := range artifact.ResourceLinks {
+			linkCopy := link
+			if result := emit(TurnEvent{Kind: TurnEventOutputItem, Output: &OutputItem{Kind: OutputItemResourceLink, Payload: linkCopy}}); result != nil {
+				return result
+			}
+		}
+	case activity.RuntimeEventTextDelta:
+		phase := runtimeEventPhase(event)
+		if phase != "" && phase != "final_answer" {
+			return nil
+		}
+		if result := emit(TurnEvent{Kind: TurnEventTextDelta, Text: event.Text}); result != nil {
+			return result
+		}
+		_, _ = output.WriteString(event.Text)
+	case activity.RuntimeEventThoughtDelta:
+		return emit(TurnEvent{Kind: TurnEventThoughtDelta, Thought: event.Text})
+	case activity.RuntimeEventToolCallStart:
+		return emit(TurnEvent{Kind: TurnEventToolCallStart, Tool: toolActivity(event)})
+	case activity.RuntimeEventToolCallUpdate:
+		return emit(TurnEvent{Kind: TurnEventToolCallUpdate, Tool: toolActivity(event)})
+	case activity.RuntimeEventPlanUpdate, activity.RuntimeEventActionDecision, activity.RuntimeEventUserInputResolved:
+		return emit(TurnEvent{Kind: TurnEventActivityUpdate, Activity: &ActivityUpdate{
+			ID: event.ActionID + event.UserInputID, Kind: string(event.Kind), Status: event.ActionStatus + event.UserInputStatus, Payload: event.Payload,
+		}})
+	}
+	return nil
+}
+
+func (a *codexRuntimeAdapter) handleInteraction(ctx context.Context, policy InteractionPolicy, interaction InteractionRequest, sink EventSink) *TurnResult {
+	switch policy {
+	case InteractionReject:
+		result := failedResult(ErrorInteractionUnsupported, "Runtime interaction is not supported by this caller")
+		return &result
+	case InteractionSkipUserInput:
+		resolution := InteractionResolution{InteractionID: interaction.ID, ResponderID: "agent-engine"}
+		if interaction.Kind == InteractionPermission {
+			snapshot, _ := interaction.Payload.(activity.ActivitySnapshot)
+			for _, option := range snapshot.Options {
+				kind := strings.ToLower(strings.TrimSpace(option.Kind))
+				if !strings.Contains(kind, "allow") && !strings.Contains(kind, "accept") {
+					resolution.OptionID = option.ID
+					break
+				}
+			}
+		}
+		if err := a.Resolve(ctx, interaction, resolution); err != nil {
+			result := failedResult(ErrorInteractionUnsupported, err.Message)
+			return &result
+		}
+		return nil
+	default:
+		if err := emitTurnEvent(ctx, sink, TurnEvent{Kind: TurnEventInteractionRequest, Interaction: &interaction}); err != nil {
+			result := resultFromContext(ctx, err)
+			return &result
+		}
+		return nil
+	}
+}
+
+func (a *codexRuntimeAdapter) Reset(ctx context.Context, key ConversationKey) *TurnError {
+	if err := a.runtime.ResetConversation(ctx, a.runtimeID, string(key)); err != nil {
+		return &TurnError{Code: ErrorRuntimeFailed, Message: err.Error()}
+	}
+	return nil
+}
+
+func (a *codexRuntimeAdapter) Resolve(ctx context.Context, request InteractionRequest, resolution InteractionResolution) *TurnError {
+	switch request.Kind {
+	case InteractionPermission:
+		if strings.TrimSpace(resolution.OptionID) == "" {
+			return &TurnError{Code: ErrorInvalidRequest, Message: "permission option ID is required"}
+		}
+		if _, err := a.runtime.PermissionBroker().Decide(ctx, request.ID, resolution.OptionID); err != nil {
+			return &TurnError{Code: ErrorInteractionNotFound, Message: err.Error()}
+		}
+	case InteractionUserInput:
+		responder, ok := a.runtime.UserInputBroker().(directUserInputResponder)
+		if !ok {
+			return &TurnError{Code: ErrorInteractionUnsupported, Message: "Codex user-input broker does not support Engine resolution"}
+		}
+		answers := make(map[string]activity.RequestUserInputAnswer, len(resolution.Answers))
+		for questionID, answer := range resolution.Answers {
+			if answer.Skipped {
+				continue
+			}
+			answers[questionID] = activity.RequestUserInputAnswer{Answers: append([]string(nil), answer.Values...)}
+		}
+		responderID := strings.TrimSpace(resolution.ResponderID)
+		if responderID == "" {
+			responderID = "agent-engine"
+		}
+		if _, err := responder.RespondDirect(ctx, request.ID, responderID, activity.RequestUserInputResponse{Answers: answers}); err != nil {
+			return &TurnError{Code: ErrorInteractionNotFound, Message: err.Error()}
+		}
+	default:
+		return &TurnError{Code: ErrorInteractionUnsupported, Message: "interaction kind is unsupported"}
+	}
+	return nil
+}
+
+func permissionInteraction(event activity.RuntimeEvent) InteractionRequest {
+	snapshot, _ := event.Payload.(activity.ActivitySnapshot)
+	id := strings.TrimSpace(event.ActionID)
+	if id == "" {
+		id = snapshot.ID
+	}
+	return InteractionRequest{ID: id, Kind: InteractionPermission, Title: snapshot.Title, Payload: snapshot}
+}
+
+func userInputInteraction(event activity.RuntimeEvent) InteractionRequest {
+	snapshot, _ := event.Payload.(activity.UserInputSnapshot)
+	id := strings.TrimSpace(event.UserInputID)
+	if id == "" {
+		id = snapshot.ID
+	}
+	return InteractionRequest{ID: id, Kind: InteractionUserInput, Title: "User input required", Payload: snapshot}
+}
+
+func toolActivity(event activity.RuntimeEvent) *ToolActivity {
+	return &ToolActivity{
+		ID: event.ToolCallID, Kind: event.ToolKind, Title: event.ToolTitle, Status: event.ToolStatus,
+		InputSummary: event.ToolInputSummary, OutputSummary: event.ToolOutputSummary, Payload: event.Payload,
+	}
+}
+
+func runtimeEventPhase(event activity.RuntimeEvent) string {
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	phase, _ := payload["phase"].(string)
+	return strings.TrimSpace(strings.ToLower(phase))
+}
+
+var safeInputNamePattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func (a *codexRuntimeAdapter) prepareInput(turnID TurnID, input []InputPart) ([]codex.PromptContentBlock, func(), *TurnError) {
+	needsFiles := false
 	for _, part := range input {
-		switch part.Kind {
-		case InputPartText:
-			text = append(text, strings.TrimSpace(part.Text))
-		case InputPartFile:
-			return "", &TurnError{Code: ErrorFileUnavailable, Message: "Codex file input is not supported yet"}
+		needsFiles = needsFiles || part.Kind == InputPartFile
+	}
+	cleanup := func() {}
+	var turnDir string
+	var workspaceRoot *os.Root
+	var workspace string
+	if needsFiles {
+		var err error
+		workspace, err = a.runtime.WorkspaceDir(a.runtimeID)
+		if err != nil {
+			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		}
+		workspaceRoot, err = os.OpenRoot(workspace)
+		if err != nil {
+			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		}
+		inputRoot := filepath.Join(".csgclaw", "engine-inputs")
+		if err := workspaceRoot.MkdirAll(inputRoot, 0o700); err != nil {
+			_ = workspaceRoot.Close()
+			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		}
+		turnDir, err = makeRootTempDir(workspaceRoot, inputRoot, safeInputName(string(turnID))+"-")
+		if err != nil {
+			_ = workspaceRoot.Close()
+			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		}
+		var cleanupOnce sync.Once
+		cleanup = func() {
+			cleanupOnce.Do(func() {
+				_ = workspaceRoot.RemoveAll(turnDir)
+				_ = workspaceRoot.Close()
+			})
 		}
 	}
-	return strings.Join(text, "\n\n"), nil
+	blocks := make([]codex.PromptContentBlock, 0, len(input))
+	for index, part := range input {
+		if part.Kind == InputPartText {
+			blocks = append(blocks, codex.TextBlock(part.Text))
+			continue
+		}
+		path, err := copyVerifiedInput(workspaceRoot, workspace, turnDir, index, *part.File)
+		if err != nil {
+			cleanup()
+			return nil, func() {}, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		}
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(part.File.MediaType)), "image/") {
+			blocks = append(blocks, codex.LocalImageBlock(path))
+		} else {
+			blocks = append(blocks, codex.TextBlock(fmt.Sprintf("Attached file %q is available in the Runtime workspace at %s", part.File.Name, path)))
+		}
+	}
+	return blocks, cleanup, nil
+}
+
+func copyVerifiedInput(root *os.Root, workspace, turnDir string, index int, input InputFile) (string, error) {
+	info, err := os.Lstat(input.SourcePath)
+	if err != nil {
+		return "", fmt.Errorf("inspect input file %q: %w", input.Name, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("input file %q must be a regular non-symlink file", input.Name)
+	}
+	source, err := os.Open(input.SourcePath)
+	if err != nil {
+		return "", fmt.Errorf("open input file %q: %w", input.Name, err)
+	}
+	defer source.Close()
+	openedInfo, err := source.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return "", fmt.Errorf("input file %q changed before it could be copied", input.Name)
+	}
+	if openedInfo.Size() != input.SizeBytes {
+		return "", fmt.Errorf("input file %q size does not match", input.Name)
+	}
+	name := fmt.Sprintf("%03d-%s-%s", index, safeInputName(input.ID), safeInputName(filepath.Base(input.Name)))
+	destination := filepath.Join(turnDir, name)
+	suffix, err := randomInputSuffix()
+	if err != nil {
+		return "", fmt.Errorf("create Runtime-local input name %q: %w", input.Name, err)
+	}
+	temporary := destination + ".tmp-" + suffix
+	target, err := root.OpenFile(temporary, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create Runtime-local input %q: %w", input.Name, err)
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(target, hash), source)
+	closeErr := target.Close()
+	if copyErr != nil || closeErr != nil {
+		_ = root.Remove(temporary)
+		return "", fmt.Errorf("copy input file %q: %v", input.Name, errors.Join(copyErr, closeErr))
+	}
+	actualHash := fmt.Sprintf("%x", hash.Sum(nil))
+	if !strings.EqualFold(actualHash, strings.TrimSpace(input.SHA256)) {
+		_ = root.Remove(temporary)
+		return "", fmt.Errorf("input file %q SHA-256 does not match", input.Name)
+	}
+	if err := root.Rename(temporary, destination); err != nil {
+		_ = root.Remove(temporary)
+		return "", fmt.Errorf("activate Runtime-local input %q: %w", input.Name, err)
+	}
+	return filepath.Join(workspace, destination), nil
+}
+
+func makeRootTempDir(root *os.Root, parent, prefix string) (string, error) {
+	for range 100 {
+		suffix, err := randomInputSuffix()
+		if err != nil {
+			return "", err
+		}
+		name := filepath.Join(parent, prefix+suffix)
+		if err := root.Mkdir(name, 0o700); err == nil {
+			return name, nil
+		} else if !errors.Is(err, os.ErrExist) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("create unique Runtime-local input directory")
+}
+
+func randomInputSuffix() (string, error) {
+	value := make([]byte, 8)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func safeInputName(value string) string {
+	value = safeInputNamePattern.ReplaceAllString(strings.TrimSpace(value), "_")
+	value = strings.Trim(value, "._-")
+	if value == "" {
+		return "input"
+	}
+	if len(value) > 80 {
+		return value[:80]
+	}
+	return value
 }
 
 func emitTurnEvent(ctx context.Context, sink EventSink, event TurnEvent) error {
@@ -166,33 +497,12 @@ func emitTurnEvent(ctx context.Context, sink EventSink, event TurnEvent) error {
 	return sink.Emit(ctx, event)
 }
 
-func toolActivity(event activity.RuntimeEvent) *ToolActivity {
-	return &ToolActivity{
-		ID:            event.ToolCallID,
-		Kind:          event.ToolKind,
-		Title:         event.ToolTitle,
-		Status:        event.ToolStatus,
-		InputSummary:  event.ToolInputSummary,
-		OutputSummary: event.ToolOutputSummary,
-		Payload:       event.Payload,
-	}
-}
-
-func runtimeEventPhase(event activity.RuntimeEvent) string {
-	payload, ok := event.Payload.(map[string]any)
-	if !ok {
-		return ""
-	}
-	phase, ok := payload["phase"].(string)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(strings.ToLower(phase))
-}
-
 func resultFromContext(ctx context.Context, err error) TurnResult {
+	if err == nil {
+		err = ctx.Err()
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return TurnResult{Status: TurnCanceled, Error: &TurnError{Code: ErrorRuntimeFailed, Message: err.Error()}}
+		return TurnResult{Status: TurnCanceled, Error: &TurnError{Code: ErrorCanceled, Message: err.Error()}}
 	}
 	return failedResult(ErrorRuntimeFailed, err.Error())
 }

--- a/internal/api/agent_sessions.go
+++ b/internal/api/agent_sessions.go
@@ -176,6 +176,7 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 	result := h.agentEngine.Conversations(selected.ID).Run(runCtx, agentengine.TurnRequest{
 		ID:              agentengine.TurnID(responseID),
 		ConversationKey: agentengine.ConversationKey(binding.ConversationKey),
+		Admission:       agentengine.AdmissionRejectIfBusy,
 		Interaction:     agentengine.InteractionReject,
 		Input: []agentengine.InputPart{{
 			Kind: agentengine.InputPartText,

--- a/internal/api/agent_sessions.go
+++ b/internal/api/agent_sessions.go
@@ -14,9 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"csgclaw/internal/agent"
 	"csgclaw/internal/agentengine"
-	agentruntime "csgclaw/internal/runtime"
 )
 
 const agentSessionResponseBodyLimit = 1024 * 1024
@@ -81,14 +79,11 @@ type agentSessionError struct {
 	Code    string  `json:"code"`
 }
 
-type sessionConversationEngine interface {
-	Conversations(agentID string) agentengine.ConversationInterface
-}
-
 type agentSessionTurn struct {
-	requestContext context.Context
-	cancel         context.CancelFunc
-	done           chan struct{}
+	agentID         string
+	conversationKey agentengine.ConversationKey
+	turnID          agentengine.TurnID
+	cancel          context.CancelFunc
 }
 
 func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Request) {
@@ -112,22 +107,14 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 		writeAgentSessionError(w, http.StatusNotFound, "agent_not_found", err.Error(), "agent")
 		return
 	}
-	if !strings.EqualFold(strings.TrimSpace(selected.RuntimeKind), agent.RuntimeKindCodex) {
-		writeAgentSessionError(w, http.StatusServiceUnavailable, "runtime_adapter_unavailable", fmt.Sprintf("runtime adapter %q is unavailable", selected.RuntimeKind), "agent")
-		return
-	}
 	if h.agentEngine == nil || h.sessionBindings == nil {
 		writeAgentSessionError(w, http.StatusServiceUnavailable, "session_service_unavailable", "session conversation service is not configured", nil)
 		return
 	}
-
-	turnKey := selected.ID + "\x00" + sessionID
-	turn, ok := h.beginSessionTurn(r.Context(), turnKey)
-	if !ok {
-		writeAgentSessionError(w, http.StatusConflict, "session_busy", "another response is already running for this session", "session_id")
+	if !strings.EqualFold(strings.TrimSpace(selected.Spec.Runtime.Adapter), "codex") {
+		writeAgentSessionError(w, http.StatusServiceUnavailable, "runtime_adapter_unavailable", fmt.Sprintf("runtime adapter %q is unavailable", selected.Spec.Runtime.Adapter), "agent")
 		return
 	}
-	defer h.endSessionTurn(turnKey, turn)
 
 	binding, err := h.sessionBindings.GetOrCreate(selected.ID, sessionID)
 	if err != nil {
@@ -151,6 +138,17 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 			"agent_id":   selected.ID,
 		},
 	}
+	turnKey := selected.ID + "\x00" + sessionID
+	runCtx, cancel := context.WithTimeout(r.Context(), agentSessionResponseTimeout)
+	defer cancel()
+	turn := agentSessionTurn{
+		agentID:         selected.ID,
+		conversationKey: agentengine.ConversationKey(binding.ConversationKey),
+		turnID:          agentengine.TurnID(responseID),
+		cancel:          cancel,
+	}
+	h.addSessionTurn(turnKey, turn)
+	defer h.removeSessionTurn(turnKey, turn.turnID)
 
 	var eventStream *agentSessionEventStream
 	var sink agentengine.EventSink
@@ -175,18 +173,17 @@ func (h *Handler) createAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 		})
 	}
 
-	runCtx, cancel := context.WithTimeout(turn.requestContext, agentSessionResponseTimeout)
-	defer cancel()
 	result := h.agentEngine.Conversations(selected.ID).Run(runCtx, agentengine.TurnRequest{
 		ID:              agentengine.TurnID(responseID),
 		ConversationKey: agentengine.ConversationKey(binding.ConversationKey),
+		Interaction:     agentengine.InteractionReject,
 		Input: []agentengine.InputPart{{
 			Kind: agentengine.InputPartText,
 			Text: prompt,
 		}},
 	}, sink)
 	if result.Status != agentengine.TurnSucceeded {
-		if errors.Is(turn.requestContext.Err(), context.Canceled) {
+		if errors.Is(r.Context().Err(), context.Canceled) {
 			return
 		}
 		if eventStream != nil {
@@ -235,7 +232,7 @@ func (h *Handler) cancelAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := h.cancelSessionTurn(r.Context(), selected.ID+"\x00"+sessionID); err != nil {
+	if err := h.cancelSessionTurns(r.Context(), selected.ID+"\x00"+sessionID); err != nil {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -243,80 +240,61 @@ func (h *Handler) cancelAgentSessionResponse(w http.ResponseWriter, r *http.Requ
 
 var errSessionAgentUnavailable = errors.New("agent is unavailable")
 
-func (h *Handler) resolveSessionAgent(selector string) (agent.Agent, error) {
-	if selector == "" || h.svc == nil {
-		return agent.Agent{}, fmt.Errorf("agent not found")
+func (h *Handler) resolveSessionAgent(selector string) (agentengine.Agent, error) {
+	if selector == "" || h.agentEngine == nil {
+		return agentengine.Agent{}, fmt.Errorf("agent not found")
 	}
-	selected, ok := h.svc.Agent(selector)
-	if !ok {
-		selected, ok = h.svc.AgentByName(selector)
+	selected, err := h.agentEngine.Agents().Get(context.Background(), selector)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			return agentengine.Agent{}, err
+		}
+		return agentengine.Agent{}, fmt.Errorf("%w: %v", errSessionAgentUnavailable, err)
 	}
-	if !ok {
-		return agent.Agent{}, fmt.Errorf("agent %q not found", selector)
-	}
-	if !strings.EqualFold(strings.TrimSpace(selected.Status), string(agentruntime.StateRunning)) || strings.TrimSpace(selected.RuntimeID) == "" {
-		return agent.Agent{}, fmt.Errorf("%w: agent %q is not running", errSessionAgentUnavailable, selected.ID)
+	if selected.Status.State != agentengine.AgentStateRunning || strings.TrimSpace(selected.Status.RuntimeID) == "" {
+		return agentengine.Agent{}, fmt.Errorf("%w: agent %q is not running", errSessionAgentUnavailable, selected.ID)
 	}
 	return selected, nil
 }
 
-func (h *Handler) beginSessionTurn(ctx context.Context, key string) (*agentSessionTurn, bool) {
-	for {
-		if ctx.Err() != nil {
-			return nil, false
-		}
-		h.sessionTurnsMu.Lock()
-		if h.sessionTurns == nil {
-			h.sessionTurns = make(map[string]*agentSessionTurn)
-		}
-		current := h.sessionTurns[key]
-		if current == nil {
-			turnCtx, cancel := context.WithCancel(ctx)
-			turn := &agentSessionTurn{requestContext: turnCtx, cancel: cancel, done: make(chan struct{})}
-			h.sessionTurns[key] = turn
-			h.sessionTurnsMu.Unlock()
-			return turn, true
-		}
-		if current.requestContext.Err() == nil {
-			h.sessionTurnsMu.Unlock()
-			return nil, false
-		}
-		done := current.done
-		h.sessionTurnsMu.Unlock()
-
-		select {
-		case <-done:
-		case <-ctx.Done():
-			return nil, false
-		}
+func (h *Handler) addSessionTurn(key string, turn agentSessionTurn) {
+	h.sessionTurnsMu.Lock()
+	defer h.sessionTurnsMu.Unlock()
+	if h.sessionTurns == nil {
+		h.sessionTurns = make(map[string]map[agentengine.TurnID]agentSessionTurn)
 	}
+	if h.sessionTurns[key] == nil {
+		h.sessionTurns[key] = make(map[agentengine.TurnID]agentSessionTurn)
+	}
+	h.sessionTurns[key][turn.turnID] = turn
 }
 
-func (h *Handler) cancelSessionTurn(ctx context.Context, key string) error {
+func (h *Handler) cancelSessionTurns(ctx context.Context, key string) error {
 	h.sessionTurnsMu.Lock()
-	current := h.sessionTurns[key]
-	if current == nil {
-		h.sessionTurnsMu.Unlock()
-		return nil
+	indexed := h.sessionTurns[key]
+	turns := make([]agentSessionTurn, 0, len(indexed))
+	for _, turn := range indexed {
+		turns = append(turns, turn)
 	}
-	current.cancel()
-	done := current.done
 	h.sessionTurnsMu.Unlock()
-
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	for _, turn := range turns {
+		if turn.cancel != nil {
+			turn.cancel()
+		}
+		if err := h.agentEngine.Conversations(turn.agentID).Cancel(ctx, turn.conversationKey, turn.turnID); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (h *Handler) endSessionTurn(key string, turn *agentSessionTurn) {
+func (h *Handler) removeSessionTurn(key string, turnID agentengine.TurnID) {
 	h.sessionTurnsMu.Lock()
-	if h.sessionTurns[key] == turn {
+	if indexed := h.sessionTurns[key]; indexed != nil {
+		delete(indexed, turnID)
+	}
+	if len(h.sessionTurns[key]) == 0 {
 		delete(h.sessionTurns, key)
-		turn.cancel()
-		close(turn.done)
 	}
 	h.sessionTurnsMu.Unlock()
 }
@@ -788,4 +766,4 @@ func newAgentSessionAPIID(prefix string) string {
 	return fmt.Sprintf("%s_%d", prefix, time.Now().UTC().UnixNano())
 }
 
-var _ sessionConversationEngine = (*agentengine.Engine)(nil)
+var _ agentengine.Interface = (*agentengine.Engine)(nil)

--- a/internal/api/agent_sessions_test.go
+++ b/internal/api/agent_sessions_test.go
@@ -16,29 +16,48 @@ import (
 
 	"csgclaw/internal/agent"
 	"csgclaw/internal/agentengine"
+	"csgclaw/internal/agentengine/enginetest"
 	"csgclaw/internal/agentsession"
 	"csgclaw/internal/config"
 	"csgclaw/internal/im"
 )
 
 type fakeSessionEngine struct {
-	run func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult
+	run       func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult
+	beforeRun func(context.Context)
+	client    *enginetest.MemoryClient
+}
+
+func (e *fakeSessionEngine) Agents() agentengine.AgentInterface {
+	return e.client.Agents()
 }
 
 func (e *fakeSessionEngine) Conversations(agentID string) agentengine.ConversationInterface {
-	return fakeSessionConversations{engine: e, agentID: agentID}
+	return fakeSessionConversations{engine: e, delegate: e.client.Conversations(agentID)}
 }
 
 type fakeSessionConversations struct {
-	engine  *fakeSessionEngine
-	agentID string
+	engine   *fakeSessionEngine
+	delegate agentengine.ConversationInterface
 }
 
 func (c fakeSessionConversations) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
-	if c.engine.run != nil {
-		return c.engine.run(ctx, c.agentID, request, sink)
+	if c.engine.beforeRun != nil {
+		c.engine.beforeRun(ctx)
 	}
-	return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "final answer"}
+	return c.delegate.Run(ctx, request, sink)
+}
+
+func (c fakeSessionConversations) Cancel(ctx context.Context, key agentengine.ConversationKey, turnID agentengine.TurnID) error {
+	return c.delegate.Cancel(ctx, key, turnID)
+}
+
+func (c fakeSessionConversations) Reset(ctx context.Context, key agentengine.ConversationKey) error {
+	return c.delegate.Reset(ctx, key)
+}
+
+func (c fakeSessionConversations) Resolve(ctx context.Context, resolution agentengine.InteractionResolution) error {
+	return c.delegate.Resolve(ctx, resolution)
 }
 
 func TestAgentSessionResponsesUsesEngineWithoutCreatingIMEntities(t *testing.T) {
@@ -144,7 +163,7 @@ func TestAgentSessionResponsesRejectsOverlapAndScopesBusyByAgent(t *testing.T) {
 	}
 }
 
-func TestAgentSessionResponsesWaitsForCanceledTurnCleanup(t *testing.T) {
+func TestAgentSessionResponsesRejectsOverlapUntilCanceledTurnCleanup(t *testing.T) {
 	started := make(chan struct{})
 	cleanupStarted := make(chan struct{})
 	releaseCleanup := make(chan struct{})
@@ -186,15 +205,9 @@ func TestAgentSessionResponsesWaitsForCanceledTurnCleanup(t *testing.T) {
 		strings.NewReader(`{"input":"second"}`),
 	)
 	secondRecorder := httptest.NewRecorder()
-	secondDone := make(chan struct{})
-	go func() {
-		router.ServeHTTP(secondRecorder, secondRequest)
-		close(secondDone)
-	}()
-	select {
-	case <-secondDone:
-		t.Fatalf("follow-up returned during cleanup: status=%d body=%s", secondRecorder.Code, secondRecorder.Body.String())
-	case <-time.After(20 * time.Millisecond):
+	router.ServeHTTP(secondRecorder, secondRequest)
+	if secondRecorder.Code != http.StatusConflict || !strings.Contains(secondRecorder.Body.String(), "session_busy") {
+		t.Fatalf("overlap status=%d body=%s", secondRecorder.Code, secondRecorder.Body.String())
 	}
 
 	close(releaseCleanup)
@@ -203,13 +216,9 @@ func TestAgentSessionResponsesWaitsForCanceledTurnCleanup(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("canceled response did not finish cleanup")
 	}
-	select {
-	case <-secondDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("follow-up response did not run after cleanup")
-	}
-	if secondRecorder.Code != http.StatusOK || !strings.Contains(secondRecorder.Body.String(), "second finished") {
-		t.Fatalf("follow-up status=%d body=%s", secondRecorder.Code, secondRecorder.Body.String())
+	retry := performAgentSessionRequest(t, handler, "agent-alpha", "cancel-cleanup", map[string]any{"input": "second"})
+	if retry.Code != http.StatusOK || !strings.Contains(retry.Body.String(), "second finished") {
+		t.Fatalf("retry status=%d body=%s", retry.Code, retry.Body.String())
 	}
 }
 
@@ -267,6 +276,44 @@ func TestAgentSessionResponsesCancelEndpointWaitsForRuntimeCleanup(t *testing.T)
 	case <-responseDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("canceled response did not return")
+	}
+}
+
+func TestAgentSessionCancelBeforeEngineRegistrationPreventsDispatch(t *testing.T) {
+	beforeRun := make(chan struct{})
+	releaseRun := make(chan struct{})
+	engine := &fakeSessionEngine{}
+	engine.beforeRun = func(context.Context) {
+		close(beforeRun)
+		<-releaseRun
+	}
+	handler, _, _, _ := newAgentSessionTestHandler(t, []agent.Agent{sessionCodexAgent("agent-alpha", "Alpha")}, engine, "")
+	router := handler.Routes()
+
+	responseDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		responseDone <- performAgentSessionRequest(t, handler, "agent-alpha", "pre-registration-cancel", map[string]any{"input": "must not run"})
+	}()
+	<-beforeRun
+
+	cancelRequest := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/agents/agent-alpha/sessions/pre-registration-cancel/responses/cancel",
+		nil,
+	)
+	cancelRecorder := httptest.NewRecorder()
+	router.ServeHTTP(cancelRecorder, cancelRequest)
+	if cancelRecorder.Code != http.StatusNoContent {
+		t.Fatalf("cancel status=%d body=%s", cancelRecorder.Code, cancelRecorder.Body.String())
+	}
+	close(releaseRun)
+	select {
+	case <-responseDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled response did not return")
+	}
+	if calls := engine.client.Calls(); len(calls) != 0 {
+		t.Fatalf("pre-registration cancellation dispatched Engine calls: %+v", calls)
 	}
 }
 
@@ -450,7 +497,7 @@ func sessionTurnText(request agentengine.TurnRequest) string {
 func newAgentSessionTestHandler(
 	t *testing.T,
 	agents []agent.Agent,
-	engine sessionConversationEngine,
+	engine *fakeSessionEngine,
 	bindingPath string,
 ) (*Handler, *im.Service, *agentsession.Store, string) {
 	t.Helper()
@@ -471,6 +518,17 @@ func newAgentSessionTestHandler(
 	if err != nil {
 		t.Fatal(err)
 	}
+	seeded, err := agentengine.New(agentSvc).Agents().List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine.client = enginetest.NewMemoryClient(seeded...)
+	engine.client.SetTurnBehavior(func(ctx context.Context, agentID string, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		if engine.run != nil {
+			return engine.run(ctx, agentID, request, sink)
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "final answer", Dispatched: true}
+	})
 	if bindingPath == "" {
 		bindingPath = filepath.Join(root, "session-bindings")
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"csgclaw/internal/agent"
+	"csgclaw/internal/agentengine"
 	"csgclaw/internal/agentsession"
 	"csgclaw/internal/agenttask"
 	"csgclaw/internal/apitypes"
@@ -83,7 +84,7 @@ type Handler struct {
 	notificationDeliver        notification.Fanouter
 	activityDecider            ActivityDecider
 	userInputResponder         UserInputResponder
-	agentEngine                sessionConversationEngine
+	agentEngine                agentengine.Interface
 	sessionBindings            *agentsession.Store
 	localDirectoryPicker       func(context.Context) (string, error)
 	feishuRegistrationStateDir string
@@ -91,7 +92,7 @@ type Handler struct {
 	participantActivityTurnsMu sync.Mutex
 	participantActivityTurns   map[string]participantActivityTurn
 	sessionTurnsMu             sync.Mutex
-	sessionTurns               map[string]*agentSessionTurn
+	sessionTurns               map[string]map[agentengine.TurnID]agentSessionTurn
 }
 
 const (
@@ -828,7 +829,7 @@ func (h *Handler) SetUserInputResponder(responder UserInputResponder) {
 	}
 }
 
-func (h *Handler) SetAgentEngine(engine sessionConversationEngine, bindings *agentsession.Store) {
+func (h *Handler) SetAgentEngine(engine agentengine.Interface, bindings *agentsession.Store) {
 	if h != nil {
 		h.agentEngine = engine
 		h.sessionBindings = bindings

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -308,7 +308,7 @@ func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req
 		sessionID = strings.TrimSpace(live.session.SessionID)
 		req.SessionID = sessionID
 	}
-	promptText, err := appServerPromptText(req)
+	promptInput, err := appServerPromptInput(req)
 	if err != nil {
 		if m.deps.EventSink != nil {
 			m.deps.EventSink.Publish(promptFailedEvent(runtimeID, sessionID, err))
@@ -325,12 +325,12 @@ func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req
 	}
 	defer live.removeAppServerTurnWaiter(sessionID, waiter)
 
-	params := appServerTurnStartParams(live.spec, sessionID, promptText)
+	params := appServerTurnStartParamsWithInput(live.spec, sessionID, promptInput, req.ClientUserMessageID)
 	turnStartAt := time.Now()
 	live.appClient.logDebug("codex app-server turn start request",
 		"runtime_id", runtimeID,
 		"thread_id", sessionID,
-		"prompt_bytes", len(promptText),
+		"prompt_blocks", len(promptInput),
 	)
 	raw, err := live.appClient.request(ctx, "turn/start", params)
 	if err != nil {
@@ -354,6 +354,9 @@ func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req
 		return PromptResponse{}, err
 	}
 	waiter.setTurnID(appServerTurnIDFromResult(raw))
+	if req.OnAccepted != nil {
+		req.OnAccepted()
+	}
 	live.trackAppServerTurn(sessionID, waiter.currentTurnID())
 	live.appClient.logDebug("codex app-server turn start accepted",
 		"runtime_id", runtimeID,
@@ -469,6 +472,28 @@ func (m *appServerManager) EnsureSession(ctx context.Context, handle SessionHand
 		return "", err
 	}
 	return threadID, nil
+}
+
+func (m *appServerManager) ExistingSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, bool, error) {
+	live, err := m.ensureLiveSession(ctx, handle)
+	if err != nil {
+		return "", false, err
+	}
+	conversationKey = strings.TrimSpace(conversationKey)
+	if conversationKey == "" {
+		return "", false, fmt.Errorf("conversation key is required")
+	}
+	live.mu.Lock()
+	threadID := strings.TrimSpace(live.conversationSessions[conversationKey])
+	live.mu.Unlock()
+	if threadID == "" {
+		return "", false, nil
+	}
+	resolved, err := m.EnsureSession(ctx, handle, conversationKey)
+	if err != nil {
+		return "", false, err
+	}
+	return resolved, true, nil
 }
 
 func (m *appServerManager) ResetConversationHistory(ctx context.Context, handle SessionHandle, conversationKey string) error {
@@ -668,12 +693,17 @@ func appServerThreadResumeParams(spec SessionSpec, threadID string) map[string]a
 }
 
 func appServerTurnStartParams(spec SessionSpec, threadID string, prompt string) map[string]any {
+	return appServerTurnStartParamsWithInput(spec, threadID, []map[string]any{{"type": "text", "text": prompt}}, "")
+}
+
+func appServerTurnStartParamsWithInput(spec SessionSpec, threadID string, input []map[string]any, clientUserMessageID string) map[string]any {
 	spec.Profile = spec.Profile.Normalized()
 	params := map[string]any{
 		"threadId": strings.TrimSpace(threadID),
-		"input": []map[string]any{
-			{"type": "text", "text": prompt},
-		},
+		"input":    input,
+	}
+	if clientUserMessageID = strings.TrimSpace(clientUserMessageID); clientUserMessageID != "" {
+		params["clientUserMessageId"] = clientUserMessageID
 	}
 	if effort := config.NormalizeReasoningEffort(spec.Profile.ReasoningEffort); !config.UsesModelReasoningDefault(effort) {
 		params["effort"] = effort
@@ -932,6 +962,37 @@ func appServerPromptText(req PromptRequest) (string, error) {
 		return "", fmt.Errorf("prompt text is required")
 	}
 	return text, nil
+}
+
+func appServerPromptInput(req PromptRequest) ([]map[string]any, error) {
+	if len(req.Prompt) == 0 {
+		return nil, fmt.Errorf("prompt input is required")
+	}
+	input := make([]map[string]any, 0, len(req.Prompt))
+	for _, block := range req.Prompt {
+		switch {
+		case block.Text != nil:
+			if strings.TrimSpace(block.Text.Text) == "" {
+				return nil, fmt.Errorf("prompt text is required")
+			}
+			input = append(input, map[string]any{"type": "text", "text": block.Text.Text})
+		case block.LocalImage != nil:
+			path := strings.TrimSpace(block.LocalImage.Path)
+			if path == "" {
+				return nil, fmt.Errorf("local image path is required")
+			}
+			input = append(input, map[string]any{"type": "localImage", "path": path})
+		case block.ResourceLink != nil || block.Resource != nil:
+			text := strings.TrimSpace(textFromPromptBlock(block))
+			if text == "" {
+				return nil, fmt.Errorf("prompt resource is empty")
+			}
+			input = append(input, map[string]any{"type": "text", "text": text})
+		default:
+			return nil, fmt.Errorf("unsupported prompt content block for codex app-server")
+		}
+	}
+	return input, nil
 }
 
 func (m *appServerManager) persistedThreadID(spec SessionSpec) string {

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -2257,6 +2257,23 @@ func TestAppServerReadOnlyDeclinesMutationApprovals(t *testing.T) {
 	}
 }
 
+func TestAppServerTurnStartPreservesNativeBlocksAndClientMessageID(t *testing.T) {
+	spec := testAppServerSessionSpec(t.TempDir())
+	input := []map[string]any{
+		{"type": "text", "text": "before"},
+		{"type": "localImage", "path": "/runtime/image.png"},
+		{"type": "text", "text": "after"},
+	}
+	params := appServerTurnStartParamsWithInput(spec, "thread-1", input, "caller-turn")
+	if got := params["clientUserMessageId"]; got != "caller-turn" {
+		t.Fatalf("clientUserMessageId = %v", got)
+	}
+	gotInput, ok := params["input"].([]map[string]any)
+	if !ok || len(gotInput) != 3 || gotInput[1]["type"] != "localImage" || gotInput[1]["path"] != "/runtime/image.png" {
+		t.Fatalf("input = %#v", params["input"])
+	}
+}
+
 func waitForAppServerPending(t *testing.T, client *appServerClient, want int) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/internal/runtime/codex/prompt.go
+++ b/internal/runtime/codex/prompt.go
@@ -8,9 +8,11 @@ const (
 )
 
 type PromptRequest struct {
-	SessionID string
-	Prompt    []PromptContentBlock
-	Meta      map[string]any
+	SessionID           string
+	ClientUserMessageID string
+	Prompt              []PromptContentBlock
+	Meta                map[string]any
+	OnAccepted          func()
 }
 
 type PromptResponse struct {
@@ -20,8 +22,13 @@ type PromptResponse struct {
 
 type PromptContentBlock struct {
 	Text         *PromptTextBlock
+	LocalImage   *PromptLocalImageBlock
 	ResourceLink *PromptResourceLink
 	Resource     *PromptResourceBlock
+}
+
+type PromptLocalImageBlock struct {
+	Path string
 }
 
 type PromptTextBlock struct {
@@ -43,10 +50,16 @@ func TextBlock(text string) PromptContentBlock {
 	}
 }
 
+func LocalImageBlock(path string) PromptContentBlock {
+	return PromptContentBlock{LocalImage: &PromptLocalImageBlock{Path: path}}
+}
+
 func textFromPromptBlock(block PromptContentBlock) string {
 	switch {
 	case block.Text != nil:
 		return block.Text.Text
+	case block.LocalImage != nil:
+		return strings.TrimSpace(block.LocalImage.Path)
 	case block.ResourceLink != nil:
 		return strings.TrimSpace(block.ResourceLink.Name) + " " + strings.TrimSpace(block.ResourceLink.URI)
 	case block.Resource != nil:

--- a/internal/runtime/codex/provision_credentials.go
+++ b/internal/runtime/codex/provision_credentials.go
@@ -1,0 +1,242 @@
+package codex
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	pathpkg "path"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+type credentialFileSnapshot struct {
+	exists bool
+	data   []byte
+	mode   os.FileMode
+}
+
+func (r *Runtime) provisionWorkspaceCredentials(ctx context.Context, workspace string, environment []string, credentials map[string]string, previous []string, initShell string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		return fmt.Errorf("Codex workspace is required for Runtime credentials")
+	}
+	if err := r.mkdirAll(workspace, 0o755); err != nil {
+		return fmt.Errorf("create Codex workspace for Runtime credentials: %w", err)
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return fmt.Errorf("open Codex workspace for Runtime credentials: %w", err)
+	}
+	defer root.Close()
+
+	normalized, err := normalizeCredentialFiles(credentials)
+	if err != nil {
+		return err
+	}
+	previousPaths, err := normalizeCredentialPaths(previous)
+	if err != nil {
+		return err
+	}
+	allPaths := make(map[string]struct{}, len(normalized)+len(previousPaths))
+	for name := range normalized {
+		allPaths[name] = struct{}{}
+	}
+	for _, name := range previousPaths {
+		allPaths[name] = struct{}{}
+	}
+	ordered := make([]string, 0, len(allPaths))
+	for name := range allPaths {
+		ordered = append(ordered, name)
+	}
+	slices.Sort(ordered)
+
+	snapshots := make(map[string]credentialFileSnapshot, len(ordered))
+	for _, name := range ordered {
+		snapshot, err := snapshotCredentialFile(root, name)
+		if err != nil {
+			return err
+		}
+		snapshots[name] = snapshot
+	}
+	rollback := func(cause error) error {
+		var rollbackErrors []error
+		for _, name := range ordered {
+			snapshot := snapshots[name]
+			if snapshot.exists {
+				if err := atomicWriteCredential(root, name, snapshot.data, snapshot.mode); err != nil {
+					rollbackErrors = append(rollbackErrors, fmt.Errorf("restore Runtime credential %q: %w", name, err))
+				}
+			} else if err := root.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+				rollbackErrors = append(rollbackErrors, fmt.Errorf("remove new Runtime credential %q: %w", name, err))
+			}
+		}
+		if len(rollbackErrors) == 0 {
+			return cause
+		}
+		return errors.Join(append([]error{cause}, rollbackErrors...)...)
+	}
+
+	for _, name := range ordered {
+		content, exists := normalized[name]
+		if !exists {
+			if err := root.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return rollback(fmt.Errorf("remove replaced Runtime credential %q: %w", name, err))
+			}
+			continue
+		}
+		if err := atomicWriteCredential(root, name, []byte(content), 0o600); err != nil {
+			return rollback(fmt.Errorf("write Runtime credential %q: %w", name, err))
+		}
+	}
+
+	if strings.TrimSpace(initShell) == "" {
+		return nil
+	}
+	if err := r.runInitShell(ctx, workspace, initShell, environment); err != nil {
+		return rollback(err)
+	}
+	return nil
+}
+
+func normalizeCredentialFiles(input map[string]string) (map[string]string, error) {
+	out := make(map[string]string, len(input))
+	for name, content := range input {
+		normalized, err := normalizeCredentialPath(name)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := out[normalized]; exists {
+			return nil, fmt.Errorf("duplicate Runtime credential path %q", normalized)
+		}
+		out[normalized] = content
+	}
+	return out, nil
+}
+
+func normalizeCredentialPaths(input []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(input))
+	out := make([]string, 0, len(input))
+	for _, name := range input {
+		normalized, err := normalizeCredentialPath(name)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+func normalizeCredentialPath(name string) (string, error) {
+	if strings.TrimSpace(name) == "" || name != strings.TrimSpace(name) {
+		return "", fmt.Errorf("Runtime credential path must be a non-empty relative path")
+	}
+	if strings.ContainsRune(name, 0) || strings.Contains(name, `\`) {
+		return "", fmt.Errorf("Runtime credential path %q is invalid", name)
+	}
+	clean := pathpkg.Clean(name)
+	if clean == "." || pathpkg.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("Runtime credential path %q must remain inside the Codex workspace", name)
+	}
+	return filepath.FromSlash(clean), nil
+}
+
+func snapshotCredentialFile(root *os.Root, name string) (credentialFileSnapshot, error) {
+	info, err := root.Lstat(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return credentialFileSnapshot{}, nil
+	}
+	if err != nil {
+		return credentialFileSnapshot{}, fmt.Errorf("inspect Runtime credential %q: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		return credentialFileSnapshot{}, fmt.Errorf("Runtime credential path %q must reference a regular file", name)
+	}
+	data, err := root.ReadFile(name)
+	if err != nil {
+		return credentialFileSnapshot{}, fmt.Errorf("read existing Runtime credential %q: %w", name, err)
+	}
+	return credentialFileSnapshot{exists: true, data: data, mode: info.Mode().Perm()}, nil
+}
+
+func atomicWriteCredential(root *os.Root, name string, data []byte, mode os.FileMode) error {
+	parent := filepath.Dir(name)
+	if parent != "." {
+		if err := root.MkdirAll(parent, 0o700); err != nil {
+			return err
+		}
+	}
+	token := make([]byte, 8)
+	if _, err := rand.Read(token); err != nil {
+		return err
+	}
+	tempName := filepath.Join(parent, "."+filepath.Base(name)+".credential-"+hex.EncodeToString(token))
+	temp, err := root.OpenFile(tempName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = root.Remove(tempName)
+		}
+	}()
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Chmod(mode.Perm()); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := root.Rename(tempName, name); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func (r *Runtime) runInitShell(ctx context.Context, workspace, script string, environment []string) error {
+	if r.deps.RunInitShell != nil {
+		if err := r.deps.RunInitShell(ctx, workspace, script, append([]string(nil), environment...)); err != nil {
+			return fmt.Errorf("Codex initShell failed: %w", err)
+		}
+		return nil
+	}
+	var command *exec.Cmd
+	if runtime.GOOS == "windows" {
+		command = exec.CommandContext(ctx, "cmd.exe", "/D", "/Q")
+	} else {
+		command = exec.CommandContext(ctx, "/bin/sh", "-eu")
+	}
+	command.Dir = workspace
+	command.Env = append([]string(nil), environment...)
+	command.Stdin = strings.NewReader(script)
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("Codex initShell failed: %w", err)
+	}
+	return nil
+}

--- a/internal/runtime/codex/provision_credentials_test.go
+++ b/internal/runtime/codex/provision_credentials_test.go
@@ -1,0 +1,171 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentruntime "csgclaw/internal/runtime"
+)
+
+func TestProvisionMaterializesCredentialsBeforeInitShell(t *testing.T) {
+	root := t.TempDir()
+	runtimeImpl := newTestCodexRuntime(root, func(agentruntime.Handle) (AgentRef, error) { return AgentRef{}, nil })
+	err := runtimeImpl.Provision(context.Background(), agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice",
+		Profile: agentruntime.Profile{APIKey: "init-api-key", Env: map[string]string{"CONTRACT_INIT": "ready"}},
+		Credentials: map[string]string{
+			"secrets/token.txt":  "token-value",
+			"config/service.ini": "enabled=true\n",
+		},
+		InitShell: `test "$(cat secrets/token.txt)" = "token-value"
+test "$(cat config/service.ini)" = "enabled=true"
+test "$CONTRACT_INIT" = "ready"
+test "$OPENAI_API_KEY" = "init-api-key"
+test -n "$HOME"
+test -n "$CODEX_HOME"
+printf initialized > init-complete
+printf %s "$HOME" > init-home
+printf %s "$CODEX_HOME" > init-codex-home`,
+	})
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	workspace := filepath.Join(root, "agent-alice", ".codex", "workspace")
+	for name, want := range map[string]string{
+		"secrets/token.txt":  "token-value",
+		"config/service.ini": "enabled=true\n",
+		"init-complete":      "initialized",
+	} {
+		path := filepath.Join(workspace, filepath.FromSlash(name))
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != want {
+			t.Fatalf("credential %q = %q, %v", name, data, err)
+		}
+		if name != "init-complete" {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat credential %q: %v", name, err)
+			}
+			if info.Mode().Perm() != 0o600 {
+				t.Fatalf("credential %q mode = %v", name, info.Mode().Perm())
+			}
+		}
+	}
+	homeRaw, err := os.ReadFile(filepath.Join(workspace, "init-home"))
+	if err != nil || string(homeRaw) != runtimeImpl.hostSessionHomeDir(filepath.Join(root, "agent-alice", ".codex", "home")) {
+		t.Fatalf("initShell HOME = %q, %v", homeRaw, err)
+	}
+	codexHomeRaw, err := os.ReadFile(filepath.Join(workspace, "init-codex-home"))
+	if err != nil || string(codexHomeRaw) != filepath.Join(root, "agent-alice", ".codex", "home") {
+		t.Fatalf("initShell CODEX_HOME = %q, %v", codexHomeRaw, err)
+	}
+}
+
+func TestProvisionReplacesManagedCredentialsAndRollsBackInitFailure(t *testing.T) {
+	root := t.TempDir()
+	runtimeImpl := newTestCodexRuntime(root, func(agentruntime.Handle) (AgentRef, error) { return AgentRef{}, nil })
+	initial := agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice",
+		Credentials: map[string]string{"secrets/keep": "old", "secrets/remove": "remove"},
+	}
+	if err := runtimeImpl.Provision(context.Background(), initial); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl.deps.RunInitShell = func(_ context.Context, workspace, _ string, environment []string) error {
+		env := testEnvironmentMap(environment)
+		if env["HOME"] != runtimeImpl.hostSessionHomeDir(filepath.Join(root, "agent-alice", ".codex", "home")) || env["CODEX_HOME"] != filepath.Join(root, "agent-alice", ".codex", "home") {
+			t.Fatalf("initShell environment HOME=%q CODEX_HOME=%q", env["HOME"], env["CODEX_HOME"])
+		}
+		if data, err := os.ReadFile(filepath.Join(workspace, "secrets", "keep")); err != nil || string(data) != "new" {
+			t.Fatalf("initShell keep credential = %q, %v", data, err)
+		}
+		if _, err := os.Stat(filepath.Join(workspace, "secrets", "remove")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("removed credential still exists: %v", err)
+		}
+		if data, err := os.ReadFile(filepath.Join(workspace, "secrets", "added")); err != nil || string(data) != "added" {
+			t.Fatalf("initShell added credential = %q, %v", data, err)
+		}
+		return errors.New("initialization failed")
+	}
+	err := runtimeImpl.Provision(context.Background(), agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice",
+		PreviousCredentials: []string{"secrets/keep", "secrets/remove"},
+		Credentials:         map[string]string{"secrets/keep": "new", "secrets/added": "added"},
+		InitShell:           "initialize",
+	})
+	if err == nil || !strings.Contains(err.Error(), "initShell failed") {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	workspace := filepath.Join(root, "agent-alice", ".codex", "workspace", "secrets")
+	for name, want := range map[string]string{"keep": "old", "remove": "remove"} {
+		data, err := os.ReadFile(filepath.Join(workspace, name))
+		if err != nil || string(data) != want {
+			t.Fatalf("rolled back credential %q = %q, %v", name, data, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "added")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("new credential survived rollback: %v", err)
+	}
+}
+
+func testEnvironmentMap(environment []string) map[string]string {
+	out := make(map[string]string, len(environment))
+	for _, entry := range environment {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func TestProvisionRejectsCredentialPathsOutsideWorkspaceAndSymlinks(t *testing.T) {
+	root := t.TempDir()
+	runtimeImpl := newTestCodexRuntime(root, func(agentruntime.Handle) (AgentRef, error) { return AgentRef{}, nil })
+	for _, name := range []string{"", ".", "../secret", "/absolute", " leading", `windows\\path`} {
+		err := runtimeImpl.Provision(context.Background(), agentruntime.ProvisionRequest{
+			AgentID: "agent-alice", AgentName: "alice", Credentials: map[string]string{name: "value"},
+		})
+		if err == nil {
+			t.Fatalf("credential path %q was accepted", name)
+		}
+	}
+
+	workspace := filepath.Join(root, "agent-alice", ".codex", "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "outside")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "credential")); err != nil {
+		t.Fatal(err)
+	}
+	err := runtimeImpl.Provision(context.Background(), agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice", Credentials: map[string]string{"credential": "replacement"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("symlink Provision() error = %v", err)
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil || string(data) != "outside" {
+		t.Fatalf("outside file changed: %q, %v", data, err)
+	}
+}
+
+func TestProvisionWithoutCredentialsOrInitShellSkipsCredentialWorkspace(t *testing.T) {
+	root := t.TempDir()
+	runtimeImpl := newTestCodexRuntime(root, func(agentruntime.Handle) (AgentRef, error) { return AgentRef{}, nil })
+	err := runtimeImpl.Provision(context.Background(), agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice",
+		RuntimeOptions: map[string]any{localWorkspaceDirOptionKey: "invalid\x00workspace"},
+	})
+	if err != nil {
+		t.Fatalf("empty Runtime provisioning touched credential workspace: %v", err)
+	}
+}

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -147,12 +147,13 @@ type Dependencies struct {
 	Permission     PermissionBroker
 	UserInput      UserInputBroker
 
-	MkdirAll  func(string, os.FileMode) error
-	ReadFile  func(string) ([]byte, error)
-	WriteFile func(string, []byte, os.FileMode) error
-	Stat      func(string) (os.FileInfo, error)
-	RemoveAll func(string) error
-	OpenFile  func(string, int, os.FileMode) (*os.File, error)
+	MkdirAll     func(string, os.FileMode) error
+	ReadFile     func(string) ([]byte, error)
+	WriteFile    func(string, []byte, os.FileMode) error
+	Stat         func(string) (os.FileInfo, error)
+	RemoveAll    func(string) error
+	OpenFile     func(string, int, os.FileMode) (*os.File, error)
+	RunInitShell func(context.Context, string, string, []string) error
 
 	StopRuntimeProcesses func(string) ([]int, error)
 }
@@ -245,12 +246,54 @@ func (r *Runtime) EnsureSession(ctx context.Context, runtimeID, conversationKey 
 	return ensurer.EnsureSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
 }
 
+func (r *Runtime) ExistingSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error) {
+	resolver, ok := r.SessionManager().(interface {
+		ExistingSession(context.Context, SessionHandle, string) (string, bool, error)
+	})
+	if !ok {
+		return "", false, fmt.Errorf("codex session manager does not support strict conversation lookup")
+	}
+	return resolver.ExistingSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
+}
+
 func (r *Runtime) Prompt(ctx context.Context, runtimeID, sessionID, prompt string) error {
 	_, err := r.SessionManager().Prompt(ctx, SessionHandle{RuntimeID: runtimeID}, PromptRequest{
 		SessionID: strings.TrimSpace(sessionID),
 		Prompt:    []PromptContentBlock{TextBlock(prompt)},
 	})
 	return err
+}
+
+func (r *Runtime) PromptTurn(ctx context.Context, runtimeID, sessionID, turnID string, blocks []PromptContentBlock, accepted func()) error {
+	_, err := r.SessionManager().Prompt(ctx, SessionHandle{RuntimeID: runtimeID}, PromptRequest{
+		SessionID:           strings.TrimSpace(sessionID),
+		ClientUserMessageID: strings.TrimSpace(turnID),
+		Prompt:              blocks,
+		OnAccepted:          accepted,
+	})
+	return err
+}
+
+func (r *Runtime) ResetConversation(ctx context.Context, runtimeID, conversationKey string) error {
+	resetter, ok := r.SessionManager().(interface {
+		ResetConversationHistory(context.Context, SessionHandle, string) error
+	})
+	if !ok {
+		return fmt.Errorf("codex session manager does not support conversation reset")
+	}
+	return resetter.ResetConversationHistory(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
+}
+
+func (r *Runtime) WorkspaceDir(runtimeID string) (string, error) {
+	session, err := r.SessionManager().LiveSession(SessionHandle{RuntimeID: strings.TrimSpace(runtimeID)})
+	if err != nil {
+		return "", err
+	}
+	workspace := strings.TrimSpace(session.WorkspaceDir)
+	if workspace == "" {
+		return "", fmt.Errorf("codex workspace is unavailable")
+	}
+	return workspace, nil
 }
 
 func (r *Runtime) Subscribe(runtimeID string) (<-chan SessionEvent, func()) {
@@ -299,7 +342,7 @@ func (r *Runtime) New(ctx context.Context, spec agentruntime.Spec) (agentruntime
 	}, nil
 }
 
-func (r *Runtime) Provision(_ context.Context, req agentruntime.ProvisionRequest) error {
+func (r *Runtime) Provision(ctx context.Context, req agentruntime.ProvisionRequest) error {
 	if r == nil {
 		return nil
 	}
@@ -338,6 +381,22 @@ func (r *Runtime) Provision(_ context.Context, req agentruntime.ProvisionRequest
 	}
 	if err := r.syncManagerTemplateSkills(agentID, codexHomeDir); err != nil {
 		return fmt.Errorf("sync manager codex skills for agent %q: %w", req.AgentName, err)
+	}
+	if len(req.Credentials) == 0 && len(req.PreviousCredentials) == 0 && strings.TrimSpace(req.InitShell) == "" {
+		return nil
+	}
+	credentialWorkspace, err := ResolveWorkspaceDir(agentHome, req.RuntimeOptions)
+	if err != nil {
+		return fmt.Errorf("resolve Codex workspace for Runtime credentials: %w", err)
+	}
+	initEnvironment := buildSessionEnv(SessionSpec{
+		WorkspaceDir: credentialWorkspace,
+		HomeDir:      r.hostSessionHomeDir(codexHomeDir),
+		CodexHomeDir: codexHomeDir,
+		Profile:      req.Profile,
+	})
+	if err := r.provisionWorkspaceCredentials(ctx, credentialWorkspace, initEnvironment, req.Credentials, req.PreviousCredentials, req.InitShell); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/runtime/codex/user_input_broker.go
+++ b/internal/runtime/codex/user_input_broker.go
@@ -305,6 +305,20 @@ func (b *MemoryUserInputBroker) Bind(requestID, channel, roomID, threadRootID, r
 }
 
 func (b *MemoryUserInputBroker) Respond(ctx context.Context, req activity.UserInputResponseRequest) (activity.UserInputSnapshot, error) {
+	return b.respond(ctx, req, true)
+}
+
+// RespondDirect resolves an Engine-owned interaction without requiring an IM
+// channel binding. It retains the same question and answer validation.
+func (b *MemoryUserInputBroker) RespondDirect(ctx context.Context, requestID, responderID string, response activity.RequestUserInputResponse) (activity.UserInputSnapshot, error) {
+	return b.respond(ctx, activity.UserInputResponseRequest{
+		ActivityID:  requestID,
+		ResponderID: responderID,
+		Response:    response,
+	}, false)
+}
+
+func (b *MemoryUserInputBroker) respond(ctx context.Context, req activity.UserInputResponseRequest, requireBinding bool) (activity.UserInputSnapshot, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -312,7 +326,7 @@ func (b *MemoryUserInputBroker) Respond(ctx context.Context, req activity.UserIn
 	req.Channel = strings.TrimSpace(req.Channel)
 	req.RoomID = strings.TrimSpace(req.RoomID)
 	req.ResponderID = strings.TrimSpace(req.ResponderID)
-	if req.ActivityID == "" || req.Channel == "" || req.RoomID == "" || req.ResponderID == "" {
+	if req.ActivityID == "" || req.ResponderID == "" || (requireBinding && (req.Channel == "" || req.RoomID == "")) {
 		return activity.UserInputSnapshot{}, ErrUserInputInvalidResponse
 	}
 
@@ -333,9 +347,9 @@ func (b *MemoryUserInputBroker) Respond(ctx context.Context, req activity.UserIn
 		b.mu.Unlock()
 		return activity.UserInputSnapshot{}, ErrUserInputNotFound
 	}
-	if pending.state.snapshot.Channel == "" ||
+	if requireBinding && (pending.state.snapshot.Channel == "" ||
 		pending.state.snapshot.Channel != req.Channel ||
-		pending.state.snapshot.RoomID != req.RoomID {
+		pending.state.snapshot.RoomID != req.RoomID) {
 		b.mu.Unlock()
 		return activity.UserInputSnapshot{}, ErrUserInputNotFound
 	}

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -33,6 +33,9 @@ type ProvisionRequest struct {
 	Profile              Profile
 	RuntimeOptions       map[string]any
 	MCPServers           map[string]any
+	Credentials          map[string]string
+	PreviousCredentials  []string
+	InitShell            string
 	WorkspaceOverlay     string
 	Gateway              *GatewayProvision
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -53,7 +53,7 @@ type Options struct {
 	Upgrade            *upgrade.Manager
 	ActivityDecider    api.ActivityDecider
 	UserInputResponder api.UserInputResponder
-	AgentEngine        *agentengine.Engine
+	AgentEngine        agentengine.Interface
 	SessionBindings    *agentsession.Store
 	ConfigPath         string
 	AccessToken        string


### PR DESCRIPTION
## Summary

- implement the complete Phase 2 Agent Engine contract, lifecycle coordination, and Session API integration
- add Codex file, interaction, cancellation, structured-output, credentials, and initShell runtime support
- add shared real-Engine and MemoryClient contracts plus a mock-backed Feishu adapter harness