### PR TITLE
fix(team): constrain team member avatar rendering

### DIFF
--- a/web/app/src/components/ui/Checkbox/Checkbox.css
+++ b/web/app/src/components/ui/Checkbox/Checkbox.css
@@ -1,0 +1,45 @@
+.csg-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 0;
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  background: var(--field);
+  color: var(--on-primary);
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.csg-checkbox:hover {
+  border-color: var(--input-border-hover);
+}
+
+.csg-checkbox:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 72%, white);
+}
+
+.csg-checkbox[data-state="checked"],
+.csg-checkbox[data-state="indeterminate"] {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.csg-checkbox:disabled {
+  border-color: var(--line);
+  background: var(--panel-soft);
+  color: var(--muted);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.csg-checkbox-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/web/app/src/components/ui/Checkbox/Checkbox.tsx
+++ b/web/app/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,0 +1,20 @@
+import { Checkbox as RadixCheckbox } from "radix-ui";
+import { Check } from "lucide-react";
+import { forwardRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import { classNames } from "@/shared/lib/classNames";
+
+export type CheckboxProps = ComponentPropsWithoutRef<typeof RadixCheckbox.Root>;
+
+export const Checkbox = forwardRef<ComponentRef<typeof RadixCheckbox.Root>, CheckboxProps>(function Checkbox(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <RadixCheckbox.Root ref={ref} className={classNames("csg-checkbox", className)} {...props}>
+      <RadixCheckbox.Indicator className="csg-checkbox-indicator">
+        <Check aria-hidden="true" size={12} strokeWidth={3} />
+      </RadixCheckbox.Indicator>
+    </RadixCheckbox.Root>
+  );
+});

--- a/web/app/src/components/ui/Checkbox/index.ts
+++ b/web/app/src/components/ui/Checkbox/index.ts
@@ -1,0 +1,3 @@
+import "./Checkbox.css";
+
+export * from "./Checkbox";

--- a/web/app/src/components/ui/index.ts
+++ b/web/app/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export * from "./AppLayout";
 export * from "./Button";
+export * from "./Checkbox";
 export * from "./Dialog";
 export * from "./DropdownMenu";
 export * from "./FormControls";

--- a/web/app/src/models/tasks.test.ts
+++ b/web/app/src/models/tasks.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { resolveTeamAvatarMembers, type WorkspaceTeam } from "@/models/tasks";
+import type { AgentLike } from "@/models/agents";
+
+const baseTeam: WorkspaceTeam = {
+  id: "team-1",
+  title: "Team 1",
+  lead_agent_id: "u-manager",
+  member_agent_ids: ["u-worker", "u-reviewer"],
+  status: "active",
+  created_at: "",
+  updated_at: "",
+};
+
+function createAgent(id: string, avatar = "", name = id): AgentLike {
+  return {
+    id,
+    name,
+    avatar,
+  } as AgentLike;
+}
+
+describe("resolveTeamAvatarMembers", () => {
+  it("prefers members with configured avatars and keeps the lead first", () => {
+    const members = resolveTeamAvatarMembers(baseTeam, [
+      createAgent("u-worker", ""),
+      createAgent("u-reviewer", "avatar/pic-2.png"),
+      createAgent("u-manager", "avatar/3D-1.png"),
+    ]);
+
+    expect(members).toHaveLength(2);
+    expect(members.map((member) => member.id)).toEqual(["u-manager", "u-reviewer"]);
+    expect(members.every((member) => member.avatar)).toBe(true);
+  });
+
+  it("falls back to member initials only when no configured avatar exists", () => {
+    const members = resolveTeamAvatarMembers(baseTeam, [
+      createAgent("u-worker", ""),
+      createAgent("u-reviewer", ""),
+      createAgent("u-manager", ""),
+    ]);
+
+    expect(members.map((member) => member.id)).toEqual(["u-worker", "u-reviewer", "u-manager"]);
+  });
+
+  it("matches the lead avatar through local identity aliases", () => {
+    const members = resolveTeamAvatarMembers(
+      {
+        ...baseTeam,
+        lead_agent_id: "manager",
+        member_agent_ids: ["u-manager"],
+      },
+      [createAgent("u-manager", "avatar/3D-1.png", "Manager")],
+    );
+
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      id: "manager",
+      avatar: "avatar/3D-1.png",
+      name: "Manager",
+    });
+  });
+
+  it("uses avatars from matched users when the agent has no direct avatar", () => {
+    const members = resolveTeamAvatarMembers(
+      {
+        ...baseTeam,
+        lead_agent_id: "manager",
+        member_agent_ids: ["u-manager"],
+      },
+      [createAgent("u-manager", "", "Manager")],
+      new Map([
+        [
+          "user-manager",
+          {
+            id: "user-manager",
+            name: "Manager",
+            avatar: "avatar/pic-3.png",
+          },
+        ],
+      ]),
+    );
+
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      id: "manager",
+      avatar: "avatar/pic-3.png",
+      name: "Manager",
+    });
+  });
+});

