### PR TITLE
fix(desktop): use native Windows update coordinator

### DIFF
--- a/cmd/csgclaw-desktop-update-helper/main.go
+++ b/cmd/csgclaw-desktop-update-helper/main.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	readyMarker          = "coordinator-ready\n"
+	parentWaitTimeout    = 60 * time.Second
+	postParentExitDelay  = 750 * time.Millisecond
+	exitInvalidArguments = 2
+	exitLogUnavailable   = 3
+	exitPreflightFailed  = 4
+	exitReadyFailed      = 5
+	exitParentWaitFailed = 6
+	exitInstallerFailed  = 7
+	exitRelaunchFailed   = 8
+)
+
+var errParentWaitTimeout = errors.New("timed out waiting for parent process")
+
+type coordinatorOptions struct {
+	parentPID          uint32
+	installerPath      string
+	rootExecutablePath string
+	readyFilePath      string
+	logFilePath        string
+}
+
+type parentProcess interface {
+	Wait(timeout time.Duration) error
+	Close() error
+}
+
+type coordinatorDependencies struct {
+	openParent      func(pid uint32) (parentProcess, error)
+	runInstaller    func(path string, output io.Writer) (int, error)
+	startExecutable func(path string) error
+	sleep           func(duration time.Duration)
+}
+
+type eventLogger struct {
+	writer io.Writer
+	now    func() time.Time
+}
+
+func main() {
+	os.Exit(realMain(os.Args[1:]))
+}
+
+func realMain(args []string) int {
+	options, err := parseCoordinatorOptions(args)
+	if err != nil {
+		return exitInvalidArguments
+	}
+	if err := os.MkdirAll(filepath.Dir(options.logFilePath), 0o700); err != nil {
+		return exitLogUnavailable
+	}
+	logFile, err := os.OpenFile(options.logFilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return exitLogUnavailable
+	}
+	defer logFile.Close()
+
+	logger := &eventLogger{writer: logFile, now: time.Now}
+	logger.Event(
+		"coordinator-started",
+		"helper-pid",
+		os.Getpid(),
+		"parent-pid",
+		options.parentPID,
+		"installer",
+		options.installerPath,
+		"root-executable",
+		options.rootExecutablePath,
+	)
+	exitCode := runCoordinator(options, platformDependencies(), logger)
+	logger.Event("coordinator-finished", "code", exitCode)
+	return exitCode
+}
+
+func parseCoordinatorOptions(args []string) (coordinatorOptions, error) {
+	var options coordinatorOptions
+	var parentPID uint64
+	flags := flag.NewFlagSet("csgclaw-desktop-update-helper", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Uint64Var(&parentPID, "parent-pid", 0, "PID of the CSGClaw desktop process")
+	flags.StringVar(&options.installerPath, "installer", "", "downloaded channel installer path")
+	flags.StringVar(&options.rootExecutablePath, "root-executable", "", "Squirrel root executable path")
+	flags.StringVar(&options.readyFilePath, "ready-file", "", "readiness marker path")
+	flags.StringVar(&options.logFilePath, "log-file", "", "coordinator log path")
+	if err := flags.Parse(args); err != nil {
+		return coordinatorOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return coordinatorOptions{}, fmt.Errorf("unexpected positional arguments")
+	}
+	if parentPID == 0 || parentPID > math.MaxUint32 {
+		return coordinatorOptions{}, fmt.Errorf("invalid parent PID")
+	}
+	options.parentPID = uint32(parentPID)
+	for name, value := range map[string]string{
+		"installer":       options.installerPath,
+		"root executable": options.rootExecutablePath,
+		"ready file":      options.readyFilePath,
+		"log file":        options.logFilePath,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return coordinatorOptions{}, fmt.Errorf("%s path is required", name)
+		}
+		if !filepath.IsAbs(value) {
+			return coordinatorOptions{}, fmt.Errorf("%s path must be absolute", name)
+		}
+	}
+	return options, nil
+}
+
+func runCoordinator(
+	options coordinatorOptions,
+	dependencies coordinatorDependencies,
+	logger *eventLogger,
+) int {
+	for name, filePath := range map[string]string{
+		"installer":       options.installerPath,
+		"root executable": options.rootExecutablePath,
+	} {
+		if err := requireFile(filePath); err != nil {
+			logger.Event("preflight-failed", "file", name, "error", err)
+			return exitPreflightFailed
+		}
+	}
+
+	parent, err := dependencies.openParent(options.parentPID)
+	if err != nil {
+		logger.Event("parent-open-failed", "error", err)
+		return exitParentWaitFailed
+	}
+	defer parent.Close()
+	logger.Event("parent-handle-opened", "parent-pid", options.parentPID)
+
+	if err := writeReadyMarker(options.readyFilePath); err != nil {
+		logger.Event("coordinator-ready-failed", "error", err)
+		return exitReadyFailed
+	}
+	logger.Event("coordinator-ready")
+
+	if err := parent.Wait(parentWaitTimeout); err != nil {
+		if errors.Is(err, errParentWaitTimeout) {
+			logger.Event("parent-wait-timeout", "timeout", parentWaitTimeout)
+		} else {
+			logger.Event("parent-wait-failed", "error", err)
+		}
+		return exitParentWaitFailed
+	}
+	logger.Event("parent-exited")
+	dependencies.sleep(postParentExitDelay)
+
+	logger.Event("installer-started")
+	installerExitCode, installerErr := dependencies.runInstaller(
+		options.installerPath,
+		logger.writer,
+	)
+	if installerErr != nil {
+		logger.Event("installer-exited", "code", installerExitCode, "error", installerErr)
+	} else {
+		logger.Event("installer-exited", "code", installerExitCode)
+	}
+
+	logger.Event("relaunch-started")
+	if err := dependencies.startExecutable(options.rootExecutablePath); err != nil {
+		logger.Event("relaunch-failed", "error", err)
+		return exitRelaunchFailed
+	}
+	logger.Event("relaunch-requested")
+	if installerErr != nil || installerExitCode != 0 {
+		return exitInstallerFailed
+	}
+	return 0
+}
+
+func requireFile(filePath string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", filePath)
+	}
+	return nil
+}
+
+func writeReadyMarker(filePath string) error {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
+		return err
+	}
+	temporaryPath := fmt.Sprintf("%s.%d.tmp", filePath, os.Getpid())
+	defer os.Remove(temporaryPath)
+	if err := os.WriteFile(temporaryPath, []byte(readyMarker), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, filePath)
+}
+
+func (logger *eventLogger) Event(name string, fields ...any) {
+	_, _ = fmt.Fprintf(
+		logger.writer,
+		"%s %s",
+		logger.now().UTC().Format(time.RFC3339Nano),
+		name,
+	)
+	for index := 0; index+1 < len(fields); index += 2 {
+		_, _ = fmt.Fprintf(
+			logger.writer,
+			" %v=%q",
+			fields[index],
+			fmt.Sprint(fields[index+1]),
+		)
+	}
+	_, _ = fmt.Fprintln(logger.writer)
+	if syncer, ok := logger.writer.(interface{ Sync() error }); ok {
+		_ = syncer.Sync()
+	}
+}

