### PR TITLE
feat(template): preserve agent execution mode

### DIFF
--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -678,6 +678,18 @@ Templates use the following layout:
 
 `AGENTS.md` and `mcp.json` are always emitted when publishing. Other instruction and memory files are optional. During agent creation, instruction files and memories are overlaid onto the runtime workspace, skills are installed under `skills/`, and MCP servers from `mcp.json` are applied unless the create request explicitly supplies `mcpServers`.
 
+Codex worker templates may persist their execution mode in `agent.toml`:
+
+```toml
+[runtime_options]
+execution_mode = "read_only"
+```
+
+Only template-safe runtime options are published.
+For Codex workers this currently means `execution_mode`; machine-local options such as `local_workspace_dir` are not published.
+Explicit runtime options in an agent create request override template values.
+Missing `execution_mode` defaults to `standard`.
+
 ### `GET /api/v1/hub/templates`
 
 Lists all templates from readable registries.
@@ -689,6 +701,7 @@ Response fields:
 - `description`
 - `runtime_kind`
 - `image`
+- `runtime_options`
 - `updated_at`
 - `source.name`
 - `source.kind`

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -658,6 +658,18 @@ catalog key。新远端条目默认写入 `enabled: true`、`startup_timeout_sec
 
 发布时始终生成 `AGENTS.md` 和 `mcp.json`，其他 instruction 和 memory 文件可选。根据模板创建 Agent 时，instruction 文件和 memories 会叠加到运行时 workspace，skills 会安装到 `skills/`，`mcp.json` 中的 MCP server 会自动应用；如果创建请求显式传入 `mcpServers`，则以请求内容为准。
 
+Codex Worker 模板可在 `agent.toml` 中保存运行模式：
+
+```toml
+[runtime_options]
+execution_mode = "read_only"
+```
+
+发布时只保存适合模板复用的运行时选项。
+Codex Worker 目前仅保存 `execution_mode`，不会保存 `local_workspace_dir` 等本机选项。
+创建请求显式提供的运行时选项优先于模板值。
+缺少 `execution_mode` 时默认为 `standard`。
+
 ### `GET /api/v1/hub/templates`
 
 列出可读 registry 中的全部模板。
@@ -669,6 +681,7 @@ catalog key。新远端条目默认写入 `enabled: true`、`startup_timeout_sec
 - `description`
 - `runtime_kind`
 - `image`
+- `runtime_options`
 - `updated_at`
 - `source.name`
 - `source.kind`

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -237,13 +237,18 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 	if err != nil {
 		return hub.PublishSpec{}, err
 	}
