### PR TITLE
fix(desktop): foreground Windows app after channel switch

### DIFF
--- a/cmd/csgclaw-desktop-update-helper/main.go
+++ b/cmd/csgclaw-desktop-update-helper/main.go
@@ -40,11 +40,23 @@ type parentProcess interface {
 	Close() error
 }
 
+type relaunchResult struct {
+	startedApplication   bool
+	foundExistingWindow  bool
+	windowDetected       bool
+	windowProcessID      uint32
+	windowRestored       bool
+	windowBroughtToFront bool
+	windowForeground     bool
+	windowFlashed        bool
+	windowLookupError    string
+}
+
 type coordinatorDependencies struct {
-	openParent      func(pid uint32) (parentProcess, error)
-	runInstaller    func(path string, output io.Writer) (int, error)
-	startExecutable func(path string) error
-	sleep           func(duration time.Duration)
+	openParent          func(pid uint32) (parentProcess, error)
+	runInstaller        func(path string, output io.Writer) (int, error)
+	relaunchApplication func(path string) (relaunchResult, error)
+	sleep               func(duration time.Duration)
 }
 
 type eventLogger struct {
@@ -175,11 +187,45 @@ func runCoordinator(
 	}
 
 	logger.Event("relaunch-started")
-	if err := dependencies.startExecutable(options.rootExecutablePath); err != nil {
+	relaunch, err := dependencies.relaunchApplication(options.rootExecutablePath)
+	if err != nil {
 		logger.Event("relaunch-failed", "error", err)
 		return exitRelaunchFailed
 	}
-	logger.Event("relaunch-requested")
+	if relaunch.startedApplication {
+		logger.Event("relaunch-requested")
+	}
+	if relaunch.windowLookupError != "" {
+		logger.Event(
+			"relaunch-window-detection-failed",
+			"error",
+			relaunch.windowLookupError,
+		)
+	}
+	if relaunch.foundExistingWindow {
+		logger.Event(
+			"relaunch-existing-window-detected",
+			"process-id",
+			relaunch.windowProcessID,
+		)
+	}
+	if relaunch.windowDetected {
+		logger.Event(
+			"relaunch-window-activation",
+			"process-id",
+			relaunch.windowProcessID,
+			"restored",
+			relaunch.windowRestored,
+			"brought-to-front",
+			relaunch.windowBroughtToFront,
+			"foreground",
+			relaunch.windowForeground,
+			"flashed",
+			relaunch.windowFlashed,
+		)
+	} else {
+		logger.Event("relaunch-window-not-detected")
+	}
 	if installerErr != nil || installerExitCode != 0 {
 		return exitInstallerFailed
 	}

--- a/cmd/csgclaw-desktop-update-helper/main_test.go
+++ b/cmd/csgclaw-desktop-update-helper/main_test.go
@@ -48,9 +48,16 @@ func TestRunCoordinatorWaitsThenInstallsAndRelaunches(t *testing.T) {
 			events = append(events, "run-installer")
 			return 0, nil
 		},
-		startExecutable: func(path string) error {
+		relaunchApplication: func(path string) (relaunchResult, error) {
 			events = append(events, "start-root")
-			return nil
+			return relaunchResult{
+				startedApplication:   true,
+				windowDetected:       true,
+				windowProcessID:      9123,
+				windowRestored:       true,
+				windowBroughtToFront: true,
+				windowForeground:     true,
+			}, nil
 		},
 		sleep: func(time.Duration) {
 			events = append(events, "post-exit-delay")
@@ -82,6 +89,7 @@ func TestRunCoordinatorWaitsThenInstallsAndRelaunches(t *testing.T) {
 		"parent-exited",
 		"installer-exited",
 		"relaunch-requested",
+		"relaunch-window-activation",
 	} {
 		if !strings.Contains(log.String(), event) {
 			t.Fatalf("log does not contain %q:\n%s", event, log.String())
@@ -102,9 +110,9 @@ func TestRunCoordinatorRelaunchesAfterInstallerFailure(t *testing.T) {
 		runInstaller: func(path string, output io.Writer) (int, error) {
 			return 23, errors.New("installer failed")
 		},
-		startExecutable: func(path string) error {
+		relaunchApplication: func(path string) (relaunchResult, error) {
 			events = append(events, "start-root")
-			return nil
+			return relaunchResult{startedApplication: true}, nil
 		},
 		sleep: func(time.Duration) {},
 	}
@@ -123,6 +131,55 @@ func TestRunCoordinatorRelaunchesAfterInstallerFailure(t *testing.T) {
 	}
 	if !reflect.DeepEqual(events, []string{"wait-parent", "start-root", "close-parent"}) {
 		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestRunCoordinatorActivatesExistingWindowWithoutStartingAnotherInstance(t *testing.T) {
+	options := coordinatorTestOptions(t)
+	var log bytes.Buffer
+	dependencies := coordinatorDependencies{
+		openParent: func(pid uint32) (parentProcess, error) {
+			return &fakeParentProcess{
+				readyFilePath: options.readyFilePath,
+				events:        &[]string{},
+			}, nil
+		},
+		runInstaller: func(path string, output io.Writer) (int, error) {
+			return 0, nil
+		},
+		relaunchApplication: func(path string) (relaunchResult, error) {
+			return relaunchResult{
+				foundExistingWindow:  true,
+				windowDetected:       true,
+				windowProcessID:      9123,
+				windowRestored:       true,
+				windowBroughtToFront: true,
+				windowFlashed:        true,
+			}, nil
+		},
+		sleep: func(time.Duration) {},
+	}
+
+	exitCode := runCoordinator(
+		options,
+		dependencies,
+		&eventLogger{writer: &log, now: time.Now},
+	)
+	if exitCode != 0 {
+		t.Fatalf("runCoordinator() exit code = %d, want 0", exitCode)
+	}
+	for _, event := range []string{
+		"relaunch-existing-window-detected",
+		"relaunch-window-activation",
+		`foreground="false"`,
+		`flashed="true"`,
+	} {
+		if !strings.Contains(log.String(), event) {
+			t.Fatalf("log does not contain %q:\n%s", event, log.String())
+		}
+	}
+	if strings.Contains(log.String(), "relaunch-requested") {
+		t.Fatalf("log unexpectedly records a duplicate relaunch:\n%s", log.String())
 	}
 }
 

--- a/cmd/csgclaw-desktop-update-helper/platform_other.go
+++ b/cmd/csgclaw-desktop-update-helper/platform_other.go
@@ -19,8 +19,8 @@ func platformDependencies() coordinatorDependencies {
 		runInstaller: func(string, io.Writer) (int, error) {
 			return -1, unsupported()
 		},
-		startExecutable: func(string) error {
-			return unsupported()
+		relaunchApplication: func(string) (relaunchResult, error) {
+			return relaunchResult{}, unsupported()
 		},
 		sleep: time.Sleep,
 	}

--- a/cmd/csgclaw-desktop-update-helper/platform_windows.go
+++ b/cmd/csgclaw-desktop-update-helper/platform_windows.go
@@ -8,13 +8,54 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-const waitTimeoutResult = 0x00000102
+const (
+	waitTimeoutResult             = 0x00000102
+	applicationWindowWaitTimeout  = 15 * time.Second
+	applicationWindowPollInterval = 250 * time.Millisecond
+	flashWindowAll                = 0x00000003
+	flashWindowUntilForeground    = 0x0000000C
+	setWindowPositionNoSize       = 0x0001
+	setWindowPositionNoMove       = 0x0002
+	setWindowPositionShowWindow   = 0x0040
+)
+
+var (
+	user32                       = windows.NewLazySystemDLL("user32.dll")
+	isIconicProcedure            = user32.NewProc("IsIconic")
+	showWindowAsyncProcedure     = user32.NewProc("ShowWindowAsync")
+	bringWindowToTopProcedure    = user32.NewProc("BringWindowToTop")
+	setForegroundWindowProcedure = user32.NewProc("SetForegroundWindow")
+	setWindowPositionProcedure   = user32.NewProc("SetWindowPos")
+	flashWindowExProcedure       = user32.NewProc("FlashWindowEx")
+)
+
+type windowsApplicationWindow struct {
+	handle    windows.HWND
+	processID uint32
+}
+
+type windowsApplicationWindowFinder struct {
+	installRoot    string
+	executableName string
+	callback       uintptr
+	found          windowsApplicationWindow
+}
+
+type flashWindowInfo struct {
+	size      uint32
+	window    windows.HWND
+	flags     uint32
+	count     uint32
+	timeoutMS uint32
+}
 
 type windowsParentProcess struct {
 	handle windows.Handle
@@ -22,10 +63,10 @@ type windowsParentProcess struct {
 
 func platformDependencies() coordinatorDependencies {
 	return coordinatorDependencies{
-		openParent:      openWindowsParentProcess,
-		runInstaller:    runWindowsInstaller,
-		startExecutable: startWindowsExecutable,
-		sleep:           time.Sleep,
+		openParent:          openWindowsParentProcess,
+		runInstaller:        runWindowsInstaller,
+		relaunchApplication: relaunchWindowsApplication,
+		sleep:               time.Sleep,
 	}
 }
 
@@ -77,11 +118,190 @@ func runWindowsInstaller(path string, output io.Writer) (int, error) {
 func startWindowsExecutable(path string) error {
 	command := exec.Command(path)
 	command.Dir = filepath.Dir(path)
-	command.SysProcAttr = hiddenWindowsProcessAttributes()
 	if err := command.Start(); err != nil {
 		return err
 	}
 	return command.Process.Release()
+}
+
+func relaunchWindowsApplication(path string) (relaunchResult, error) {
+	finder := newWindowsApplicationWindowFinder(path)
+	result := relaunchResult{}
+	window, err := finder.Find()
+	if err != nil {
+		result.windowLookupError = fmt.Sprintf("find existing application window: %v", err)
+	} else if window.handle != 0 {
+		activated := activateWindowsApplicationWindow(window)
+		activated.foundExistingWindow = true
+		return activated, nil
+	}
+
+	result.startedApplication = true
+	if err := startWindowsExecutable(path); err != nil {
+		return result, err
+	}
+
+	deadline := time.Now().Add(applicationWindowWaitTimeout)
+	for {
+		window, err = finder.Find()
+		if err != nil {
+			result.windowLookupError = fmt.Sprintf(
+				"find relaunched application window: %v",
+				err,
+			)
+			return result, nil
+		}
+		if window.handle != 0 {
+			activated := activateWindowsApplicationWindow(window)
+			activated.startedApplication = true
+			return activated, nil
+		}
+		if !time.Now().Before(deadline) {
+			return result, nil
+		}
+		time.Sleep(applicationWindowPollInterval)
+	}
+}
+
+func newWindowsApplicationWindowFinder(
+	rootExecutablePath string,
+) *windowsApplicationWindowFinder {
+	finder := &windowsApplicationWindowFinder{
+		installRoot:    filepath.Clean(filepath.Dir(rootExecutablePath)),
+		executableName: filepath.Base(rootExecutablePath),
+	}
+	finder.callback = windows.NewCallback(func(windowHandle uintptr, _ uintptr) uintptr {
+		window := windows.HWND(windowHandle)
+		if !windows.IsWindowVisible(window) {
+			return 1
+		}
+		processID, executablePath, ok := windowProcess(window)
+		if !ok || !finder.matches(executablePath) {
+			return 1
+		}
+		finder.found = windowsApplicationWindow{
+			handle:    window,
+			processID: processID,
+		}
+		return 1
+	})
+	return finder
+}
+
+func (finder *windowsApplicationWindowFinder) Find() (windowsApplicationWindow, error) {
+	finder.found = windowsApplicationWindow{}
+	if err := windows.EnumWindows(finder.callback, nil); err != nil {
+		return windowsApplicationWindow{}, err
+	}
+	return finder.found, nil
+}
+
+func (finder *windowsApplicationWindowFinder) matches(executablePath string) bool {
+	if !strings.EqualFold(filepath.Base(executablePath), finder.executableName) {
+		return false
+	}
+	relativePath, err := filepath.Rel(finder.installRoot, filepath.Clean(executablePath))
+	if err != nil || relativePath == "." || relativePath == ".." {
+		return false
+	}
+	return !strings.HasPrefix(relativePath, ".."+string(filepath.Separator))
+}
+
+func windowProcess(window windows.HWND) (uint32, string, bool) {
+	var processID uint32
+	if _, err := windows.GetWindowThreadProcessId(window, &processID); err != nil {
+		return 0, "", false
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false,
+		processID,
+	)
+	if err != nil {
+		return 0, "", false
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, 32768)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buffer[0], &size); err != nil {
+		return 0, "", false
+	}
+	return processID, windows.UTF16ToString(buffer[:size]), true
+}
+
+func activateWindowsApplicationWindow(window windowsApplicationWindow) relaunchResult {
+	result := relaunchResult{
+		windowDetected:  true,
+		windowProcessID: window.processID,
+	}
+	showCommand := uintptr(windows.SW_SHOW)
+	if callWindowProcedure(isIconicProcedure, uintptr(window.handle)) {
+		showCommand = windows.SW_RESTORE
+	}
+	result.windowRestored = callWindowProcedure(
+		showWindowAsyncProcedure,
+		uintptr(window.handle),
+		showCommand,
+	)
+	result.windowBroughtToFront = bringWindowsWindowToFront(window.handle)
+	_ = callWindowProcedure(setForegroundWindowProcedure, uintptr(window.handle))
+	result.windowForeground = windows.GetForegroundWindow() == window.handle
+	if !result.windowForeground {
+		result.windowFlashed = flashWindowsWindow(window.handle)
+	}
+	return result
+}
+
+func bringWindowsWindowToFront(window windows.HWND) bool {
+	flags := uintptr(
+		setWindowPositionNoSize |
+			setWindowPositionNoMove |
+			setWindowPositionShowWindow,
+	)
+	topMost := ^uintptr(0)
+	notTopMost := ^uintptr(1)
+	madeTopMost := callWindowProcedure(
+		setWindowPositionProcedure,
+		uintptr(window),
+		topMost,
+		0,
+		0,
+		0,
+		0,
+		flags,
+	)
+	restoredZOrder := callWindowProcedure(
+		setWindowPositionProcedure,
+		uintptr(window),
+		notTopMost,
+		0,
+		0,
+		0,
+		0,
+		flags,
+	)
+	broughtToTop := callWindowProcedure(bringWindowToTopProcedure, uintptr(window))
+	return madeTopMost && restoredZOrder && broughtToTop
+}
+
+func flashWindowsWindow(window windows.HWND) bool {
+	info := flashWindowInfo{
+		size:      uint32(unsafe.Sizeof(flashWindowInfo{})),
+		window:    window,
+		flags:     flashWindowAll | flashWindowUntilForeground,
+		count:     0,
+		timeoutMS: 0,
+	}
+	return callWindowProcedure(
+		flashWindowExProcedure,
+		uintptr(unsafe.Pointer(&info)),
+	)
+}
+
+func callWindowProcedure(procedure *windows.LazyProc, arguments ...uintptr) bool {
+	result, _, _ := procedure.Call(arguments...)
+	return result != 0
 }
 
 func hiddenWindowsProcessAttributes() *syscall.SysProcAttr {

--- a/docs/tech/desktop/electron-desktop-logs.zh.md
+++ b/docs/tech/desktop/electron-desktop-logs.zh.md
@@ -124,11 +124,14 @@ parent-exited
 installer-started
 installer-exited code="0"
 relaunch-started
-relaunch-requested
+relaunch-existing-window-detected
+relaunch-window-activation foreground="true"
 coordinator-finished code="0"
 ```
 
-如果日志停在 `coordinator-ready`，检查 `process-status.txt` 中 helper 是否在 60 秒后按超时退出；如果停在 `installer-started`，结合 `Squirrel-*.log` 判断安装器阶段。
+安装器未主动启动新应用时，helper 会记录 `relaunch-requested`，等待窗口出现后再记录 `relaunch-window-activation`。如果 Windows 拒绝 helper 抢占前台，`foreground="false" flashed="true"` 表示 helper 已尝试恢复和置前窗口，并通过持续闪烁任务栏提醒用户。
+
+如果日志停在 `coordinator-ready`，检查 `process-status.txt` 中 helper 是否在 60 秒后按超时退出；如果停在 `installer-started`，结合 `Squirrel-*.log` 判断安装器阶段；如果出现 `relaunch-window-not-detected`，说明启动请求已发出，但 15 秒内没有找到目标应用窗口。
 
 查找并查看最新 `backend.log` 的最后 300 行：
 


### PR DESCRIPTION
- Restore and foreground the existing Windows desktop window after a channel switch, launch a visible instance only when needed, and flash the taskbar when foreground activation is denied.