--- a/web/app/src/models/tasks.ts
+++ b/web/app/src/models/tasks.ts
@@ -1,4 +1,6 @@
-import type { AgentLike } from "@/models/agents";
+import { resolveAgentAvatarSource, type AgentLike, type AvatarLikeUser } from "@/models/agents";
+import { localIdentitiesMatch } from "@/models/conversations";
+import { normalizeAvatarPath } from "@/shared/avatar";
 
 export type WorkspaceTask = {
   id: string;
@@ -315,16 +317,29 @@ export function teamMemberIDs(team: WorkspaceTeam): string[] {
   return Array.from(ids);
 }
 
-export function resolveTeamAvatarMembers(team: WorkspaceTeam, agents: readonly AgentLike[]) {
-  return teamMemberIDs(team).map((memberID) => {
-    const agent = agents.find((item) => item.id === memberID);
+export function resolveTeamAvatarMembers(
+  team: WorkspaceTeam,
+  agents: readonly AgentLike[],
+  usersById?: Map<string, AvatarLikeUser> | null,
+) {
+  const members = teamMemberIDs(team).map((memberID) => {
+    const agent = agents.find((item) => localIdentitiesMatch(item.id, memberID));
+    const avatar = resolveAgentAvatarSource(agent, usersById) || agent?.avatar || "";
     return {
       id: memberID,
       name: agent?.name || memberID,
-      avatar: agent?.avatar || "",
+      avatar,
       accent_hex: undefined,
     };
   });
+  const membersWithAvatar = members
+    .filter((member) => Boolean(normalizeAvatarPath(member.avatar)))
+    .sort(
+      (left, right) =>
+        Number(localIdentitiesMatch(right.id, team.lead_agent_id)) -
+        Number(localIdentitiesMatch(left.id, team.lead_agent_id)),
+    );
+  return membersWithAvatar.length ? membersWithAvatar : members;
 }
 
 type TranslateFn = (key: string) => string;

--- a/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.module.css
+++ b/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.module.css
@@ -339,6 +339,7 @@
   width: 40px;
   height: 40px;
   border-radius: var(--radius-xl);
+  overflow: hidden;
   background: var(--panel-soft);
   color: var(--muted);
   font-size: 13px;
@@ -349,14 +350,15 @@
   background: var(--panel);
 }
 
-.teamMemberAvatar .agent-avatar-image {
+.teamMemberAvatar :global(.agent-avatar-image) {
   width: 100%;
   height: 100%;
   border-radius: inherit;
+  display: block;
   object-fit: cover;
 }
 
-.teamMemberAvatar .agent-avatar-fallback {
+.teamMemberAvatar :global(.agent-avatar-fallback) {
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.tsx
+++ b/web/app/src/pages/TeamPage/components/TeamDetailPane/TeamDetailPane.tsx
@@ -14,8 +14,9 @@ import {
   DialogRoot,
   DialogTitle,
 } from "@/components/ui";
-import { isAgentRunning } from "@/models/agents";
+import { isAgentRunning, resolveAgentAvatarSource } from "@/models/agents";
 import type { AgentLike } from "@/models/agents";
+import { localIdentitiesMatch } from "@/models/conversations";
 import type { IMUser, TranslateFn, UsersById } from "@/models/conversations";
 import {
   displayTeam,
@@ -91,7 +92,7 @@ export function TeamDetailPane({
 
   const memberIDs = teamMemberIDs(team);
   const members = memberIDs.map((memberID) => memberDisplay(memberID, agents, usersById, team.lead_agent_id));
-  const avatarMembers = resolveTeamAvatarMembers(team, agents);
+  const avatarMembers = resolveTeamAvatarMembers(team, agents, usersById instanceof Map ? usersById : null);
   const parentTasks = rootTasks(tasks);
   const locale = document.documentElement.lang || "en";
 
@@ -348,6 +349,7 @@ function DetailField({ label, value }: DetailFieldProps) {
 
 type TeamMemberDisplay = {
   agent: AgentLike | null;
+  avatar: string;
   id: string;
   initials: string;
   leader: boolean;
@@ -361,8 +363,8 @@ function MemberRowContent({ member, t }: { member: TeamMemberDisplay; t: Transla
       <span className={classNames(styles.teamMemberAvatar, member.agent && styles.agent)}>
         {member.agent ? (
           <AgentAvatarContent
-            avatar={member.agent.avatar}
-            fallback={avatarFallbackText(member.agent.avatar, member.agent.name, member.agent.id)}
+            avatar={member.avatar}
+            fallback={avatarFallbackText(member.avatar, member.agent.name, member.agent.id)}
           />
         ) : (
           member.initials
@@ -388,14 +390,16 @@ function memberDisplay(
   usersById: UsersLookup,
   leadAgentID: string,
 ): TeamMemberDisplay {
-  const agent = agents.find((item) => item.id === memberID) ?? null;
+  const agent = agents.find((item) => localIdentitiesMatch(item.id, memberID)) ?? null;
   const user = lookupUser(usersById, memberID);
   const name = agent?.name || user?.name || memberID;
+  const usersMap = usersById instanceof Map ? usersById : null;
   return {
     id: memberID,
     agent,
+    avatar: agent ? resolveAgentAvatarSource(agent, usersMap) || agent.avatar || "" : user?.avatar || "",
     initials: initialsForName(name),
-    leader: memberID === leadAgentID,
+    leader: localIdentitiesMatch(memberID, leadAgentID),
     name,
     running: agent ? isAgentRunning(agent) : false,
   };

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -522,7 +522,7 @@
   line-height: 1;
 }
 
-.field input,
+.field input:not([type="checkbox"], [type="radio"]),
 .field textarea,
 .field select {
   width: 100%;
@@ -1744,7 +1744,7 @@
 
 .workspace-tab:focus-visible,
 .composer-send-button:focus-visible,
-.field input:focus,
+.field input:not([type="checkbox"], [type="radio"]):focus,
 .field textarea:focus,
 .field select:focus,
 .composer-editor:focus,
@@ -1754,7 +1754,7 @@
   box-shadow: var(--focus-ring);
 }
 
-.field input:focus,
+.field input:not([type="checkbox"], [type="radio"]):focus,
 .field textarea:focus,
 .field select:focus {
   border-color: var(--input-border-focus);
@@ -2556,7 +2556,7 @@ button[disabled],
 }
 
 .composer-editor:focus,
-.field input:focus,
+.field input:not([type="checkbox"], [type="radio"]):focus,
 .field textarea:focus,
 .field select:focus,
 .secondary-button:focus-visible,
@@ -2604,10 +2604,10 @@ button[disabled],
   letter-spacing: 0;
 }
 
-.field input,
+.field input:not([type="checkbox"], [type="radio"]),
 .field textarea,
 .field select,
-.profile-section .field input,
+.profile-section .field input:not([type="checkbox"], [type="radio"]),
 .profile-section .field textarea,
 .profile-section .field select,
 .env-row input {
@@ -2618,10 +2618,10 @@ button[disabled],
   box-shadow: var(--input-shadow);
 }
 
-:root[data-theme="dark"] .field input,
+:root[data-theme="dark"] .field input:not([type="checkbox"], [type="radio"]),
 :root[data-theme="dark"] .field textarea,
 :root[data-theme="dark"] .field select,
-:root[data-theme="dark"] .profile-section .field input,
+:root[data-theme="dark"] .profile-section .field input:not([type="checkbox"], [type="radio"]),
 :root[data-theme="dark"] .profile-section .field textarea,
 :root[data-theme="dark"] .profile-section .field select,
 :root[data-theme="dark"] .env-row input {
@@ -2631,10 +2631,10 @@ button[disabled],
   box-shadow: var(--input-shadow);
 }
 
-.field input:hover,
+.field input:not([type="checkbox"], [type="radio"]):hover,
 .field textarea:hover,
 .field select:hover,
-.profile-section .field input:hover,
+.profile-section .field input:not([type="checkbox"], [type="radio"]):hover,
 .profile-section .field textarea:hover,
 .profile-section .field select:hover,
 .env-row input:hover {
@@ -2944,10 +2944,10 @@ select,
   color: #ffffff;
 }
 
-:root[data-theme="dark"] .modal-card .field input,
+:root[data-theme="dark"] .modal-card .field input:not([type="checkbox"], [type="radio"]),
 :root[data-theme="dark"] .modal-card .field textarea,
 :root[data-theme="dark"] .modal-card .field select,
-:root[data-theme="dark"] .profile-section .field input,
+:root[data-theme="dark"] .profile-section .field input:not([type="checkbox"], [type="radio"]),
 :root[data-theme="dark"] .profile-section .field textarea,
 :root[data-theme="dark"] .profile-section .field select,
 :root[data-theme="dark"] .env-row input,
@@ -2958,9 +2958,9 @@ select,
   box-shadow: none;
 }
 
-:root[data-theme="dark"] .modal-card .field input::placeholder,
+:root[data-theme="dark"] .modal-card .field input:not([type="checkbox"], [type="radio"])::placeholder,
 :root[data-theme="dark"] .modal-card .field textarea::placeholder,
-:root[data-theme="dark"] .profile-section .field input::placeholder,
+:root[data-theme="dark"] .profile-section .field input:not([type="checkbox"], [type="radio"])::placeholder,
 :root[data-theme="dark"] .profile-section .field textarea::placeholder,
 :root[data-theme="dark"] .env-row input::placeholder,
 :root[data-theme="dark"] .composer-editor:empty::before {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -478,7 +478,7 @@
 }
 
 .composer-editor:focus,
-.field input:focus,
+.field input:not([type="checkbox"], [type="radio"]):focus,
 .field textarea:focus,
 .field select:focus {
   border-color: rgba(43, 109, 246, 0.44);

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateTeamModal.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/CreateTeamModal.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui";
+import { Button, Checkbox } from "@/components/ui";
 import { toggleSelection } from "@/shared/lib/collections";
 import type { AgentLike } from "@/models/agents";
 import { requiredFieldLabel } from "@/components/business/ProfileControls";
@@ -70,12 +70,12 @@ export function CreateTeamModal({
           <div className={`selection-list${editing ? " team-members-dialog-list" : ""}`}>
             {candidates.length ? (
               <>
-                <label className="selection-item selection-all-item">
-                  <input
-                    type="checkbox"
+                <label className="selection-item selection-all-item" htmlFor="team-member-all">
+                  <Checkbox
+                    id="team-member-all"
                     checked={allCandidatesSelected}
                     disabled={selectableCandidateIDs.length === 0}
-                    onChange={() => {
+                    onCheckedChange={() => {
                       onTeamMemberIDsChange((current) => {
                         const allSelected = candidateIDs.every(
                           (id) => lockedTeamMemberIDs.includes(id) || current.includes(id),
@@ -94,13 +94,14 @@ export function CreateTeamModal({
                 {candidates.map((item) => {
                   const itemID = item.id || "";
                   const memberLocked = itemID ? lockedTeamMemberIDs.includes(itemID) : false;
+                  const checkboxID = teamMemberCheckboxID(itemID || item.name);
                   return (
-                    <label key={itemID || item.name} className="selection-item">
-                      <input
-                        type="checkbox"
+                    <label key={itemID || item.name} className="selection-item" htmlFor={checkboxID}>
+                      <Checkbox
+                        id={checkboxID}
                         checked={itemID ? memberLocked || teamMemberIDs.includes(itemID) : false}
                         disabled={!itemID || memberLocked}
-                        onChange={() =>
+                        onCheckedChange={() =>
                           itemID ? onTeamMemberIDsChange((current) => toggleSelection(current, itemID)) : undefined
                         }
                       />
@@ -136,4 +137,8 @@ export function CreateTeamModal({
       </div>
     </div>
   );
+}
+
+function teamMemberCheckboxID(value: string | null | undefined): string {
+  return `team-member-${String(value || "unknown").replace(/[^a-zA-Z0-9_-]+/g, "-")}`;
 }

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -1579,6 +1579,20 @@
     linear-gradient(90deg, color-mix(in oklab, var(--primary) 13%, transparent), transparent 72%), var(--field);
 }
 
+.selection-item > input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  min-height: 16px;
+  margin: 0;
+  accent-color: var(--primary);
+}
+
+.selection-item > input[type="checkbox"]:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 72%, white);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
 .selection-item.compact-toggle-row {
   min-height: 40px;
   display: inline-flex;

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -235,7 +235,7 @@
   grid-column: 1 / -1;
 }
 
-.create-model-provider-modal .field input,
+.create-model-provider-modal .field input:not([type="checkbox"], [type="radio"]),
 .create-model-provider-modal .field textarea,
 .create-model-provider-modal .field select {
   min-height: 44px;
@@ -361,7 +361,7 @@
   line-height: 1;
 }
 
-.create-room-modal .field input {
+.create-room-modal .field input:not([type="checkbox"], [type="radio"]) {
   height: 44px;
 }
 
@@ -1319,7 +1319,7 @@
   white-space: nowrap;
 }
 
-.profile-section .field input,
+.profile-section .field input:not([type="checkbox"], [type="radio"]),
 .profile-section .field select {
   min-height: 38px;
   padding: 9px 11px;
@@ -1582,7 +1582,12 @@
 .selection-item > input[type="checkbox"] {
   width: 16px;
   height: 16px;
+  inline-size: 16px;
+  block-size: 16px;
   min-height: 16px;
+  min-block-size: 16px;
+  max-block-size: 16px;
+  align-self: center;
   margin: 0;
   accent-color: var(--primary);
 }
@@ -1971,10 +1976,10 @@
   width: 100%;
 }
 
-.modal-card .field input,
+.modal-card .field input:not([type="checkbox"], [type="radio"]),
 .modal-card .field textarea,
 .modal-card .field select,
-.profile-section .field input,
+.profile-section .field input:not([type="checkbox"], [type="radio"]),
 .profile-section .field textarea,
 .profile-section .field select,
 .env-row input {
@@ -1996,9 +2001,9 @@
     color 160ms ease;
 }
 
-.modal-card .field input,
+.modal-card .field input:not([type="checkbox"], [type="radio"]),
 .modal-card .field select,
-.profile-section .field input,
+.profile-section .field input:not([type="checkbox"], [type="radio"]),
 .profile-section .field select,
 .env-row input {
   height: 44px;
@@ -2020,28 +2025,28 @@
   line-height: 20px;
 }
 
-.modal-card .field input::placeholder,
+.modal-card .field input:not([type="checkbox"], [type="radio"])::placeholder,
 .modal-card .field textarea::placeholder,
-.profile-section .field input::placeholder,
+.profile-section .field input:not([type="checkbox"], [type="radio"])::placeholder,
 .profile-section .field textarea::placeholder,
 .env-row input::placeholder {
   color: var(--input-text-placeholder);
 }
 
-.modal-card .field input:hover,
+.modal-card .field input:not([type="checkbox"], [type="radio"]):hover,
 .modal-card .field textarea:hover,
 .modal-card .field select:hover,
-.profile-section .field input:hover,
+.profile-section .field input:not([type="checkbox"], [type="radio"]):hover,
 .profile-section .field textarea:hover,
 .profile-section .field select:hover,
 .env-row input:hover {
   border-color: var(--input-border-hover);
 }
 
-.modal-card .field input:focus,
+.modal-card .field input:not([type="checkbox"], [type="radio"]):focus,
 .modal-card .field textarea:focus,
 .modal-card .field select:focus,
-.profile-section .field input:focus,
+.profile-section .field input:not([type="checkbox"], [type="radio"]):focus,
 .profile-section .field textarea:focus,
 .profile-section .field select:focus,
 .env-row input:focus {
@@ -2049,10 +2054,10 @@
   box-shadow: var(--input-shadow-focus);
 }
 
-.modal-card .field input:disabled,
+.modal-card .field input:not([type="checkbox"], [type="radio"]):disabled,
 .modal-card .field textarea:disabled,
 .modal-card .field select:disabled,
-.profile-section .field input:disabled,
+.profile-section .field input:not([type="checkbox"], [type="radio"]):disabled,
 .profile-section .field textarea:disabled,
 .profile-section .field select:disabled,
 .env-row input:disabled {
@@ -2158,10 +2163,10 @@
   background: #6384f8;
 }
 
-:root[data-theme="dark"] .modal-card .field input:hover,
+:root[data-theme="dark"] .modal-card .field input:not([type="checkbox"], [type="radio"]):hover,
 :root[data-theme="dark"] .modal-card .field textarea:hover,
 :root[data-theme="dark"] .modal-card .field select:hover,
-:root[data-theme="dark"] .profile-section .field input:hover,
+:root[data-theme="dark"] .profile-section .field input:not([type="checkbox"], [type="radio"]):hover,
 :root[data-theme="dark"] .profile-section .field textarea:hover,
 :root[data-theme="dark"] .profile-section .field select:hover,
 :root[data-theme="dark"] .env-row input:hover {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -805,7 +805,7 @@
   grid-template-columns: auto 1fr auto;
   gap: var(--space-3);
   align-items: center;
-  padding: var(--space-3) 14px;
+  padding: var(--space-3) 16px;
   border: 1px solid var(--line);
 }
 
@@ -1589,6 +1589,7 @@
   max-block-size: 16px;
   align-self: center;
   margin: 0;
+  border-radius: 4px;
   accent-color: var(--primary);
 }
 

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -1594,9 +1594,8 @@
 }
 
 .selection-item > input[type="checkbox"]:focus-visible {
-  outline: 2px solid color-mix(in oklab, var(--primary) 72%, white);
-  outline-offset: 2px;
-  box-shadow: none;
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 72%, white);
 }
 
 .selection-item.compact-toggle-row {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -1727,7 +1727,8 @@
 }
 
 .selection-item:hover {
-  border-color: color-mix(in srgb, var(--success-400) 38%, transparent);
+  border-color: color-mix(in oklab, var(--brand-600) 42%, var(--line));
+  box-shadow: var(--shadow-xs), 0 0 0 3px color-mix(in oklab, var(--brand-600) 12%, transparent);
 }
 
 .profile-editor-shell {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceTabPanels.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/WorkspaceTabPanels.tsx
@@ -747,7 +747,7 @@ export function WorkspaceTabPanels({
             visibleTeams.map((team) => {
               const memberIDs = teamMemberIDs(team);
               const memberCount = memberIDs.length;
-              const avatarMembers = resolveTeamAvatarMembers(team, agentItems);
+              const avatarMembers = resolveTeamAvatarMembers(team, agentItems, usersById);
               return (
                 <button
                   key={team.id}


### PR DESCRIPTION
## Summary
- fix Team detail member avatar styles to target global avatar classes inside the CSS module
- add overflow clipping and block image rendering so member avatars stay constrained to the 40x40 tile on initial load
- prevent the intermittent oversized or incorrect-looking avatar rendering on the team members panel