### PR TITLE
fix(ci): pass target platform to kaniko

### DIFF
--- a/.gitlab/ci.yml
+++ b/.gitlab/ci.yml
@@ -322,13 +322,15 @@ docker-build-amd64:
     - job: web-build
       artifacts: true
   script:
-    - export COMMIT="$(git rev-parse --short HEAD)"
+    - export COMMIT="${CI_COMMIT_SHORT_SHA}"
     - export BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     - |
       /kaniko/executor \
         --context "${CI_PROJECT_DIR}" \
         --dockerfile "${CI_PROJECT_DIR}/Dockerfile" \
         --custom-platform linux/amd64 \
+        --build-arg TARGETOS=linux \
+        --build-arg TARGETARCH=amd64 \
         --destination "${ACR_REGISTRY}/opencsghq/csgclaw:${CI_COMMIT_TAG}" \
         --build-arg GO_IMAGE="${ACR_REGISTRY}/opencsg_public/golang:1.26.2-alpine" \
         --build-arg NODE_IMAGE="${ACR_REGISTRY}/opencsghq/node:22.13.0-alpine" \


### PR DESCRIPTION
## Summary

- pass explicit Linux target build arguments to Kaniko
- use the GitLab-provided commit SHA instead of requiring git in the Kaniko image

## Validation

- `glab ci lint .gitlab/ci.yml`