### PR TITLE
fix(docker): build csgclaw images for target architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ ARG NODE_IMAGE=node:22.13.0-alpine
 ARG PNPM_VERSION=11.1.3
 ARG NPM_REGISTRY=https://registry.npmmirror.com
 ARG RUNTIME_IMAGE=alpine:3.23
+ARG APK_REPOSITORY=https://mirrors.aliyun.com/alpine
 
-FROM ${NODE_IMAGE} AS web
+# The Web UI is architecture-independent. Build it on the BuildKit worker so a
+# multi-platform image build does not run Node under QEMU for every target.
+FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} AS web
 
 WORKDIR /src/web/app
 
@@ -18,14 +21,18 @@ RUN pnpm config set registry ${NPM_REGISTRY} && pnpm install --frozen-lockfile
 COPY web/app ./
 RUN pnpm build && test -f ../static-dist/index.html
 
-FROM ${GO_IMAGE} AS build
+# CGO is disabled below, so Go can cross-compile the target binary while the
+# compiler itself runs natively on the BuildKit worker.
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS build
 
 WORKDIR /src
 
 ARG GOPROXY=https://goproxy.cn,direct
+ARG APK_REPOSITORY
 ENV GOPROXY=${GOPROXY}
 
-RUN apk add --no-cache bash ca-certificates curl tar gzip
+RUN sed -i "s|https://dl-cdn.alpinelinux.org/alpine|${APK_REPOSITORY}|g" /etc/apk/repositories && \
+    apk add --no-cache bash ca-certificates curl tar gzip
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -33,8 +40,10 @@ RUN go mod download
 COPY . .
 COPY --from=web /src/web/static-dist ./web/static-dist
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# These are supplied automatically by Buildx. Do not give them defaults: a
+# default here would override the target platform selected by --platform.
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_TIME=unknown
@@ -54,19 +63,23 @@ RUN set -eux; \
     test "${TARGETOS}" = linux || { echo "unsupported bundled Codex CLI target: ${TARGETOS}/${TARGETARCH}" >&2; exit 1; }; \
     CODEX_CLI_DOWNLOAD_BASE_URL="${CODEX_CLI_DOWNLOAD_BASE_URL}" \
       ./scripts/fetch-codex-cli.sh "${TARGETOS}" "${TARGETARCH}" /out; \
-    /out/codex --version
+    test -x /out/codex
 
 FROM ${RUNTIME_IMAGE}
 
 USER root
 
-RUN apk add --no-cache ca-certificates tzdata
+ARG APK_REPOSITORY
+
+RUN sed -i "s|https://dl-cdn.alpinelinux.org/alpine|${APK_REPOSITORY}|g" /etc/apk/repositories && \
+    apk add --no-cache ca-certificates tzdata
 
 COPY --from=build /out/csgclaw /opt/csgclaw/bin/csgclaw
 COPY --from=build /out/csgclaw-cli /opt/csgclaw/bin/csgclaw-cli
 COPY --from=build /out/codex /opt/csgclaw/bin/codex
 
 RUN chmod 755 /opt/csgclaw/bin/csgclaw /opt/csgclaw/bin/csgclaw-cli /opt/csgclaw/bin/codex && \
+    /opt/csgclaw/bin/codex --version && \
     printf '%s\n' '{"app":"csgclaw","layout":"official-bundle"}' > /opt/csgclaw/.csgclaw-bundle.json && \
     ln -s /opt/csgclaw/bin/csgclaw /usr/local/bin/csgclaw && \
     ln -s /opt/csgclaw/bin/csgclaw-cli /usr/local/bin/csgclaw-cli && \


### PR DESCRIPTION
## Summary
- build Web UI and Go binaries on the BuildKit worker platform
- honor Buildx target OS/architecture for Go and bundled Codex
- validate Codex in the final target image and use the configured Alpine mirror

## Validation
- make
- docker buildx build --platform linux/amd64,linux/arm64 --call=check -f Dockerfile .