### PR TITLE
feat(channel): add built-in IM adapter core

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -34,6 +34,12 @@ import (
 	"csgclaw/internal/app/channelwiring"
 	"csgclaw/internal/app/runtimewiring"
 	csgclawchannel "csgclaw/internal/channel/csgclaw"
+	"csgclaw/internal/channel/csgclaw/binding"
+	"csgclaw/internal/channel/csgclaw/delivery"
+	"csgclaw/internal/channel/csgclaw/execution"
+	"csgclaw/internal/channel/csgclaw/files"
+	csgclawinteraction "csgclaw/internal/channel/csgclaw/interaction"
+	csgclawsource "csgclaw/internal/channel/csgclaw/source"
 	"csgclaw/internal/channel/feishu"
 	feishubinding "csgclaw/internal/channel/feishu/binding"
 	"csgclaw/internal/channel/feishu/participantprovider"
@@ -51,6 +57,7 @@ import (
 	"csgclaw/internal/modelprovider"
 	internalonboard "csgclaw/internal/onboard"
 	"csgclaw/internal/participant"
+	agentruntime "csgclaw/internal/runtime"
 	runtimecodex "csgclaw/internal/runtime/codex"
 	"csgclaw/internal/runtimecatalog"
 	"csgclaw/internal/sandboxproviders"
@@ -104,6 +111,7 @@ var (
 	}
 	NewCodexBridgeManager   = newCodexBridgeManager
 	NewFeishuBindingManager = newFeishuBindingManager
+	NewCSGClawAdapterSource = newCSGClawAdapterSource
 	OpenBrowser             = openBrowser
 	WaitForHealthy          = waitForHealthy
 	stopServerProcessByPID  = stopServerProcess
@@ -113,6 +121,11 @@ type serveCmd struct{}
 type stopCmd struct{}
 type internalServeCmd struct{}
 type desktopServeCmd struct{}
+
+type csgclawAdapterSource interface {
+	Start(context.Context) error
+	Close()
+}
 
 const cliproxyAutoLoginEnv = "CSGCLAW_CLIPROXY_AUTO_LOGIN"
 
@@ -605,6 +618,7 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 	if err != nil {
 		return err
 	}
+	participantBridge := im.NewParticipantBridge(cfg.Server.AccessToken)
 	workBus := worklease.NewBus()
 	workControlBus := worklease.NewControlBus()
 	turnControlDispatcher := worklease.NewTurnControlDispatcher(workControlBus)
@@ -646,6 +660,16 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 		if err := feishuBindingMgr.Start(ctx); err != nil {
 			return err
 		}
+	}
+	imAdapterSource, err := NewCSGClawAdapterSource(conversationEngine, svc, imSvc, imBus, participantSvc, workRegistry, participantBridge)
+	if err != nil {
+		return err
+	}
+	if imAdapterSource != nil {
+		if err := imAdapterSource.Start(ctx); err != nil {
+			return err
+		}
+		defer imAdapterSource.Close()
 	}
 	llmSvc, err := NewLLMService(cfg, svc)
 	if err != nil {
@@ -759,7 +783,7 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 		WorkReporter:       workRegistry,
 		WorkBus:            workBus,
 		WorkControlBus:     workControlBus,
-		ParticipantBridge:  im.NewParticipantBridge(cfg.Server.AccessToken),
+		ParticipantBridge:  participantBridge,
 		Feishu:             feishuSvc,
 		LLM:                llmSvc,
 		Team:               teamSvc,
@@ -768,8 +792,8 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 		AgentRuntimes:      agentRuntimeSvc,
 		TeamAdapters:       teamAdapters,
 		Upgrade:            upgradeManager,
-		ActivityDecider:    channelActivityDecider(codexBridgeMgr),
-		UserInputResponder: channelUserInputResponder(codexBridgeMgr),
+		ActivityDecider:    channelActivityDecider(svc),
+		UserInputResponder: channelUserInputResponder(svc),
 		AgentEngine:        conversationEngine,
 		SessionBindings:    sessionBindings,
 		ConfigPath:         configPath,
@@ -1306,28 +1330,36 @@ func (a *channelBindingActivator) CanRefreshStoppedAgentBinding(channel string) 
 	return a != nil && a.feishu != nil && strings.EqualFold(strings.TrimSpace(channel), feishu.ChannelID)
 }
 
-func channelActivityDecider(m codexBridgeManager) api.ActivityDecider {
-	withPermissions, ok := m.(interface {
-		PermissionDecider() runtimecodex.PermissionDecider
-	})
-	if !ok {
+func channelActivityDecider(svc *agent.Service) api.ActivityDecider {
+	codexRuntime := codexRuntimeForService(svc)
+	if codexRuntime == nil {
 		return nil
 	}
-	decider := withPermissions.PermissionDecider()
+	decider := codexRuntime.PermissionBroker()
 	if decider == nil {
 		return nil
 	}
 	return runtimecodex.NewPermissionActivityDecider(csgclawchannel.ChannelID, decider)
 }
 
-func channelUserInputResponder(m codexBridgeManager) api.UserInputResponder {
-	withUserInput, ok := m.(interface {
-		UserInputResponder() runtimecodex.UserInputBroker
-	})
-	if !ok {
+func channelUserInputResponder(svc *agent.Service) api.UserInputResponder {
+	codexRuntime := codexRuntimeForService(svc)
+	if codexRuntime == nil {
 		return nil
 	}
-	return withUserInput.UserInputResponder()
+	return codexRuntime.UserInputBroker()
+}
+
+func codexRuntimeForService(svc *agent.Service) *runtimecodex.Runtime {
+	if svc == nil {
+		return nil
+	}
+	runtimeImpl, err := svc.Runtime(agent.RuntimeKindCodex)
+	if err != nil {
+		return nil
+	}
+	codexRuntime, _ := runtimeImpl.(*runtimecodex.Runtime)
+	return codexRuntime
 }
 
 func newCodexBridgeManager(cfg config.Config, svc *agent.Service, _ *feishu.Service, workReporter worklease.ParticipantWorkReporter) (codexBridgeManager, error) {
@@ -1377,6 +1409,63 @@ func newFeishuBindingManager(feishuSvc *feishu.Service, engine agentengine.Inter
 		return nil, err
 	}
 	return manager, nil
+}
+
+func newCSGClawAdapterSource(
+	engine *agentengine.Engine,
+	agentSvc *agent.Service,
+	imSvc *im.Service,
+	imBus *im.Bus,
+	participantSvc *participant.Service,
+	workReporter worklease.ParticipantWorkReporter,
+	participantBridge *im.ParticipantBridge,
+) (csgclawAdapterSource, error) {
+	if engine == nil || agentSvc == nil || imSvc == nil || participantSvc == nil || participantBridge == nil {
+		return nil, nil
+	}
+	store, err := delivery.NewIMTranscriptStore(imSvc, participantSvc)
+	if err != nil {
+		return nil, err
+	}
+	attachmentResolver, err := files.NewLocalResolver(imSvc, agentSvc, engine)
+	if err != nil {
+		return nil, err
+	}
+	var interactionCoordinator *csgclawinteraction.Coordinator
+	var rendererOptions []delivery.RendererOption
+	if codexRuntime := codexRuntimeForService(agentSvc); codexRuntime != nil {
+		interactionCoordinator = csgclawinteraction.NewCoordinator(codexRuntime.UserInputBroker(), participantSvc, store)
+		if interactionCoordinator != nil {
+			rendererOptions = append(rendererOptions,
+				delivery.WithUserInputBinder(interactionCoordinator),
+				delivery.WithStructuredUserInputActivator(interactionCoordinator),
+			)
+		}
+	}
+	adapterOptions := []execution.Option{
+		execution.WithAttachmentResolver(attachmentResolver),
+		execution.WithParticipantWorkReporter(workReporter),
+	}
+	if registrar, ok := workReporter.(agentruntime.TurnControllerRegistrar); ok {
+		adapterOptions = append(adapterOptions, execution.WithTurnControllerRegistrar(registrar))
+	}
+	adapter, err := execution.New(engine, delivery.NewTranscriptRenderer(store, rendererOptions...), adapterOptions...)
+	if err != nil {
+		return nil, err
+	}
+	manager, err := binding.NewManager(adapter)
+	if err != nil {
+		return nil, err
+	}
+	if interactionCoordinator != nil {
+		interactionCoordinator.SetSubmitter(manager)
+	}
+	source, err := csgclawsource.New(participantBridge, imBus, participantSvc, engine.Agents(), manager)
+	if err != nil {
+		manager.Close()
+		return nil, err
+	}
+	return source, nil
 }
 
 func sandboxServiceOptions(cfg config.SandboxConfig) ([]agent.ServiceOption, error) {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1222,6 +1222,51 @@ func TestServeForegroundSharesOneAgentEngineWithFeishuBindings(t *testing.T) {
 	}
 }
 
+func TestServeForegroundStartsBuiltInIMAdapterSource(t *testing.T) {
+	restore := stubServeDependencies(t)
+	defer restore()
+
+	started := make(chan struct{})
+	closed := make(chan struct{})
+	NewCSGClawAdapterSource = func(
+		engine *agentengine.Engine,
+		_ *agent.Service,
+		_ *im.Service,
+		_ *im.Bus,
+		_ *participant.Service,
+		workReporter worklease.ParticipantWorkReporter,
+		bridge *im.ParticipantBridge,
+	) (csgclawAdapterSource, error) {
+		if engine == nil || workReporter == nil || bridge == nil {
+			t.Fatal("built-in IM adapter dependencies were not assembled")
+		}
+		return &fakeCSGClawAdapterSource{
+			start: func(context.Context) error {
+				close(started)
+				return nil
+			},
+			close: func() { close(closed) },
+		}, nil
+	}
+	RunServer = func(server.Options) error { return nil }
+
+	if err := serveForeground(context.Background(), testContext(), config.Config{
+		Server: config.ServerConfig{ListenAddr: "127.0.0.1:18080"},
+	}, "json"); err != nil {
+		t.Fatalf("serveForeground() error = %v", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("built-in IM adapter source was not started")
+	}
+	select {
+	case <-closed:
+	default:
+		t.Fatal("built-in IM adapter source was not closed")
+	}
+}
+
 func TestChannelBindingActivatorRoutesToChannelOwner(t *testing.T) {
 	t.Parallel()
 
@@ -1746,6 +1791,7 @@ func stubServeDependencies(t *testing.T) func() {
 	origStopRunningSandboxAgents := StopRunningSandboxAgents
 	origNewCodexBridgeManager := NewCodexBridgeManager
 	origNewFeishuBindingManager := NewFeishuBindingManager
+	origNewCSGClawAdapterSource := NewCSGClawAdapterSource
 	origEnsureCLIProxy := EnsureCLIProxy
 	origShutdownCLIProxy := ShutdownCLIProxy
 	origDetectBootstrapState := DetectBootstrapState
@@ -1778,6 +1824,9 @@ func stubServeDependencies(t *testing.T) func() {
 	NewFeishuBindingManager = func(*feishu.Service, agentengine.Interface) (feishuBindingManager, error) {
 		return nil, nil
 	}
+	NewCSGClawAdapterSource = func(*agentengine.Engine, *agent.Service, *im.Service, *im.Bus, *participant.Service, worklease.ParticipantWorkReporter, *im.ParticipantBridge) (csgclawAdapterSource, error) {
+		return nil, nil
+	}
 	EnsureCLIProxy = func(context.Context) error { return nil }
 	ShutdownCLIProxy = func(context.Context) error { return nil }
 	CheckModelProvider = checkModelProvider
@@ -1808,6 +1857,7 @@ func stubServeDependencies(t *testing.T) func() {
 		StopRunningSandboxAgents = origStopRunningSandboxAgents
 		NewCodexBridgeManager = origNewCodexBridgeManager
 		NewFeishuBindingManager = origNewFeishuBindingManager
+		NewCSGClawAdapterSource = origNewCSGClawAdapterSource
 		EnsureCLIProxy = origEnsureCLIProxy
 		ShutdownCLIProxy = origShutdownCLIProxy
 		DetectBootstrapState = origDetectBootstrapState
@@ -2057,6 +2107,24 @@ type fakeFeishuBindingManager struct {
 	start     func(context.Context) error
 	reconcile func(context.Context) error
 	close     func()
+}
+
+type fakeCSGClawAdapterSource struct {
+	start func(context.Context) error
+	close func()
+}
+
+func (s *fakeCSGClawAdapterSource) Start(ctx context.Context) error {
+	if s != nil && s.start != nil {
+		return s.start(ctx)
+	}
+	return nil
+}
+
+func (s *fakeCSGClawAdapterSource) Close() {
+	if s != nil && s.close != nil {
+		s.close()
+	}
 }
 
 func (m *fakeFeishuBindingManager) Start(ctx context.Context) error {

--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -4,7 +4,7 @@ Chinese version: [agent-engine-decoupling.zh.md](agent-engine-decoupling.zh.md)
 
 ## Status
 
-Status: **Architecture proposal; Phase 2 Engine and Mock Client baseline complete, with production Channel Adapter integration remaining in Phase 3**.
+Status: **Architecture proposal; Phase 2 Engine and Mock Client baseline complete; Phase 3 built-in IM Adapter integration in progress**.
 
 The contract and Phase 1 in-process Conversation implementation are in [`internal/agentengine`](../../internal/agentengine).
 Phase 1 connects the anonymous Session API to the existing Codex Runtime and removes anonymous Session dependence on IM entities.
@@ -13,6 +13,13 @@ It does not introduce or switch a production Channel Adapter.
 Phase 3 integrates them with an atomic switch, and Phase 4 then refactors the internal Engine components.
 That package is the source of truth for exact Go types and method signatures.
 This document explains the intended ownership, behavior, and incremental implementation plan.
+
+`internal/channel/csgclaw` now contains the runtime-neutral core for Phase 3,
+including binding-scoped workers, conversation key/input conversion, the
+attachment resolver boundary, and transcript rendering. These components are
+not wired into the composition root yet; the production built-in IM path still
+uses `internal/channelbridge/codexbridge`. The current implementation therefore
+does not mean Phase 3 is complete and does not change existing channel behavior.
 
 ## 1. Scope
 

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -4,7 +4,7 @@
 
 ## 状态
 
-状态：**架构提案；阶段 2 的 Engine 与 Mock Client 基线已完成，生产 Channel Adapter 融合留在阶段 3**。
+状态：**架构提案；阶段 2 的 Engine 与 Mock Client 基线已完成；阶段 3 内置 IM Adapter 融合开发中**。
 
 Contract 和阶段 1 的进程内 Conversation 实现位于 [`internal/agentengine`](../../internal/agentengine)。
 阶段 1 已把匿名 Session API 接入现有 Codex Runtime，并移除匿名 Session 对 IM Entity 的依赖。
@@ -13,6 +13,11 @@ Contract 和阶段 1 的进程内 Conversation 实现位于 [`internal/agentengi
 阶段 3 负责两侧融合与原子切换，阶段 4 再重构 Engine 内部组件。
 该 Package 是精确 Go Type 和 Method Signature 的 Source of Truth。
 本文档说明期望的 Owner、行为和增量实现计划。
+
+`internal/channel/csgclaw` 已包含阶段 3 的 Runtime-neutral Core，包括 Binding-scoped Worker、
+Conversation Key/Input 转换、Attachment Resolver Boundary 和 Transcript Renderer。
+这些组件尚未接入 Composition Root；生产内置 IM Path 仍使用 `internal/channelbridge/codexbridge`。
+因此当前实现不代表阶段 3 已完成，也不改变现有 Channel 行为。
 
 ## 1. 范围
 

--- a/internal/channel/csgclaw/binding/binding.go
+++ b/internal/channel/csgclaw/binding/binding.go
@@ -1,0 +1,140 @@
+package binding
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/execution"
+	"csgclaw/internal/channel/csgclaw/ingress"
+	"csgclaw/internal/channelbridge"
+)
+
+const workerCloseTimeout = 5 * time.Second
+
+// Manager owns Binding-scoped ingress workers. Agent Start/Stop/Recreate must
+// not call Ensure or Stop; only Binding create/update/delete should.
+type Manager struct {
+	adapter *execution.Adapter
+
+	mu      sync.Mutex
+	workers map[channel.BindingID]*ingress.Worker
+}
+
+func NewManager(adapter *execution.Adapter) (*Manager, error) {
+	if adapter == nil {
+		return nil, fmt.Errorf("built-in IM adapter is required")
+	}
+	return &Manager{adapter: adapter, workers: make(map[channel.BindingID]*ingress.Worker)}, nil
+}
+
+func (m *Manager) Ensure(value channel.Binding) error {
+	if m == nil || m.adapter == nil {
+		return fmt.Errorf("built-in IM worker manager is not configured")
+	}
+	bindingID := value.StableID()
+	if bindingID == "" || strings.TrimSpace(value.AgentID) == "" {
+		return fmt.Errorf("binding id and agent id are required")
+	}
+	normalized := channel.Binding{
+		ID:            string(bindingID),
+		Channel:       channel.ChannelCSGClaw,
+		ParticipantID: strings.TrimSpace(value.ParticipantID),
+		AgentID:       strings.TrimSpace(value.AgentID),
+		Enabled:       true,
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing := m.workers[bindingID]; existing != nil {
+		if existing.SameBinding(normalized) {
+			return nil
+		}
+		delete(m.workers, bindingID)
+		if err := closeWorker(existing); err != nil {
+			return fmt.Errorf("replace built-in IM binding %q: %w", bindingID, err)
+		}
+	}
+	worker, err := ingress.NewWorker(m.adapter, normalized)
+	if err != nil {
+		return err
+	}
+	m.workers[bindingID] = worker
+	return nil
+}
+
+func (m *Manager) Stop(bindingID channel.BindingID) {
+	if m == nil {
+		return
+	}
+	bindingID = channel.BindingID(strings.TrimSpace(string(bindingID)))
+	m.mu.Lock()
+	worker := m.workers[bindingID]
+	delete(m.workers, bindingID)
+	m.mu.Unlock()
+	if worker != nil {
+		if err := closeWorker(worker); err != nil {
+			slog.Warn("stop built-in IM binding failed", "binding_id", bindingID, "error", err)
+		}
+	}
+}
+
+func (m *Manager) Close() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	workers := make([]*ingress.Worker, 0, len(m.workers))
+	for id, worker := range m.workers {
+		workers = append(workers, worker)
+		delete(m.workers, id)
+	}
+	m.mu.Unlock()
+	for _, worker := range workers {
+		if err := closeWorker(worker); err != nil {
+			slog.Warn("close built-in IM binding failed", "error", err)
+		}
+	}
+}
+
+// Submit enqueues an already-routed source event onto the binding worker.
+func (m *Manager) Submit(value channel.Binding, event channelbridge.BotEvent) error {
+	if m == nil {
+		return fmt.Errorf("built-in IM worker manager is not configured")
+	}
+	bindingID := value.StableID()
+	m.mu.Lock()
+	worker := m.workers[bindingID]
+	m.mu.Unlock()
+	if worker == nil {
+		return fmt.Errorf("binding worker %q is not running", bindingID)
+	}
+	return worker.Submit(event)
+}
+
+// IsCurrent checks detached continuation freshness without changing the
+// Binding worker lifecycle.
+func (m *Manager) IsCurrent(bindingID channel.BindingID, key agentengine.ConversationKey, sourceMessageID string) bool {
+	if m == nil {
+		return false
+	}
+	bindingID = channel.BindingID(strings.TrimSpace(string(bindingID)))
+	m.mu.Lock()
+	worker := m.workers[bindingID]
+	m.mu.Unlock()
+	return worker != nil && worker.IsCurrent(key, sourceMessageID)
+}
+
+func closeWorker(worker *ingress.Worker) error {
+	if worker == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workerCloseTimeout)
+	defer cancel()
+	return worker.Close(ctx)
+}

--- a/internal/channel/csgclaw/binding/binding_test.go
+++ b/internal/channel/csgclaw/binding/binding_test.go
@@ -1,0 +1,413 @@
+package binding
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/execution"
+	"csgclaw/internal/channelbridge"
+)
+
+type fakeEngine struct {
+	mu      sync.Mutex
+	agentID string
+	request agentengine.TurnRequest
+	run     func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult
+	resets  atomic.Int32
+}
+
+func (f *fakeEngine) Conversations(agentID string) agentengine.ConversationInterface {
+	f.mu.Lock()
+	f.agentID = agentID
+	f.mu.Unlock()
+	return fakeConversation{engine: f}
+}
+
+type fakeConversation struct {
+	engine *fakeEngine
+}
+
+func (fakeConversation) Files() agentengine.FileInterface {
+	return nil
+}
+
+func (f fakeConversation) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+	f.engine.mu.Lock()
+	f.engine.request = request
+	f.engine.mu.Unlock()
+	if f.engine.run != nil {
+		return f.engine.run(ctx, request, sink)
+	}
+	return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "done"}
+}
+
+func (f *fakeEngine) requestSnapshot() agentengine.TurnRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.request
+}
+
+func (fakeConversation) Cancel(context.Context, agentengine.ConversationKey, agentengine.TurnID) error {
+	return nil
+}
+
+func (f fakeConversation) Reset(context.Context, agentengine.ConversationKey) error {
+	f.engine.resets.Add(1)
+	return nil
+}
+
+func (fakeConversation) Resolve(context.Context, agentengine.InteractionResolution) error {
+	return nil
+}
+
+type fakeRenderer struct{}
+
+func (fakeRenderer) Emit(context.Context, channel.TurnContext, agentengine.TurnEvent) error {
+	return nil
+}
+
+func (fakeRenderer) Complete(context.Context, channel.TurnContext, agentengine.TurnResult) error {
+	return nil
+}
+
+func TestManagerSubmitDedupesSourceMessage(t *testing.T) {
+	var runs atomic.Int32
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	engine := &fakeEngine{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		runs.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "ok"}
+	}}
+	adapter, err := execution.New(engine, fakeRenderer{}, execution.WithTurnIDGenerator(func() (agentengine.TurnID, error) {
+		return "turn-1", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+	defer close(release)
+
+	value := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, value)
+	event := channelbridge.BotEvent{MessageID: "message-1", RoomID: "room-1", Text: "hello"}
+	if err := manager.Submit(value, event); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if err := manager.Submit(value, event); err != nil {
+		t.Fatalf("duplicate Submit() error = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first turn")
+	}
+	waitFor(t, func() bool { return runs.Load() == 1 })
+}
+
+func TestManagerSubmitResetDoesNotRunEngine(t *testing.T) {
+	engine := &fakeEngine{}
+	adapter, err := execution.New(engine, fakeRenderer{}, execution.WithTurnIDGenerator(func() (agentengine.TurnID, error) {
+		return "turn-reset", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, binding)
+	if err := manager.Submit(binding, channelbridge.BotEvent{
+		MessageID: "message-new",
+		RoomID:    "room-1",
+		Text:      `<slash-command name="new" arg="conversation"></slash-command>`,
+	}); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	waitFor(t, func() bool { return engine.resets.Load() == 1 })
+	if request := engine.requestSnapshot(); request.ID != "" {
+		t.Fatalf("engine ran %+v", request)
+	}
+}
+
+func TestManagerRunsIndependentConversationsConcurrently(t *testing.T) {
+	roomOneStarted := make(chan struct{})
+	roomTwoStarted := make(chan struct{})
+	releaseRoomOne := make(chan struct{})
+	engine := &fakeEngine{run: func(_ context.Context, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+		if strings.Contains(string(request.ConversationKey), "room-1") {
+			close(roomOneStarted)
+			<-releaseRoomOne
+		} else if strings.Contains(string(request.ConversationKey), "room-2") {
+			close(roomTwoStarted)
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "ok"}
+	}}
+	adapter, err := execution.New(engine, fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+	defer close(releaseRoomOne)
+
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, binding)
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-1", RoomID: "room-1", Text: "first"}); err != nil {
+		t.Fatalf("first Submit() error = %v", err)
+	}
+	select {
+	case <-roomOneStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for room-1 turn")
+	}
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-2", RoomID: "room-2", Text: "second"}); err != nil {
+		t.Fatalf("second Submit() error = %v", err)
+	}
+	select {
+	case <-roomTwoStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("room-2 turn was blocked by room-1")
+	}
+}
+
+func TestManagerPreservesOrderWithinConversation(t *testing.T) {
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var runs atomic.Int32
+	engine := &fakeEngine{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		switch runs.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			close(secondStarted)
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "ok"}
+	}}
+	adapter, err := execution.New(engine, fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, binding)
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-1", RoomID: "room-1", Text: "first"}); err != nil {
+		t.Fatalf("first Submit() error = %v", err)
+	}
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first turn")
+	}
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-2", RoomID: "room-1", Text: "second"}); err != nil {
+		t.Fatalf("second Submit() error = %v", err)
+	}
+	select {
+	case <-secondStarted:
+		t.Fatal("second turn started before the first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second turn")
+	}
+}
+
+func TestStoppedWorkerRejectsSubmit(t *testing.T) {
+	adapter, err := execution.New(&fakeEngine{}, fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	if err := manager.Ensure(binding); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	manager.mu.Lock()
+	worker := manager.workers[binding.StableID()]
+	manager.mu.Unlock()
+	manager.Stop(binding.StableID())
+	if err := worker.Submit(channelbridge.BotEvent{MessageID: "message-late", RoomID: "room-1", Text: "late"}); err == nil {
+		t.Fatal("stopped worker accepted a late event")
+	}
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-revive", RoomID: "room-1", Text: "revive"}); err == nil {
+		t.Fatal("late submit recreated a stopped binding worker")
+	}
+	manager.mu.Lock()
+	recreated := manager.workers[binding.StableID()]
+	manager.mu.Unlock()
+	if recreated != nil {
+		t.Fatal("stopped binding worker was recreated")
+	}
+}
+
+func TestManagerSubmitResetCancelsActiveTurnBeforeReset(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	engine := &fakeEngine{run: func(ctx context.Context, _ agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return agentengine.TurnResult{Status: agentengine.TurnCanceled}
+	}}
+	adapter, err := execution.New(engine, fakeRenderer{}, execution.WithTurnIDGenerator(func() (agentengine.TurnID, error) {
+		return "turn-reset", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, binding)
+	if err := manager.Submit(binding, channelbridge.BotEvent{
+		MessageID: "message-run", RoomID: "room-1", Text: "keep working",
+	}); err != nil {
+		t.Fatalf("run Submit() error = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for active turn")
+	}
+
+	if err := manager.Submit(binding, channelbridge.BotEvent{
+		MessageID: "message-new",
+		RoomID:    "room-1",
+		Text:      `<slash-command name="new" arg="conversation"></slash-command>`,
+	}); err != nil {
+		t.Fatalf("reset Submit() error = %v", err)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset did not cancel the active turn")
+	}
+	waitFor(t, func() bool { return engine.resets.Load() == 1 })
+}
+
+func TestManagerSubmitResetDiscardsOlderQueuedMessages(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	nextInput := make(chan string, 1)
+	var runs atomic.Int32
+	engine := &fakeEngine{run: func(ctx context.Context, request agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+		if runs.Add(1) == 1 {
+			close(started)
+			<-ctx.Done()
+			close(canceled)
+			return agentengine.TurnResult{Status: agentengine.TurnCanceled}
+		}
+		if len(request.Input) > 0 {
+			nextInput <- request.Input[len(request.Input)-1].Text
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "ok"}
+	}}
+	adapter, err := execution.New(engine, fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	manager, err := NewManager(adapter)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	defer manager.Close()
+
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	ensureManagerBinding(t, manager, binding)
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-active", RoomID: "room-1", Text: "active"}); err != nil {
+		t.Fatalf("active Submit() error = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for active turn")
+	}
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-stale", RoomID: "room-1", Text: "stale"}); err != nil {
+		t.Fatalf("stale Submit() error = %v", err)
+	}
+	if err := manager.Submit(binding, channelbridge.BotEvent{
+		MessageID: "message-new",
+		RoomID:    "room-1",
+		Text:      `<slash-command name="new" arg="conversation"></slash-command>`,
+	}); err != nil {
+		t.Fatalf("reset Submit() error = %v", err)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset did not cancel the active turn")
+	}
+	waitFor(t, func() bool { return engine.resets.Load() == 1 })
+
+	if err := manager.Submit(binding, channelbridge.BotEvent{MessageID: "message-fresh", RoomID: "room-1", Text: "fresh"}); err != nil {
+		t.Fatalf("fresh Submit() error = %v", err)
+	}
+	select {
+	case input := <-nextInput:
+		if !strings.Contains(input, "fresh") {
+			t.Fatalf("next input = %q, want fresh message; stale queued message crossed reset", input)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for post-reset turn")
+	}
+	if got := runs.Load(); got != 2 {
+		t.Fatalf("engine runs = %d, want active and fresh only", got)
+	}
+}
+
+func ensureManagerBinding(t *testing.T, manager *Manager, binding channel.Binding) {
+	t.Helper()
+	if err := manager.Ensure(binding); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+}
+
+func waitFor(t *testing.T, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out")
+}

--- a/internal/channel/csgclaw/conv/conv.go
+++ b/internal/channel/csgclaw/conv/conv.go
@@ -1,0 +1,160 @@
+package conv
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+)
+
+// RoomScope is the channel-owned room policy used before a turn is submitted.
+type RoomScope struct {
+	Direct    bool
+	NotifyAll bool
+}
+
+// ConversationKey builds a stable Engine key from Binding + Room + optional Thread.
+func ConversationKey(binding channel.Binding, event channelbridge.BotEvent) (agentengine.ConversationKey, error) {
+	bindingID := strings.TrimSpace(string(binding.StableID()))
+	roomID := strings.TrimSpace(event.RoomID)
+	if bindingID == "" || roomID == "" {
+		return "", fmt.Errorf("binding id and room id are required")
+	}
+
+	key := "csgclaw-im:" + url.QueryEscape(bindingID) + ":room:" + url.QueryEscape(roomID)
+	if threadRootID := strings.TrimSpace(event.ThreadRootID); threadRootID != "" {
+		key += ":thread:" + url.QueryEscape(threadRootID)
+	}
+	return agentengine.ConversationKey(key), nil
+}
+
+// TextInput returns hidden channel/thread context followed by the current message.
+func TextInput(binding channel.Binding, event channelbridge.BotEvent) []agentengine.InputPart {
+	var input []agentengine.InputPart
+	if hidden := hiddenContext(binding, event); hidden != "" {
+		input = append(input, agentengine.InputPart{Kind: agentengine.InputPartText, Text: hidden})
+	}
+	if text := strings.TrimSpace(event.Text); text != "" {
+		label := "Current message:\n"
+		if event.ThreadContext != nil {
+			label = "Current thread message:\n"
+		}
+		input = append(input, agentengine.InputPart{Kind: agentengine.InputPartText, Text: label + text})
+	}
+	return input
+}
+
+// ShouldDispatch reports whether this binding should execute the source event.
+func ShouldDispatch(binding channel.Binding, event channelbridge.BotEvent, senderID string, room RoomScope) bool {
+	senderID = strings.TrimSpace(senderID)
+	participantID := strings.TrimSpace(binding.ParticipantID)
+	agentID := strings.TrimSpace(binding.AgentID)
+	if senderID != "" && (senderID == participantID || senderID == agentID) {
+		return false
+	}
+	if room.Direct || room.NotifyAll || event.Mentioned {
+		return true
+	}
+	for _, mention := range event.Mentions {
+		mention = strings.TrimSpace(mention)
+		if mention != "" && (mention == participantID || mention == agentID) {
+			return true
+		}
+	}
+	return false
+}
+
+func hiddenContext(binding channel.Binding, event channelbridge.BotEvent) string {
+	channelID := strings.TrimSpace(event.Channel)
+	if channelID == "" {
+		channelID = string(channel.ChannelCSGClaw)
+	}
+	participantID := strings.TrimSpace(event.ParticipantID)
+	if participantID == "" {
+		participantID = strings.TrimSpace(binding.ParticipantID)
+	}
+
+	var parts []string
+	var channelContext strings.Builder
+	channelContext.WriteString("Current channel context for CSGClaw CLI operations.\n")
+	channelContext.WriteString("- channel: ")
+	channelContext.WriteString(channelID)
+	if roomID := strings.TrimSpace(event.RoomID); roomID != "" {
+		channelContext.WriteString("\n- room_id: ")
+		channelContext.WriteString(roomID)
+	}
+	if participantID != "" {
+		channelContext.WriteString("\n- participant_id: ")
+		channelContext.WriteString(participantID)
+	}
+	channelContext.WriteString("\nUse these values when a skill asks for <current_channel>, <target_room_id>, or message create/list channel flags.")
+	parts = append(parts, channelContext.String())
+
+	if thread := formatThreadContext(event.ThreadContext); thread != "" {
+		parts = append(parts, thread)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func formatThreadContext(thread *channelbridge.BotThreadContext) string {
+	if thread == nil || len(thread.Context) == 0 {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("Hidden thread context for this new conversation. Use it only to understand what the thread started from; do not treat these messages as thread replies.\n")
+	rootID := strings.TrimSpace(thread.RootMessageID)
+	if rootID != "" {
+		out.WriteString("Thread root message ID: ")
+		out.WriteString(rootID)
+		out.WriteByte('\n')
+	}
+	for _, message := range thread.Context {
+		content := strings.Join(strings.Fields(strings.TrimSpace(message.Content)), " ")
+		if content == "" && len(message.Attachments) == 0 {
+			continue
+		}
+		out.WriteString("- ")
+		if createdAt := strings.TrimSpace(message.CreatedAt); createdAt != "" {
+			out.WriteString(createdAt)
+			out.WriteByte(' ')
+		}
+		if senderID := strings.TrimSpace(message.SenderID); senderID != "" {
+			out.WriteString(senderID)
+			out.WriteString(": ")
+		}
+		if strings.TrimSpace(message.ID) == rootID {
+			out.WriteString("[root] ")
+		}
+		out.WriteString(content)
+		if len(message.Attachments) > 0 {
+			if content != "" {
+				out.WriteByte(' ')
+			}
+			out.WriteString(formatAttachmentSummary(message.Attachments))
+		}
+		out.WriteByte('\n')
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func formatAttachmentSummary(attachments []channelbridge.MessageAttachment) string {
+	if len(attachments) == 0 {
+		return ""
+	}
+	items := make([]string, 0, len(attachments))
+	for _, attachment := range attachments {
+		name := strings.TrimSpace(attachment.Name)
+		if name == "" {
+			name = strings.TrimSpace(attachment.ID)
+		}
+		if name == "" {
+			name = "attachment"
+		}
+		items = append(items, "[attachment: "+name+"]")
+	}
+	return strings.Join(items, " ")
+}

--- a/internal/channel/csgclaw/conv/conv_test.go
+++ b/internal/channel/csgclaw/conv/conv_test.go
@@ -1,0 +1,54 @@
+package conv
+
+import (
+	"testing"
+
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+)
+
+func TestConversationKeySeparatesTopLevelAndThread(t *testing.T) {
+	binding := channel.Binding{ID: "binding-1", ParticipantID: "manager", AgentID: "u-manager"}
+	top, err := ConversationKey(binding, channelbridge.BotEvent{RoomID: "room-1"})
+	if err != nil {
+		t.Fatalf("top ConversationKey() error = %v", err)
+	}
+	thread, err := ConversationKey(binding, channelbridge.BotEvent{RoomID: "room-1", ThreadRootID: "root-1"})
+	if err != nil {
+		t.Fatalf("thread ConversationKey() error = %v", err)
+	}
+	if top == thread {
+		t.Fatalf("top and thread keys are equal: %q", top)
+	}
+}
+
+func TestShouldDispatch(t *testing.T) {
+	binding := channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}
+	event := channelbridge.BotEvent{MessageID: "m1", RoomID: "room-1", Text: "hello"}
+
+	if !ShouldDispatch(binding, event, "u-admin", RoomScope{Direct: true}) {
+		t.Fatal("direct room should dispatch")
+	}
+	if ShouldDispatch(binding, event, "manager", RoomScope{Direct: true}) {
+		t.Fatal("self-sent participant message should not dispatch")
+	}
+	if ShouldDispatch(binding, event, "u-manager", RoomScope{Direct: true}) {
+		t.Fatal("self-sent agent message should not dispatch")
+	}
+	if ShouldDispatch(binding, event, "u-admin", RoomScope{}) {
+		t.Fatal("group message without mention should not dispatch")
+	}
+	if !ShouldDispatch(binding, event, "u-admin", RoomScope{NotifyAll: true}) {
+		t.Fatal("notify-all should dispatch")
+	}
+	mentioned := event
+	mentioned.Mentioned = true
+	if !ShouldDispatch(binding, mentioned, "u-admin", RoomScope{}) {
+		t.Fatal("mentioned event should dispatch")
+	}
+	named := event
+	named.Mentions = []string{"manager"}
+	if !ShouldDispatch(binding, named, "u-admin", RoomScope{}) {
+		t.Fatal("explicit mention should dispatch")
+	}
+}

--- a/internal/channel/csgclaw/delivery/delivery.go
+++ b/internal/channel/csgclaw/delivery/delivery.go
@@ -1,0 +1,585 @@
+package delivery
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"csgclaw/internal/activity"
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge/runtimebridge"
+)
+
+const (
+	completedTurnWindow = 1024
+	thoughtTailBytes    = 1536
+	thoughtFlushEvery   = 400 * time.Millisecond
+)
+
+// Renderer owns channel-specific event rendering and transcript delivery.
+// Returning an error from Emit causes Agent Engine to cancel the active turn.
+type Renderer interface {
+	Emit(ctx context.Context, turn channel.TurnContext, event agentengine.TurnEvent) error
+	Complete(ctx context.Context, turn channel.TurnContext, result agentengine.TurnResult) error
+}
+
+// TranscriptStore is the narrow IM write surface used by the renderer.
+type TranscriptStore interface {
+	DeliverMessage(ctx context.Context, turn channel.TurnContext, text string) error
+	DeliverActivity(ctx context.Context, turn channel.TurnContext, event agentengine.TurnEvent) error
+}
+
+// ActivityDelivery is the legacy-compatible activity representation persisted
+// by the built-in IM adapter. Event remains available for delivery metadata.
+type ActivityDelivery struct {
+	MessageID      string
+	Text           string
+	Metadata       map[string]any
+	ThreadRootID   string
+	EnsureTurnRoot bool
+	Event          agentengine.TurnEvent
+}
+
+type renderedActivityStore interface {
+	DeliverRenderedActivity(context.Context, channel.TurnContext, ActivityDelivery) error
+}
+
+type thoughtStore interface {
+	DeliverThought(context.Context, channel.TurnContext, string) error
+}
+
+type failureStore interface {
+	DeliverFailure(context.Context, channel.TurnContext, string) error
+}
+
+// UserInputBinder attaches a Runtime-native blocking question to its IM scope
+// before the activity card becomes actionable in the Web UI.
+type UserInputBinder interface {
+	Bind(requestID, channel, roomID, threadRootID, requesterID string) (activity.UserInputSnapshot, error)
+}
+
+// StructuredUserInputActivator turns a validated request_user_input output
+// item into a detached, actionable IM question.
+type StructuredUserInputActivator interface {
+	Activate(context.Context, channel.TurnContext, activity.RequestUserInputArgs) (activity.UserInputSnapshot, error)
+}
+
+type RendererOption func(*TranscriptRenderer)
+
+func WithUserInputBinder(binder UserInputBinder) RendererOption {
+	return func(renderer *TranscriptRenderer) {
+		renderer.userInput = binder
+	}
+}
+
+func WithStructuredUserInputActivator(activator StructuredUserInputActivator) RendererOption {
+	return func(renderer *TranscriptRenderer) {
+		renderer.structuredUserInput = activator
+	}
+}
+
+// TranscriptRenderer maps Engine turn events onto the existing IM activity
+// and transcript contract. Rendering state is isolated by the complete Turn
+// identity so interleaved conversations cannot overwrite each other.
+type TranscriptRenderer struct {
+	store               TranscriptStore
+	userInput           UserInputBinder
+	structuredUserInput StructuredUserInputActivator
+
+	mu             sync.Mutex
+	turns          map[turnBufferKey]*turnRenderState
+	completed      map[turnBufferKey]struct{}
+	completedOrder []turnBufferKey
+	now            func() time.Time
+	thoughtLimit   int
+	thoughtEvery   time.Duration
+}
+
+type turnRenderState struct {
+	renderer            *runtimebridge.TurnRenderer
+	thought             string
+	thoughtDirty        bool
+	lastThoughtFlush    time.Time
+	lastSequence        uint64
+	hasText             bool
+	structuredUserInput *activity.RequestUserInputArgs
+}
+
+type turnBufferKey struct {
+	bindingID       channel.BindingID
+	agentID         string
+	conversationKey agentengine.ConversationKey
+	turnID          agentengine.TurnID
+	sourceMessageID string
+}
+
+func NewTranscriptRenderer(store TranscriptStore, opts ...RendererOption) *TranscriptRenderer {
+	renderer := &TranscriptRenderer{
+		store:        store,
+		now:          time.Now,
+		thoughtLimit: thoughtTailBytes,
+		thoughtEvery: thoughtFlushEvery,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(renderer)
+		}
+	}
+	return renderer
+}
+
+func (r *TranscriptRenderer) Emit(ctx context.Context, turn channel.TurnContext, event agentengine.TurnEvent) error {
+	if r == nil {
+		return nil
+	}
+	state, ok := r.acceptEvent(turn, event)
+	if !ok {
+		return nil
+	}
+
+	switch event.Kind {
+	case agentengine.TurnEventTextDelta:
+		if event.Text == "" {
+			return nil
+		}
+		r.mu.Lock()
+		state.renderer.ApplyText(activity.RuntimeEvent{Kind: activity.RuntimeEventTextDelta, Text: event.Text})
+		state.hasText = true
+		r.mu.Unlock()
+		return nil
+	case agentengine.TurnEventThoughtDelta:
+		if event.Thought == "" {
+			return nil
+		}
+		thought, flush := r.appendThought(state, event.Thought)
+		if store, ok := r.store.(thoughtStore); ok && flush && thought != "" {
+			if err := store.DeliverThought(ctx, turn, thought); err != nil {
+				r.markThoughtDirty(state)
+				return err
+			}
+		}
+		return nil
+	case agentengine.TurnEventOutputItem:
+		return r.captureOutputItem(state, event)
+	case agentengine.TurnEventInteractionRequest:
+		bound, err := r.bindInteraction(turn, event)
+		if err != nil {
+			return err
+		}
+		event = bound
+	}
+
+	runtimeEvent, renderable := normalizedRuntimeEvent(turn, event)
+	if !renderable {
+		if r.store != nil && (event.Kind == agentengine.TurnEventToolCallStart ||
+			event.Kind == agentengine.TurnEventToolCallUpdate ||
+			event.Kind == agentengine.TurnEventActivityUpdate ||
+			event.Kind == agentengine.TurnEventInteractionRequest) {
+			return r.store.DeliverActivity(ctx, turn, event)
+		}
+		return nil
+	}
+	r.mu.Lock()
+	rendered, renderedOK := state.renderer.RenderActivity(runtimeEvent, string(channel.ChannelCSGClaw), turn.RoomID, turn.ParticipantID)
+	r.mu.Unlock()
+	if !renderedOK {
+		if r.store != nil {
+			return r.store.DeliverActivity(ctx, turn, event)
+		}
+		return nil
+	}
+	return r.deliverRenderedActivity(ctx, turn, activityDelivery(turn, event, rendered))
+}
+
+func (r *TranscriptRenderer) Complete(ctx context.Context, turn channel.TurnContext, result agentengine.TurnResult) error {
+	if r == nil {
+		return nil
+	}
+	state := r.finishState(turn)
+	if r.store == nil || result.Status == agentengine.TurnCanceled {
+		return nil
+	}
+	if state == nil {
+		state = newTurnRenderState(turn.Locale)
+	}
+	if store, ok := r.store.(thoughtStore); ok {
+		if thought := r.pendingThought(state); thought != "" {
+			if err := store.DeliverThought(ctx, turn, thought); err != nil {
+				return err
+			}
+		}
+	}
+	if result.Status == agentengine.TurnFailed {
+		state.renderer.DiscardStructuredOutput()
+		message := "turn failed"
+		if result.Error != nil && strings.TrimSpace(result.Error.Message) != "" {
+			message = strings.TrimSpace(result.Error.Message)
+		}
+		if store, ok := r.store.(failureStore); ok {
+			return store.DeliverFailure(ctx, turn, message)
+		}
+		return r.store.DeliverMessage(ctx, turn, message)
+	}
+
+	if !state.hasText && strings.TrimSpace(result.Output) != "" {
+		state.renderer.ApplyText(activity.RuntimeEvent{Kind: activity.RuntimeEventTextDelta, Text: result.Output})
+	}
+	if text := strings.TrimSpace(strings.Join(state.renderer.FinalMessages(), "\n\n")); text != "" {
+		if err := r.store.DeliverMessage(ctx, turn, text); err != nil {
+			return err
+		}
+	}
+	if state.structuredUserInput == nil || r.structuredUserInput == nil {
+		return nil
+	}
+	snapshot, err := r.structuredUserInput.Activate(ctx, turn, *cloneRequestUserInputArgs(state.structuredUserInput))
+	if err != nil {
+		return err
+	}
+	event := agentengine.TurnEvent{
+		TurnID:   turn.TurnID,
+		Kind:     agentengine.TurnEventInteractionRequest,
+		Sequence: state.lastSequence + 1,
+		Interaction: &agentengine.InteractionRequest{
+			ID:      snapshot.ID,
+			Kind:    agentengine.InteractionUserInput,
+			Title:   "User input required",
+			Payload: snapshot,
+		},
+	}
+	runtimeEvent, ok := normalizedRuntimeEvent(turn, event)
+	if !ok {
+		return nil
+	}
+	rendered, ok := state.renderer.RenderActivity(runtimeEvent, string(channel.ChannelCSGClaw), turn.RoomID, turn.ParticipantID)
+	if !ok {
+		return nil
+	}
+	return r.deliverRenderedActivity(ctx, turn, activityDelivery(turn, event, rendered))
+}
+
+func (r *TranscriptRenderer) acceptEvent(turn channel.TurnContext, event agentengine.TurnEvent) (*turnRenderState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := bufferKey(turn)
+	if _, completed := r.completed[key]; completed {
+		return nil, false
+	}
+	if r.turns == nil {
+		r.turns = make(map[turnBufferKey]*turnRenderState)
+	}
+	state := r.turns[key]
+	if state == nil {
+		state = newTurnRenderState(turn.Locale)
+		r.turns[key] = state
+	}
+	if event.Sequence > 0 {
+		if event.Sequence <= state.lastSequence {
+			return nil, false
+		}
+		state.lastSequence = event.Sequence
+	}
+	return state, true
+}
+
+func newTurnRenderState(locale string) *turnRenderState {
+	renderer := runtimebridge.NewTurnRenderer()
+	renderer.SetLocale(locale)
+	return &turnRenderState{renderer: renderer}
+}
+
+func (r *TranscriptRenderer) appendThought(state *turnRenderState, delta string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	limit := r.thoughtLimit
+	if limit <= 0 {
+		limit = thoughtTailBytes
+	}
+	state.thought = tailUTF8(state.thought+delta, limit)
+	state.thoughtDirty = true
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	interval := r.thoughtEvery
+	if interval <= 0 {
+		interval = thoughtFlushEvery
+	}
+	if !state.lastThoughtFlush.IsZero() && now.Sub(state.lastThoughtFlush) < interval {
+		return "", false
+	}
+	state.lastThoughtFlush = now
+	state.thoughtDirty = false
+	return strings.TrimSpace(state.thought), true
+}
+
+func (r *TranscriptRenderer) markThoughtDirty(state *turnRenderState) {
+	r.mu.Lock()
+	state.thoughtDirty = true
+	r.mu.Unlock()
+}
+
+func (r *TranscriptRenderer) pendingThought(state *turnRenderState) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if state == nil || !state.thoughtDirty {
+		return ""
+	}
+	state.thoughtDirty = false
+	return strings.TrimSpace(state.thought)
+}
+
+func tailUTF8(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	start := len(value) - limit
+	for start < len(value) && !utf8.RuneStart(value[start]) {
+		start++
+	}
+	return value[start:]
+}
+
+func (r *TranscriptRenderer) captureOutputItem(state *turnRenderState, event agentengine.TurnEvent) error {
+	if event.Output == nil {
+		return nil
+	}
+	switch event.Output.Kind {
+	case agentengine.OutputItemResourceLink:
+		link, ok := event.Output.Payload.(activity.ResourceLink)
+		if !ok {
+			return nil
+		}
+		r.mu.Lock()
+		state.renderer.ApplyStructuredOutput(activity.RuntimeEvent{
+			Kind: activity.RuntimeEventStructuredOutput,
+			Payload: activity.StructuredOutputArtifact{
+				ResourceLinks: []activity.ResourceLink{link},
+			},
+		})
+		r.mu.Unlock()
+	case agentengine.OutputItemRequestUserInput:
+		args, ok := requestUserInputArgs(event.Output.Payload)
+		if !ok {
+			return nil
+		}
+		r.mu.Lock()
+		state.structuredUserInput = cloneRequestUserInputArgs(&args)
+		state.renderer.ApplyStructuredOutput(activity.RuntimeEvent{
+			Kind: activity.RuntimeEventStructuredOutput,
+			Payload: activity.StructuredOutputArtifact{
+				RequestUserInput: cloneRequestUserInputArgs(&args),
+			},
+		})
+		r.mu.Unlock()
+	}
+	return nil
+}
+
+func (r *TranscriptRenderer) bindInteraction(turn channel.TurnContext, event agentengine.TurnEvent) (agentengine.TurnEvent, error) {
+	if r.userInput == nil || event.Interaction == nil || event.Interaction.Kind != agentengine.InteractionUserInput {
+		return event, nil
+	}
+	snapshot, ok := userInputSnapshot(event.Interaction.Payload)
+	if !ok {
+		return event, nil
+	}
+	bound, err := r.userInput.Bind(snapshot.ID, string(channel.ChannelCSGClaw), turn.RoomID, turn.ThreadRootID, turn.ParticipantID)
+	if err != nil {
+		return event, err
+	}
+	interaction := *event.Interaction
+	interaction.Payload = bound
+	event.Interaction = &interaction
+	return event, nil
+}
+
+func (r *TranscriptRenderer) deliverRenderedActivity(ctx context.Context, turn channel.TurnContext, rendered ActivityDelivery) error {
+	if store, ok := r.store.(renderedActivityStore); ok {
+		return store.DeliverRenderedActivity(ctx, turn, rendered)
+	}
+	if r.store != nil {
+		return r.store.DeliverActivity(ctx, turn, rendered.Event)
+	}
+	return nil
+}
+
+func (r *TranscriptRenderer) finishState(turn channel.TurnContext) *turnRenderState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := bufferKey(turn)
+	state := r.turns[key]
+	delete(r.turns, key)
+	if r.completed == nil {
+		r.completed = make(map[turnBufferKey]struct{})
+	}
+	if _, exists := r.completed[key]; exists {
+		return state
+	}
+	r.completed[key] = struct{}{}
+	r.completedOrder = append(r.completedOrder, key)
+	if len(r.completedOrder) <= completedTurnWindow {
+		return state
+	}
+	oldest := r.completedOrder[0]
+	r.completedOrder = r.completedOrder[1:]
+	delete(r.completed, oldest)
+	return state
+}
+
+func normalizedRuntimeEvent(turn channel.TurnContext, event agentengine.TurnEvent) (activity.RuntimeEvent, bool) {
+	value := activity.RuntimeEvent{
+		RuntimeKind: "codex",
+		RuntimeID:   string(turn.BindingID),
+		SessionID:   activitySessionID(turn),
+		TurnID:      string(turn.TurnID),
+		ReceivedAt:  time.Now().UTC(),
+	}
+	switch event.Kind {
+	case agentengine.TurnEventToolCallStart, agentengine.TurnEventToolCallUpdate:
+		if event.Tool == nil {
+			return value, false
+		}
+		if event.Kind == agentengine.TurnEventToolCallStart {
+			value.Kind = activity.RuntimeEventToolCallStart
+		} else {
+			value.Kind = activity.RuntimeEventToolCallUpdate
+		}
+		value.ToolCallID = event.Tool.ID
+		value.ToolKind = event.Tool.Kind
+		value.ToolTitle = event.Tool.Title
+		value.ToolStatus = event.Tool.Status
+		value.ToolInputSummary = event.Tool.InputSummary
+		value.ToolOutputSummary = event.Tool.OutputSummary
+		value.Payload = event.Tool.Payload
+	case agentengine.TurnEventActivityUpdate:
+		if event.Activity == nil {
+			return value, false
+		}
+		value.Payload = event.Activity.Payload
+		switch activity.RuntimeEventKind(strings.TrimSpace(event.Activity.Kind)) {
+		case activity.RuntimeEventActionDecision:
+			value.Kind = activity.RuntimeEventActionDecision
+			value.ActionID = event.Activity.ID
+			value.ActionStatus = event.Activity.Status
+		case activity.RuntimeEventUserInputResolved:
+			value.Kind = activity.RuntimeEventUserInputResolved
+			value.UserInputID = event.Activity.ID
+			value.UserInputStatus = event.Activity.Status
+		default:
+			return value, false
+		}
+	case agentengine.TurnEventInteractionRequest:
+		if event.Interaction == nil {
+			return value, false
+		}
+		value.Payload = event.Interaction.Payload
+		switch event.Interaction.Kind {
+		case agentengine.InteractionPermission:
+			value.Kind = activity.RuntimeEventActionRequest
+			value.ActionID = event.Interaction.ID
+		case agentengine.InteractionUserInput:
+			value.Kind = activity.RuntimeEventUserInputRequest
+			value.UserInputID = event.Interaction.ID
+		default:
+			return value, false
+		}
+	default:
+		return value, false
+	}
+	return value, true
+}
+
+func activitySessionID(turn channel.TurnContext) string {
+	conversationKey := strings.TrimSpace(string(turn.ConversationKey))
+	turnID := strings.TrimSpace(string(turn.TurnID))
+	if turnID == "" {
+		return conversationKey
+	}
+	// Activity IDs must be stable within one Turn and distinct across Turns,
+	// even if a Runtime reuses a tool-call ID in the same conversation.
+	return conversationKey + "\x00" + turnID
+}
+
+func activityDelivery(turn channel.TurnContext, event agentengine.TurnEvent, rendered runtimebridge.RenderedActivity) ActivityDelivery {
+	delivery := ActivityDelivery{
+		MessageID: rendered.MessageID,
+		Text:      rendered.Text,
+		Metadata:  rendered.Metadata,
+		Event:     event,
+	}
+	switch event.Kind {
+	case agentengine.TurnEventToolCallStart, agentengine.TurnEventToolCallUpdate:
+		// Legacy tool activities are top-level timeline entries.
+	case agentengine.TurnEventInteractionRequest:
+		if event.Interaction != nil && event.Interaction.Kind == agentengine.InteractionUserInput {
+			delivery.ThreadRootID = turn.ThreadRootID
+		} else if turn.ThreadRootID != "" {
+			delivery.ThreadRootID = turn.ThreadRootID
+		} else {
+			delivery.EnsureTurnRoot = true
+		}
+	case agentengine.TurnEventActivityUpdate:
+		if event.Activity != nil && strings.TrimSpace(event.Activity.Kind) == string(activity.RuntimeEventUserInputResolved) {
+			delivery.ThreadRootID = turn.ThreadRootID
+		} else if turn.ThreadRootID != "" {
+			delivery.ThreadRootID = turn.ThreadRootID
+		} else {
+			delivery.EnsureTurnRoot = true
+		}
+	}
+	return delivery
+}
+
+func requestUserInputArgs(value any) (activity.RequestUserInputArgs, bool) {
+	switch typed := value.(type) {
+	case activity.RequestUserInputArgs:
+		return typed, true
+	case *activity.RequestUserInputArgs:
+		if typed != nil {
+			return *typed, true
+		}
+	}
+	return activity.RequestUserInputArgs{}, false
+}
+
+func userInputSnapshot(value any) (activity.UserInputSnapshot, bool) {
+	switch typed := value.(type) {
+	case activity.UserInputSnapshot:
+		return typed, true
+	case *activity.UserInputSnapshot:
+		if typed != nil {
+			return *typed, true
+		}
+	}
+	return activity.UserInputSnapshot{}, false
+}
+
+func cloneRequestUserInputArgs(input *activity.RequestUserInputArgs) *activity.RequestUserInputArgs {
+	if input == nil {
+		return nil
+	}
+	out := *input
+	out.Questions = append([]activity.RequestUserInputQuestion(nil), input.Questions...)
+	for index := range out.Questions {
+		out.Questions[index].Options = append([]activity.RequestUserInputOption(nil), input.Questions[index].Options...)
+	}
+	if input.AutoResolutionMS != nil {
+		value := *input.AutoResolutionMS
+		out.AutoResolutionMS = &value
+	}
+	return &out
+}
+
+func bufferKey(turn channel.TurnContext) turnBufferKey {
+	return turnBufferKey{
+		bindingID:       turn.BindingID,
+		agentID:         turn.AgentID,
+		conversationKey: turn.ConversationKey,
+		turnID:          turn.TurnID,
+		sourceMessageID: turn.SourceMessageID,
+	}
+}

--- a/internal/channel/csgclaw/delivery/delivery_test.go
+++ b/internal/channel/csgclaw/delivery/delivery_test.go
@@ -1,0 +1,197 @@
+package delivery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+)
+
+type recordingStore struct {
+	messages   []deliveredMessage
+	activities int
+}
+
+type deliveredMessage struct {
+	turn channel.TurnContext
+	text string
+}
+
+type thoughtRecordingStore struct {
+	recordingStore
+	thoughts []string
+}
+
+func (s *thoughtRecordingStore) DeliverThought(_ context.Context, _ channel.TurnContext, text string) error {
+	s.thoughts = append(s.thoughts, text)
+	return nil
+}
+
+func (s *recordingStore) DeliverMessage(_ context.Context, turn channel.TurnContext, text string) error {
+	s.messages = append(s.messages, deliveredMessage{turn: turn, text: text})
+	return nil
+}
+
+func (s *recordingStore) DeliverActivity(_ context.Context, _ channel.TurnContext, _ agentengine.TurnEvent) error {
+	s.activities++
+	return nil
+}
+
+func TestTranscriptRendererWritesFinalTextAndSkipsCanceled(t *testing.T) {
+	store := &recordingStore{}
+	renderer := NewTranscriptRenderer(store)
+	turn := channel.TurnContext{RoomID: "room-1", SourceMessageID: "m1"}
+
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "hel"}); err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	}
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "lo"}); err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	}
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{Kind: agentengine.TurnEventToolCallStart}); err != nil {
+		t.Fatalf("Emit tool error = %v", err)
+	}
+	if err := renderer.Complete(context.Background(), turn, agentengine.TurnResult{Status: agentengine.TurnSucceeded}); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if store.activities != 1 || len(store.messages) != 1 || store.messages[0].text != "hello" {
+		t.Fatalf("store = %+v", store)
+	}
+
+	if err := renderer.Complete(context.Background(), turn, agentengine.TurnResult{Status: agentengine.TurnCanceled}); err != nil {
+		t.Fatalf("canceled Complete() error = %v", err)
+	}
+	if len(store.messages) != 1 {
+		t.Fatalf("canceled turn wrote transcript: %+v", store.messages)
+	}
+
+	if err := renderer.Complete(context.Background(), turn, agentengine.TurnResult{
+		Status: agentengine.TurnFailed,
+		Error:  &agentengine.TurnError{Message: "runtime exploded"},
+	}); err != nil {
+		t.Fatalf("failed Complete() error = %v", err)
+	}
+	if len(store.messages) != 2 || store.messages[1].text != "runtime exploded" {
+		t.Fatalf("failed transcript = %+v", store.messages)
+	}
+}
+
+func TestTranscriptRendererIsolatesInterleavedTurns(t *testing.T) {
+	store := &recordingStore{}
+	renderer := NewTranscriptRenderer(store)
+	first := channel.TurnContext{
+		BindingID:       "binding-1",
+		AgentID:         "agent-1",
+		SourceMessageID: "message-1",
+		ConversationKey: "conversation-1",
+		TurnID:          "turn-1",
+	}
+	second := channel.TurnContext{
+		BindingID:       "binding-2",
+		AgentID:         "agent-2",
+		SourceMessageID: "message-2",
+		ConversationKey: "conversation-2",
+		TurnID:          "turn-2",
+	}
+
+	for _, item := range []struct {
+		turn channel.TurnContext
+		text string
+	}{
+		{turn: first, text: "first "},
+		{turn: second, text: "second "},
+		{turn: first, text: "answer"},
+		{turn: second, text: "answer"},
+	} {
+		if err := renderer.Emit(context.Background(), item.turn, agentengine.TurnEvent{
+			Kind: agentengine.TurnEventTextDelta,
+			Text: item.text,
+		}); err != nil {
+			t.Fatalf("Emit() error = %v", err)
+		}
+	}
+
+	if err := renderer.Complete(context.Background(), first, agentengine.TurnResult{Status: agentengine.TurnSucceeded}); err != nil {
+		t.Fatalf("first Complete() error = %v", err)
+	}
+	if err := renderer.Complete(context.Background(), second, agentengine.TurnResult{Status: agentengine.TurnSucceeded}); err != nil {
+		t.Fatalf("second Complete() error = %v", err)
+	}
+
+	if len(store.messages) != 2 {
+		t.Fatalf("messages = %+v, want two isolated results", store.messages)
+	}
+	if store.messages[0].turn.TurnID != first.TurnID || store.messages[0].text != "first answer" {
+		t.Fatalf("first message = %+v", store.messages[0])
+	}
+	if store.messages[1].turn.TurnID != second.TurnID || store.messages[1].text != "second answer" {
+		t.Fatalf("second message = %+v", store.messages[1])
+	}
+}
+
+func TestTranscriptRendererCoalescesAndBoundsThoughts(t *testing.T) {
+	store := &thoughtRecordingStore{}
+	renderer := NewTranscriptRenderer(store)
+	now := time.Unix(100, 0)
+	renderer.now = func() time.Time { return now }
+	turn := channel.TurnContext{TurnID: "turn-thought", SourceMessageID: "message-thought"}
+
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{
+		Kind: agentengine.TurnEventThoughtDelta, Thought: "start ",
+	}); err != nil {
+		t.Fatalf("first Emit() error = %v", err)
+	}
+	now = now.Add(100 * time.Millisecond)
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{
+		Kind: agentengine.TurnEventThoughtDelta, Thought: strings.Repeat("界", 800),
+	}); err != nil {
+		t.Fatalf("coalesced Emit() error = %v", err)
+	}
+	if len(store.thoughts) != 1 {
+		t.Fatalf("thought deliveries = %d, want 1 before flush interval", len(store.thoughts))
+	}
+
+	now = now.Add(thoughtFlushEvery)
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{
+		Kind: agentengine.TurnEventThoughtDelta, Thought: " end",
+	}); err != nil {
+		t.Fatalf("flush Emit() error = %v", err)
+	}
+	if len(store.thoughts) != 2 {
+		t.Fatalf("thought deliveries = %d, want 2", len(store.thoughts))
+	}
+	got := store.thoughts[1]
+	if len(got) > thoughtTailBytes || !utf8.ValidString(got) || !strings.HasSuffix(got, " end") {
+		t.Fatalf("bounded thought len=%d valid=%v suffix=%v", len(got), utf8.ValidString(got), strings.HasSuffix(got, " end"))
+	}
+}
+
+func TestTranscriptRendererFlushesPendingThoughtOnComplete(t *testing.T) {
+	store := &thoughtRecordingStore{}
+	renderer := NewTranscriptRenderer(store)
+	now := time.Unix(100, 0)
+	renderer.now = func() time.Time { return now }
+	turn := channel.TurnContext{TurnID: "turn-thought", SourceMessageID: "message-thought"}
+
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{
+		Kind: agentengine.TurnEventThoughtDelta, Thought: "first",
+	}); err != nil {
+		t.Fatalf("first Emit() error = %v", err)
+	}
+	now = now.Add(100 * time.Millisecond)
+	if err := renderer.Emit(context.Background(), turn, agentengine.TurnEvent{
+		Kind: agentengine.TurnEventThoughtDelta, Thought: " second",
+	}); err != nil {
+		t.Fatalf("second Emit() error = %v", err)
+	}
+	if err := renderer.Complete(context.Background(), turn, agentengine.TurnResult{Status: agentengine.TurnSucceeded}); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if len(store.thoughts) != 2 || store.thoughts[1] != "first second" {
+		t.Fatalf("thoughts = %#v, want final coalesced flush", store.thoughts)
+	}
+}

--- a/internal/channel/csgclaw/delivery/im_store.go
+++ b/internal/channel/csgclaw/delivery/im_store.go
@@ -1,0 +1,335 @@
+package delivery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge/runtimebridge"
+	"csgclaw/internal/im"
+	"csgclaw/internal/participant"
+)
+
+const (
+	channelMetadataKey     = "channel"
+	channelMetadataVersion = 2
+)
+
+type participantResolver interface {
+	Get(channel, id string) (apitypes.Participant, bool)
+}
+
+// IMTranscriptStore persists final responses, failures, and tool activity in
+// the built-in IM service using the participant's local channel identity.
+type IMTranscriptStore struct {
+	im           *im.Service
+	participants participantResolver
+}
+
+func NewIMTranscriptStore(imService *im.Service, participants participantResolver) (*IMTranscriptStore, error) {
+	if imService == nil {
+		return nil, fmt.Errorf("IM service is required")
+	}
+	if participants == nil {
+		return nil, fmt.Errorf("participant resolver is required")
+	}
+	return &IMTranscriptStore{im: imService, participants: participants}, nil
+}
+
+func (s *IMTranscriptStore) DeliverMessage(ctx context.Context, turn channel.TurnContext, text string) error {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	_, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+		RoomID:       strings.TrimSpace(turn.RoomID),
+		SenderID:     s.senderID(turn.ParticipantID),
+		Content:      text,
+		MessageID:    finalMessageID(turn),
+		ThreadRootID: strings.TrimSpace(turn.ThreadRootID),
+		Metadata:     transcriptMetadata("final", turn, nil),
+	})
+	return err
+}
+
+// DeliverFailure keeps Runtime internals out of the transcript and preserves
+// the legacy localized error presentation and metadata contract.
+func (s *IMTranscriptStore) DeliverFailure(ctx context.Context, turn channel.TurnContext, internalError string) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	renderer := runtimebridge.NewTurnRenderer()
+	renderer.SetLocale(turn.Locale)
+	renderer.SetPromptError(internalError)
+	publicError := renderer.PromptError()
+	messages := renderer.FinalMessages()
+	if len(messages) == 0 {
+		return nil
+	}
+	metadata := transcriptMetadata("final", turn, nil)
+	metadata = mergeCSGClawMetadata(metadata, map[string]any{
+		runtimebridge.RuntimeErrorMetaKey: true,
+		"error_code":                      publicError.Code,
+		"presentation_version":            2,
+	})
+	_, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+		RoomID:       strings.TrimSpace(turn.RoomID),
+		SenderID:     s.senderID(turn.ParticipantID),
+		Content:      strings.TrimSpace(strings.Join(messages, "\n\n")),
+		MessageID:    finalMessageID(turn),
+		ThreadRootID: strings.TrimSpace(turn.ThreadRootID),
+		Metadata:     metadata,
+	})
+	return err
+}
+
+func (s *IMTranscriptStore) DeliverActivity(ctx context.Context, turn channel.TurnContext, event agentengine.TurnEvent) error {
+	if event.Tool == nil {
+		return nil
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	text := renderToolActivity(*event.Tool)
+	if text == "" {
+		return nil
+	}
+	_, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+		RoomID:       strings.TrimSpace(turn.RoomID),
+		SenderID:     s.senderID(turn.ParticipantID),
+		Content:      text,
+		MessageID:    toolMessageID(turn, *event.Tool),
+		ThreadRootID: strings.TrimSpace(turn.ThreadRootID),
+		Metadata:     transcriptMetadata("tool", turn, event.Tool),
+	})
+	return err
+}
+
+// DeliverRenderedActivity persists the same activity payload and update key as
+// the legacy Codex bridge so the existing browser activity cards keep working.
+func (s *IMTranscriptStore) DeliverRenderedActivity(ctx context.Context, turn channel.TurnContext, rendered ActivityDelivery) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	text := strings.TrimSpace(rendered.Text)
+	if text == "" {
+		return nil
+	}
+	senderID := s.senderID(turn.ParticipantID)
+	threadRootID := strings.TrimSpace(rendered.ThreadRootID)
+	if rendered.EnsureTurnRoot && threadRootID == "" {
+		threadRootID = activityRootMessageID(turn)
+		if _, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+			RoomID:    strings.TrimSpace(turn.RoomID),
+			SenderID:  senderID,
+			Content:   "\u200b",
+			MessageID: threadRootID,
+			Metadata:  withChannelMetadata(nil),
+		}); err != nil {
+			return err
+		}
+	}
+	metadata := cloneMetadata(rendered.Metadata)
+	if rendered.Event.Tool != nil {
+		metadata = mergeMetadata(transcriptMetadata("tool", turn, rendered.Event.Tool), metadata)
+	} else {
+		metadata = withChannelMetadata(metadata)
+	}
+	_, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+		RoomID:       strings.TrimSpace(turn.RoomID),
+		SenderID:     senderID,
+		Content:      text,
+		MessageID:    strings.TrimSpace(rendered.MessageID),
+		ThreadRootID: threadRootID,
+		Metadata:     metadata,
+	})
+	return err
+}
+
+// DeliverThought updates one turn-scoped commentary message. A stable ID
+// prevents streaming deltas from creating an unbounded message list.
+func (s *IMTranscriptStore) DeliverThought(ctx context.Context, turn channel.TurnContext, text string) error {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	_, err := s.im.DeliverMessage(im.DeliverMessageRequest{
+		RoomID:       strings.TrimSpace(turn.RoomID),
+		SenderID:     s.senderID(turn.ParticipantID),
+		Content:      text,
+		MessageID:    thoughtMessageID(turn),
+		ThreadRootID: strings.TrimSpace(turn.ThreadRootID),
+		Metadata:     transcriptMetadata("thought", turn, nil),
+	})
+	return err
+}
+
+func (s *IMTranscriptStore) senderID(participantID string) string {
+	participantID = strings.TrimSpace(participantID)
+	if item, ok := s.participants.Get(participant.ChannelCSGClaw, participantID); ok {
+		if channelUserRef := strings.TrimSpace(item.ChannelUserRef); channelUserRef != "" {
+			return channelUserRef
+		}
+	}
+	return participantID
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+func renderToolActivity(tool agentengine.ToolActivity) string {
+	title := strings.TrimSpace(tool.Title)
+	if title == "" {
+		title = strings.TrimSpace(tool.Kind)
+	}
+	if title == "" {
+		title = "tool"
+	}
+	var lines []string
+	lines = append(lines, "🔧 "+title)
+	if status := strings.TrimSpace(tool.Status); status != "" {
+		lines = append(lines, "status: "+status)
+	}
+	if summary := strings.TrimSpace(tool.OutputSummary); summary != "" {
+		lines = append(lines, summary)
+	} else if summary := strings.TrimSpace(tool.InputSummary); summary != "" {
+		lines = append(lines, summary)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func finalMessageID(turn channel.TurnContext) string {
+	turnID := strings.TrimSpace(string(turn.TurnID))
+	if turnID == "" {
+		turnID = strings.TrimSpace(turn.SourceMessageID)
+	}
+	if turnID == "" {
+		return ""
+	}
+	return turnID + "-final"
+}
+
+func thoughtMessageID(turn channel.TurnContext) string {
+	turnID := strings.TrimSpace(string(turn.TurnID))
+	if turnID == "" {
+		turnID = strings.TrimSpace(turn.SourceMessageID)
+	}
+	if turnID == "" {
+		return ""
+	}
+	return turnID + "-thought"
+}
+
+func activityRootMessageID(turn channel.TurnContext) string {
+	turnID := strings.TrimSpace(string(turn.TurnID))
+	if turnID == "" {
+		turnID = strings.TrimSpace(turn.SourceMessageID)
+	}
+	if turnID == "" {
+		return ""
+	}
+	return turnID + "-activity-root"
+}
+
+func toolMessageID(turn channel.TurnContext, tool agentengine.ToolActivity) string {
+	turnID := strings.TrimSpace(string(turn.TurnID))
+	toolID := strings.TrimSpace(tool.ID)
+	if toolID == "" {
+		toolID = strings.TrimSpace(tool.Kind)
+	}
+	if toolID == "" {
+		toolID = "activity"
+	}
+	return turnID + "-tool-" + toolID
+}
+
+func transcriptMetadata(kind string, turn channel.TurnContext, tool *agentengine.ToolActivity) map[string]any {
+	entry := map[string]any{
+		"delivery_kind":     strings.TrimSpace(kind),
+		"request_id":        strings.TrimSpace(turn.SourceMessageID),
+		"source_message_id": strings.TrimSpace(turn.SourceMessageID),
+	}
+	if tool != nil {
+		entry["tool_call_id"] = strings.TrimSpace(tool.ID)
+		entry["tool_kind"] = strings.TrimSpace(tool.Kind)
+		entry["tool_status"] = strings.TrimSpace(tool.Status)
+	}
+	metadata := map[string]any{
+		"codex":    cloneMetadata(entry),
+		"openclaw": cloneMetadata(entry),
+	}
+	return withChannelMetadata(metadata)
+}
+
+// withChannelMetadata identifies messages emitted through the reworked
+// built-in channel while legacy Runtime metadata remains intact.
+func withChannelMetadata(metadata map[string]any) map[string]any {
+	out := cloneMetadata(metadata)
+	if out == nil {
+		out = make(map[string]any)
+	}
+	out[channelMetadataKey] = map[string]any{
+		"type":    string(channel.ChannelCSGClaw),
+		"version": channelMetadataVersion,
+	}
+	return out
+}
+
+func mergeCSGClawMetadata(metadata map[string]any, values map[string]any) map[string]any {
+	out := cloneMetadata(metadata)
+	if out == nil {
+		out = make(map[string]any)
+	}
+	namespace, _ := out[runtimebridge.CSGClawMetadataKey].(map[string]any)
+	namespace = cloneMetadata(namespace)
+	if namespace == nil {
+		namespace = make(map[string]any)
+	}
+	for key, value := range values {
+		namespace[key] = value
+	}
+	out[runtimebridge.CSGClawMetadataKey] = namespace
+	return out
+}
+
+func cloneMetadata(value map[string]any) map[string]any {
+	if len(value) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(value))
+	for key, item := range value {
+		out[key] = item
+	}
+	return out
+}
+
+func mergeMetadata(values ...map[string]any) map[string]any {
+	var out map[string]any
+	for _, value := range values {
+		for key, item := range value {
+			if out == nil {
+				out = make(map[string]any)
+			}
+			out[key] = item
+		}
+	}
+	return out
+}

--- a/internal/channel/csgclaw/delivery/im_store_test.go
+++ b/internal/channel/csgclaw/delivery/im_store_test.go
@@ -1,0 +1,140 @@
+package delivery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge/runtimebridge"
+	"csgclaw/internal/im"
+)
+
+type fixedParticipantResolver struct {
+	item apitypes.Participant
+}
+
+func (r fixedParticipantResolver) Get(_, id string) (apitypes.Participant, bool) {
+	return r.item, id == r.item.ID
+}
+
+func TestIMTranscriptStoreWritesFinalAndUpdatesToolActivity(t *testing.T) {
+	imService := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "user-admin",
+		Users: []im.User{
+			{ID: "user-admin", Name: "admin"},
+			{ID: "user-worker", Name: "worker"},
+		},
+		Rooms: []im.Room{{
+			ID: "room-1", IsDirect: true, Members: []string{"user-admin", "user-worker"},
+		}},
+	})
+	store, err := NewIMTranscriptStore(imService, fixedParticipantResolver{item: apitypes.Participant{
+		ID: "pt-worker", ChannelUserRef: "user-worker",
+	}})
+	if err != nil {
+		t.Fatalf("NewIMTranscriptStore() error = %v", err)
+	}
+	turn := channel.TurnContext{
+		ParticipantID: "pt-worker", RoomID: "room-1", SourceMessageID: "message-1",
+		ConversationKey: "conversation-1", TurnID: "turn-1",
+	}
+	for _, status := range []string{"running", "completed"} {
+		if err := store.DeliverActivity(context.Background(), turn, agentengine.TurnEvent{
+			Kind: agentengine.TurnEventToolCallUpdate,
+			Tool: &agentengine.ToolActivity{ID: "tool-1", Kind: "exec_command", Status: status},
+		}); err != nil {
+			t.Fatalf("DeliverActivity(%s) error = %v", status, err)
+		}
+	}
+	if err := store.DeliverMessage(context.Background(), turn, "finished"); err != nil {
+		t.Fatalf("DeliverMessage() error = %v", err)
+	}
+	if err := store.DeliverMessage(context.Background(), turn, "finished again"); err != nil {
+		t.Fatalf("DeliverMessage(replay) error = %v", err)
+	}
+
+	room, ok := imService.Room("room-1")
+	if !ok || len(room.Messages) != 2 {
+		t.Fatalf("room = %+v, want replaced tool activity and one final response", room)
+	}
+	if room.Messages[0].SenderID != "user-worker" || !strings.Contains(room.Messages[0].Content, "completed") {
+		t.Fatalf("tool message = %+v", room.Messages[0])
+	}
+	if room.Messages[1].SenderID != "user-worker" || room.Messages[1].Content != "finished again" || room.Messages[1].ID != "turn-1-final" {
+		t.Fatalf("final message = %+v", room.Messages[1])
+	}
+	for _, message := range room.Messages {
+		assertChannelMetadata(t, message.Metadata)
+	}
+}
+
+func TestIMTranscriptStorePreservesActivityAndRuntimeErrorMetadata(t *testing.T) {
+	imService := im.NewServiceFromBootstrap(im.Bootstrap{
+		CurrentUserID: "user-admin",
+		Users: []im.User{
+			{ID: "user-admin", Name: "admin"},
+			{ID: "user-worker", Name: "worker"},
+		},
+		Rooms: []im.Room{{
+			ID: "room-1", IsDirect: true, Members: []string{"user-admin", "user-worker"},
+		}},
+	})
+	store, err := NewIMTranscriptStore(imService, fixedParticipantResolver{item: apitypes.Participant{
+		ID: "pt-worker", ChannelUserRef: "user-worker",
+	}})
+	if err != nil {
+		t.Fatalf("NewIMTranscriptStore() error = %v", err)
+	}
+	turn := channel.TurnContext{
+		ParticipantID: "pt-worker", RoomID: "room-1", SourceMessageID: "message-1",
+		ConversationKey: "conversation-1", TurnID: "turn-1",
+	}
+	activityPayload := map[string]any{"type": runtimebridge.AgentActivityType}
+	if err := store.DeliverRenderedActivity(context.Background(), turn, ActivityDelivery{
+		MessageID: "question-1",
+		Text:      "question",
+		Metadata: map[string]any{
+			runtimebridge.CSGClawMetadataKey: map[string]any{
+				runtimebridge.AgentActivityMetaKey: activityPayload,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("DeliverRenderedActivity() error = %v", err)
+	}
+
+	failureTurn := turn
+	failureTurn.TurnID = "turn-2"
+	if err := store.DeliverFailure(context.Background(), failureTurn, "unexpected status 429"); err != nil {
+		t.Fatalf("DeliverFailure() error = %v", err)
+	}
+
+	room, ok := imService.Room("room-1")
+	if !ok || len(room.Messages) != 2 {
+		t.Fatalf("room = %+v, want question and failure", room)
+	}
+	assertChannelMetadata(t, room.Messages[0].Metadata)
+	questionMetadata, _ := room.Messages[0].Metadata[runtimebridge.CSGClawMetadataKey].(map[string]any)
+	if questionMetadata[runtimebridge.AgentActivityMetaKey] == nil {
+		t.Fatalf("question metadata = %#v, want preserved agent activity", room.Messages[0].Metadata)
+	}
+	assertChannelMetadata(t, room.Messages[1].Metadata)
+	failureMetadata, _ := room.Messages[1].Metadata[runtimebridge.CSGClawMetadataKey].(map[string]any)
+	if failureMetadata[runtimebridge.RuntimeErrorMetaKey] != true || failureMetadata["error_code"] != "rate_limit_exceeded" {
+		t.Fatalf("failure metadata = %#v, want runtime error fields", failureMetadata)
+	}
+}
+
+func assertChannelMetadata(t *testing.T, metadata map[string]any) map[string]any {
+	t.Helper()
+	namespace, ok := metadata[channelMetadataKey].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata = %#v, want channel namespace", metadata)
+	}
+	if len(namespace) != 2 || namespace["type"] != string(channel.ChannelCSGClaw) || namespace["version"] != channelMetadataVersion {
+		t.Fatalf("channel metadata = %#v, want only CSGClaw and version %d", namespace, channelMetadataVersion)
+	}
+	return namespace
+}

--- a/internal/channel/csgclaw/execution/execution.go
+++ b/internal/channel/csgclaw/execution/execution.go
@@ -1,0 +1,345 @@
+package execution
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/conv"
+	"csgclaw/internal/channel/csgclaw/delivery"
+	"csgclaw/internal/channel/csgclaw/files"
+	"csgclaw/internal/channelbridge"
+	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/slashcommand"
+	"csgclaw/internal/worklease"
+)
+
+// Engine is the narrow Agent Engine surface used by the built-in IM adapter.
+type Engine interface {
+	Conversations(agentID string) agentengine.ConversationInterface
+}
+
+type inboundKind string
+
+const (
+	inboundRun   inboundKind = "run"
+	inboundReset inboundKind = "reset"
+	inboundSkip  inboundKind = "skip"
+)
+
+type idGenerator func() (agentengine.TurnID, error)
+
+// Adapter converts built-in IM events into runtime-neutral Agent Engine turns.
+type Adapter struct {
+	engine      Engine
+	attachments files.Resolver
+	renderer    delivery.Renderer
+	newTurnID   idGenerator
+	work        workOptions
+}
+
+// builtInIMAdmissionPolicy deliberately preserves queued, in-order delivery
+// for consecutive messages in one conversation. A later message does not
+// cancel an earlier turn; explicit Stop and /new remain the cancellation paths.
+const builtInIMAdmissionPolicy = agentengine.AdmissionWait
+
+type Option func(*Adapter)
+
+func WithAttachmentResolver(resolver files.Resolver) Option {
+	return func(adapter *Adapter) {
+		adapter.attachments = resolver
+	}
+}
+
+func WithTurnIDGenerator(generator func() (agentengine.TurnID, error)) Option {
+	return func(adapter *Adapter) {
+		if generator != nil {
+			adapter.newTurnID = generator
+		}
+	}
+}
+
+// WithParticipantWorkReporter enables the built-in IM working/idle lease
+// lifecycle for each Engine turn.
+func WithParticipantWorkReporter(reporter worklease.ParticipantWorkReporter) Option {
+	return func(adapter *Adapter) {
+		adapter.work.reporter = reporter
+	}
+}
+
+// WithTurnControllerRegistrar exposes active built-in IM turns to the
+// participant work stop API. The stop capability is advertised only when a
+// registrar is configured.
+func WithTurnControllerRegistrar(registrar agentruntime.TurnControllerRegistrar) Option {
+	return func(adapter *Adapter) {
+		adapter.work.turnControls = registrar
+	}
+}
+
+func New(engine Engine, renderer delivery.Renderer, opts ...Option) (*Adapter, error) {
+	if engine == nil {
+		return nil, fmt.Errorf("agent engine is required")
+	}
+	adapter := &Adapter{
+		engine:   engine,
+		renderer: renderer,
+		work:     defaultWorkOptions(),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(adapter)
+		}
+	}
+	return adapter, nil
+}
+
+// Classify reports whether a source event should run, reset, or be skipped.
+func Classify(event channelbridge.BotEvent) string {
+	return string(classifyInbound(event))
+}
+
+func classifyInbound(event channelbridge.BotEvent) inboundKind {
+	text := strings.TrimSpace(event.Text)
+	if cmd, ok, err := slashcommand.Parse(text); err == nil && ok && slashcommand.IsNewConversationCommand(cmd) {
+		return inboundReset
+	}
+	if text == "" && len(event.Attachments) == 0 {
+		return inboundSkip
+	}
+	return inboundRun
+}
+
+// Handle classifies an already-routed source event and either runs a turn or
+// invokes the available Engine control capability.
+func (a *Adapter) Handle(ctx context.Context, binding channel.Binding, event channelbridge.BotEvent) (channel.Outcome, error) {
+	switch classifyInbound(event) {
+	case inboundSkip:
+		return channel.Outcome{}, nil
+	case inboundReset:
+		return a.reset(ctx, binding, event)
+	default:
+		return a.Run(ctx, binding, event)
+	}
+}
+
+// Reset delegates to the Agent Engine conversation selected by agentID.
+func (a *Adapter) Reset(ctx context.Context, agentID string, key agentengine.ConversationKey) error {
+	conversation, err := a.conversation(agentID)
+	if err != nil {
+		return err
+	}
+	return conversation.Reset(ctx, key)
+}
+
+// Cancel stops exactly one Engine turn for the selected Agent conversation.
+func (a *Adapter) Cancel(ctx context.Context, agentID string, key agentengine.ConversationKey, turnID agentengine.TurnID) error {
+	conversation, err := a.conversation(agentID)
+	if err != nil {
+		return err
+	}
+	return conversation.Cancel(ctx, key, turnID)
+}
+
+// Resolve answers one pending Engine interaction for the selected Agent.
+func (a *Adapter) Resolve(ctx context.Context, agentID string, resolution agentengine.InteractionResolution) error {
+	conversation, err := a.conversation(agentID)
+	if err != nil {
+		return err
+	}
+	return conversation.Resolve(ctx, resolution)
+}
+
+func (a *Adapter) conversation(agentID string) (agentengine.ConversationInterface, error) {
+	if a == nil || a.engine == nil {
+		return nil, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "agent engine is unavailable"}
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, &agentengine.TurnError{Code: agentengine.ErrorInvalidRequest, Message: "agent ID is required"}
+	}
+	conversation := a.engine.Conversations(agentID)
+	if conversation == nil {
+		return nil, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "agent conversation is unavailable"}
+	}
+	return conversation, nil
+}
+
+func (a *Adapter) reset(ctx context.Context, binding channel.Binding, event channelbridge.BotEvent) (outcome channel.Outcome, err error) {
+	turn, err := a.turnContext(binding, event)
+	if err != nil {
+		return channel.Outcome{}, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, finishWork := a.startWork(ctx, turn)
+	defer func() { finishWork(outcome.Result) }()
+	if err := a.Reset(ctx, turn.AgentID, turn.ConversationKey); err != nil {
+		code := agentengine.ErrorCodeOf(err)
+		if code == "" {
+			code = agentengine.ErrorRuntimeFailed
+		}
+		result := failed(code, err.Error())
+		return a.complete(ctx, turn, result)
+	}
+	return a.complete(ctx, turn, agentengine.TurnResult{
+		Status: agentengine.TurnSucceeded,
+		Output: "Cleared my internal history for this conversation. The IM room messages were not cleared.",
+	})
+}
+
+// Run executes one already-routed and already-deduplicated built-in IM event.
+func (a *Adapter) Run(ctx context.Context, binding channel.Binding, event channelbridge.BotEvent) (outcome channel.Outcome, err error) {
+	turn, err := a.turnContext(binding, event)
+	if err != nil {
+		return channel.Outcome{}, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, finishWork := a.startWork(ctx, turn)
+	defer func() { finishWork(outcome.Result) }()
+
+	input, release, inputErr := a.input(ctx, binding, event)
+	if release != nil {
+		defer release()
+	}
+	if inputErr != nil {
+		result := failed(agentengine.ErrorFileUnavailable, inputErr.Error())
+		return a.complete(ctx, turn, result)
+	}
+	if len(input) == 0 {
+		result := failed(agentengine.ErrorInvalidRequest, "message text or attachments are required")
+		return a.complete(ctx, turn, result)
+	}
+
+	conversation := a.engine.Conversations(turn.AgentID)
+	if conversation == nil {
+		result := failed(agentengine.ErrorAgentUnavailable, "agent conversation is unavailable")
+		return a.complete(ctx, turn, result)
+	}
+	result := conversation.Run(ctx, agentengine.TurnRequest{
+		ID:              turn.TurnID,
+		ConversationKey: turn.ConversationKey,
+		Input:           input,
+		Admission:       builtInIMAdmissionPolicy,
+		Continuation:    agentengine.ContinuationCreateOrResume,
+		Interaction:     agentengine.InteractionResolve,
+	}, rendererSink{renderer: a.renderer, turn: turn})
+	return a.complete(ctx, turn, result)
+}
+
+func (a *Adapter) turnContext(binding channel.Binding, event channelbridge.BotEvent) (channel.TurnContext, error) {
+	if a == nil || a.engine == nil {
+		return channel.TurnContext{}, fmt.Errorf("built-in IM adapter is not configured")
+	}
+	agentID := strings.TrimSpace(binding.AgentID)
+	participantID := strings.TrimSpace(binding.ParticipantID)
+	messageID := strings.TrimSpace(event.MessageID)
+	if agentID == "" || participantID == "" || messageID == "" {
+		return channel.TurnContext{}, fmt.Errorf("agent id, participant id, and source message id are required")
+	}
+	key, err := conv.ConversationKey(binding, event)
+	if err != nil {
+		return channel.TurnContext{}, err
+	}
+	turnID := sourceTurnID(binding, event)
+	if a.newTurnID != nil {
+		turnID, err = a.newTurnID()
+		if err != nil {
+			return channel.TurnContext{}, fmt.Errorf("generate turn id: %w", err)
+		}
+	}
+	if strings.TrimSpace(string(turnID)) == "" {
+		return channel.TurnContext{}, fmt.Errorf("generated turn id is empty")
+	}
+	return channel.TurnContext{
+		BindingID:       binding.StableID(),
+		ParticipantID:   participantID,
+		AgentID:         agentID,
+		RoomID:          strings.TrimSpace(event.RoomID),
+		Locale:          strings.TrimSpace(event.Locale),
+		ChatType:        strings.TrimSpace(event.ChatType),
+		ThreadRootID:    strings.TrimSpace(event.ThreadRootID),
+		SourceMessageID: messageID,
+		ConversationKey: key,
+		TurnID:          turnID,
+	}, nil
+}
+
+func (a *Adapter) input(ctx context.Context, binding channel.Binding, event channelbridge.BotEvent) ([]agentengine.InputPart, func(), error) {
+	if a.attachments == nil && len(event.Attachments) > 0 {
+		return nil, nil, fmt.Errorf("attachment resolver is not configured")
+	}
+
+	releases := make([]func(), 0, len(event.Attachments))
+	releaseAll := func() {
+		for index := len(releases) - 1; index >= 0; index-- {
+			if releases[index] != nil {
+				releases[index]()
+			}
+		}
+	}
+	if contextResolver, ok := a.attachments.(files.ContextResolver); ok {
+		resolved, release, err := contextResolver.ResolveContext(ctx, binding, event)
+		if err != nil {
+			return nil, nil, err
+		}
+		event = resolved
+		releases = append(releases, release)
+	}
+	input := conv.TextInput(binding, event)
+	for _, attachment := range event.Attachments {
+		file, release, err := a.attachments.Resolve(ctx, binding, event, attachment)
+		if err != nil {
+			releaseAll()
+			return nil, nil, fmt.Errorf("resolve attachment %q: %w", strings.TrimSpace(attachment.ID), err)
+		}
+		releases = append(releases, release)
+		input = append(input, agentengine.InputPart{Kind: agentengine.InputPartFile, File: &file})
+	}
+	if len(releases) == 0 {
+		return input, nil, nil
+	}
+	return input, releaseAll, nil
+}
+
+func (a *Adapter) complete(ctx context.Context, turn channel.TurnContext, result agentengine.TurnResult) (channel.Outcome, error) {
+	outcome := channel.Outcome{Turn: turn, Result: result}
+	if a.renderer == nil {
+		return outcome, nil
+	}
+	if err := a.renderer.Complete(ctx, turn, result); err != nil {
+		return outcome, fmt.Errorf("render turn result: %w", err)
+	}
+	return outcome, nil
+}
+
+func failed(code agentengine.ErrorCode, message string) agentengine.TurnResult {
+	return agentengine.TurnResult{
+		Status: agentengine.TurnFailed,
+		Error:  &agentengine.TurnError{Code: code, Message: message},
+	}
+}
+
+func sourceTurnID(binding channel.Binding, event channelbridge.BotEvent) agentengine.TurnID {
+	identity := string(binding.StableID()) + "\x00" + strings.TrimSpace(event.MessageID)
+	sum := sha256.Sum256([]byte(identity))
+	return agentengine.TurnID("turn-csgclaw-" + hex.EncodeToString(sum[:16]))
+}
+
+type rendererSink struct {
+	renderer delivery.Renderer
+	turn     channel.TurnContext
+}
+
+func (s rendererSink) Emit(ctx context.Context, event agentengine.TurnEvent) error {
+	if s.renderer == nil {
+		return nil
+	}
+	return s.renderer.Emit(ctx, s.turn, event)
+}

--- a/internal/channel/csgclaw/execution/execution_test.go
+++ b/internal/channel/csgclaw/execution/execution_test.go
@@ -1,0 +1,590 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/worklease"
+)
+
+type fakeEngine struct {
+	agentID     string
+	request     agentengine.TurnRequest
+	run         func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult
+	reset       func(context.Context, agentengine.ConversationKey) error
+	resetKey    agentengine.ConversationKey
+	cancel      func(context.Context, agentengine.ConversationKey, agentengine.TurnID) error
+	cancelCalls atomic.Int32
+	resolve     func(context.Context, agentengine.InteractionResolution) error
+}
+
+func (f *fakeEngine) Conversations(agentID string) agentengine.ConversationInterface {
+	f.agentID = agentID
+	return fakeConversation{engine: f}
+}
+
+type fakeConversation struct {
+	engine *fakeEngine
+}
+
+func (fakeConversation) Files() agentengine.FileInterface {
+	return nil
+}
+
+func (f fakeConversation) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+	f.engine.request = request
+	if f.engine.run != nil {
+		return f.engine.run(ctx, request, sink)
+	}
+	return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "done"}
+}
+
+func (f fakeConversation) Cancel(ctx context.Context, key agentengine.ConversationKey, turnID agentengine.TurnID) error {
+	f.engine.cancelCalls.Add(1)
+	if f.engine.cancel != nil {
+		return f.engine.cancel(ctx, key, turnID)
+	}
+	return nil
+}
+
+func (f fakeConversation) Reset(ctx context.Context, key agentengine.ConversationKey) error {
+	f.engine.resetKey = key
+	if f.engine.reset != nil {
+		return f.engine.reset(ctx, key)
+	}
+	return nil
+}
+
+func (f fakeConversation) Resolve(ctx context.Context, resolution agentengine.InteractionResolution) error {
+	if f.engine.resolve != nil {
+		return f.engine.resolve(ctx, resolution)
+	}
+	return nil
+}
+
+type fakeRenderer struct {
+	events   []agentengine.TurnEvent
+	complete []agentengine.TurnResult
+}
+
+func (f *fakeRenderer) Emit(_ context.Context, _ channel.TurnContext, event agentengine.TurnEvent) error {
+	f.events = append(f.events, event)
+	return nil
+}
+
+func (f *fakeRenderer) Complete(_ context.Context, _ channel.TurnContext, result agentengine.TurnResult) error {
+	f.complete = append(f.complete, result)
+	return nil
+}
+
+type fakeAttachmentResolver struct {
+	released int
+}
+
+func (f *fakeAttachmentResolver) Resolve(
+	_ context.Context,
+	_ channel.Binding,
+	_ channelbridge.BotEvent,
+	attachment channelbridge.MessageAttachment,
+) (agentengine.InputFile, func(), error) {
+	return agentengine.InputFile{ID: attachment.ID}, func() { f.released++ }, nil
+}
+
+type failingRenderer struct {
+	emitErr error
+}
+
+type recordingWorkReporter struct {
+	mu           sync.Mutex
+	starts       []worklease.ParticipantWorkLease
+	statuses     []apitypes.ParticipantWorkStatusPatchRequest
+	finishes     []string
+	controller   agentruntime.TurnController
+	unregisters  int
+	firstStarted chan struct{}
+	startOnce    sync.Once
+}
+
+func newRecordingWorkReporter() *recordingWorkReporter {
+	return &recordingWorkReporter{firstStarted: make(chan struct{})}
+}
+
+func (r *recordingWorkReporter) StartOrRenew(_ context.Context, lease worklease.ParticipantWorkLease) (apitypes.ParticipantWorkUpdate, error) {
+	r.mu.Lock()
+	r.starts = append(r.starts, lease)
+	r.mu.Unlock()
+	r.startOnce.Do(func() { close(r.firstStarted) })
+	return apitypes.ParticipantWorkUpdate{LeaseID: lease.LeaseID}, nil
+}
+
+func (r *recordingWorkReporter) Stop(context.Context, string, string) error {
+	r.mu.Lock()
+	r.finishes = append(r.finishes, apitypes.ParticipantWorkOutcomeReleased)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingWorkReporter) Finish(_ context.Context, _, _ string, outcome string) error {
+	r.mu.Lock()
+	r.finishes = append(r.finishes, outcome)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingWorkReporter) UpdateStatus(
+	_ context.Context,
+	_, _ string,
+	request apitypes.ParticipantWorkStatusPatchRequest,
+) (apitypes.ParticipantWorkUpdate, bool, error) {
+	r.mu.Lock()
+	r.statuses = append(r.statuses, request)
+	r.mu.Unlock()
+	return apitypes.ParticipantWorkUpdate{}, true, nil
+}
+
+func (r *recordingWorkReporter) RegisterTurnController(_ string, controller agentruntime.TurnController) func() {
+	r.mu.Lock()
+	r.controller = controller
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		if r.controller == controller {
+			r.controller = nil
+		}
+		r.unregisters++
+		r.mu.Unlock()
+	}
+}
+
+func (r *recordingWorkReporter) snapshot() (
+	[]worklease.ParticipantWorkLease,
+	[]apitypes.ParticipantWorkStatusPatchRequest,
+	[]string,
+	agentruntime.TurnController,
+	int,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]worklease.ParticipantWorkLease(nil), r.starts...),
+		append([]apitypes.ParticipantWorkStatusPatchRequest(nil), r.statuses...),
+		append([]string(nil), r.finishes...), r.controller, r.unregisters
+}
+
+func (f *failingRenderer) Emit(context.Context, channel.TurnContext, agentengine.TurnEvent) error {
+	return f.emitErr
+}
+
+func (f *failingRenderer) Complete(context.Context, channel.TurnContext, agentengine.TurnResult) error {
+	return nil
+}
+
+func TestAdapterRunBuildsRuntimeNeutralTurn(t *testing.T) {
+	engine := &fakeEngine{}
+	renderer := &fakeRenderer{}
+	attachments := &fakeAttachmentResolver{}
+	engine.run = func(ctx context.Context, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "answer"}); err != nil {
+			t.Fatalf("Emit() error = %v", err)
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer"}
+	}
+	adapter, err := New(
+		engine,
+		renderer,
+		WithAttachmentResolver(attachments),
+		WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-fixed", nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Run(context.Background(), channel.Binding{
+		ID: "binding:manager", ParticipantID: "manager", AgentID: "u-manager",
+	}, channelbridge.BotEvent{
+		Channel:       string(channel.ChannelCSGClaw),
+		ParticipantID: "manager",
+		MessageID:     "message-1",
+		RoomID:        "room/1",
+		ThreadRootID:  "root-1",
+		Text:          "please inspect this",
+		ThreadContext: &channelbridge.BotThreadContext{
+			RootMessageID: "root-1",
+			Context: []channelbridge.BotThreadContextMessage{{
+				ID: "root-1", SenderID: "u-admin", Content: "original question",
+			}},
+		},
+		Attachments: []channelbridge.MessageAttachment{{
+			ID: "attachment-1", Name: "report.pdf", MediaType: "application/pdf", SizeBytes: 42, SHA256: "sha",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.Result.Status != agentengine.TurnSucceeded || engine.agentID != "u-manager" {
+		t.Fatalf("outcome = %+v, agentID = %q", outcome, engine.agentID)
+	}
+	if got, want := string(engine.request.ConversationKey), "csgclaw-im:binding%3Amanager:room:room%2F1:thread:root-1"; got != want {
+		t.Fatalf("ConversationKey = %q, want %q", got, want)
+	}
+	if engine.request.ID != "turn-fixed" || outcome.Turn.SourceMessageID != "message-1" {
+		t.Fatalf("turn = %+v, request = %+v", outcome.Turn, engine.request)
+	}
+	if engine.request.Admission != agentengine.AdmissionWait ||
+		engine.request.Continuation != agentengine.ContinuationCreateOrResume ||
+		engine.request.Interaction != agentengine.InteractionResolve {
+		t.Fatalf("turn policies = %+v", engine.request)
+	}
+	if len(engine.request.Input) != 3 {
+		t.Fatalf("Input = %#v, want hidden text, current text, and file", engine.request.Input)
+	}
+	if !strings.Contains(engine.request.Input[0].Text, "Hidden thread context") || !strings.Contains(engine.request.Input[1].Text, "Current thread message") {
+		t.Fatalf("text input = %#v", engine.request.Input)
+	}
+	if file := engine.request.Input[2].File; file == nil || file.ID != "attachment-1" {
+		t.Fatalf("file input = %#v", engine.request.Input[2])
+	}
+	if attachments.released != 1 {
+		t.Fatalf("release count = %d, want 1", attachments.released)
+	}
+	if len(renderer.events) != 1 || len(renderer.complete) != 1 {
+		t.Fatalf("renderer events = %#v, complete = %#v", renderer.events, renderer.complete)
+	}
+}
+
+func TestAdapterRunReportsParticipantWorkLeaseLifecycle(t *testing.T) {
+	reporter := newRecordingWorkReporter()
+	adapter, err := New(
+		&fakeEngine{},
+		&fakeRenderer{},
+		WithParticipantWorkReporter(reporter),
+		WithTurnControllerRegistrar(reporter),
+		WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-work", nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Run(context.Background(), channel.Binding{
+		ParticipantID: "pt-worker", AgentID: "agent-worker",
+	}, channelbridge.BotEvent{
+		MessageID: "message-work", RoomID: "room-work", ThreadRootID: "thread-work", Text: "handle this",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.Result.Status != agentengine.TurnSucceeded {
+		t.Fatalf("result = %+v", outcome.Result)
+	}
+
+	starts, statuses, finishes, controller, unregisters := reporter.snapshot()
+	if len(starts) != 1 {
+		t.Fatalf("StartOrRenew calls = %#v, want one start", starts)
+	}
+	lease := starts[0]
+	if lease.ParticipantID != "pt-worker" || lease.RoomID != "room-work" || lease.ThreadRootID != "thread-work" ||
+		lease.RequestID != "message-work" || lease.Kind != apitypes.ParticipantWorkKindAgentTurn ||
+		!lease.TTLExplicit || lease.TTLSeconds != defaultWorkLeaseTTL || !worklease.ValidID(lease.LeaseID) {
+		t.Fatalf("lease = %+v", lease)
+	}
+	if len(statuses) != 1 || statuses[0].Sequence != 1 || statuses[0].Phase != apitypes.ParticipantWorkPhaseWorking ||
+		len(statuses[0].Capabilities) != 1 || statuses[0].Capabilities[0] != apitypes.ParticipantWorkCapabilityTurnStopV1 {
+		t.Fatalf("status updates = %#v", statuses)
+	}
+	if len(finishes) != 1 || finishes[0] != apitypes.ParticipantWorkOutcomeReleased {
+		t.Fatalf("finish outcomes = %#v", finishes)
+	}
+	if controller != nil || unregisters != 1 {
+		t.Fatalf("controller = %T, unregisters = %d", controller, unregisters)
+	}
+}
+
+func TestAdapterWorkStopCancelsTurnAndFinishesStopped(t *testing.T) {
+	reporter := newRecordingWorkReporter()
+	engineStarted := make(chan struct{})
+	engine := &fakeEngine{run: func(ctx context.Context, _ agentengine.TurnRequest, _ agentengine.EventSink) agentengine.TurnResult {
+		close(engineStarted)
+		<-ctx.Done()
+		return agentengine.TurnResult{Status: agentengine.TurnCanceled, Error: &agentengine.TurnError{
+			Code: agentengine.ErrorRuntimeFailed, Message: ctx.Err().Error(),
+		}}
+	}}
+	adapter, err := New(
+		engine,
+		&fakeRenderer{},
+		WithParticipantWorkReporter(reporter),
+		WithTurnControllerRegistrar(reporter),
+		WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-stop", nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result := make(chan channel.Outcome, 1)
+	go func() {
+		outcome, _ := adapter.Run(context.Background(), channel.Binding{
+			ParticipantID: "pt-worker", AgentID: "agent-worker",
+		}, channelbridge.BotEvent{MessageID: "message-stop", RoomID: "room-stop", Text: "keep working"})
+		result <- outcome
+	}()
+	select {
+	case <-engineStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Engine turn")
+	}
+	starts, _, _, controller, _ := reporter.snapshot()
+	if len(starts) != 1 || controller == nil {
+		t.Fatalf("starts = %#v, controller = %T", starts, controller)
+	}
+	lease := starts[0]
+	if err := controller.StopTurn(context.Background(), agentruntime.TurnRef{
+		ParticipantID: lease.ParticipantID,
+		RoomID:        lease.RoomID,
+		LeaseID:       lease.LeaseID,
+		RequestID:     lease.RequestID,
+	}); err != nil {
+		t.Fatalf("StopTurn() error = %v", err)
+	}
+
+	select {
+	case outcome := <-result:
+		if outcome.Result.Status != agentengine.TurnCanceled {
+			t.Fatalf("result = %+v", outcome.Result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopped turn did not return")
+	}
+	_, _, finishes, controller, unregisters := reporter.snapshot()
+	if len(finishes) != 1 || finishes[0] != apitypes.ParticipantWorkOutcomeStopped {
+		t.Fatalf("finish outcomes = %#v", finishes)
+	}
+	if controller != nil || unregisters != 1 {
+		t.Fatalf("controller = %T, unregisters = %d", controller, unregisters)
+	}
+	if engine.cancelCalls.Load() != 1 {
+		t.Fatalf("Engine Cancel calls = %d, want 1", engine.cancelCalls.Load())
+	}
+}
+
+func TestAdapterRenewsParticipantWorkLeaseUntilTurnCompletes(t *testing.T) {
+	reporter := newRecordingWorkReporter()
+	release := make(chan struct{})
+	engine := &fakeEngine{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		<-release
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "done"}
+	}}
+	adapter, err := New(
+		engine,
+		&fakeRenderer{},
+		WithParticipantWorkReporter(reporter),
+		WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-renew", nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	adapter.work.renewEvery = 5 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = adapter.Run(context.Background(), channel.Binding{
+			ParticipantID: "pt-worker", AgentID: "agent-worker",
+		}, channelbridge.BotEvent{MessageID: "message-renew", RoomID: "room-renew", Text: "keep working"})
+		close(done)
+	}()
+	select {
+	case <-reporter.firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for work lease start")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		starts, _, _, _, _ := reporter.snapshot()
+		if len(starts) >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("StartOrRenew calls = %d, want at least one renewal", len(starts))
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn did not complete")
+	}
+	_, _, finishes, _, _ := reporter.snapshot()
+	if len(finishes) != 1 || finishes[0] != apitypes.ParticipantWorkOutcomeReleased {
+		t.Fatalf("finish outcomes = %#v", finishes)
+	}
+}
+
+func TestAdapterRunRejectsAttachmentsWithoutResolver(t *testing.T) {
+	engine := &fakeEngine{}
+	renderer := &fakeRenderer{}
+	adapter, err := New(engine, renderer, WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-fixed", nil }))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Run(context.Background(), channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}, channelbridge.BotEvent{
+		MessageID: "message-1",
+		RoomID:    "room-1",
+		Text:      "see file",
+		Attachments: []channelbridge.MessageAttachment{{
+			ID: "attachment-1", Name: "report.pdf",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.Result.Error == nil || outcome.Result.Error.Code != agentengine.ErrorFileUnavailable {
+		t.Fatalf("result = %+v", outcome.Result)
+	}
+	if engine.request.ID != "" {
+		t.Fatalf("engine unexpectedly called with request %+v", engine.request)
+	}
+	if len(renderer.complete) != 1 {
+		t.Fatalf("complete calls = %d, want 1", len(renderer.complete))
+	}
+}
+
+func TestAdapterRunKeepsRendererFailureOnEnginePath(t *testing.T) {
+	engine := &fakeEngine{}
+	renderer := &failingRenderer{emitErr: errors.New("store unavailable")}
+	engine.run = func(ctx context.Context, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "partial"}); err != nil {
+			return agentengine.TurnResult{
+				Status: agentengine.TurnFailed,
+				Error:  &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()},
+			}
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded}
+	}
+	adapter, err := New(engine, renderer, WithTurnIDGenerator(func() (agentengine.TurnID, error) { return "turn-fixed", nil }))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Run(context.Background(), channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}, channelbridge.BotEvent{
+		MessageID: "message-1", RoomID: "room-1", Text: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.Result.Error == nil || !strings.Contains(outcome.Result.Error.Message, "store unavailable") {
+		t.Fatalf("result = %+v", outcome.Result)
+	}
+}
+
+func TestAdapterHandleResetUsesEngineConversation(t *testing.T) {
+	engine := &fakeEngine{}
+	adapter, err := New(engine, &fakeRenderer{}, WithTurnIDGenerator(func() (agentengine.TurnID, error) {
+		return "turn-reset", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Handle(context.Background(), channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}, channelbridge.BotEvent{
+		MessageID: "message-new",
+		RoomID:    "room-1",
+		Text:      `<slash-command name="new" arg="conversation"></slash-command>`,
+	})
+	if err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+	if outcome.Result.Status != agentengine.TurnSucceeded {
+		t.Fatalf("result = %+v", outcome.Result)
+	}
+	if engine.request.ID != "" {
+		t.Fatalf("engine unexpectedly ran request %+v", engine.request)
+	}
+	if string(engine.resetKey) == "" {
+		t.Fatal("Reset conversation key is empty")
+	}
+}
+
+func TestAdapterHandleResetMapsEngineError(t *testing.T) {
+	engine := &fakeEngine{reset: func(context.Context, agentengine.ConversationKey) error {
+		return &agentengine.TurnError{Code: agentengine.ErrorRuntimeAdapterUnavailable, Message: "reset unavailable"}
+	}}
+	renderer := &fakeRenderer{}
+	adapter, err := New(engine, renderer, WithTurnIDGenerator(func() (agentengine.TurnID, error) {
+		return "turn-reset", nil
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	outcome, err := adapter.Handle(context.Background(), channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}, channelbridge.BotEvent{
+		MessageID: "message-new",
+		RoomID:    "room-1",
+		Text:      `<slash-command name="new" arg="conversation"></slash-command>`,
+	})
+	if err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+	if outcome.Result.Status != agentengine.TurnFailed || outcome.Result.Error == nil ||
+		outcome.Result.Error.Code != agentengine.ErrorRuntimeAdapterUnavailable {
+		t.Fatalf("result = %+v", outcome.Result)
+	}
+	if len(renderer.complete) != 1 {
+		t.Fatalf("complete calls = %d, want 1", len(renderer.complete))
+	}
+}
+
+func TestAdapterDerivesStableScopedTurnIDFromSourceMessage(t *testing.T) {
+	adapter, err := New(&fakeEngine{}, &fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	binding := channel.Binding{ID: "binding-a", ParticipantID: "pt-a", AgentID: "agent-a"}
+	event := channelbridge.BotEvent{MessageID: "message-1", RoomID: "room-1", Text: "hello"}
+	first, err := adapter.turnContext(binding, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := adapter.turnContext(binding, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.TurnID == "" || first.TurnID != second.TurnID {
+		t.Fatalf("Turn IDs = %q and %q, want one stable non-empty ID", first.TurnID, second.TurnID)
+	}
+	event.MessageID = "message-2"
+	different, err := adapter.turnContext(binding, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if different.TurnID == first.TurnID {
+		t.Fatalf("different source messages shared Turn ID %q", first.TurnID)
+	}
+}
+
+func TestAdapterHandleSkipsEmptyEvents(t *testing.T) {
+	engine := &fakeEngine{}
+	adapter, err := New(engine, &fakeRenderer{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	outcome, err := adapter.Handle(context.Background(), channel.Binding{ParticipantID: "manager", AgentID: "u-manager"}, channelbridge.BotEvent{
+		MessageID: "message-empty",
+		RoomID:    "room-1",
+	})
+	if err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+	if outcome.Turn.TurnID != "" || engine.request.ID != "" {
+		t.Fatalf("empty event was executed: outcome=%+v request=%+v", outcome, engine.request)
+	}
+}

--- a/internal/channel/csgclaw/execution/work.go
+++ b/internal/channel/csgclaw/execution/work.go
@@ -1,0 +1,229 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/worklease"
+)
+
+const (
+	defaultWorkLeaseTTL      = worklease.DefaultTTLSeconds
+	defaultWorkRenewEvery    = 5 * time.Second
+	defaultWorkFinishTimeout = 2 * time.Second
+)
+
+type workOptions struct {
+	reporter      worklease.ParticipantWorkReporter
+	turnControls  agentruntime.TurnControllerRegistrar
+	ttlSeconds    int
+	renewEvery    time.Duration
+	finishTimeout time.Duration
+}
+
+func defaultWorkOptions() workOptions {
+	return workOptions{
+		ttlSeconds:    defaultWorkLeaseTTL,
+		renewEvery:    defaultWorkRenewEvery,
+		finishTimeout: defaultWorkFinishTimeout,
+	}
+}
+
+type activeWorkTurn struct {
+	lease    worklease.ParticipantWorkLease
+	cancel   context.CancelFunc
+	stop     func(context.Context) error
+	finished bool
+	stopping bool
+
+	mu sync.Mutex
+}
+
+func (a *Adapter) startWork(ctx context.Context, turn channel.TurnContext) (context.Context, func(agentengine.TurnResult)) {
+	if a == nil || a.work.reporter == nil {
+		return ctx, func(agentengine.TurnResult) {}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	turnCtx, cancelTurn := context.WithCancel(ctx)
+	lease := worklease.ParticipantWorkLease{
+		ParticipantID: strings.TrimSpace(turn.ParticipantID),
+		LeaseID:       worklease.NewID(),
+		RoomID:        strings.TrimSpace(turn.RoomID),
+		ThreadRootID:  strings.TrimSpace(turn.ThreadRootID),
+		RequestID:     strings.TrimSpace(turn.SourceMessageID),
+		Kind:          apitypes.ParticipantWorkKindAgentTurn,
+		TTLSeconds:    a.work.ttlSeconds,
+		TTLExplicit:   true,
+	}
+	active := &activeWorkTurn{
+		lease:  lease,
+		cancel: cancelTurn,
+		stop: func(stopCtx context.Context) error {
+			return a.Cancel(stopCtx, turn.AgentID, turn.ConversationKey, turn.TurnID)
+		},
+	}
+	unregister := func() {}
+	advertiseStop := a.work.turnControls != nil
+	if advertiseStop {
+		unregister = a.work.turnControls.RegisterTurnController(lease.ParticipantID, active)
+		if unregister == nil {
+			unregister = func() {}
+		}
+	}
+
+	closed := false
+	if _, err := a.work.reporter.StartOrRenew(turnCtx, lease); err != nil {
+		closed = errors.Is(err, worklease.ErrClosed)
+		logWorkFailure("start", lease, err)
+	}
+	if !closed && advertiseStop {
+		if statusReporter, ok := a.work.reporter.(worklease.ParticipantWorkStatusReporter); ok {
+			if _, _, err := statusReporter.UpdateStatus(turnCtx, lease.ParticipantID, lease.LeaseID, apitypes.ParticipantWorkStatusPatchRequest{
+				Capabilities: []string{apitypes.ParticipantWorkCapabilityTurnStopV1},
+				Sequence:     1,
+				Phase:        apitypes.ParticipantWorkPhaseWorking,
+			}); err != nil {
+				logWorkFailure("advertise stop capability", lease, err)
+			}
+		}
+	}
+
+	renewCtx, cancelRenew := context.WithCancel(turnCtx)
+	renewDone := make(chan struct{})
+	if closed {
+		close(renewDone)
+	} else {
+		go renewWorkLease(renewCtx, renewDone, a.work.reporter, lease, a.work.renewEvery)
+	}
+
+	var once sync.Once
+	return turnCtx, func(result agentengine.TurnResult) {
+		once.Do(func() {
+			stopping := active.finish()
+			unregister()
+			cancelRenew()
+			cancelTurn()
+			<-renewDone
+
+			outcome := apitypes.ParticipantWorkOutcomeReleased
+			if stopping {
+				if result.Status == agentengine.TurnCanceled {
+					outcome = apitypes.ParticipantWorkOutcomeStopped
+				} else {
+					outcome = apitypes.ParticipantWorkOutcomeStopTimedOut
+				}
+			}
+			finishCtx, cancelFinish := context.WithTimeout(context.WithoutCancel(ctx), a.work.finishTimeout)
+			defer cancelFinish()
+			var err error
+			if finisher, ok := a.work.reporter.(worklease.ParticipantWorkFinisher); ok {
+				err = finisher.Finish(finishCtx, lease.ParticipantID, lease.LeaseID, outcome)
+			} else {
+				err = a.work.reporter.Stop(finishCtx, lease.ParticipantID, lease.LeaseID)
+			}
+			if err != nil {
+				logWorkFailure("finish", lease, err)
+			}
+		})
+	}
+}
+
+func renewWorkLease(
+	ctx context.Context,
+	done chan<- struct{},
+	reporter worklease.ParticipantWorkReporter,
+	lease worklease.ParticipantWorkLease,
+	every time.Duration,
+) {
+	defer close(done)
+	if every <= 0 {
+		return
+	}
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := reporter.StartOrRenew(ctx, lease); err != nil {
+				logWorkFailure("renew", lease, err)
+				if errors.Is(err, worklease.ErrClosed) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (t *activeWorkTurn) StopTurn(ctx context.Context, ref agentruntime.TurnRef) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if t == nil || !sameWorkTurn(t.lease, ref) {
+		return agentruntime.ErrTurnNotFound
+	}
+	t.mu.Lock()
+	if t.finished {
+		t.mu.Unlock()
+		return agentruntime.ErrTurnNotFound
+	}
+	t.stopping = true
+	cancel := t.cancel
+	stop := t.stop
+	t.mu.Unlock()
+	// Cancel the caller context first so a stop that races Engine admission
+	// prevents dispatch. The exact Engine Cancel then waits for an admitted
+	// Runtime turn to finish cleanup.
+	if cancel != nil {
+		cancel()
+	}
+	if stop != nil {
+		return stop(ctx)
+	}
+	return nil
+}
+
+func (t *activeWorkTurn) finish() bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.finished = true
+	return t.stopping
+}
+
+func sameWorkTurn(lease worklease.ParticipantWorkLease, ref agentruntime.TurnRef) bool {
+	return strings.TrimSpace(lease.ParticipantID) == strings.TrimSpace(ref.ParticipantID) &&
+		strings.TrimSpace(lease.RoomID) == strings.TrimSpace(ref.RoomID) &&
+		strings.TrimSpace(lease.LeaseID) == strings.TrimSpace(ref.LeaseID) &&
+		strings.TrimSpace(lease.RequestID) == strings.TrimSpace(ref.RequestID)
+}
+
+func logWorkFailure(action string, lease worklease.ParticipantWorkLease, err error) {
+	if err == nil {
+		return
+	}
+	slog.Warn("built-in IM participant work lease "+action+" failed",
+		"participant_id", lease.ParticipantID,
+		"room_id", lease.RoomID,
+		"message_id", lease.RequestID,
+		"lease_id", lease.LeaseID,
+		"error", err,
+	)
+}

--- a/internal/channel/csgclaw/files/files.go
+++ b/internal/channel/csgclaw/files/files.go
@@ -1,0 +1,31 @@
+package files
+
+import (
+	"context"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+)
+
+// Resolver authorizes one source attachment and resolves it to an Engine InputFile.
+// The returned release function must keep the source valid until the turn finishes.
+type Resolver interface {
+	Resolve(
+		ctx context.Context,
+		binding channel.Binding,
+		event channelbridge.BotEvent,
+		attachment channelbridge.MessageAttachment,
+	) (file agentengine.InputFile, release func(), err error)
+}
+
+// ContextResolver rematerializes hidden thread-context attachments for the
+// current source message. This avoids queued replies sharing a workspace path
+// that an earlier turn may release before the later turn starts.
+type ContextResolver interface {
+	ResolveContext(
+		ctx context.Context,
+		binding channel.Binding,
+		event channelbridge.BotEvent,
+	) (resolved channelbridge.BotEvent, release func(), err error)
+}

--- a/internal/channel/csgclaw/files/local_resolver.go
+++ b/internal/channel/csgclaw/files/local_resolver.go
@@ -1,0 +1,301 @@
+package files
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+	"csgclaw/internal/im"
+)
+
+type workspaceResolver interface {
+	WorkspaceRootByID(agentID string) (string, error)
+}
+
+// LocalResolver authorizes an attachment against the routed source event and
+// materializes it inside the bound Agent workspace when needed.
+type LocalResolver struct {
+	im         *im.Service
+	workspaces workspaceResolver
+	engine     agentengine.Interface
+}
+
+func NewLocalResolver(imService *im.Service, workspaces workspaceResolver, engine agentengine.Interface) (*LocalResolver, error) {
+	if imService == nil {
+		return nil, fmt.Errorf("IM service is required")
+	}
+	if workspaces == nil {
+		return nil, fmt.Errorf("workspace resolver is required")
+	}
+	if engine == nil {
+		return nil, fmt.Errorf("agent engine is required")
+	}
+	return &LocalResolver{im: imService, workspaces: workspaces, engine: engine}, nil
+}
+
+func (r *LocalResolver) Resolve(
+	ctx context.Context,
+	binding channel.Binding,
+	event channelbridge.BotEvent,
+	attachment channelbridge.MessageAttachment,
+) (agentengine.InputFile, func(), error) {
+	if err := contextError(ctx); err != nil {
+		return agentengine.InputFile{}, nil, err
+	}
+	attachmentID := strings.TrimSpace(attachment.ID)
+	if attachmentID == "" || !eventContainsAttachment(event, attachmentID) {
+		return agentengine.InputFile{}, nil, fmt.Errorf("attachment is not part of the routed source event")
+	}
+	workspaceRoot, err := r.workspaces.WorkspaceRootByID(strings.TrimSpace(binding.AgentID))
+	if err != nil {
+		return agentengine.InputFile{}, nil, fmt.Errorf("resolve agent workspace: %w", err)
+	}
+	resolved := attachment
+	if strings.TrimSpace(resolved.WorkspacePath) == "" {
+		relativeDir := filepath.ToSlash(filepath.Join(".csgclaw", "attachments", strings.TrimSpace(event.RoomID), strings.TrimSpace(event.MessageID)))
+		resolved, err = r.im.MaterializeAttachment(attachmentID, workspaceRoot, relativeDir)
+		if err != nil {
+			return agentengine.InputFile{}, nil, err
+		}
+	}
+	release := managedAttachmentRelease(workspaceRoot, resolved.WorkspacePath)
+	sourcePath, err := resolveManagedAttachmentSourcePath(workspaceRoot, resolved.WorkspacePath)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("resolve materialized attachment source: %w", err)
+	}
+	conversation := r.engine.Conversations(strings.TrimSpace(binding.AgentID))
+	if conversation == nil || conversation.Files() == nil {
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("agent file store is unavailable")
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("open materialized attachment: %w", err)
+	}
+	info, statErr := source.Stat()
+	if statErr != nil {
+		_ = source.Close()
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("inspect materialized attachment: %w", statErr)
+	}
+	created, createErr := conversation.Files().Create(ctx, agentengine.FileCreateRequest{
+		Name:      resolved.Name,
+		MIMEType:  resolved.MediaType,
+		SizeBytes: info.Size(),
+		SHA256:    resolved.SHA256,
+	}, source)
+	closeErr := source.Close()
+	if createErr != nil || closeErr != nil {
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("store materialized attachment: %w", errors.Join(createErr, closeErr))
+	}
+	if strings.TrimSpace(created.ID) == "" {
+		if release != nil {
+			release()
+		}
+		return agentengine.InputFile{}, nil, fmt.Errorf("stored attachment file id is empty")
+	}
+	files := conversation.Files()
+	var releaseOnce sync.Once
+	return agentengine.InputFile{ID: created.ID}, func() {
+		releaseOnce.Do(func() {
+			if err := files.Delete(context.Background(), created.ID); err != nil && agentengine.ErrorCodeOf(err) != agentengine.ErrorFileNotFound {
+				slog.Warn("delete staged IM attachment from Agent Engine failed", "agent_file_id", created.ID, "error", err)
+			}
+			if release != nil {
+				release()
+			}
+		})
+	}, nil
+}
+
+func (r *LocalResolver) ResolveContext(
+	ctx context.Context,
+	binding channel.Binding,
+	event channelbridge.BotEvent,
+) (channelbridge.BotEvent, func(), error) {
+	if event.ThreadContext == nil || len(event.ThreadContext.Context) == 0 {
+		return event, nil, nil
+	}
+	if err := contextError(ctx); err != nil {
+		return channelbridge.BotEvent{}, nil, err
+	}
+	workspaceRoot, err := r.workspaces.WorkspaceRootByID(strings.TrimSpace(binding.AgentID))
+	if err != nil {
+		return channelbridge.BotEvent{}, nil, fmt.Errorf("resolve agent workspace for thread context: %w", err)
+	}
+	thread := *event.ThreadContext
+	thread.Context = append([]channelbridge.BotThreadContextMessage(nil), event.ThreadContext.Context...)
+	var releases []func()
+	releaseAll := func() {
+		for index := len(releases) - 1; index >= 0; index-- {
+			if releases[index] != nil {
+				releases[index]()
+			}
+		}
+	}
+	for messageIndex := range thread.Context {
+		message := &thread.Context[messageIndex]
+		message.Attachments = append([]channelbridge.MessageAttachment(nil), message.Attachments...)
+		for attachmentIndex := range message.Attachments {
+			attachment := &message.Attachments[attachmentIndex]
+			if release := managedAttachmentRelease(workspaceRoot, attachment.WorkspacePath); release != nil {
+				releases = append(releases, release)
+			}
+			attachmentID := strings.TrimSpace(attachment.ID)
+			if attachmentID == "" {
+				continue
+			}
+			relativeDir := filepath.ToSlash(filepath.Join(
+				".csgclaw", "attachments",
+				strings.TrimSpace(event.RoomID),
+				strings.TrimSpace(event.MessageID),
+				"thread-context",
+				strings.TrimSpace(message.ID),
+			))
+			resolved, resolveErr := r.im.MaterializeAttachment(attachmentID, workspaceRoot, relativeDir)
+			if resolveErr != nil {
+				releaseAll()
+				return channelbridge.BotEvent{}, nil, fmt.Errorf("materialize thread context attachment %q: %w", attachmentID, resolveErr)
+			}
+			*attachment = resolved
+			releases = append(releases, managedAttachmentRelease(workspaceRoot, resolved.WorkspacePath))
+		}
+	}
+	event.ThreadContext = &thread
+	if len(releases) == 0 {
+		return event, nil, nil
+	}
+	return event, releaseAll, nil
+}
+
+// resolveManagedAttachmentSourcePath converts the API-facing workspace path
+// into a host path that Agent Engine can read without depending on the server
+// process working directory. The resolved file must remain under the managed
+// attachment directory, including when workspace path components are symlinks.
+func resolveManagedAttachmentSourcePath(workspaceRoot, sourcePath string) (string, error) {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	sourcePath = strings.TrimSpace(filepath.FromSlash(sourcePath))
+	if workspaceRoot == "" || sourcePath == "" {
+		return "", fmt.Errorf("workspace root and attachment path are required")
+	}
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace root symlinks: %w", err)
+	}
+	target := sourcePath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", fmt.Errorf("resolve attachment path: %w", err)
+	}
+	target, err = filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", fmt.Errorf("resolve attachment path symlinks: %w", err)
+	}
+	managedRoot := filepath.Join(root, ".csgclaw", "attachments")
+	managedRoot, err = filepath.EvalSymlinks(managedRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve managed attachment root: %w", err)
+	}
+	if !pathWithinRoot(managedRoot, target) || target == managedRoot {
+		return "", fmt.Errorf("attachment path is outside the managed workspace directory")
+	}
+	return target, nil
+}
+
+func pathWithinRoot(root, target string) bool {
+	relative, err := filepath.Rel(root, target)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func managedAttachmentRelease(workspaceRoot, sourcePath string) func() {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	sourcePath = strings.TrimSpace(filepath.FromSlash(sourcePath))
+	if workspaceRoot == "" || sourcePath == "" {
+		return nil
+	}
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return nil
+	}
+	target := sourcePath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return nil
+	}
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	managedRoot := filepath.Join(root, ".csgclaw", "attachments")
+	managedRelative, err := filepath.Rel(managedRoot, target)
+	if err != nil || managedRelative == "." || managedRelative == ".." || strings.HasPrefix(managedRelative, ".."+string(filepath.Separator)) {
+		return nil
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+				slog.Warn("remove materialized IM attachment failed", "path", target, "error", err)
+				return
+			}
+			for parent := filepath.Dir(target); parent != managedRoot; parent = filepath.Dir(parent) {
+				if err := os.Remove(parent); err != nil {
+					break
+				}
+			}
+		})
+	}
+}
+
+func eventContainsAttachment(event channelbridge.BotEvent, attachmentID string) bool {
+	for _, candidate := range event.Attachments {
+		if strings.TrimSpace(candidate.ID) == attachmentID {
+			return true
+		}
+	}
+	return false
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}

--- a/internal/channel/csgclaw/files/local_resolver_test.go
+++ b/internal/channel/csgclaw/files/local_resolver_test.go
@@ -1,0 +1,146 @@
+package files
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+	"csgclaw/internal/im"
+)
+
+type staticWorkspaceResolver struct {
+	root string
+}
+
+func (r staticWorkspaceResolver) WorkspaceRootByID(string) (string, error) {
+	return r.root, nil
+}
+
+type staticEngine struct {
+	files agentengine.FileInterface
+}
+
+func (e staticEngine) Agents() agentengine.AgentInterface {
+	return nil
+}
+
+func (e staticEngine) Conversations(string) agentengine.ConversationInterface {
+	return staticConversation{files: e.files}
+}
+
+type staticConversation struct {
+	files agentengine.FileInterface
+}
+
+func (c staticConversation) Files() agentengine.FileInterface {
+	return c.files
+}
+
+func (staticConversation) Run(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+	return agentengine.TurnResult{}
+}
+
+func (staticConversation) Cancel(context.Context, agentengine.ConversationKey, agentengine.TurnID) error {
+	return nil
+}
+
+func (staticConversation) Reset(context.Context, agentengine.ConversationKey) error {
+	return nil
+}
+
+func (staticConversation) Resolve(context.Context, agentengine.InteractionResolution) error {
+	return nil
+}
+
+func TestLocalResolverStoresManagedAttachmentInAgentEngine(t *testing.T) {
+	service, err := im.NewServiceFromPath(filepath.Join(t.TempDir(), "im", "state.json"))
+	if err != nil {
+		t.Fatalf("NewServiceFromPath() error = %v", err)
+	}
+	if _, _, err := service.EnsureAgentUser(im.EnsureAgentUserRequest{ID: "agent-worker", Name: "worker", Role: "worker"}); err != nil {
+		t.Fatalf("EnsureAgentUser() error = %v", err)
+	}
+	room, err := service.CreateRoom(im.CreateRoomRequest{
+		Title: "Ops", CreatorID: "user-admin", MemberIDs: []string{"user-worker"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRoom() error = %v", err)
+	}
+	payload := []byte("image fixture")
+	message, err := service.CreateMessage(im.CreateMessageRequest{
+		RoomID: room.ID, SenderID: "user-admin", Attachments: []im.MessageAttachmentUpload{{
+			Name: "diagram.png", MediaType: "image/png", Data: payload,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage() error = %v", err)
+	}
+	if len(message.Attachments) != 1 {
+		t.Fatalf("attachments = %+v, want one attachment", message.Attachments)
+	}
+
+	workspaceRoot := t.TempDir()
+	fileStore := agentengine.NewFileStore().Scope("agent-worker")
+	resolver, err := NewLocalResolver(service, staticWorkspaceResolver{root: workspaceRoot}, staticEngine{files: fileStore})
+	if err != nil {
+		t.Fatalf("NewLocalResolver() error = %v", err)
+	}
+	attachment := message.Attachments[0]
+	input, release, err := resolver.Resolve(
+		context.Background(),
+		channel.Binding{AgentID: "agent-worker"},
+		channelbridge.BotEvent{RoomID: room.ID, MessageID: message.ID, Attachments: message.Attachments},
+		attachment,
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if input.ID == "" {
+		t.Fatal("InputFile.ID is empty")
+	}
+	download, err := fileStore.Get(context.Background(), input.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	got, readErr := io.ReadAll(download.Content)
+	closeErr := download.Content.Close()
+	if readErr != nil || closeErr != nil || string(got) != string(payload) {
+		t.Fatalf("stored content = %q, readErr=%v, closeErr=%v, want %q", string(got), readErr, closeErr, string(payload))
+	}
+	if release == nil {
+		t.Fatal("release = nil, want managed attachment cleanup")
+	}
+	release()
+	if _, err := fileStore.Get(context.Background(), input.ID); agentengine.ErrorCodeOf(err) != agentengine.ErrorFileNotFound {
+		t.Fatalf("Get() after release error = %v, want file_not_found", err)
+	}
+	managedFiles, err := filepath.Glob(filepath.Join(workspaceRoot, ".csgclaw", "attachments", "*", "*", "*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range managedFiles {
+		if info, statErr := os.Stat(path); statErr == nil && info.Mode().IsRegular() {
+			t.Fatalf("managed source still exists after release: %s", path)
+		}
+	}
+}
+
+func TestResolveManagedAttachmentSourcePathRejectsOutsideWorkspace(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	managedRoot := filepath.Join(workspaceRoot, ".csgclaw", "attachments")
+	if err := os.MkdirAll(managedRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(t.TempDir(), "outside.png")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveManagedAttachmentSourcePath(workspaceRoot, outsidePath); err == nil {
+		t.Fatal("resolveManagedAttachmentSourcePath() error = nil, want outside path rejected")
+	}
+}

--- a/internal/channel/csgclaw/ingress/ingress.go
+++ b/internal/channel/csgclaw/ingress/ingress.go
@@ -1,0 +1,350 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/conv"
+	"csgclaw/internal/channel/csgclaw/execution"
+	"csgclaw/internal/channel/csgclaw/state"
+	"csgclaw/internal/channelbridge"
+)
+
+const (
+	defaultQueueSize        = 32
+	defaultSeenWindow       = 256
+	defaultConcurrentScopes = 8
+)
+
+// Worker is a Binding-scoped source buffer. It dedupes source events, preserves
+// source order within one Conversation, and lets independent Conversations run
+// concurrently. Agent Engine remains the final owner of Turn admission.
+type Worker struct {
+	adapter *execution.Adapter
+	binding channel.Binding
+	queue   chan queuedEvent
+	cancel  context.CancelFunc
+	done    chan struct{}
+
+	mu         sync.Mutex
+	stopped    bool
+	queued     map[string]struct{}
+	latest     map[string]string
+	seen       *state.SeenWindow
+	processing map[string]struct{}
+	active     map[agentengine.ConversationKey]map[string]context.CancelFunc
+	generation map[agentengine.ConversationKey]uint64
+}
+
+type queuedEvent struct {
+	event           channelbridge.BotEvent
+	dedupeKey       string
+	conversationKey agentengine.ConversationKey
+	generation      uint64
+}
+
+func NewWorker(adapter *execution.Adapter, binding channel.Binding) (*Worker, error) {
+	if adapter == nil {
+		return nil, fmt.Errorf("built-in IM adapter is required")
+	}
+	if binding.StableID() == "" || strings.TrimSpace(binding.AgentID) == "" {
+		return nil, fmt.Errorf("binding id and agent id are required")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &Worker{
+		adapter:    adapter,
+		binding:    binding,
+		queue:      make(chan queuedEvent, defaultQueueSize),
+		queued:     make(map[string]struct{}),
+		latest:     make(map[string]string),
+		seen:       state.NewSeenWindow(defaultSeenWindow),
+		processing: make(map[string]struct{}),
+		active:     make(map[agentengine.ConversationKey]map[string]context.CancelFunc),
+		generation: make(map[agentengine.ConversationKey]uint64),
+		cancel:     cancel,
+		done:       make(chan struct{}),
+	}
+	go w.run(ctx)
+	return w, nil
+}
+
+func (w *Worker) SameBinding(binding channel.Binding) bool {
+	if w == nil {
+		return false
+	}
+	return w.binding.AgentID == strings.TrimSpace(binding.AgentID) &&
+		w.binding.ParticipantID == strings.TrimSpace(binding.ParticipantID)
+}
+
+func (w *Worker) Submit(event channelbridge.BotEvent) error {
+	if w == nil {
+		return fmt.Errorf("binding worker is not running")
+	}
+	item, accepted, err := w.acceptAndEnqueue(event)
+	if err != nil {
+		return err
+	}
+	if !accepted {
+		return nil
+	}
+	// A reset must interrupt the current context before it can reach the
+	// conversation-aware ingress scheduler. Waiting for handle to return would
+	// otherwise leave /new stuck behind the turn that it is supposed to stop.
+	if execution.Classify(event) == "reset" {
+		w.cancelConversation(item.conversationKey)
+	}
+	return nil
+}
+
+func (w *Worker) Close(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	w.mu.Lock()
+	if !w.stopped {
+		w.stopped = true
+		w.cancel()
+		for _, turns := range w.active {
+			for _, cancel := range turns {
+				if cancel != nil {
+					cancel()
+				}
+			}
+		}
+		w.active = make(map[agentengine.ConversationKey]map[string]context.CancelFunc)
+	}
+	w.mu.Unlock()
+	select {
+	case <-w.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// IsCurrent reports whether sourceMessageID is still the newest accepted
+// source for one Conversation. Detached interactions use this to avoid
+// resuming an older workflow after a newer message has already been queued.
+func (w *Worker) IsCurrent(key agentengine.ConversationKey, sourceMessageID string) bool {
+	if w == nil {
+		return false
+	}
+	scope := strings.TrimSpace(string(key))
+	sourceMessageID = strings.TrimSpace(sourceMessageID)
+	if scope == "" || sourceMessageID == "" {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.TrimSpace(w.latest[scope]) == sourceMessageID
+}
+
+func (w *Worker) run(ctx context.Context) {
+	defer close(w.done)
+	pending := make([]queuedEvent, 0, defaultQueueSize)
+	activeScopes := make(map[agentengine.ConversationKey]struct{})
+	completed := make(chan agentengine.ConversationKey, defaultConcurrentScopes)
+	var handlers sync.WaitGroup
+	defer handlers.Wait()
+
+	dispatch := func() {
+		for index := 0; index < len(pending); {
+			item := pending[index]
+			if w.isCurrentGeneration(item) {
+				index++
+				continue
+			}
+			pending = append(pending[:index], pending[index+1:]...)
+			w.discardQueued(item.dedupeKey)
+		}
+		for len(activeScopes) < defaultConcurrentScopes {
+			index := nextDispatchable(pending, activeScopes)
+			if index < 0 {
+				return
+			}
+			item := pending[index]
+			pending = append(pending[:index], pending[index+1:]...)
+			activeScopes[item.conversationKey] = struct{}{}
+			w.beginProcessing(item.dedupeKey)
+			handlers.Add(1)
+			go func() {
+				defer handlers.Done()
+				w.handle(ctx, item)
+				w.finishProcessing(item.dedupeKey)
+				completed <- item.conversationKey
+			}()
+		}
+	}
+
+	for {
+		dispatch()
+		select {
+		case <-ctx.Done():
+			return
+		case item := <-w.queue:
+			pending = append(pending, item)
+		case scope := <-completed:
+			delete(activeScopes, scope)
+		}
+	}
+}
+
+func (w *Worker) handle(ctx context.Context, item queuedEvent) {
+	if ctx.Err() != nil {
+		return
+	}
+	turnCtx, cancel := context.WithCancel(ctx)
+	if !w.setActive(item, cancel) {
+		cancel()
+		return
+	}
+	defer func() {
+		cancel()
+		w.clearActive(item.conversationKey, item.dedupeKey)
+	}()
+	outcome, err := w.adapter.Handle(turnCtx, w.binding, item.event)
+	if err != nil {
+		slog.Error("handle built-in IM event failed",
+			"binding_id", w.binding.StableID(),
+			"participant_id", w.binding.ParticipantID,
+			"message_id", item.event.MessageID,
+			"conversation_key", item.conversationKey,
+			"turn_id", outcome.Turn.TurnID,
+			"error", err,
+		)
+	}
+}
+
+func (w *Worker) acceptAndEnqueue(event channelbridge.BotEvent) (queuedEvent, bool, error) {
+	key := eventDedupKey(event)
+	if key == "" {
+		return queuedEvent{}, false, nil
+	}
+	conversationKey, err := conv.ConversationKey(w.binding, event)
+	if err != nil {
+		return queuedEvent{}, false, err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stopped {
+		return queuedEvent{}, false, fmt.Errorf("binding worker is stopped")
+	}
+	if w.seen.Has(key) {
+		return queuedEvent{}, false, nil
+	}
+	if _, ok := w.queued[key]; ok {
+		return queuedEvent{}, false, nil
+	}
+	if _, ok := w.processing[key]; ok {
+		return queuedEvent{}, false, nil
+	}
+	if len(w.queued) >= defaultQueueSize {
+		return queuedEvent{}, false, fmt.Errorf("binding worker queue is full")
+	}
+	generation := w.generation[conversationKey]
+	if execution.Classify(event) == "reset" {
+		generation++
+	}
+	item := queuedEvent{
+		event:           event,
+		dedupeKey:       key,
+		conversationKey: conversationKey,
+		generation:      generation,
+	}
+	select {
+	case w.queue <- item:
+		w.generation[conversationKey] = generation
+		w.queued[key] = struct{}{}
+		w.latest[string(conversationKey)] = key
+		return item, true, nil
+	default:
+		return queuedEvent{}, false, fmt.Errorf("binding worker queue is full")
+	}
+}
+
+func (w *Worker) isCurrentGeneration(item queuedEvent) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.generation[item.conversationKey] == item.generation
+}
+
+func (w *Worker) discardQueued(key string) {
+	w.mu.Lock()
+	delete(w.queued, key)
+	w.seen.Add(key)
+	w.mu.Unlock()
+}
+
+func (w *Worker) beginProcessing(key string) {
+	w.mu.Lock()
+	delete(w.queued, key)
+	w.processing[key] = struct{}{}
+	w.mu.Unlock()
+}
+
+func (w *Worker) finishProcessing(key string) {
+	w.mu.Lock()
+	delete(w.processing, key)
+	w.seen.Add(key)
+	w.mu.Unlock()
+}
+
+func (w *Worker) setActive(item queuedEvent, cancel context.CancelFunc) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.generation[item.conversationKey] != item.generation {
+		return false
+	}
+	if w.active[item.conversationKey] == nil {
+		w.active[item.conversationKey] = make(map[string]context.CancelFunc)
+	}
+	w.active[item.conversationKey][item.dedupeKey] = cancel
+	return true
+}
+
+func (w *Worker) clearActive(key agentengine.ConversationKey, sourceMessageID string) {
+	w.mu.Lock()
+	if turns := w.active[key]; turns != nil {
+		delete(turns, sourceMessageID)
+		if len(turns) == 0 {
+			delete(w.active, key)
+		}
+	}
+	w.mu.Unlock()
+}
+
+func (w *Worker) cancelConversation(key agentengine.ConversationKey) {
+	if key == "" {
+		return
+	}
+	w.mu.Lock()
+	turns := w.active[key]
+	delete(w.active, key)
+	w.mu.Unlock()
+	for _, cancel := range turns {
+		if cancel != nil {
+			cancel()
+		}
+	}
+}
+
+func nextDispatchable(pending []queuedEvent, active map[agentengine.ConversationKey]struct{}) int {
+	for index, item := range pending {
+		if _, busy := active[item.conversationKey]; !busy {
+			return index
+		}
+	}
+	return -1
+}
+
+func eventDedupKey(event channelbridge.BotEvent) string {
+	return strings.TrimSpace(event.MessageID)
+}

--- a/internal/channel/csgclaw/interaction/interaction.go
+++ b/internal/channel/csgclaw/interaction/interaction.go
@@ -1,0 +1,258 @@
+// Package interaction connects Agent Engine interaction events to the existing
+// built-in IM question UI and Codex user-input broker.
+package interaction
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"csgclaw/internal/activity"
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/delivery"
+	"csgclaw/internal/channelbridge"
+	"csgclaw/internal/channelbridge/runtimebridge"
+	"csgclaw/internal/participant"
+	runtimecodex "csgclaw/internal/runtime/codex"
+)
+
+type participantResolver interface {
+	Get(channel, id string) (apitypes.Participant, bool)
+}
+
+type eventSubmitter interface {
+	Submit(channel.Binding, channelbridge.BotEvent) error
+	IsCurrent(channel.BindingID, agentengine.ConversationKey, string) bool
+}
+
+type detachedRequest struct {
+	turn    channel.TurnContext
+	binding channel.Binding
+}
+
+// Coordinator binds blocking Runtime interactions and activates detached
+// request_user_input structured outputs. It intentionally reuses the existing
+// broker and Web APIs instead of adding an Engine-specific browser endpoint.
+type Coordinator struct {
+	broker       runtimecodex.UserInputBroker
+	participants participantResolver
+	store        *delivery.IMTranscriptStore
+
+	mu        sync.Mutex
+	submitter eventSubmitter
+	requests  map[string]detachedRequest
+}
+
+func NewCoordinator(
+	broker runtimecodex.UserInputBroker,
+	participants participantResolver,
+	store *delivery.IMTranscriptStore,
+) *Coordinator {
+	if broker == nil || participants == nil || store == nil {
+		return nil
+	}
+	coordinator := &Coordinator{
+		broker:       broker,
+		participants: participants,
+		store:        store,
+		requests:     make(map[string]detachedRequest),
+	}
+	broker.AddDetachedHandler(coordinator.handleDetachedResolution)
+	return coordinator
+}
+
+func (c *Coordinator) SetSubmitter(submitter eventSubmitter) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.submitter = submitter
+	c.mu.Unlock()
+}
+
+func (c *Coordinator) Bind(requestID, channelID, roomID, threadRootID, requesterID string) (activity.UserInputSnapshot, error) {
+	if c == nil || c.broker == nil {
+		return activity.UserInputSnapshot{}, activity.ErrUserInputNotFound
+	}
+	return c.broker.Bind(requestID, channelID, roomID, threadRootID, c.channelUserID(requesterID))
+}
+
+func (c *Coordinator) Activate(
+	ctx context.Context,
+	turn channel.TurnContext,
+	args activity.RequestUserInputArgs,
+) (activity.UserInputSnapshot, error) {
+	if c == nil || c.broker == nil {
+		return activity.UserInputSnapshot{}, fmt.Errorf("structured user input is not configured")
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return activity.UserInputSnapshot{}, ctx.Err()
+		default:
+		}
+	}
+	questions := make([]activity.UserInputQuestionSnapshot, 0, len(args.Questions))
+	for _, question := range args.Questions {
+		options := make([]activity.UserInputOptionSnapshot, 0, len(question.Options))
+		for _, option := range question.Options {
+			options = append(options, activity.UserInputOptionSnapshot{
+				Label:       option.Label,
+				Description: option.Description,
+			})
+		}
+		questions = append(questions, activity.UserInputQuestionSnapshot{
+			ID:       question.ID,
+			Header:   question.Header,
+			Question: question.Question,
+			Options:  options,
+			IsOther:  question.IsOther,
+			IsSecret: question.IsSecret,
+		})
+	}
+	var autoResolve time.Duration
+	if args.AutoResolutionMS != nil {
+		autoResolve = time.Duration(*args.AutoResolutionMS) * time.Millisecond
+	}
+	snapshot, err := c.broker.CreateDetached(runtimecodex.PendingUserInputRequest{
+		Execution: activity.ExecutionRef{
+			RuntimeKind: "codex",
+			TurnID:      string(turn.TurnID),
+			ToolCallID:  "structured-output-" + strings.TrimSpace(turn.SourceMessageID),
+			ToolKind:    "request_user_input",
+		},
+		Questions:   questions,
+		RequestedAt: time.Now().UTC(),
+		AutoResolve: autoResolve,
+	}, runtimecodex.DetachedUserInputContext{
+		Channel:         string(channel.ChannelCSGClaw),
+		RoomID:          strings.TrimSpace(turn.RoomID),
+		ThreadRootID:    strings.TrimSpace(turn.ThreadRootID),
+		SourceMessageID: strings.TrimSpace(turn.SourceMessageID),
+		RequesterID:     c.channelUserID(turn.ParticipantID),
+	})
+	if err != nil {
+		return activity.UserInputSnapshot{}, err
+	}
+	c.mu.Lock()
+	c.requests[snapshot.ID] = detachedRequest{
+		turn: turn,
+		binding: channel.Binding{
+			ID:            string(turn.BindingID),
+			Channel:       channel.ChannelCSGClaw,
+			ParticipantID: turn.ParticipantID,
+			AgentID:       turn.AgentID,
+			Enabled:       true,
+		},
+	}
+	c.mu.Unlock()
+	return snapshot, nil
+}
+
+func (c *Coordinator) handleDetachedResolution(resolution runtimecodex.DetachedUserInputResolution) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	request, ok := c.requests[resolution.Snapshot.ID]
+	if ok {
+		delete(c.requests, resolution.Snapshot.ID)
+	}
+	submitter := c.submitter
+	c.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	snapshot := resolution.Snapshot
+	if snapshot.Status == activity.UserInputStatusAnswered &&
+		(submitter == nil || !submitter.IsCurrent(request.turn.BindingID, request.turn.ConversationKey, request.turn.SourceMessageID)) {
+		snapshot.Status = activity.UserInputStatusInterrupted
+		now := time.Now().UTC()
+		snapshot.ResolvedAt = &now
+	}
+	if err := c.persistResolution(request.turn, snapshot); err != nil {
+		slog.Warn("persist structured user input resolution failed", "request_id", resolution.Snapshot.ID, "error", err)
+		return
+	}
+	if snapshot.Status != activity.UserInputStatusAnswered || submitter == nil {
+		return
+	}
+	body, err := json.Marshal(activity.RedactSecretUserInputResponse(snapshot, resolution.Response))
+	if err != nil {
+		slog.Warn("encode structured user input continuation failed", "request_id", resolution.Snapshot.ID, "error", err)
+		return
+	}
+	prompt := "The user answered the request_user_input emitted by the previous successful command. Continue the same workflow using this wire-compatible response JSON. Secret values are replaced with <redacted> before entering the model session:\n" + string(body)
+	if err := submitter.Submit(request.binding, channelbridge.BotEvent{
+		Channel:       string(channel.ChannelCSGClaw),
+		ParticipantID: request.binding.ParticipantID,
+		MessageID:     "structured-user-input-" + resolution.Snapshot.ID,
+		RoomID:        request.turn.RoomID,
+		Locale:        request.turn.Locale,
+		ChatType:      request.turn.ChatType,
+		Text:          prompt,
+		ThreadRootID:  request.turn.ThreadRootID,
+	}); err != nil {
+		slog.Warn("submit structured user input continuation failed", "request_id", resolution.Snapshot.ID, "error", err)
+	}
+}
+
+func (c *Coordinator) persistResolution(turn channel.TurnContext, snapshot activity.UserInputSnapshot) error {
+	event := activity.RuntimeEvent{
+		RuntimeKind:     "codex",
+		RuntimeID:       string(turn.BindingID),
+		SessionID:       string(turn.ConversationKey),
+		TurnID:          string(turn.TurnID),
+		Kind:            activity.RuntimeEventUserInputResolved,
+		ReceivedAt:      time.Now().UTC(),
+		UserInputID:     snapshot.ID,
+		UserInputStatus: string(snapshot.Status),
+		Payload:         snapshot,
+	}
+	rendered, ok := runtimebridge.NewTurnRenderer().RenderActivity(
+		event,
+		string(channel.ChannelCSGClaw),
+		turn.RoomID,
+		turn.ParticipantID,
+	)
+	if !ok {
+		return fmt.Errorf("render structured user input resolution")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return c.store.DeliverRenderedActivity(ctx, turn, delivery.ActivityDelivery{
+		MessageID:    rendered.MessageID,
+		Text:         rendered.Text,
+		Metadata:     rendered.Metadata,
+		ThreadRootID: turn.ThreadRootID,
+		Event: agentengine.TurnEvent{
+			TurnID: turn.TurnID,
+			Kind:   agentengine.TurnEventActivityUpdate,
+			Activity: &agentengine.ActivityUpdate{
+				ID:      snapshot.ID,
+				Kind:    string(activity.RuntimeEventUserInputResolved),
+				Status:  string(snapshot.Status),
+				Payload: snapshot,
+			},
+		},
+	})
+}
+
+func (c *Coordinator) channelUserID(participantID string) string {
+	participantID = strings.TrimSpace(participantID)
+	if c != nil && c.participants != nil {
+		if item, ok := c.participants.Get(participant.ChannelCSGClaw, participantID); ok {
+			if channelUserRef := strings.TrimSpace(item.ChannelUserRef); channelUserRef != "" {
+				return channelUserRef
+			}
+		}
+	}
+	return participantID
+}

--- a/internal/channel/csgclaw/source/source.go
+++ b/internal/channel/csgclaw/source/source.go
@@ -1,0 +1,471 @@
+// Package source connects built-in IM participant events to Binding-scoped
+// ingress workers without using the legacy HTTP/SSE Codex bridge.
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/binding"
+	"csgclaw/internal/channelbridge"
+	"csgclaw/internal/im"
+	"csgclaw/internal/participant"
+	agentruntime "csgclaw/internal/runtime"
+)
+
+const (
+	defaultReconcileInterval = 30 * time.Second
+	defaultRetryInitial      = 50 * time.Millisecond
+	defaultRetryMax          = time.Second
+)
+
+type participantProvider interface {
+	List(participant.ListOptions) []apitypes.Participant
+}
+
+type agentProvider interface {
+	Get(context.Context, string) (agentengine.Agent, error)
+}
+
+type workerManager interface {
+	Ensure(channel.Binding) error
+	Stop(channel.BindingID)
+	Submit(channel.Binding, channelbridge.BotEvent) error
+	Close()
+}
+
+// Source owns the in-process event subscriptions for built-in IM bindings.
+// The subscription lifetime follows the Binding, not the Agent runtime.
+type Source struct {
+	bridge         *im.ParticipantBridge
+	bus            *im.Bus
+	participants   participantProvider
+	agents         agentProvider
+	workers        workerManager
+	reconcileEvery time.Duration
+	retryInitial   time.Duration
+	retryMax       time.Duration
+
+	reconcileMu   sync.Mutex
+	mu            sync.Mutex
+	cancel        context.CancelFunc
+	cancelBus     func()
+	subscriptions map[channel.BindingID]*subscription
+	wg            sync.WaitGroup
+}
+
+type subscription struct {
+	binding channel.Binding
+	cancel  func()
+}
+
+func New(
+	bridge *im.ParticipantBridge,
+	bus *im.Bus,
+	participants participantProvider,
+	agents agentProvider,
+	workers *binding.Manager,
+) (*Source, error) {
+	return newSource(bridge, bus, participants, agents, workers)
+}
+
+func newSource(
+	bridge *im.ParticipantBridge,
+	bus *im.Bus,
+	participants participantProvider,
+	agents agentProvider,
+	workers workerManager,
+) (*Source, error) {
+	if bridge == nil {
+		return nil, fmt.Errorf("participant event bridge is required")
+	}
+	if participants == nil {
+		return nil, fmt.Errorf("participant provider is required")
+	}
+	if agents == nil {
+		return nil, fmt.Errorf("agent provider is required")
+	}
+	if workers == nil {
+		return nil, fmt.Errorf("binding worker manager is required")
+	}
+	return &Source{
+		bridge:         bridge,
+		bus:            bus,
+		participants:   participants,
+		agents:         agents,
+		workers:        workers,
+		reconcileEvery: defaultReconcileInterval,
+		retryInitial:   defaultRetryInitial,
+		retryMax:       defaultRetryMax,
+		subscriptions:  make(map[channel.BindingID]*subscription),
+	}, nil
+}
+
+// Start ensures workers and event subscriptions for persisted Codex bindings,
+// then follows Participant events and periodically reconciles Agent eligibility.
+func (s *Source) Start(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	s.mu.Lock()
+	if s.cancel != nil {
+		s.mu.Unlock()
+		return nil
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	var lifecycleEvents <-chan im.Event
+	if s.bus != nil {
+		lifecycleEvents, s.cancelBus = s.bus.Subscribe()
+	}
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	if err := s.Reconcile(runCtx); err != nil {
+		s.Close()
+		return err
+	}
+	s.wg.Add(1)
+	go s.followDesiredState(runCtx, lifecycleEvents)
+	return nil
+}
+
+func (s *Source) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	cancelBus := s.cancelBus
+	s.cancelBus = nil
+	subscriptions := make([]*subscription, 0, len(s.subscriptions))
+	for id, sub := range s.subscriptions {
+		subscriptions = append(subscriptions, sub)
+		delete(s.subscriptions, id)
+	}
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if cancelBus != nil {
+		cancelBus()
+	}
+	for _, sub := range subscriptions {
+		if sub != nil && sub.cancel != nil {
+			sub.cancel()
+		}
+	}
+	s.wg.Wait()
+	if s.workers != nil {
+		s.workers.Close()
+	}
+}
+
+func (s *Source) followDesiredState(ctx context.Context, events <-chan im.Event) {
+	defer s.wg.Done()
+	interval := s.reconcileEvery
+	if interval <= 0 {
+		interval = defaultReconcileInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.Reconcile(ctx); err != nil && ctx.Err() == nil {
+				slog.Warn("reconcile built-in IM bindings failed", "error", err)
+			}
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			if event.Participant == nil || !strings.EqualFold(strings.TrimSpace(event.Participant.Channel), participant.ChannelCSGClaw) {
+				continue
+			}
+			switch event.Type {
+			case im.EventTypeParticipantCreated, im.EventTypeParticipantUpdated, im.EventTypeParticipantDeleted:
+				if err := s.Reconcile(ctx); err != nil && ctx.Err() == nil {
+					slog.Warn("refresh built-in IM bindings failed", "participant_id", event.Participant.ID, "error", err)
+				}
+			}
+		}
+	}
+}
+
+// Reconcile makes subscriptions and Binding workers match the authoritative
+// Participant + Agent snapshot. This repairs missed bus events and Agent
+// runtime/profile changes that do not emit Participant events.
+func (s *Source) Reconcile(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.reconcileMu.Lock()
+	defer s.reconcileMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	desired := make(map[channel.BindingID]channel.Binding)
+	for _, item := range s.participants.List(participant.ListOptions{
+		Channel: participant.ChannelCSGClaw,
+		Type:    participant.TypeAgent,
+	}) {
+		value, ok := s.binding(ctx, item)
+		if !ok {
+			continue
+		}
+		desired[value.StableID()] = value
+	}
+
+	var outErr error
+	for _, value := range desired {
+		if err := s.ensureBinding(ctx, value); err != nil {
+			outErr = errors.Join(outErr, err)
+		}
+	}
+
+	s.mu.Lock()
+	stale := make([]channel.BindingID, 0)
+	for id := range s.subscriptions {
+		if _, ok := desired[id]; !ok {
+			stale = append(stale, id)
+		}
+	}
+	s.mu.Unlock()
+	for _, id := range stale {
+		s.stop(id)
+	}
+	return outErr
+}
+
+func (s *Source) ensureBinding(ctx context.Context, value channel.Binding) error {
+	if err := s.workers.Ensure(value); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		s.workers.Stop(value.StableID())
+		return err
+	}
+
+	bindingID := value.StableID()
+	s.mu.Lock()
+	if s.cancel == nil {
+		s.mu.Unlock()
+		s.workers.Stop(bindingID)
+		return context.Canceled
+	}
+	if existing := s.subscriptions[bindingID]; existing != nil {
+		existing.binding = value
+		s.mu.Unlock()
+		return nil
+	}
+	events, cancel := s.bridge.Subscribe(value.ParticipantID)
+	s.subscriptions[bindingID] = &subscription{binding: value, cancel: cancel}
+	s.wg.Add(1)
+	s.mu.Unlock()
+	go s.forward(ctx, bindingID, value.ParticipantID, events)
+	return nil
+}
+
+func (s *Source) stop(bindingID channel.BindingID) {
+	bindingID = channel.BindingID(strings.TrimSpace(string(bindingID)))
+	if bindingID == "" {
+		return
+	}
+	s.mu.Lock()
+	sub := s.subscriptions[bindingID]
+	delete(s.subscriptions, bindingID)
+	s.mu.Unlock()
+	if sub != nil && sub.cancel != nil {
+		sub.cancel()
+	}
+	s.workers.Stop(bindingID)
+}
+
+func (s *Source) forward(ctx context.Context, bindingID channel.BindingID, participantID string, events <-chan im.ParticipantEvent) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			if s.submitWithRetry(ctx, bindingID, event) {
+				s.bridge.Ack(participantID, event.MessageID)
+				continue
+			}
+			// The source or this subscription stopped while the event was still
+			// inflight. Preserve it for the next subscription instead of losing it.
+			s.bridge.Requeue(participantID, event)
+			return
+		}
+	}
+}
+
+func (s *Source) submitWithRetry(ctx context.Context, bindingID channel.BindingID, event im.ParticipantEvent) bool {
+	delay := s.retryInitial
+	if delay <= 0 {
+		delay = defaultRetryInitial
+	}
+	maxDelay := s.retryMax
+	if maxDelay < delay {
+		maxDelay = defaultRetryMax
+	}
+	for {
+		if !s.hasSubscription(bindingID) {
+			return false
+		}
+		value, ok := s.currentBinding(ctx, bindingID)
+		if ok {
+			if err := s.workers.Submit(value, botEvent(value, event)); err == nil {
+				return true
+			} else {
+				slog.Warn("submit built-in IM event failed; retrying",
+					"binding_id", bindingID,
+					"message_id", event.MessageID,
+					"retry_in", delay,
+					"error", err,
+				)
+			}
+		} else {
+			slog.Warn("built-in IM binding temporarily unavailable; retrying",
+				"binding_id", bindingID,
+				"message_id", event.MessageID,
+				"retry_in", delay,
+			)
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+		if delay < maxDelay {
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+		}
+	}
+}
+
+func (s *Source) hasSubscription(bindingID channel.BindingID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.subscriptions[bindingID] != nil
+}
+
+func (s *Source) currentBinding(ctx context.Context, bindingID channel.BindingID) (channel.Binding, bool) {
+	s.mu.Lock()
+	sub := s.subscriptions[bindingID]
+	var value channel.Binding
+	if sub != nil {
+		value = sub.binding
+	}
+	s.mu.Unlock()
+	if sub == nil {
+		return channel.Binding{}, false
+	}
+	selected, err := s.agents.Get(ctx, value.AgentID)
+	if err != nil || !usesHostCodex(selected) {
+		return channel.Binding{}, false
+	}
+	return value, true
+}
+
+func (s *Source) binding(ctx context.Context, item apitypes.Participant) (channel.Binding, bool) {
+	if !strings.EqualFold(strings.TrimSpace(item.Channel), participant.ChannelCSGClaw) ||
+		!strings.EqualFold(strings.TrimSpace(item.Type), participant.TypeAgent) {
+		return channel.Binding{}, false
+	}
+	participantID := strings.TrimSpace(item.ID)
+	agentID := strings.TrimSpace(item.AgentID)
+	if participantID == "" || agentID == "" {
+		return channel.Binding{}, false
+	}
+	selected, err := s.agents.Get(ctx, agentID)
+	if err != nil || !usesHostCodex(selected) {
+		return channel.Binding{}, false
+	}
+	return channel.Binding{
+		ID:            participantID,
+		Channel:       channel.ChannelCSGClaw,
+		ParticipantID: participantID,
+		AgentID:       agentID,
+		Enabled:       true,
+	}, true
+}
+
+func usesHostCodex(selected agentengine.Agent) bool {
+	return strings.EqualFold(strings.TrimSpace(selected.Spec.Runtime.Adapter), agentruntime.NameCodex) &&
+		!selected.Spec.Runtime.Sandboxed
+}
+
+func botEvent(value channel.Binding, event im.ParticipantEvent) channelbridge.BotEvent {
+	return channelbridge.BotEvent{
+		Channel:       string(channel.ChannelCSGClaw),
+		ParticipantID: value.ParticipantID,
+		MessageID:     strings.TrimSpace(event.MessageID),
+		RoomID:        strings.TrimSpace(event.RoomID),
+		Locale:        strings.TrimSpace(event.Locale),
+		ChatType:      strings.TrimSpace(event.ChatType),
+		Text:          event.Text,
+		Attachments:   append([]channelbridge.MessageAttachment(nil), event.Attachments...),
+		Mentions:      append([]string(nil), event.Mentions...),
+		Mentioned:     event.Mentioned,
+		ThreadRootID:  strings.TrimSpace(event.ThreadRootID),
+		ThreadContext: botThreadContext(event.ThreadContext),
+	}
+}
+
+func botThreadContext(value *im.ParticipantThreadContext) *channelbridge.BotThreadContext {
+	if value == nil {
+		return nil
+	}
+	out := &channelbridge.BotThreadContext{
+		RootMessageID: strings.TrimSpace(value.RootMessageID),
+		Summary: channelbridge.BotThreadContextSummary{
+			RootExcerpt:  value.Summary.RootExcerpt,
+			MessageCount: value.Summary.MessageCount,
+			BeforeCount:  value.Summary.BeforeCount,
+			AfterCount:   value.Summary.AfterCount,
+		},
+	}
+	for _, message := range value.Context {
+		createdAt := ""
+		if !message.CreatedAt.IsZero() {
+			createdAt = message.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		}
+		out.Context = append(out.Context, channelbridge.BotThreadContextMessage{
+			ID:          message.ID,
+			SenderID:    message.SenderID,
+			Content:     message.Content,
+			CreatedAt:   createdAt,
+			Attachments: append([]channelbridge.MessageAttachment(nil), message.Attachments...),
+		})
+	}
+	return out
+}

--- a/internal/channel/csgclaw/source/source_test.go
+++ b/internal/channel/csgclaw/source/source_test.go
@@ -1,0 +1,321 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channelbridge"
+	"csgclaw/internal/im"
+	"csgclaw/internal/participant"
+)
+
+type fakeParticipants struct {
+	items []apitypes.Participant
+}
+
+func (f fakeParticipants) List(participant.ListOptions) []apitypes.Participant {
+	return append([]apitypes.Participant(nil), f.items...)
+}
+
+type fakeAgents struct {
+	items map[string]agentengine.Agent
+}
+
+func (f fakeAgents) Get(_ context.Context, id string) (agentengine.Agent, error) {
+	item, ok := f.items[id]
+	if !ok {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "agent not found"}
+	}
+	return item, nil
+}
+
+type fakeWorkers struct {
+	ensured   chan channel.Binding
+	submits   chan submittedEvent
+	stops     chan channel.BindingID
+	submitErr error
+	submit    func(channel.Binding, channelbridge.BotEvent) error
+}
+
+type submittedEvent struct {
+	binding channel.Binding
+	event   channelbridge.BotEvent
+}
+
+func (f *fakeWorkers) Ensure(value channel.Binding) error {
+	select {
+	case f.ensured <- value:
+	default:
+	}
+	return nil
+}
+
+func (f *fakeWorkers) Stop(id channel.BindingID) {
+	if f.stops == nil {
+		return
+	}
+	select {
+	case f.stops <- id:
+	default:
+	}
+}
+
+func (f *fakeWorkers) Submit(value channel.Binding, event channelbridge.BotEvent) error {
+	f.submits <- submittedEvent{binding: value, event: event}
+	if f.submit != nil {
+		return f.submit(value, event)
+	}
+	return f.submitErr
+}
+
+func (*fakeWorkers) Close() {}
+
+type mutableParticipants struct {
+	mu    sync.Mutex
+	items []apitypes.Participant
+}
+
+func (p *mutableParticipants) List(participant.ListOptions) []apitypes.Participant {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]apitypes.Participant(nil), p.items...)
+}
+
+type mutableAgents struct {
+	mu    sync.Mutex
+	items map[string]agentengine.Agent
+}
+
+func (a *mutableAgents) Get(_ context.Context, id string) (agentengine.Agent, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	item, ok := a.items[id]
+	if !ok {
+		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentUnavailable, Message: "agent not found"}
+	}
+	return item, nil
+}
+
+func (a *mutableAgents) set(item agentengine.Agent) {
+	a.mu.Lock()
+	a.items[item.ID] = item
+	a.mu.Unlock()
+}
+
+func TestSourceForwardsInProcessParticipantEventsToBindingWorker(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	workers := &fakeWorkers{
+		ensured: make(chan channel.Binding, 2),
+		submits: make(chan submittedEvent, 1),
+	}
+	source, err := newSource(
+		bridge,
+		im.NewBus(),
+		fakeParticipants{items: []apitypes.Participant{{
+			ID: "pt-worker", Channel: participant.ChannelCSGClaw, Type: participant.TypeAgent,
+			ChannelUserRef: "user-worker", AgentID: "agent-worker",
+		}}},
+		fakeAgents{items: map[string]agentengine.Agent{
+			"agent-worker": {ID: "agent-worker", Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{Adapter: "codex"}}},
+		}},
+		workers,
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := source.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer source.Close()
+
+	select {
+	case binding := <-workers.ensured:
+		if binding.ParticipantID != "pt-worker" || binding.AgentID != "agent-worker" {
+			t.Fatalf("binding = %+v", binding)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("binding was not ensured")
+	}
+
+	room := im.Room{ID: "room-1", IsDirect: true, Members: []string{"user-admin", "user-worker"}}
+	sender := im.User{ID: "user-admin", Name: "admin"}
+	message := im.Message{
+		ID:       "message-1",
+		SenderID: sender.ID,
+		Content:  "hello",
+		RelatesTo: &im.MessageRelation{
+			RelType: im.RelationTypeThread,
+			EventID: "root-1",
+		},
+	}
+	if ok := bridge.EnqueueMessageEvent(room, sender, message, "pt-worker"); !ok {
+		t.Fatal("participant event was not delivered to the in-process source")
+	}
+
+	select {
+	case got := <-workers.submits:
+		if got.binding.AgentID != "agent-worker" || got.event.MessageID != "message-1" ||
+			got.event.ParticipantID != "pt-worker" || got.event.ThreadRootID != "root-1" {
+			t.Fatalf("submitted = %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("participant event was not submitted")
+	}
+
+	if ok := bridge.EnqueueMessageEvent(room, sender, message, "pt-worker"); !ok {
+		t.Fatal("acked duplicate should be recognized as already handled")
+	}
+	select {
+	case got := <-workers.submits:
+		t.Fatalf("duplicate event was submitted after Ack: %+v", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSourceReconcilesAgentEligibilityWithoutParticipantEvent(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	participants := &mutableParticipants{items: []apitypes.Participant{{
+		ID: "pt-worker", Channel: participant.ChannelCSGClaw, Type: participant.TypeAgent, AgentID: "agent-worker",
+	}}}
+	agents := &mutableAgents{items: map[string]agentengine.Agent{
+		"agent-worker": {
+			ID:   "agent-worker",
+			Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{Adapter: "codex", Sandboxed: true}},
+		},
+	}}
+	workers := &fakeWorkers{
+		ensured: make(chan channel.Binding, 2),
+		submits: make(chan submittedEvent, 1),
+		stops:   make(chan channel.BindingID, 2),
+	}
+	source, err := newSource(bridge, nil, participants, agents, workers)
+	if err != nil {
+		t.Fatalf("newSource() error = %v", err)
+	}
+	if err := source.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer source.Close()
+
+	select {
+	case binding := <-workers.ensured:
+		t.Fatalf("sandboxed agent unexpectedly created binding %+v", binding)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := bridge.SubscriberCount("pt-worker"); got != 0 {
+		t.Fatalf("subscriber count = %d, want 0", got)
+	}
+
+	agents.set(agentengine.Agent{
+		ID:   "agent-worker",
+		Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{Adapter: "codex"}},
+	})
+	if err := source.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() eligible error = %v", err)
+	}
+	select {
+	case binding := <-workers.ensured:
+		if binding.AgentID != "agent-worker" || binding.ParticipantID != "pt-worker" {
+			t.Fatalf("binding = %+v", binding)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("eligible Agent was not reconciled")
+	}
+	if got := bridge.SubscriberCount("pt-worker"); got != 1 {
+		t.Fatalf("subscriber count = %d, want 1", got)
+	}
+
+	agents.set(agentengine.Agent{
+		ID: "agent-worker",
+		Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{
+			Adapter: "codex", Sandboxed: true,
+		}},
+	})
+	if err := source.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile() ineligible error = %v", err)
+	}
+	select {
+	case id := <-workers.stops:
+		if id != "pt-worker" {
+			t.Fatalf("stopped binding = %q, want pt-worker", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ineligible Agent binding was not stopped")
+	}
+	if got := bridge.SubscriberCount("pt-worker"); got != 0 {
+		t.Fatalf("subscriber count = %d, want 0", got)
+	}
+}
+
+func TestSourceRetriesEventWhileSubscriptionRemainsActive(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	var attempts atomic.Int32
+	workers := &fakeWorkers{
+		ensured: make(chan channel.Binding, 1),
+		submits: make(chan submittedEvent, 2),
+		submit: func(channel.Binding, channelbridge.BotEvent) error {
+			if attempts.Add(1) == 1 {
+				return errors.New("worker stopped")
+			}
+			return nil
+		},
+	}
+	source, err := newSource(
+		bridge,
+		nil,
+		fakeParticipants{items: []apitypes.Participant{{
+			ID: "pt-worker", Channel: participant.ChannelCSGClaw, Type: participant.TypeAgent, AgentID: "agent-worker",
+		}}},
+		fakeAgents{items: map[string]agentengine.Agent{
+			"agent-worker": {ID: "agent-worker", Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{Adapter: "codex"}}},
+		}},
+		workers,
+	)
+	if err != nil {
+		t.Fatalf("newSource() error = %v", err)
+	}
+	source.retryInitial = time.Millisecond
+	source.retryMax = 2 * time.Millisecond
+	if err := source.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer source.Close()
+
+	room := im.Room{ID: "room-1", IsDirect: true, Members: []string{"user-admin", "pt-worker"}}
+	sender := im.User{ID: "user-admin", Name: "admin"}
+	message := im.Message{ID: "message-retry", SenderID: sender.ID, Content: "retry me"}
+	if ok := bridge.EnqueueMessageEvent(room, sender, message, "pt-worker"); !ok {
+		t.Fatal("participant event was not delivered")
+	}
+	select {
+	case <-workers.submits:
+	case <-time.After(time.Second):
+		t.Fatal("participant event was not submitted")
+	}
+	select {
+	case got := <-workers.submits:
+		if got.event.MessageID != message.ID {
+			t.Fatalf("retried message = %q, want %q", got.event.MessageID, message.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("participant event was not retried on the active subscription")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for attempts.Load() != 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("submit attempts = %d, want 2", attempts.Load())
+	}
+	if ok := bridge.EnqueueMessageEvent(room, sender, message, "pt-worker"); !ok {
+		t.Fatal("acked retried event should be recognized as handled")
+	}
+}

--- a/internal/channel/csgclaw/state/state.go
+++ b/internal/channel/csgclaw/state/state.go
@@ -1,0 +1,42 @@
+package state
+
+// SeenWindow is an in-memory source-event window.
+// Durable InboundLedger / DeliveryOutbox stay out of this package until a
+// persistence owner exists.
+type SeenWindow struct {
+	limit int
+	order []string
+	items map[string]struct{}
+}
+
+func NewSeenWindow(limit int) *SeenWindow {
+	if limit <= 0 {
+		limit = 256
+	}
+	return &SeenWindow{limit: limit, items: make(map[string]struct{})}
+}
+
+func (s *SeenWindow) Has(key string) bool {
+	if s == nil || key == "" {
+		return false
+	}
+	_, ok := s.items[key]
+	return ok
+}
+
+func (s *SeenWindow) Add(key string) {
+	if s == nil || key == "" {
+		return
+	}
+	if _, ok := s.items[key]; ok {
+		return
+	}
+	s.items[key] = struct{}{}
+	s.order = append(s.order, key)
+	if len(s.order) <= s.limit {
+		return
+	}
+	oldest := s.order[0]
+	s.order = s.order[1:]
+	delete(s.items, oldest)
+}

--- a/internal/channel/types.go
+++ b/internal/channel/types.go
@@ -2,7 +2,41 @@
 // channel adapters.
 package channel
 
-import "time"
+import (
+	"strings"
+	"time"
+
+	"csgclaw/internal/agentengine"
+)
+
+// ChannelID identifies a channel implementation, such as csgclaw or feishu.
+type ChannelID string
+
+const (
+	ChannelCSGClaw = "csgclaw"
+	ChannelFeishu  = "feishu"
+)
+
+// BindingID is a stable channel binding identity, not a Runtime or Session ID.
+type BindingID string
+
+// SourceEventID is the source-side dedupe key for a message or action.
+type SourceEventID string
+
+// ActorRef is a source sender or interaction actor.
+type ActorRef struct {
+	ID          string
+	DisplayName string
+	IsBot       bool
+}
+
+// ConversationScope is channel context used to build an Engine ConversationKey.
+type ConversationScope struct {
+	BindingID BindingID
+	RoomID    string
+	ThreadID  string
+	ReplyToID string
+}
 
 // Binding is the stable relationship between one external channel identity and
 // one CSGClaw Agent. Runtime and native session identifiers deliberately do not
@@ -12,6 +46,36 @@ type Binding struct {
 	Channel       string `json:"channel"`
 	AgentID       string `json:"agent_id"`
 	ParticipantID string `json:"participant_id"`
+	Enabled       bool   `json:"enabled,omitempty"`
+}
+
+// StableID returns the persistent binding identity, falling back to ParticipantID.
+func (b Binding) StableID() BindingID {
+	if id := strings.TrimSpace(b.ID); id != "" {
+		return BindingID(id)
+	}
+	return BindingID(strings.TrimSpace(b.ParticipantID))
+}
+
+// TurnContext is channel-owned identity for rendering and source delivery.
+// SourceMessageID is a dedupe key, not a TurnID.
+type TurnContext struct {
+	BindingID       BindingID
+	ParticipantID   string
+	AgentID         string
+	RoomID          string
+	Locale          string
+	ChatType        string
+	ThreadRootID    string
+	SourceMessageID string
+	ConversationKey agentengine.ConversationKey
+	TurnID          agentengine.TurnID
+}
+
+// Outcome keeps the channel context next to the normalized Engine result.
+type Outcome struct {
+	Turn   TurnContext
+	Result agentengine.TurnResult
 }
 
 // Source identifies the external event that produced one normalized inbound


### PR DESCRIPTION
- Route eligible host Codex participants through a binding-scoped built-in IM adapter backed by Agent Engine while preserving existing direct, mention, room, thread, and reply behavior.
- Render final answers, thoughts, tool activity, permissions, and structured user input through the existing message and activity APIs with stable IDs and legacy-compatible metadata.
- Materialize source-scoped attachments, serialize turns with wait admission, prevent stale turn updates, and release runtime work state across success, failure, and cancellation.