+	runtimeOptions, err := templateSafeRuntimeOptions(got)
+	if err != nil {
+		return hub.PublishSpec{}, err
+	}
 	return hub.PublishSpec{
-		ID:          got.Name,
-		Name:        got.Name,
-		Description: got.Description,
-		Role:        got.Role,
-		RuntimeKind: got.RuntimeConfig().Kind(),
-		Image:       got.Image,
+		ID:             got.Name,
+		Name:           got.Name,
+		Description:    got.Description,
+		Role:           got.Role,
+		RuntimeKind:    got.RuntimeConfig().Kind(),
+		Image:          got.Image,
+		RuntimeOptions: runtimeOptions,
 		WorkspaceRef: hub.WorkspaceRef{
 			Kind:             hub.WorkspaceKindDir,
 			Path:             layout.WorkspaceRoot,
@@ -1243,6 +1248,13 @@ func applyTemplateDefaults(spec CreateAgentSpec, item hub.Template) CreateAgentS
 	}
 	if strings.TrimSpace(spec.RuntimeKind) == "" {
 		spec.RuntimeKind = item.RuntimeKind
+	}
+	if len(item.RuntimeOptions) > 0 {
+		options := utils.CloneAnyMap(item.RuntimeOptions)
+		for key, value := range spec.RuntimeOptions {
+			options[key] = value
+		}
+		spec.RuntimeOptions = options
 	}
 	return spec
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -7857,10 +7857,11 @@ func TestCreateWorkerFromTemplateAppliesDefaultsAndOverlaysWorkspace(t *testing.
 
 func TestResolveCodexTemplateCreateSpecSeparatesBaseFromProfileInstructions(t *testing.T) {
 	hubSvc := mustNewLocalTemplateHubService(t, "codex-worker", hub.Template{
-		ID:          "codex-worker",
-		Name:        "codex-worker",
-		Role:        hub.TemplateRoleWorker,
-		RuntimeKind: RuntimeNameCodex,
+		ID:             "codex-worker",
+		Name:           "codex-worker",
+		Role:           hub.TemplateRoleWorker,
+		RuntimeKind:    RuntimeNameCodex,
+		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
 	})
 	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:1", "", WithHubService(hubSvc))
 	if err != nil {
@@ -7881,11 +7882,31 @@ func TestResolveCodexTemplateCreateSpecSeparatesBaseFromProfileInstructions(t *t
 	if resolved.Instructions != "" {
 		t.Fatalf("Instructions = %q, want empty for Codex template creation", resolved.Instructions)
 	}
+	if got, want := resolved.RuntimeOptions["execution_mode"], "read_only"; got != want {
+		t.Fatalf("RuntimeOptions[execution_mode] = %v, want %q", got, want)
+	}
 	if !strings.Contains(resolved.TemplateInstructions, "# Agent Instructions") {
 		t.Fatalf("TemplateInstructions = %q, want template base document", resolved.TemplateInstructions)
 	}
 	if _, err := os.Stat(filepath.Join(resolved.FromTemplate, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("workspace AGENTS.md stat error = %v, want template instructions separated from overlay", err)
+	}
+}
+
+func TestApplyTemplateDefaultsMergesExplicitRuntimeOptions(t *testing.T) {
+	item := hub.Template{RuntimeOptions: map[string]any{"execution_mode": "read_only"}}
+	got := applyTemplateDefaults(CreateAgentSpec{
+		RuntimeOptions: map[string]any{"local_workspace_dir": "/tmp/project"},
+	}, item)
+	if got.RuntimeOptions["execution_mode"] != "read_only" || got.RuntimeOptions["local_workspace_dir"] != "/tmp/project" {
+		t.Fatalf("merged RuntimeOptions = %#v", got.RuntimeOptions)
+	}
+
+	overridden := applyTemplateDefaults(CreateAgentSpec{
+		RuntimeOptions: map[string]any{"execution_mode": "standard"},
+	}, item)
+	if overridden.RuntimeOptions["execution_mode"] != "standard" {
+		t.Fatalf("explicit execution_mode = %v, want standard", overridden.RuntimeOptions["execution_mode"])
 	}
 }
 
@@ -9074,6 +9095,7 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 	}
 	svc.agents["u-alice"] = Agent{
 		ID: "u-alice", Name: "alice", Role: RoleWorker, RuntimeKind: RuntimeKindCodex,
+		RuntimeOptions: map[string]any{"execution_mode": "read_only", "local_workspace_dir": "/private/project"},
 		MCPServers: map[string]any{"remote": map[string]any{
 			"url": "https://mcp.example.test", "headers": map[string]any{"Authorization": "secret"},
 		}},
@@ -9101,6 +9123,12 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 	}
 	if got, want := spec.WorkspaceRef.SkillsPath, layout.SkillsRoot; got != want {
 		t.Fatalf("SkillsPath = %q, want %q", got, want)
+	}
+	if got, want := spec.RuntimeOptions["execution_mode"], "read_only"; got != want {
+		t.Fatalf("RuntimeOptions[execution_mode] = %v, want %q", got, want)
+	}
+	if _, exists := spec.RuntimeOptions["local_workspace_dir"]; exists {
+		t.Fatalf("published runtime options leaked local_workspace_dir: %#v", spec.RuntimeOptions)
 	}
 	remote := spec.MCPServers["remote"].(map[string]any)
 	if _, ok := remote["headers"]; ok {
@@ -11288,14 +11316,15 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 
 	store := hub.NewLocalStore(registryRoot)
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
-		ID:           id,
-		Name:         item.Name,
-		Description:  item.Description,
-		Role:         item.Role,
-		RuntimeKind:  item.RuntimeKind,
-		Version:      item.Version,
-		Image:        item.Image,
-		WorkspaceRef: hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
+		ID:             id,
+		Name:           item.Name,
+		Description:    item.Description,
+		Role:           item.Role,
+		RuntimeKind:    item.RuntimeKind,
+		Version:        item.Version,
+		Image:          item.Image,
+		RuntimeOptions: item.RuntimeOptions,
+		WorkspaceRef:   hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
 		MCPServers: map[string]any{
 			"template-docs": map[string]any{"command": "npx", "args": []any{"-y", "template-docs"}},
 		},

--- a/internal/agent/template_runtime_options.go
+++ b/internal/agent/template_runtime_options.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	templateExecutionModeKey      = "execution_mode"
+	templateExecutionModeStandard = "standard"
+	templateExecutionModeReadOnly = "read_only"
+)
+
+func templateSafeRuntimeOptions(item Agent) (map[string]any, error) {
+	if item.ID == ManagerUserID || item.Role == RoleManager || strings.TrimSpace(item.RuntimeKind) != RuntimeKindCodex {
+		return nil, nil
+	}
+	mode := templateExecutionModeStandard
+	if raw, ok := item.RuntimeOptions[templateExecutionModeKey]; ok && raw != nil {
+		value, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("agent %q runtime_options.execution_mode must be a string", item.ID)
+		}
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			mode = value
+		}
+	}
+	switch mode {
+	case templateExecutionModeStandard, templateExecutionModeReadOnly:
+		return map[string]any{templateExecutionModeKey: mode}, nil
+	default:
+		return nil, fmt.Errorf("agent %q runtime_options.execution_mode must be %q or %q", item.ID, templateExecutionModeStandard, templateExecutionModeReadOnly)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1910,16 +1910,17 @@ func presentHubTemplates(items []hub.Template) []apitypes.HubTemplate {
 
 func presentHubTemplate(item hub.Template) apitypes.HubTemplate {
 	presented := apitypes.HubTemplate{
-		ID:          item.ID,
-		Namespace:   item.Namespace,
-		Name:        item.Name,
-		Description: item.Description,
-		Role:        item.Role,
-		RuntimeKind: bootstrapRuntimeKind(item.RuntimeKind),
-		Version:     item.Version,
-		Image:       item.Image,
-		ImageEnv:    append([]apitypes.ImageEnvContract(nil), item.ImageEnv...),
-		UpdatedAt:   item.UpdatedAt,
+		ID:             item.ID,
+		Namespace:      item.Namespace,
+		Name:           item.Name,
+		Description:    item.Description,
+		Role:           item.Role,
+		RuntimeKind:    bootstrapRuntimeKind(item.RuntimeKind),
+		Version:        item.Version,
+		Image:          item.Image,
+		ImageEnv:       append([]apitypes.ImageEnvContract(nil), item.ImageEnv...),
+		RuntimeOptions: utils.CloneAnyMap(item.RuntimeOptions),
+		UpdatedAt:      item.UpdatedAt,
 		Source: apitypes.HubTemplateSource{
 			Name: item.Source.Name,
 			Kind: item.Source.Kind,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3519,10 +3519,11 @@ func TestAgentCreateRequestFromAPIIncludesFromTemplate(t *testing.T) {
 
 func TestHandleHubTemplatesListsAggregatedTemplates(t *testing.T) {
 	hubSvc := mustNewLocalTemplateHubService(t, "review-bot", hub.Template{
-		ID:          "review-bot",
-		Name:        "review-bot",
-		Role:        hub.TemplateRoleWorker,
-		RuntimeKind: agent.RuntimeKindCodex,
+		ID:             "review-bot",
+		Name:           "review-bot",
+		Role:           hub.TemplateRoleWorker,
+		RuntimeKind:    agent.RuntimeKindCodex,
+		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
 	})
 	srv := &Handler{}
 	srv.SetHubService(hubSvc)
@@ -3543,6 +3544,16 @@ func TestHandleHubTemplatesListsAggregatedTemplates(t *testing.T) {
 	}
 	if got[0].Source.Name == "" || got[0].Source.Kind == "" {
 		t.Fatalf("template source = %+v, want populated source", got[0].Source)
+	}
+	var published apitypes.HubTemplate
+	for _, item := range got {
+		if item.Name == "review-bot" && item.Source.Kind == hub.RegistryKindLocal {
+			published = item
+			break
+		}
+	}
+	if mode := published.RuntimeOptions["execution_mode"]; mode != "read_only" {
+		t.Fatalf("template RuntimeOptions[execution_mode] = %v, want read_only", mode)
 	}
 }
 
@@ -5345,15 +5356,16 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 
 	store := hub.NewLocalStore(registryRoot)
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
-		ID:           id,
-		Name:         item.Name,
-		Description:  item.Description,
-		Role:         item.Role,
-		RuntimeKind:  item.RuntimeKind,
-		Version:      item.Version,
-		Image:        item.Image,
-		WorkspaceRef: hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
-		UpdatedAt:    time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
+		ID:             id,
+		Name:           item.Name,
+		Description:    item.Description,
+		Role:           item.Role,
+		RuntimeKind:    item.RuntimeKind,
+		Version:        item.Version,
+		Image:          item.Image,
+		RuntimeOptions: item.RuntimeOptions,
+		WorkspaceRef:   hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
+		UpdatedAt:      time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
 	}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -5376,14 +5388,15 @@ func mustNewLocalTemplateHubServiceWithoutWorkspace(t *testing.T, id string, ite
 	registryRoot := t.TempDir()
 	store := hub.NewLocalStore(registryRoot)
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
-		ID:          id,
-		Name:        item.Name,
-		Description: item.Description,
-		Role:        item.Role,
-		RuntimeKind: item.RuntimeKind,
-		Version:     item.Version,
-		Image:       item.Image,
-		UpdatedAt:   time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
+		ID:             id,
+		Name:           item.Name,
+		Description:    item.Description,
+		Role:           item.Role,
+		RuntimeKind:    item.RuntimeKind,
+		Version:        item.Version,
+		Image:          item.Image,
+		RuntimeOptions: item.RuntimeOptions,
+		UpdatedAt:      time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
 	}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}

--- a/internal/apitypes/hub.go
+++ b/internal/apitypes/hub.go
@@ -24,19 +24,20 @@ type ImageEnvContract struct {
 }
 
 type HubTemplate struct {
-	ID          string               `json:"id"`
-	Namespace   string               `json:"namespace,omitempty"`
-	Name        string               `json:"name"`
-	Description string               `json:"description,omitempty"`
-	Role        string               `json:"role,omitempty"`
-	RuntimeKind string               `json:"runtime_kind,omitempty"`
-	Version     string               `json:"version,omitempty"`
-	Image       string               `json:"image,omitempty"`
-	ImageEnv    []ImageEnvContract   `json:"image_env,omitempty"`
-	Metadata    *HubTemplateMetadata `json:"metadata,omitempty"`
-	Source      HubTemplateSource    `json:"source"`
-	UpdatedAt   time.Time            `json:"updated_at,omitempty"`
-	Workspace   HubTemplateWorkspace `json:"workspace,omitempty"`
+	ID             string               `json:"id"`
+	Namespace      string               `json:"namespace,omitempty"`
+	Name           string               `json:"name"`
+	Description    string               `json:"description,omitempty"`
+	Role           string               `json:"role,omitempty"`
+	RuntimeKind    string               `json:"runtime_kind,omitempty"`
+	Version        string               `json:"version,omitempty"`
+	Image          string               `json:"image,omitempty"`
+	ImageEnv       []ImageEnvContract   `json:"image_env,omitempty"`
+	RuntimeOptions map[string]any       `json:"runtime_options,omitempty"`
+	Metadata       *HubTemplateMetadata `json:"metadata,omitempty"`
+	Source         HubTemplateSource    `json:"source"`
+	UpdatedAt      time.Time            `json:"updated_at,omitempty"`
+	Workspace      HubTemplateWorkspace `json:"workspace,omitempty"`
 }
 
 type HubTemplateMetadata struct {

--- a/internal/template/builtin_store.go
+++ b/internal/template/builtin_store.go
@@ -54,17 +54,22 @@ func (s *BuiltinStore) Get(_ context.Context, id string) (Template, error) {
 	if err != nil {
 		return Template{}, fmt.Errorf("validate builtin hub manifest %q: %w", id, err)
 	}
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	if err != nil {
+		return Template{}, fmt.Errorf("validate builtin hub manifest %q runtime options: %w", id, err)
+	}
 	return Template{
-		ID:           id,
-		Name:         manifest.Name,
-		Description:  manifest.Description,
-		Role:         normalizeTemplateRole(manifest.Role),
-		RuntimeKind:  normalizeTemplateRuntimeKind(manifest.RuntimeKind),
-		Version:      strings.TrimSpace(manifest.Version),
-		Image:        manifestImageRef(manifest.Image),
-		ImageEnv:     manifestImageEnv(manifest.Image),
-		WorkspaceRef: s.workspaceRef(id),
-		UpdatedAt:    updatedAt,
+		ID:             id,
+		Name:           manifest.Name,
+		Description:    manifest.Description,
+		Role:           normalizeTemplateRole(manifest.Role),
+		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
+		Version:        strings.TrimSpace(manifest.Version),
+		Image:          manifestImageRef(manifest.Image),
+		ImageEnv:       manifestImageEnv(manifest.Image),
+		RuntimeOptions: runtimeOptions,
+		WorkspaceRef:   s.workspaceRef(id),
+		UpdatedAt:      updatedAt,
 	}, nil
 }
 

--- a/internal/template/embed/worker/codex/agent.toml
+++ b/internal/template/embed/worker/codex/agent.toml
@@ -4,3 +4,6 @@ role = "worker"
 runtime_kind = "codex"
 updated_at = "2026-07-09T00:00:00Z"
 version = "0.1.0"
+
+[runtime_options]
+execution_mode = "standard"

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -92,17 +92,22 @@ func (s *LocalStore) Get(_ context.Context, id string) (Template, error) {
 	if err != nil {
 		return Template{}, fmt.Errorf("validate local hub manifest %q: %w", id, err)
 	}
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	if err != nil {
+		return Template{}, fmt.Errorf("validate local hub manifest %q runtime options: %w", id, err)
+	}
 	return Template{
-		ID:           id,
-		Name:         manifest.Name,
-		Description:  manifest.Description,
-		Role:         normalizeTemplateRole(manifest.Role),
-		RuntimeKind:  normalizeTemplateRuntimeKind(manifest.RuntimeKind),
-		Version:      strings.TrimSpace(manifest.Version),
-		Image:        manifestImageRef(manifest.Image),
-		ImageEnv:     manifestImageEnv(manifest.Image),
-		WorkspaceRef: s.workspaceRef(id),
-		UpdatedAt:    updatedAt,
+		ID:             id,
+		Name:           manifest.Name,
+		Description:    manifest.Description,
+		Role:           normalizeTemplateRole(manifest.Role),
+		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
+		Version:        strings.TrimSpace(manifest.Version),
+		Image:          manifestImageRef(manifest.Image),
+		ImageEnv:       manifestImageEnv(manifest.Image),
+		RuntimeOptions: runtimeOptions,
+		WorkspaceRef:   s.workspaceRef(id),
+		UpdatedAt:      updatedAt,
 	}, nil
 }
 
@@ -264,7 +269,8 @@ func (s *LocalStore) writeManifest(path string, spec PublishSpec) error {
 		Image: templateImageSection{
 			Ref: spec.Image,
 		},
-		UpdatedAt: spec.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		RuntimeOptions: cloneTemplateRuntimeOptions(spec.RuntimeOptions),
+		UpdatedAt:      spec.UpdatedAt.UTC().Format(time.RFC3339Nano),
 	}
 	data, err := toml.Marshal(manifest)
 	if err != nil {
@@ -298,6 +304,11 @@ func normalizePublishSpec(spec PublishSpec) (PublishSpec, error) {
 	spec.Version = strings.TrimSpace(spec.Version)
 	spec.Image = strings.TrimSpace(spec.Image)
 	spec.Description = strings.TrimSpace(spec.Description)
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(spec.RuntimeKind, spec.Role, spec.RuntimeOptions)
+	if err != nil {
+		return PublishSpec{}, err
+	}
+	spec.RuntimeOptions = runtimeOptions
 	if spec.RuntimeKind == "" {
 		return PublishSpec{}, ErrRuntimeKindRequired
 	}

--- a/internal/template/local_store_test.go
+++ b/internal/template/local_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,13 +28,14 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	store := NewLocalStore(registryRoot)
 	publishedAt := time.Date(2026, 5, 12, 8, 30, 0, 0, time.UTC)
 	published, err := store.Publish(context.Background(), PublishSpec{
-		Name:         "frontend-alice",
-		Description:  "Frontend worker with UI and styling skills",
-		Role:         TemplateRoleWorker,
-		RuntimeKind:  runtime.KindCodex,
-		Image:        "worker:latest",
-		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
-		UpdatedAt:    publishedAt,
+		Name:           "frontend-alice",
+		Description:    "Frontend worker with UI and styling skills",
+		Role:           TemplateRoleWorker,
+		RuntimeKind:    runtime.KindCodex,
+		Image:          "worker:latest",
+		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
+		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
+		UpdatedAt:      publishedAt,
 	})
 	if err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -46,6 +48,9 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	}
 	if got, want := published.Role, TemplateRoleWorker; got != want {
 		t.Fatalf("Publish().Role = %q, want %q", got, want)
+	}
+	if got, want := published.RuntimeOptions["execution_mode"], "read_only"; got != want {
+		t.Fatalf("Publish().RuntimeOptions[execution_mode] = %v, want %q", got, want)
 	}
 	if got, want := published.UpdatedAt, publishedAt; !got.Equal(want) {
 		t.Fatalf("Publish().UpdatedAt = %v, want %v", got, want)
@@ -74,6 +79,16 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	}
 	if got.Image != "worker:latest" {
 		t.Fatalf("Get().Image = %q, want %q", got.Image, "worker:latest")
+	}
+	if gotMode, want := got.RuntimeOptions["execution_mode"], "read_only"; gotMode != want {
+		t.Fatalf("Get().RuntimeOptions[execution_mode] = %v, want %q", gotMode, want)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(registryRoot, localTemplatesDirName, "frontend-alice", localManifestFileName))
+	if err != nil {
+		t.Fatalf("ReadFile(agent.toml) error = %v", err)
+	}
+	if !strings.Contains(string(manifestData), "[runtime_options]") || !strings.Contains(string(manifestData), "execution_mode = 'read_only'") {
+		t.Fatalf("agent.toml missing read-only runtime options:\n%s", manifestData)
 	}
 
 	workspace, err := store.FetchWorkspace(context.Background(), "frontend-alice")

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -301,19 +301,24 @@ func (s *RemoteStore) getTemplate(ctx context.Context, id string, repository rem
 		name = strings.TrimSpace(repository.Name)
 	}
 	namespace := strings.SplitN(id, "/", 2)[0]
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	if err != nil {
+		return Template{}, fmt.Errorf("validate remote hub manifest %q runtime options: %w", id, err)
+	}
 	return Template{
-		ID:           remoteTemplateName(id),
-		Namespace:    namespace,
-		Name:         name,
-		Description:  description,
-		Role:         normalizeTemplateRole(manifest.Role),
-		RuntimeKind:  normalizeTemplateRuntimeKind(manifest.RuntimeKind),
-		Version:      strings.TrimSpace(manifest.Version),
-		Image:        manifestImageRef(manifest.Image),
-		ImageEnv:     manifestImageEnv(manifest.Image),
-		Metadata:     repository.Metadata,
-		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir},
-		UpdatedAt:    updatedAt,
+		ID:             remoteTemplateName(id),
+		Namespace:      namespace,
+		Name:           name,
+		Description:    description,
+		Role:           normalizeTemplateRole(manifest.Role),
+		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
+		Version:        strings.TrimSpace(manifest.Version),
+		Image:          manifestImageRef(manifest.Image),
+		ImageEnv:       manifestImageEnv(manifest.Image),
+		RuntimeOptions: runtimeOptions,
+		Metadata:       repository.Metadata,
+		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir},
+		UpdatedAt:      updatedAt,
 	}, nil
 }
 
@@ -757,16 +762,17 @@ func (s *RemoteStore) Publish(ctx context.Context, spec PublishSpec) (Template, 
 		id = path.Join(s.username, normalized.Name)
 	}
 	return Template{
-		ID:           id,
-		Namespace:    s.username,
-		Name:         normalized.Name,
-		Description:  normalized.Description,
-		Role:         normalized.Role,
-		RuntimeKind:  normalized.RuntimeKind,
-		Version:      normalized.Version,
-		Image:        normalized.Image,
-		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir},
-		UpdatedAt:    normalized.UpdatedAt,
+		ID:             id,
+		Namespace:      s.username,
+		Name:           normalized.Name,
+		Description:    normalized.Description,
+		Role:           normalized.Role,
+		RuntimeKind:    normalized.RuntimeKind,
+		Version:        normalized.Version,
+		Image:          normalized.Image,
+		RuntimeOptions: cloneTemplateRuntimeOptions(normalized.RuntimeOptions),
+		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir},
+		UpdatedAt:      normalized.UpdatedAt,
 	}, nil
 }
 

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -138,11 +138,12 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	store := NewRemoteStore(srv.URL, "access-token")
 	store.username = "alice"
 	item, err := store.Publish(context.Background(), PublishSpec{
-		ID:          "legacy-internal-id",
-		Name:        "ReviewBot_2",
-		Description: "Reviews changes",
-		Role:        TemplateRoleWorker,
-		RuntimeKind: "codex",
+		ID:             "legacy-internal-id",
+		Name:           "ReviewBot_2",
+		Description:    "Reviews changes",
+		Role:           TemplateRoleWorker,
+		RuntimeKind:    "codex",
+		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
 		WorkspaceRef: WorkspaceRef{
 			Kind:             WorkspaceKindDir,
 			Path:             workspace,
@@ -154,6 +155,9 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	}
 	if got, want := item.ID, "alice/ReviewBot_2"; got != want {
 		t.Fatalf("Publish().ID = %q, want %q", got, want)
+	}
+	if got, want := item.RuntimeOptions["execution_mode"], "read_only"; got != want {
+		t.Fatalf("Publish().RuntimeOptions[execution_mode] = %v, want %q", got, want)
 	}
 	if got, want := created.CodeFile, "package-uuid"; got != want {
 		t.Fatalf("create code_file = %q, want %q", got, want)
@@ -202,6 +206,9 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 			}
 			if !strings.Contains(string(manifest), `description = 'Reviews changes'`) {
 				t.Errorf("agent.toml missing template description: %s", manifest)
+			}
+			if !strings.Contains(string(manifest), "[runtime_options]") || !strings.Contains(string(manifest), "execution_mode = 'read_only'") {
+				t.Errorf("agent.toml missing read-only runtime options: %s", manifest)
 			}
 		}
 	}

--- a/internal/template/service.go
+++ b/internal/template/service.go
@@ -251,17 +251,18 @@ func (s *Service) PublishTemplate(ctx context.Context, id, registry string) (Tem
 		}
 	}
 	return s.Publish(ctx, PublishSpec{
-		Registry:     registry,
-		ID:           item.Name,
-		Name:         item.Name,
-		Description:  item.Description,
-		Role:         item.Role,
-		RuntimeKind:  item.RuntimeKind,
-		Version:      item.Version,
-		Image:        item.Image,
-		WorkspaceRef: workspace,
-		MCPServers:   mcpServers,
-		UpdatedAt:    item.UpdatedAt,
+		Registry:       registry,
+		ID:             item.Name,
+		Name:           item.Name,
+		Description:    item.Description,
+		Role:           item.Role,
+		RuntimeKind:    item.RuntimeKind,
+		Version:        item.Version,
+		Image:          item.Image,
+		RuntimeOptions: cloneTemplateRuntimeOptions(item.RuntimeOptions),
+		WorkspaceRef:   workspace,
+		MCPServers:     mcpServers,
+		UpdatedAt:      item.UpdatedAt,
 	})
 }
 

--- a/internal/template/template_manifest.go
+++ b/internal/template/template_manifest.go
@@ -26,14 +26,15 @@ func ValidatePublishTemplateName(name string) error {
 }
 
 type templateManifest struct {
-	SchemaVersion string               `toml:"schema_version,omitempty"`
-	Name          string               `toml:"name"`
-	Description   string               `toml:"description,omitempty"`
-	Role          string               `toml:"role"`
-	RuntimeKind   string               `toml:"runtime_kind"`
-	Version       string               `toml:"version,omitempty"`
-	Image         templateImageSection `toml:"image"`
-	UpdatedAt     string               `toml:"updated_at,omitempty"`
+	SchemaVersion  string               `toml:"schema_version,omitempty"`
+	Name           string               `toml:"name"`
+	Description    string               `toml:"description,omitempty"`
+	Role           string               `toml:"role"`
+	RuntimeKind    string               `toml:"runtime_kind"`
+	Version        string               `toml:"version,omitempty"`
+	Image          templateImageSection `toml:"image"`
+	RuntimeOptions map[string]any       `toml:"runtime_options,omitempty"`
+	UpdatedAt      string               `toml:"updated_at,omitempty"`
 }
 
 type templateImageSection struct {
@@ -164,10 +165,53 @@ func validateManifest(manifest templateManifest) error {
 	if err := validateImageEnvContracts(manifest.Image.Env); err != nil {
 		return err
 	}
+	if _, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions); err != nil {
+		return err
+	}
 	if _, err := parseManifestUpdatedAt(manifest.UpdatedAt); err != nil {
 		return err
 	}
 	return nil
+}
+
+func normalizeTemplateRuntimeOptions(runtimeKind, role string, raw map[string]any) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	runtimeKind = normalizeTemplateRuntimeKind(runtimeKind)
+	role = normalizeTemplateRole(role)
+	if runtimeKind != runtime.KindCodex || role != TemplateRoleWorker {
+		return nil, fmt.Errorf("runtime_options are supported only for Codex worker templates")
+	}
+	if len(raw) != 1 {
+		return nil, fmt.Errorf("runtime_options supports only execution_mode")
+	}
+	value, ok := raw["execution_mode"]
+	if !ok {
+		return nil, fmt.Errorf("runtime_options supports only execution_mode")
+	}
+	mode, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("runtime_options.execution_mode must be a string")
+	}
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	switch mode {
+	case "standard", "read_only":
+		return map[string]any{"execution_mode": mode}, nil
+	default:
+		return nil, fmt.Errorf("runtime_options.execution_mode must be %q or %q", "standard", "read_only")
+	}
+}
+
+func cloneTemplateRuntimeOptions(raw map[string]any) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(raw))
+	for key, value := range raw {
+		out[key] = value
+	}
+	return out
 }
 
 func requiresTemplateImage(runtimeKind string) bool {

--- a/internal/template/template_manifest_test.go
+++ b/internal/template/template_manifest_test.go
@@ -79,3 +79,32 @@ func TestValidatePublishTemplateName(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeTemplateRuntimeOptions(t *testing.T) {
+	got, err := normalizeTemplateRuntimeOptions(runtime.KindCodex, TemplateRoleWorker, map[string]any{
+		"execution_mode": " READ_ONLY ",
+	})
+	if err != nil {
+		t.Fatalf("normalizeTemplateRuntimeOptions() error = %v", err)
+	}
+	if got["execution_mode"] != "read_only" {
+		t.Fatalf("execution_mode = %v, want read_only", got["execution_mode"])
+	}
+
+	for name, test := range map[string]struct {
+		runtimeKind string
+		role        string
+		options     map[string]any
+	}{
+		"manager":        {runtimeKind: runtime.KindCodex, role: TemplateRoleManager, options: map[string]any{"execution_mode": "read_only"}},
+		"non codex":      {runtimeKind: runtime.NameOpenClaw, role: TemplateRoleWorker, options: map[string]any{"execution_mode": "read_only"}},
+		"unknown option": {runtimeKind: runtime.KindCodex, role: TemplateRoleWorker, options: map[string]any{"local_workspace_dir": "/tmp/project"}},
+		"invalid mode":   {runtimeKind: runtime.KindCodex, role: TemplateRoleWorker, options: map[string]any{"execution_mode": "unsafe"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := normalizeTemplateRuntimeOptions(test.runtimeKind, test.role, test.options); err == nil {
+				t.Fatal("normalizeTemplateRuntimeOptions() error = nil, want rejection")
+			}
+		})
+	}
+}

--- a/internal/template/types.go
+++ b/internal/template/types.go
@@ -16,19 +16,20 @@ const (
 )
 
 type Template struct {
-	ID           string
-	Namespace    string
-	Name         string
-	Description  string
-	Role         string
-	RuntimeKind  string
-	Version      string
-	Image        string
-	ImageEnv     []apitypes.ImageEnvContract
-	Metadata     *TemplateMetadata
-	WorkspaceRef WorkspaceRef
-	Source       RegistryRef
-	UpdatedAt    time.Time
+	ID             string
+	Namespace      string
+	Name           string
+	Description    string
+	Role           string
+	RuntimeKind    string
+	Version        string
+	Image          string
+	ImageEnv       []apitypes.ImageEnvContract
+	RuntimeOptions map[string]any
+	Metadata       *TemplateMetadata
+	WorkspaceRef   WorkspaceRef
+	Source         RegistryRef
+	UpdatedAt      time.Time
 }
 
 type TemplateMetadata struct {
@@ -61,15 +62,16 @@ type WorkspaceRef struct {
 }
 
 type PublishSpec struct {
-	Registry     string
-	ID           string
-	Name         string
-	Description  string
-	Role         string
-	RuntimeKind  string
-	Version      string
-	Image        string
-	WorkspaceRef WorkspaceRef
-	MCPServers   map[string]any
-	UpdatedAt    time.Time
+	Registry       string
+	ID             string
+	Name           string
+	Description    string
+	Role           string
+	RuntimeKind    string
+	Version        string
+	Image          string
+	RuntimeOptions map[string]any
+	WorkspaceRef   WorkspaceRef
+	MCPServers     map[string]any
+	UpdatedAt      time.Time
 }

--- a/web/app/src/components/business/ConversationPane/ConversationComposer.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationComposer.tsx
@@ -629,148 +629,153 @@ function ComposerAddMenu({
   return (
     <>
       <PopoverRoot open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <Tooltip content={t("composerAddContent")}>
-        <PopoverTrigger asChild>
-          <span>
-            <Button
-              aria-haspopup="dialog"
-              aria-label={t("composerAddContent")}
-              className="composer-add-button"
-              disabled={disabled}
-              iconOnly
-              size="lg"
-              variant="tertiaryGray"
-            >
-              <Plus aria-hidden="true" size={24} strokeWidth={1.8} />
-            </Button>
-          </span>
-        </PopoverTrigger>
-      </Tooltip>
-      <PopoverContent
-        aria-label={t("composerAddContent")}
-        className={classNames("composer-add-popover", hasConnectedConnector ? "is-wide" : "is-compact")}
-        role="dialog"
-        side="top"
-      >
-        <section className="composer-add-section" aria-label={t("composerAdd")}>
-          <div className="composer-add-section-label">{t("composerAdd")}</div>
-          <PopoverClose asChild>
-            <button
-              type="button"
-              className="composer-add-menu-item"
-              aria-label={t("addAttachment")}
-              title={t("addAttachment")}
-              onClick={onAddFiles}
-            >
-              <Paperclip aria-hidden="true" size={19} />
-              <span>{t("addAttachment")}</span>
-            </button>
-          </PopoverClose>
-        </section>
-        <div className="composer-add-separator" />
-        <section className="composer-add-section" aria-label={t("composerConnectors")}>
-          <div className="composer-add-section-label">{t("composerConnectors")}</div>
-          <div className="connector-provider-row">
-            <div className="connector-provider-main">
-              <span className="connector-provider-icon" aria-hidden="true">
-                {IconImage("github")}
-              </span>
-              <div className="connector-provider-copy">
-                <strong>{t("connectorGitHub")}</strong>
-                <span>{connectorStateLabel}</span>
+        <Tooltip content={t("composerAddContent")}>
+          <PopoverTrigger asChild>
+            <span>
+              <Button
+                aria-haspopup="dialog"
+                aria-label={t("composerAddContent")}
+                className="composer-add-button"
+                disabled={disabled}
+                iconOnly
+                size="lg"
+                variant="tertiaryGray"
+              >
+                <Plus aria-hidden="true" size={24} strokeWidth={1.8} />
+              </Button>
+            </span>
+          </PopoverTrigger>
+        </Tooltip>
+        <PopoverContent
+          aria-label={t("composerAddContent")}
+          className={classNames("composer-add-popover", hasConnectedConnector ? "is-wide" : "is-compact")}
+          role="dialog"
+          side="top"
+        >
+          <section className="composer-add-section" aria-label={t("composerAdd")}>
+            <div className="composer-add-section-label">{t("composerAdd")}</div>
+            <PopoverClose asChild>
+              <button
+                type="button"
+                className="composer-add-menu-item"
+                aria-label={t("addAttachment")}
+                title={t("addAttachment")}
+                onClick={onAddFiles}
+              >
+                <Paperclip aria-hidden="true" size={19} />
+                <span>{t("addAttachment")}</span>
+              </button>
+            </PopoverClose>
+          </section>
+          <div className="composer-add-separator" />
+          <section className="composer-add-section" aria-label={t("composerConnectors")}>
+            <div className="composer-add-section-label">{t("composerConnectors")}</div>
+            <div className="connector-provider-row">
+              <div className="connector-provider-main">
+                <span className="connector-provider-icon" aria-hidden="true">
+                  {IconImage("github")}
+                </span>
+                <div className="connector-provider-copy">
+                  <strong>{t("connectorGitHub")}</strong>
+                  <span>{connectorStateLabel}</span>
+                </div>
               </div>
-            </div>
-            {status.connected ? (
-              <div className="connector-provider-actions">
-                <span className="connector-connected-state">{t("connectorConnected")}</span>
-                <div className="connector-provider-action-buttons">
-                  {status.app_manageable ? (
+              {status.connected ? (
+                <div className="connector-provider-actions">
+                  <span className="connector-connected-state">{t("connectorConnected")}</span>
+                  <div className="connector-provider-action-buttons">
+                    {status.app_manageable ? (
+                      <Button
+                        aria-busy={busyAction === "manage" ? true : undefined}
+                        className="connector-manage-button"
+                        loading={busyAction === "manage"}
+                        size="sm"
+                        variant="secondaryGray"
+                        onClick={handleManageGitHub}
+                      >
+                        {t("connectorManage")}
+                      </Button>
+                    ) : null}
                     <Button
-                      aria-busy={busyAction === "manage" ? true : undefined}
+                      aria-busy={busyAction === "disconnect" ? true : undefined}
+                      className="connector-disconnect-button connector-disconnect-button-danger"
+                      loading={busyAction === "disconnect"}
+                      size="sm"
+                      variant="outlineDanger"
+                      onClick={handleDisconnectGitHub}
+                    >
+                      {t("connectorDisconnect")}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  aria-busy={githubBusy ? true : undefined}
+                  className="connector-connect-button"
+                  loading={githubBusy}
+                  size="sm"
+                  variant="tertiaryGray"
+                  onClick={handleConnectGitHub}
+                >
+                  {t("connectorConnect")}
+                </Button>
+              )}
+            </div>
+            <div className="connector-provider-row">
+              <div className="connector-provider-main">
+                <span className="connector-provider-icon" aria-hidden="true">
+                  <ConnectorGitLabIcon size={16} />
+                </span>
+                <div className="connector-provider-copy">
+                  <strong>{t("connectorGitLab")}</strong>
+                  <span>
+                    {gitlabStatus.account?.login ||
+                      (gitlabStatus.connected ? t("connectorConnected") : t("connectorNotConnected"))}
+                  </span>
+                </div>
+              </div>
+              {gitlabStatus.connected ? (
+                <div className="connector-provider-actions">
+                  <span className="connector-connected-state">{t("connectorConnected")}</span>
+                  <div className="connector-provider-action-buttons">
+                    <Button
                       className="connector-manage-button"
-                      loading={busyAction === "manage"}
                       size="sm"
                       variant="secondaryGray"
-                      onClick={handleManageGitHub}
+                      onClick={handleOpenGitLabForm}
                     >
-                      {t("connectorManage")}
+                      {t("connectorEdit")}
                     </Button>
-                  ) : null}
-                  <Button
-                    aria-busy={busyAction === "disconnect" ? true : undefined}
-                    className="connector-disconnect-button connector-disconnect-button-danger"
-                    loading={busyAction === "disconnect"}
-                    size="sm"
-                    variant="outlineDanger"
-                    onClick={handleDisconnectGitHub}
-                  >
-                    {t("connectorDisconnect")}
-                  </Button>
+                    <Button
+                      className="connector-disconnect-button connector-disconnect-button-danger"
+                      loading={gitlabBusy && busyAction === "disconnect"}
+                      size="sm"
+                      variant="outlineDanger"
+                      onClick={() => void onDisconnectGitLab?.()}
+                    >
+                      {t("connectorDisconnect")}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <Button
-                aria-busy={githubBusy ? true : undefined}
-                className="connector-connect-button"
-                loading={githubBusy}
-                size="sm"
-                variant="tertiaryGray"
-                onClick={handleConnectGitHub}
-              >
-                {t("connectorConnect")}
-              </Button>
-            )}
-          </div>
-          <div className="connector-provider-row">
-            <div className="connector-provider-main">
-              <span className="connector-provider-icon" aria-hidden="true">
-                <ConnectorGitLabIcon size={16} />
-              </span>
-              <div className="connector-provider-copy">
-                <strong>{t("connectorGitLab")}</strong>
-                <span>
-                  {gitlabStatus.account?.login ||
-                    (gitlabStatus.connected ? t("connectorConnected") : t("connectorNotConnected"))}
-                </span>
-              </div>
+              ) : (
+                <Button
+                  className="connector-connect-button"
+                  size="sm"
+                  variant="tertiaryGray"
+                  onClick={handleOpenGitLabForm}
+                >
+                  {t("connectorConnect")}
+                </Button>
+              )}
             </div>
-            {gitlabStatus.connected ? (
-              <div className="connector-provider-actions">
-                <span className="connector-connected-state">{t("connectorConnected")}</span>
-                <div className="connector-provider-action-buttons">
-                  <Button className="connector-manage-button" size="sm" variant="secondaryGray" onClick={handleOpenGitLabForm}>
-                    {t("connectorEdit")}
-                  </Button>
-                  <Button
-                    className="connector-disconnect-button connector-disconnect-button-danger"
-                    loading={gitlabBusy && busyAction === "disconnect"}
-                    size="sm"
-                    variant="outlineDanger"
-                    onClick={() => void onDisconnectGitLab?.()}
-                  >
-                    {t("connectorDisconnect")}
-                  </Button>
-                </div>
+            {pending ? (
+              <div className="connector-pending" role="status">
+                {t("connectorOAuthPending")}
               </div>
-            ) : (
-              <Button
-                className="connector-connect-button"
-                size="sm"
-                variant="tertiaryGray"
-                onClick={handleOpenGitLabForm}
-              >
-                {t("connectorConnect")}
-              </Button>
-            )}
-          </div>
-          {pending ? (
-            <div className="connector-pending" role="status">
-              {t("connectorOAuthPending")}
-            </div>
-          ) : null}
-          {error ? <div className="form-error connector-form-error">{error}</div> : null}
-        </section>
-      </PopoverContent>
+            ) : null}
+            {error ? <div className="form-error connector-form-error">{error}</div> : null}
+          </section>
+        </PopoverContent>
       </PopoverRoot>
       <DialogRoot open={gitlabFormOpen} onOpenChange={setGitLabFormOpen}>
         <DialogContent className="connector-config-dialog">
@@ -833,7 +838,9 @@ function ComposerAddMenu({
             <Button
               loading={gitlabBusy && busyAction === "save"}
               size="sm"
-              disabled={!gitlabDraft.base_url.trim() || (!gitlabStatus.access_token_set && !gitlabDraft.access_token.trim())}
+              disabled={
+                !gitlabDraft.base_url.trim() || (!gitlabStatus.access_token_set && !gitlabDraft.access_token.trim())
+              }
               onClick={() => void handleSaveGitLab()}
             >
               {t("connectorSave")}

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -458,6 +458,7 @@ export type AgentTemplateLike = {
   name?: string | null;
   role?: string | null;
   runtime_kind?: string | null;
+  runtime_options?: JSONRecord | null;
 };
 
 export type AgentProfileModelsResponse = {
@@ -987,7 +988,11 @@ export function agentStatusLabel(status: unknown, t: TranslateFn): string {
 }
 
 export function agentRuntimeStatusDetailLabel(item: AgentLike | null | undefined, t: TranslateFn): string {
-  if (String(item?.runtime?.sandbox_provider || "").trim().toLowerCase() !== "docker") {
+  if (
+    String(item?.runtime?.sandbox_provider || "")
+      .trim()
+      .toLowerCase() !== "docker"
+  ) {
     return "";
   }
   const status = agentRuntimeState(item).toLowerCase();
@@ -1530,6 +1535,7 @@ export function applyTemplateToDraft(
     template.runtime_kind || draft.runtime_kind || bootstrapConfig?.runtime_kind,
   );
   const runtimeSelection = resolveRuntimeSelection({ runtime_kind: runtimeKind });
+  const templateRuntimeOptions = normalizeRuntimeOptionsRecord(template.runtime_options);
   return {
     ...draft,
     from_template: template.id || "",
@@ -1542,6 +1548,10 @@ export function applyTemplateToDraft(
       template.image || runtimeImageForKind(runtimeKind, bootstrapConfig, fallbackImage || draft.default_image || ""),
     description: template.description || draft.description || "",
     envRows: mapImageEnvToRows(template.image_env),
+    runtime_options: {
+      ...normalizeRuntimeOptionsRecord(draft.runtime_options),
+      ...templateRuntimeOptions,
+    },
   };
 }
 

--- a/web/app/tests/api/hub.test.ts
+++ b/web/app/tests/api/hub.test.ts
@@ -52,10 +52,7 @@ describe("hub API", () => {
 
     await fetchHubTemplate("team~one/resume~scorer");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "api/v1/hub/templates/team~~one~s~resume~~scorer",
-      expect.any(Object),
-    );
+    expect(fetchMock).toHaveBeenCalledWith("api/v1/hub/templates/team~~one~s~resume~~scorer", expect.any(Object));
   });
 
   it.each([

--- a/web/app/tests/components/ConversationComposerConnectors.test.tsx
+++ b/web/app/tests/components/ConversationComposerConnectors.test.tsx
@@ -420,7 +420,7 @@ describe("ConversationComposer connectors", () => {
     const actions = connectedState.closest(".connector-provider-actions");
     expect(actions?.children[0]).toHaveTextContent("Connected");
     expect(actions?.children[1]).toHaveTextContent("Manage");
-    expect(actions?.children[2]).toHaveTextContent("Disconnect");
+    expect(actions?.children[1]).toHaveTextContent("Disconnect");
     const manageButton = screen.getByRole("button", { name: "Manage" });
     expect(manageButton).toHaveClass("connector-manage-button");
     expect(manageButton).toHaveClass("btn-secondary-gray");

--- a/web/app/tests/models/agents.test.ts
+++ b/web/app/tests/models/agents.test.ts
@@ -288,6 +288,30 @@ describe("agent model helpers", () => {
     });
   });
 
+  it("inherits template execution mode while preserving explicit local runtime options", () => {
+    const draft = applyTemplateToDraft(
+      {
+        ...agentToDraft({
+          runtime_kind: "codex",
+          role: "worker",
+          runtime_options: { local_workspace_dir: "/tmp/project" },
+        }),
+      },
+      {
+        id: "custom/read-only-worker",
+        runtime_kind: "codex",
+        role: "worker",
+        runtime_options: { execution_mode: "read_only" },
+      },
+      null,
+    );
+
+    expect(draft?.runtime_options).toEqual({
+      execution_mode: "read_only",
+      local_workspace_dir: "/tmp/project",
+    });
+  });
+
   it("resolves CSGClaw DM identity from participant channel user before runtime agent id", () => {
     expect(
       resolveAgentChannelUserID({


### PR DESCRIPTION
## Summary

- persist template-safe Codex execution mode in agent.toml across local, builtin, and remote templates
- inherit template execution mode when creating agents while allowing explicit create options to override it
- restore Web connector validation required by the current frontend checks