--- a/cmd/csgclaw-desktop-update-helper/main_test.go
+++ b/cmd/csgclaw-desktop-update-helper/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeParentProcess struct {
+	readyFilePath string
+	events        *[]string
+	waitError     error
+}
+
+func (process *fakeParentProcess) Wait(time.Duration) error {
+	marker, err := os.ReadFile(process.readyFilePath)
+	if err != nil || string(marker) != readyMarker {
+		return errors.New("ready marker was not written before parent wait")
+	}
+	*process.events = append(*process.events, "wait-parent")
+	return process.waitError
+}
+
+func (process *fakeParentProcess) Close() error {
+	*process.events = append(*process.events, "close-parent")
+	return nil
+}
+
+func TestRunCoordinatorWaitsThenInstallsAndRelaunches(t *testing.T) {
+	options := coordinatorTestOptions(t)
+	var events []string
+	var log bytes.Buffer
+	dependencies := coordinatorDependencies{
+		openParent: func(pid uint32) (parentProcess, error) {
+			events = append(events, "open-parent")
+			return &fakeParentProcess{
+				readyFilePath: options.readyFilePath,
+				events:        &events,
+			}, nil
+		},
+		runInstaller: func(path string, output io.Writer) (int, error) {
+			events = append(events, "run-installer")
+			return 0, nil
+		},
+		startExecutable: func(path string) error {
+			events = append(events, "start-root")
+			return nil
+		},
+		sleep: func(time.Duration) {
+			events = append(events, "post-exit-delay")
+		},
+	}
+
+	exitCode := runCoordinator(
+		options,
+		dependencies,
+		&eventLogger{writer: &log, now: time.Now},
+	)
+	if exitCode != 0 {
+		t.Fatalf("runCoordinator() exit code = %d, want 0", exitCode)
+	}
+	wantEvents := []string{
+		"open-parent",
+		"wait-parent",
+		"post-exit-delay",
+		"run-installer",
+		"start-root",
+		"close-parent",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %#v, want %#v", events, wantEvents)
+	}
+	for _, event := range []string{
+		"parent-handle-opened",
+		"coordinator-ready",
+		"parent-exited",
+		"installer-exited",
+		"relaunch-requested",
+	} {
+		if !strings.Contains(log.String(), event) {
+			t.Fatalf("log does not contain %q:\n%s", event, log.String())
+		}
+	}
+}
+
+func TestRunCoordinatorRelaunchesAfterInstallerFailure(t *testing.T) {
+	options := coordinatorTestOptions(t)
+	var events []string
+	dependencies := coordinatorDependencies{
+		openParent: func(pid uint32) (parentProcess, error) {
+			return &fakeParentProcess{
+				readyFilePath: options.readyFilePath,
+				events:        &events,
+			}, nil
+		},
+		runInstaller: func(path string, output io.Writer) (int, error) {
+			return 23, errors.New("installer failed")
+		},
+		startExecutable: func(path string) error {
+			events = append(events, "start-root")
+			return nil
+		},
+		sleep: func(time.Duration) {},
+	}
+
+	exitCode := runCoordinator(
+		options,
+		dependencies,
+		&eventLogger{writer: io.Discard, now: time.Now},
+	)
+	if exitCode != exitInstallerFailed {
+		t.Fatalf(
+			"runCoordinator() exit code = %d, want %d",
+			exitCode,
+			exitInstallerFailed,
+		)
+	}
+	if !reflect.DeepEqual(events, []string{"wait-parent", "start-root", "close-parent"}) {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func coordinatorTestOptions(t *testing.T) coordinatorOptions {
+	t.Helper()
+	directory := t.TempDir()
+	installerPath := filepath.Join(directory, "Setup.exe")
+	rootExecutablePath := filepath.Join(directory, "CSGClaw.exe")
+	for _, filePath := range []string{installerPath, rootExecutablePath} {
+		if err := os.WriteFile(filePath, []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return coordinatorOptions{
+		parentPID:          9040,
+		installerPath:      installerPath,
+		rootExecutablePath: rootExecutablePath,
+		readyFilePath:      filepath.Join(directory, "coordinator.ready"),
+		logFilePath:        filepath.Join(directory, "coordinator.log"),
+	}
+}

--- a/cmd/csgclaw-desktop-update-helper/platform_other.go
+++ b/cmd/csgclaw-desktop-update-helper/platform_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+func platformDependencies() coordinatorDependencies {
+	unsupported := func() error {
+		return fmt.Errorf("desktop update helper is only supported on Windows")
+	}
+	return coordinatorDependencies{
+		openParent: func(uint32) (parentProcess, error) {
+			return nil, unsupported()
+		},
+		runInstaller: func(string, io.Writer) (int, error) {
+			return -1, unsupported()
+		},
+		startExecutable: func(string) error {
+			return unsupported()
+		},
+		sleep: time.Sleep,
+	}
+}

--- a/cmd/csgclaw-desktop-update-helper/platform_windows.go
+++ b/cmd/csgclaw-desktop-update-helper/platform_windows.go
@@ -1,0 +1,92 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const waitTimeoutResult = 0x00000102
+
+type windowsParentProcess struct {
+	handle windows.Handle
+}
+
+func platformDependencies() coordinatorDependencies {
+	return coordinatorDependencies{
+		openParent:      openWindowsParentProcess,
+		runInstaller:    runWindowsInstaller,
+		startExecutable: startWindowsExecutable,
+		sleep:           time.Sleep,
+	}
+}
+
+func openWindowsParentProcess(pid uint32) (parentProcess, error) {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
+	if err != nil {
+		return nil, fmt.Errorf("open parent process %d: %w", pid, err)
+	}
+	return &windowsParentProcess{handle: handle}, nil
+}
+
+func (process *windowsParentProcess) Wait(timeout time.Duration) error {
+	waitMilliseconds := uint32(timeout / time.Millisecond)
+	result, err := windows.WaitForSingleObject(process.handle, waitMilliseconds)
+	if err != nil {
+		return err
+	}
+	switch result {
+	case windows.WAIT_OBJECT_0:
+		return nil
+	case waitTimeoutResult:
+		return errParentWaitTimeout
+	default:
+		return fmt.Errorf("unexpected parent wait result %#x", result)
+	}
+}
+
+func (process *windowsParentProcess) Close() error {
+	return windows.CloseHandle(process.handle)
+}
+
+func runWindowsInstaller(path string, output io.Writer) (int, error) {
+	command := exec.Command(path, "--silent")
+	command.Dir = filepath.Dir(path)
+	command.Stdout = output
+	command.Stderr = output
+	command.SysProcAttr = hiddenWindowsProcessAttributes()
+	err := command.Run()
+	if err == nil {
+		return 0, nil
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		return exitError.ExitCode(), err
+	}
+	return -1, err
+}
+
+func startWindowsExecutable(path string) error {
+	command := exec.Command(path)
+	command.Dir = filepath.Dir(path)
+	command.SysProcAttr = hiddenWindowsProcessAttributes()
+	if err := command.Start(); err != nil {
+		return err
+	}
+	return command.Process.Release()
+}
+
+func hiddenWindowsProcessAttributes() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+		HideWindow:    true,
+	}
+}

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -19,6 +19,7 @@ import {
   normalizeDesktopReleaseVersion,
   numericDesktopAppVersion,
 } from "./src/shared/releaseVersion";
+import { WINDOWS_UPDATE_HELPER_RESOURCE_NAME } from "./src/shared/windowsUpdateCoordinator";
 
 const targetGoOS = process.env.CSGCLAW_DESKTOP_GOOS || goOSForDesktopPlatform(process.platform);
 const targetGoArch = process.env.CSGCLAW_DESKTOP_GOARCH || goArchForDesktopArch(process.arch);
@@ -40,6 +41,13 @@ const macDockDarkIcon = path.join(iconDirectory, "csgclaw-dock-dark.png");
 const markLightIcon = path.join(iconDirectory, "csgclaw-mark-light.svg");
 const markDarkIcon = path.join(iconDirectory, "csgclaw-mark-dark.svg");
 const windowsIcon = path.join(iconDirectory, "csgclaw.ico");
+const windowsUpdateHelper = path.resolve(
+  __dirname,
+  "out",
+  "input",
+  `${targetGoOS}-${targetGoArch}`,
+  WINDOWS_UPDATE_HELPER_RESOURCE_NAME,
+);
 const linuxIcon = path.join(iconDirectory, "csgclaw.png");
 const windowsIconURL =
   "https://raw.githubusercontent.com/OpenCSGs/csgclaw/main/desktop/resources/icons/csgclaw.ico";
@@ -124,7 +132,7 @@ const config: ForgeConfig = {
       markLightIcon,
       markDarkIcon,
       ...(isMacTarget ? [macDockLightIcon, macDockDarkIcon] : []),
-      ...(isWindowsTarget ? [windowsIcon] : []),
+      ...(isWindowsTarget ? [windowsIcon, windowsUpdateHelper] : []),
     ],
     icon: appIcon,
     name: "CSGClaw",

--- a/desktop/src/main/channelSwitchUpdate.test.ts
+++ b/desktop/src/main/channelSwitchUpdate.test.ts
@@ -11,7 +11,7 @@ import {
   officialMacReleaseArchiveURL,
   parseMacChannelUpdate,
   startMacChannelUpdateFeed,
-  windowsChannelInstallerCoordinatorScript,
+  windowsUpdateCoordinatorArguments,
 } from "./channelSwitchUpdate";
 
 test("selects the target latest release from a static macOS feed", () => {
@@ -119,20 +119,26 @@ test("downloads and verifies a complete channel installer", async () => {
   }
 });
 
-test("coordinates a Windows channel install after the parent exits", () => {
-  const script = windowsChannelInstallerCoordinatorScript();
-  const readyIndex = script.indexOf("coordinator-ready");
-  const parentWaitIndex = script.indexOf(":wait_for_parent");
-  const installerIndex = script.indexOf(
-    '"%CSGCLAW_CHANNEL_INSTALLER%" --silent',
+test("passes explicit inputs to the native Windows update coordinator", () => {
+  assert.deepEqual(
+    windowsUpdateCoordinatorArguments({
+      parentProcessId: 9040,
+      installerPath: "C:\\updates\\Setup.exe",
+      rootExecutablePath: "C:\\csgclaw_desktop\\CSGClaw.exe",
+      readyFilePath: "C:\\updates\\coordinator.ready",
+      logPath: "C:\\logs\\channel-installer.log",
+    }),
+    [
+      "--parent-pid",
+      "9040",
+      "--installer",
+      "C:\\updates\\Setup.exe",
+      "--root-executable",
+      "C:\\csgclaw_desktop\\CSGClaw.exe",
+      "--ready-file",
+      "C:\\updates\\coordinator.ready",
+      "--log-file",
+      "C:\\logs\\channel-installer.log",
+    ],
   );
-  const relaunchIndex = script.indexOf(
-    'start "" "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%"',
-  );
-
-  assert.ok(readyIndex >= 0);
-  assert.ok(parentWaitIndex > readyIndex);
-  assert.ok(installerIndex > parentWaitIndex);
-  assert.ok(relaunchIndex > installerIndex);
-  assert.match(script, /installer-exited code=%installerExit%/);
 });

--- a/desktop/src/main/channelSwitchUpdate.ts
+++ b/desktop/src/main/channelSwitchUpdate.ts
@@ -249,40 +249,35 @@ export async function isVerifiedArtifact(
 }
 
 const WINDOWS_COORDINATOR_READY = "coordinator-ready";
-const WINDOWS_COORDINATOR_READY_TIMEOUT_MS = 5_000;
+// Leave enough time for endpoint protection to inspect the newly staged,
+// signed helper before it opens the parent handle and reports readiness.
+const WINDOWS_COORDINATOR_READY_TIMEOUT_MS = 10_000;
+const WINDOWS_COORDINATOR_HELPER_PREFIX = "csgclaw-update-helper-";
+const WINDOWS_COORDINATOR_READY_PREFIX = "channel-installer-";
 
-export function windowsChannelInstallerCoordinatorScript(): string {
+export type WindowsUpdateCoordinatorInputs = {
+  parentProcessId: number;
+  installerPath: string;
+  rootExecutablePath: string;
+  readyFilePath: string;
+  logPath: string;
+};
+
+export function windowsUpdateCoordinatorArguments(
+  inputs: WindowsUpdateCoordinatorInputs,
+): string[] {
   return [
-    "@echo off",
-    "setlocal EnableExtensions DisableDelayedExpansion",
-    "echo coordinator-started parent-pid=%CSGCLAW_CHANNEL_PARENT_PID%",
-    `> "%CSGCLAW_CHANNEL_READY_FILE%" echo ${WINDOWS_COORDINATOR_READY}`,
-    `echo ${WINDOWS_COORDINATOR_READY}`,
-    ":wait_for_parent",
-    '"%SystemRoot%\\System32\\tasklist.exe" /FI "PID eq %CSGCLAW_CHANNEL_PARENT_PID%" /NH 2>NUL | "%SystemRoot%\\System32\\findstr.exe" /C:"%CSGCLAW_CHANNEL_PARENT_PID%" >NUL',
-    "if errorlevel 1 goto parent_exited",
-    '"%SystemRoot%\\System32\\ping.exe" 127.0.0.1 -n 2 >NUL',
-    "goto wait_for_parent",
-    ":parent_exited",
-    "echo parent-exited",
-    "echo installer-started",
-    '"%CSGCLAW_CHANNEL_INSTALLER%" --silent',
-    'set "installerExit=%ERRORLEVEL%"',
-    "echo installer-exited code=%installerExit%",
-    'if not exist "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%" goto relaunch_missing',
-    "echo relaunch-started",
-    'start "" "%CSGCLAW_CHANNEL_ROOT_EXECUTABLE%"',
-    "if errorlevel 1 goto relaunch_failed",
-    "echo relaunch-requested",
-    "exit /b %installerExit%",
-    ":relaunch_failed",
-    "echo relaunch-failed code=%ERRORLEVEL%",
-    "exit /b 1",
-    ":relaunch_missing",
-    "echo relaunch-missing",
-    "exit /b 1",
-    "",
-  ].join("\r\n");
+    "--parent-pid",
+    String(inputs.parentProcessId),
+    "--installer",
+    inputs.installerPath,
+    "--root-executable",
+    inputs.rootExecutablePath,
+    "--ready-file",
+    inputs.readyFilePath,
+    "--log-file",
+    inputs.logPath,
+  ];
 }
 
 async function waitForWindowsCoordinatorReady(
@@ -364,63 +359,63 @@ async function waitForWindowsCoordinatorReady(
 }
 
 export async function launchWindowsChannelInstaller(
-  installerPath: string,
-  rootExecutablePath: string,
-  logPath: string,
-  parentProcessId: number,
+  options: Omit<WindowsUpdateCoordinatorInputs, "readyFilePath"> & {
+    helperResourcePath: string;
+  },
 ): Promise<void> {
-  // Keep the coordinator independent from the Electron process so it can wait
-  // for the current app to exit before running the full Squirrel installer.
-  // The ready-file handshake proves that cmd.exe parsed and started the batch
-  // file; merely observing ChildProcess's spawn event does not prove that.
-  const coordinatorDirectory = path.dirname(installerPath);
-  const coordinatorPath = path.join(
+  // Stage the signed, no-console Windows helper outside the installed app
+  // directory. It opens a handle to this exact Electron process before
+  // signaling readiness, then uses the Windows wait API rather than parsing
+  // tasklist output. The full installer can therefore replace the old app
+  // directory without locking the helper executable that coordinates it.
+  const coordinatorDirectory = path.dirname(options.installerPath);
+  await fs.promises.mkdir(coordinatorDirectory, { recursive: true });
+  await fs.promises.mkdir(path.dirname(options.logPath), { recursive: true });
+  await removeStaleWindowsCoordinatorArtifacts(coordinatorDirectory);
+
+  const attemptId = crypto.randomUUID();
+  const helperPath = path.join(
     coordinatorDirectory,
-    "channel-installer.cmd",
+    `${WINDOWS_COORDINATOR_HELPER_PREFIX}${attemptId}.exe`,
   );
   const readyFilePath = path.join(
     coordinatorDirectory,
-    "channel-installer.ready",
+    `${WINDOWS_COORDINATOR_READY_PREFIX}${attemptId}.ready`,
   );
-  await fs.promises.mkdir(coordinatorDirectory, { recursive: true });
-  await fs.promises.mkdir(path.dirname(logPath), { recursive: true });
-  await Promise.all([
-    fs.promises.writeFile(
-      coordinatorPath,
-      windowsChannelInstallerCoordinatorScript(),
-      { encoding: "utf8", mode: 0o600 },
-    ),
-    fs.promises.writeFile(logPath, "", { encoding: "utf8", mode: 0o600 }),
-    fs.promises.rm(readyFilePath, { force: true }),
-  ]);
-
-  const logDescriptor = fs.openSync(logPath, "a");
-  let child: ReturnType<typeof spawn>;
+  const partialHelperPath = `${helperPath}.part`;
   try {
-    child = spawn(
-      process.env.ComSpec || "cmd.exe",
-      ["/d", "/q", "/s", "/c", 'call "%CSGCLAW_CHANNEL_COORDINATOR%"'],
-      {
-        detached: true,
-        env: {
-          ...process.env,
-          CSGCLAW_CHANNEL_COORDINATOR: coordinatorPath,
-          CSGCLAW_CHANNEL_INSTALLER: installerPath,
-          CSGCLAW_CHANNEL_PARENT_PID: String(parentProcessId),
-          CSGCLAW_CHANNEL_READY_FILE: readyFilePath,
-          CSGCLAW_CHANNEL_ROOT_EXECUTABLE: rootExecutablePath,
-        },
-        stdio: ["ignore", logDescriptor, logDescriptor],
-        windowsHide: true,
-        windowsVerbatimArguments: true,
-      },
+    await fs.promises.copyFile(options.helperResourcePath, partialHelperPath);
+    await fs.promises.rename(partialHelperPath, helperPath);
+  } catch (error) {
+    await fs.promises.rm(partialHelperPath, { force: true });
+    throw new Error(
+      `Could not stage the Windows update coordinator: ${error instanceof Error ? error.message : String(error)}`,
     );
-  } finally {
-    fs.closeSync(logDescriptor);
   }
+  await fs.promises.writeFile(options.logPath, "", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+
+  const child = spawn(
+    helperPath,
+    windowsUpdateCoordinatorArguments({
+      installerPath: options.installerPath,
+      logPath: options.logPath,
+      parentProcessId: options.parentProcessId,
+      readyFilePath,
+      rootExecutablePath: options.rootExecutablePath,
+    }),
+    {
+      cwd: coordinatorDirectory,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    },
+  );
 
   try {
-    await waitForWindowsCoordinatorReady(readyFilePath, child, logPath);
+    await waitForWindowsCoordinatorReady(readyFilePath, child, options.logPath);
   } catch (error) {
     try {
       child.kill();
@@ -430,4 +425,32 @@ export async function launchWindowsChannelInstaller(
     throw error;
   }
   child.unref();
+}
+
+async function removeStaleWindowsCoordinatorArtifacts(
+  directory: string,
+): Promise<void> {
+  const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          (entry.name === "channel-installer.cmd" ||
+            entry.name === "channel-installer.ready" ||
+            entry.name.startsWith(WINDOWS_COORDINATOR_HELPER_PREFIX) ||
+            (entry.name.startsWith(WINDOWS_COORDINATOR_READY_PREFIX) &&
+              entry.name.endsWith(".ready"))),
+      )
+      .map(async (entry) => {
+        try {
+          await fs.promises.rm(path.join(directory, entry.name), {
+            force: true,
+          });
+        } catch {
+          // A still-running helper is locked on Windows. A unique filename lets
+          // the new attempt proceed while preserving that process for diagnosis.
+        }
+      }),
+  );
 }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -10,6 +10,7 @@ import {
   compareDesktopReleaseVersions,
   inferDesktopUpdateChannel,
 } from "../shared/releaseVersion";
+import { WINDOWS_UPDATE_HELPER_RESOURCE_NAME } from "../shared/windowsUpdateCoordinator";
 import {
   desktopInstallerArtifact,
   desktopDownloadsManifestURL,
@@ -442,12 +443,16 @@ export class DesktopUpdater {
           "..",
           path.basename(process.execPath),
         );
-        await launchWindowsChannelInstaller(
-          this.windowsChannelInstallerPath,
+        await launchWindowsChannelInstaller({
+          helperResourcePath: path.join(
+            process.resourcesPath,
+            WINDOWS_UPDATE_HELPER_RESOURCE_NAME,
+          ),
+          installerPath: this.windowsChannelInstallerPath,
+          logPath: path.join(app.getPath("logs"), "channel-installer.log"),
+          parentProcessId: process.pid,
           rootExecutablePath,
-          path.join(app.getPath("logs"), "channel-installer.log"),
-          process.pid,
-        );
+        });
         logDesktopInfo("desktop-channel-switch-windows-coordinator-ready", {
           availableVersion: this.expectedVersion,
           channel: this.effectiveUpdateChannel(),

--- a/desktop/src/shared/windowsUpdateCoordinator.ts
+++ b/desktop/src/shared/windowsUpdateCoordinator.ts
@@ -1,0 +1,1 @@
+export const WINDOWS_UPDATE_HELPER_RESOURCE_NAME = "csgclaw-update-helper.exe";

--- a/docs/tech/desktop/electron-desktop-logs.zh.md
+++ b/docs/tech/desktop/electron-desktop-logs.zh.md
@@ -80,7 +80,7 @@ Windows Website/Squirrel 安装包的日志位于 Electron `userData` 目录下�
 .\scripts\collect-desktop-diagnostics.cmd
 ```
 
-脚本会把最新的 `main.log`、`main.previous.log`、`backend.log`、Crashpad dump、当前进程状态以及最近 30 分钟的 Windows Application 事件打包到桌面：
+脚本会把最新的 `main.log`、`main.previous.log`、`backend.log`、Windows 渠道安装协调器日志和 ready 标记、安装目录下的 `Squirrel-*.log`、Crashpad dump、当前进程状态以及最近 30 分钟的 Windows Application 事件打包到桌面：
 
 ```text
 csgclaw-diagnostics-YYYYMMDD-HHMMSS.zip
@@ -113,6 +113,22 @@ Get-Content -LiteralPath $mainLog.FullName -Tail 300
 ```powershell
 Get-Content -LiteralPath $mainLog.FullName -Wait
 ```
+
+Windows 渠道切换由无控制台的原生 helper 协调。`channel-installer.log` 中正常的阶段顺序应为：
+
+```text
+coordinator-started
+parent-handle-opened
+coordinator-ready
+parent-exited
+installer-started
+installer-exited code="0"
+relaunch-started
+relaunch-requested
+coordinator-finished code="0"
+```
+
+如果日志停在 `coordinator-ready`，检查 `process-status.txt` 中 helper 是否在 60 秒后按超时退出；如果停在 `installer-started`，结合 `Squirrel-*.log` 判断安装器阶段。
 
 查找并查看最新 `backend.log` 的最后 300 行：
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -501,6 +501,15 @@ function Invoke-DesktopBackendBundle {
     } -Quiet
     Fetch-CodexCli -Goos $Goos -Goarch $Goarch -OutputDir $binDir
 
+    if ($Goos -eq "windows") {
+        Invoke-GoBuild `
+            -OutputPath (Join-Path $outputRoot "csgclaw-update-helper.exe") `
+            -PackagePath "./cmd/csgclaw-desktop-update-helper" `
+            -Ldflags "-s -w -H=windowsgui" `
+            -Env $targetEnv `
+            -Quiet
+    }
+
     Write-Host "Desktop backend ready: $bundleRoot"
 }
 

--- a/scripts/collect-desktop-diagnostics.ps1
+++ b/scripts/collect-desktop-diagnostics.ps1
@@ -43,6 +43,16 @@ try {
         $collectedPaths.Add($source.FullName)
     }
 
+    $nativeReadyMarker = Get-ChildItem -LiteralPath $UserDataDirectory -Recurse -File -Filter "channel-installer-*.ready" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+    if ($null -ne $nativeReadyMarker) {
+        Copy-Item -LiteralPath $nativeReadyMarker.FullName `
+            -Destination (Join-Path $stagingDirectory $nativeReadyMarker.Name) `
+            -Force
+        $collectedPaths.Add($nativeReadyMarker.FullName)
+    }
+
     $squirrelLog = Join-Path $env:LOCALAPPDATA "SquirrelTemp\SquirrelSetup.log"
     if (Test-Path -LiteralPath $squirrelLog -PathType Leaf) {
         Copy-Item -LiteralPath $squirrelLog `
@@ -79,16 +89,30 @@ try {
             Set-Content -LiteralPath (Join-Path $stagingDirectory "collected-paths.txt") -Encoding UTF8
     }
 
-    $processes = @(Get-Process -Name "CSGClaw" -ErrorAction SilentlyContinue)
+    $processes = @(
+        Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.ProcessName -eq "CSGClaw" -or
+                $_.ProcessName -like "csgclaw-update-helper-*"
+            }
+    )
     if ($processes.Count -eq 0) {
-        "No running CSGClaw process was found." |
+        "No running CSGClaw or desktop update helper process was found." |
             Set-Content -LiteralPath (Join-Path $stagingDirectory "process-status.txt") -Encoding UTF8
     }
     else {
         $processes |
-            Select-Object Id, StartTime, Path |
+            Select-Object Id, ProcessName, StartTime, Path |
             Format-List |
             Out-File -LiteralPath (Join-Path $stagingDirectory "process-status.txt") -Encoding UTF8
+    }
+
+    $desktopUpdatesDirectory = Join-Path $UserDataDirectory "desktop-updates"
+    if (Test-Path -LiteralPath $desktopUpdatesDirectory -PathType Container) {
+        Get-ChildItem -LiteralPath $desktopUpdatesDirectory -Force -ErrorAction SilentlyContinue |
+            Select-Object Name, FullName, Length, LastWriteTime, Attributes |
+            Format-List |
+            Out-File -LiteralPath (Join-Path $stagingDirectory "update-coordinator-status.txt") -Encoding UTF8
     }
 
     if (Test-Path -LiteralPath $installationDirectory -PathType Container) {

--- a/scripts/package-desktop-backend.sh
+++ b/scripts/package-desktop-backend.sh
@@ -60,6 +60,20 @@ fi
 test -f "$BACKEND_ROOT/csgclaw/.csgclaw-bundle.json"
 if [ "$GOOS_TARGET" = "windows" ]; then
   test -f "$BACKEND_ROOT/csgclaw/bin/codex.exe"
+  (
+    cd "$ROOT_DIR"
+    env \
+      CGO_ENABLED=0 \
+      GOOS="$GOOS_TARGET" \
+      GOARCH="$GOARCH_TARGET" \
+      GOCACHE="${GOCACHE:-$ROOT_DIR/.gocache}" \
+      GOWORK=off \
+      go build \
+        -ldflags "-s -w -H=windowsgui" \
+        -o "$OUTPUT_ROOT/csgclaw-update-helper.exe" \
+        ./cmd/csgclaw-desktop-update-helper
+  )
+  test -f "$OUTPUT_ROOT/csgclaw-update-helper.exe"
 else
   test -f "$BACKEND_ROOT/csgclaw/bin/codex"
 fi


### PR DESCRIPTION
- Replace command-shell-based Windows channel switching with a packaged no-console native coordinator that waits for the exact desktop process, runs the full installer, relaunches the app, and records diagnosable lifecycle events.
