### PR TITLE
feat(agent-engine): support secure runtime file delivery

### DIFF
--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -454,15 +454,20 @@ Built-in IM continues to own its durable attachment metadata, blobs, download to
 Before calling `Run`, a caller uploads content through `Conversations(agentID).Files().Create` and receives immutable metadata with an opaque FileID.
 `InputFile` carries only that FileID, so callers and Engine do not need a shared filesystem or `SourcePath`.
 Engine resolves the ID within the selected Agent scope and the Runtime Adapter copies the immutable snapshot into its execution environment.
+Resolution acquires a lease before admission, so an invalid superseding request cannot cancel active work and a concurrent Delete cannot invalidate an admitted input.
 
 Files are included only when newly uploaded or explicitly referenced.
 Previous file bytes are not resent merely to continue a Runtime-native conversation.
 
 For output, each Runtime Adapter consumes a typed native file reference and resolves it before crossing the Engine boundary.
-The Codex app-server Adapter exposes `csgclaw_publish_file` as a typed dynamic tool with a workspace-relative path; a direct Responses Adapter should consume native generated-file references and tool outputs.
+The Codex app-server Adapter exposes `csgclaw_publish_file` only on Engine-created threads as a typed dynamic tool with a workspace-relative path; legacy bridge threads do not advertise an unsupported delivery capability.
+Because the current app-server protocol cannot attach dynamic tools during cold `thread/resume`, a restored Engine mapping is honestly non-resumable for strict continuation, while create-or-resume replaces it with a new file-capable thread.
+A direct Responses Adapter should consume native generated-file references and tool outputs.
 The Runtime Adapter opens the resolved local path through workspace-rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot with authoritative name, MIME type, size, and SHA-256 metadata.
 Engine assigns an opaque random ID independent from SHA-256 and returns metadata in a successful `TurnResult.Files` without exposing the host path.
 Channel Adapters call `Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent snapshot stream, and Turn replay preserves both ID and content.
+Each file is limited to 25 MiB and each Agent may retain at most 256 MiB of physical snapshots, including deleted snapshots held by active leases.
+`Get` verifies the immutable snapshot in place and returns a leased descriptor; Delete immediately revokes new access and removes bytes after the final active lease closes.
 They may upload only files from a successful `TurnResult`.
 They never download `resource_link`; ordinary HTTP(S) resource links remain Markdown links.
 

--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -461,7 +461,7 @@ Previous file bytes are not resent merely to continue a Runtime-native conversat
 
 For output, each Runtime Adapter consumes a typed native file reference and resolves it before crossing the Engine boundary.
 The Codex app-server Adapter exposes `csgclaw_publish_file` only on Engine-created threads as a typed dynamic tool with a workspace-relative path; legacy bridge threads do not advertise an unsupported delivery capability.
-Because the current app-server protocol cannot attach dynamic tools during cold `thread/resume`, a restored Engine mapping is honestly non-resumable for strict continuation, while create-or-resume replaces it with a new file-capable thread.
+Because the current app-server protocol cannot attach dynamic tools during cold `thread/resume`, a restored Engine mapping resumes the same native thread to preserve conversation context but does not advertise file publication until the protocol supports reattachment.
 A direct Responses Adapter should consume native generated-file references and tool outputs.
 The Runtime Adapter opens the resolved local path through workspace-rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot with authoritative name, MIME type, size, and SHA-256 metadata.
 Engine assigns an opaque random ID independent from SHA-256 and returns metadata in a successful `TurnResult.Files` without exposing the host path.

--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -466,7 +466,6 @@ A direct Responses Adapter should consume native generated-file references and t
 The Runtime Adapter opens the resolved local path through workspace-rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot with authoritative name, MIME type, size, and SHA-256 metadata.
 Engine assigns an opaque random ID independent from SHA-256 and returns metadata in a successful `TurnResult.Files` without exposing the host path.
 Channel Adapters call `Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent snapshot stream, and Turn replay preserves both ID and content.
-Each file is limited to 25 MiB and each Agent may retain at most 256 MiB of physical snapshots, including deleted snapshots held by active leases.
 `Get` verifies the immutable snapshot in place and returns a leased descriptor; Delete immediately revokes new access and removes bytes after the final active lease closes.
 They may upload only files from a successful `TurnResult`.
 They never download `resource_link`; ordinary HTTP(S) resource links remain Markdown links.

--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -24,10 +24,10 @@ CSGClaw needs one runtime-neutral execution path for anonymous sessions, built-i
 Channel Adapter or Session API -> Agent Engine -> Runtime Adapter
 ```
 
-The design has two public resource interfaces:
+The design has two top-level public resource interfaces:
 
 - `Agents()` manages persisted Agent resources and Runtime lifecycle.
-- `Conversations(agentID)` executes conversations for one selected Agent.
+- `Conversations(agentID)` executes conversations and manages immutable files for one selected Agent.
 
 The interface follows the Kubernetes client style by selecting a resource scope first and then exposing focused operations.
 It does not introduce a Kubernetes controller, API server, object metadata model, or reconciliation framework.
@@ -217,15 +217,30 @@ The review surface is:
 | Resource | Operations | Purpose |
 |---|---|---|
 | `Agents()` | Create, Get, List, Update, Delete, Start, Stop, Recreate | Desired Agent configuration and Runtime lifecycle |
-| `Conversations(agentID)` | Run, Cancel, Reset, Resolve | Conversation execution scoped to one Agent |
+| `Conversations(agentID)` | Files, Run, Cancel, Reset, Resolve | Conversation execution scoped to one Agent |
+| `Conversations(agentID).Files()` | Create, Get, Delete | Immutable files scoped by the selected Agent |
 | `ConversationRuntime` | Run, Cancel, Reset, Resolve | Runtime-specific direct execution behind Engine |
+
+The public contract is transport-ready without defining a remote Engine protocol in this phase:
+
+| Engine operation | HTTP mapping |
+|---|---|
+| `Agents().Create/Get/List/Update/Delete` | Agent collection and resource POST, GET, PUT, DELETE |
+| `Agents().Start/Stop/Recreate` | Agent action POST endpoints |
+| `Conversations(agentID).Run` | Turn POST with JSON request and JSON or SSE result stream |
+| `Cancel/Reset/Resolve` | Conversation action POST endpoints with typed JSON bodies |
+| `Conversations(agentID).Files().Create` | File metadata plus streaming HTTP request body |
+| `Conversations(agentID).Files().Get/Delete` | Content GET with metadata headers, and DELETE |
+
+`context.Context`, `io.Reader`, `io.ReadCloser`, and `EventSink` belong to the Go client and server adapter boundary.
+Every request, resource, event, result, and error value crossing that boundary has a stable JSON representation and contains no Runtime path or process-local capability.
 
 `AgentInterface` is the collection-scoped API for Agent resources, and callers cannot depend on the current `internal/agent.Service`.
 The Phase 2 Engine Facade may wrap the current Agent Service through a private backend so it can first reuse the already verified Agent persistence and Runtime lifecycle code.
 That wrapper is only an internal Engine implementation; it does not enter the public contract or prevent Phase 4 from separating the broad Service into explicit storage, lifecycle, and Runtime components.
 Conversation execution keeps no duplicate Agent records and coordinates active Turns with lifecycle changes.
 The Phase 1 Conversation implementation may reach the current Agent Service only through the private Adapter wired by the composition root.
-Phase 2 extends this boundary so the complete Engine implements `Agents()` and `Conversations()` through one private Facade instead of first rewriting the existing Agent components.
+Phase 2 extends this boundary so the complete Engine implements `Agents()` and `Conversations(agentID)`, including its nested `Files()` resource, without first rewriting the existing Agent components.
 Phase 4 then replaces the transitional Facade and consolidates the internal owners of Agent state and Runtime lifecycle while preserving external behavior.
 If the internal refactor genuinely requires a public interface change, the change remains subject to joint review and must update every implementation, the Mock Client, and the contract tests together.
 
@@ -307,7 +322,7 @@ Feishu keeps its current `skip_user_input` behavior.
 
 `TurnRequest.Input` is one ordered list of `InputPart` values.
 A text part contains `Text`.
-A file part contains one caller-authorized `InputFile`.
+A file part contains one Agent-scoped `InputFile` reference with only a FileID.
 There is no parallel file list and no Engine file-preparation step.
 Incremental implementation does not narrow this contract to a string.
 The Phase 1 Session HTTP Adapter creates one text part, and the private Codex Runtime Adapter joins ordered text parts before calling the current Runtime API.
@@ -319,13 +334,14 @@ The Event Sink receives ordered progress for a logical Turn:
 - Thought delta.
 - Activity update.
 - Interaction request.
-- Validated output item.
+- Validated non-file output item.
 
 The sink is not an event bus, transcript store, or Channel renderer.
 Every event carries `TurnID` and monotonic `Sequence`.
 The tuple `(TurnID, Sequence)` lets an Adapter deduplicate replayed envelopes after a retry.
 
 `Run` returns exactly one `TurnResult` and no second raw Runtime error.
+A successful result contains JSON-safe immutable file metadata in `Files`; failed or canceled results contain no deliverable files.
 `Dispatched=false` means the native Turn was not submitted.
 This includes Engine admission rejection and failure to create, resolve, or persist a required Runtime-native conversation mapping.
 `Dispatched=true` means the Continuation Policy succeeded, the required mapping was durably established or resolved, and the native Turn was submitted.
@@ -340,9 +356,9 @@ Each fact has one owner:
 | Component | Owns | Does not own |
 |---|---|---|
 | Agent resource implementation | Agent persistence, desired configuration including Runtime credentials and `InitShell`, Runtime lifecycle, Workspace and Runtime provisioning | Turn input, transcript, Runtime-native conversation mapping, Channel Event Worker lifecycle |
-| Agent Engine | Admission, per-Conversation serialization, dispatch, active Turn, pending interaction, event ordering, normalized result | Durable Agent or Conversation state, files, Channel behavior |
-| Runtime Adapter | Runtime credential serialization, `InitShell` execution, native conversation mapping, direct Runtime protocol, Runtime event translation, file exposure to Runtime | Channel subscription, transcript, Agent persistence |
-| Channel Adapter | Ingress, identity, binding and Channel Event Worker lifecycle, host-side Channel credentials, deduplication, hidden context, file authorization, transcript, rendering, acknowledgment | Runtime-native mapping, Engine admission |
+| Agent Engine | Admission, per-Conversation serialization, dispatch, active Turn, pending interaction, event ordering, normalized result, process-local immutable Artifact Store | Durable Agent or Conversation state, external file transport, Channel behavior |
+| Runtime Adapter | Runtime credential serialization, `InitShell` execution, native conversation mapping, direct Runtime protocol, Runtime event translation, input-file exposure, output-file authorization | Channel subscription, transcript, Agent persistence |
+| Channel Adapter | Ingress, identity, binding and Channel Event Worker lifecycle, host-side Channel credentials, deduplication, hidden context, input-file authorization, authorized output-file delivery, transcript, rendering, acknowledgment | Runtime-native mapping, Engine admission |
 | Session HTTP Adapter | HTTP validation, Session Binding, SSE and error mapping | IM Room, Message, Participant, transcript |
 
 The minimal Phase 1 Session implementation has no lifecycle coordination.
@@ -434,21 +450,26 @@ The design does not promise cross-restart replay, exactly-once execution, or rec
 
 ### 6.2 Files
 
-Built-in IM continues to own attachment metadata, blobs, download tokens, and garbage collection.
-Before calling Engine, the trusted caller authorizes the file and resolves an `InputFile` containing ID, source path, name, media type, size, and hash.
-
-Engine validates the Input shape but treats `SourcePath` as opaque.
-It does not call IM APIs, read file bytes, write Workspace files, manage blobs, or mount sandboxes.
-The Runtime Adapter decides how to mount, copy, or expose the file and preserves path, symlink, size, and hash checks.
-The caller keeps the resolved source valid until `Run` returns.
+Built-in IM continues to own its durable attachment metadata, blobs, download tokens, and garbage collection.
+Before calling `Run`, a caller uploads content through `Conversations(agentID).Files().Create` and receives immutable metadata with an opaque FileID.
+`InputFile` carries only that FileID, so callers and Engine do not need a shared filesystem or `SourcePath`.
+Engine resolves the ID within the selected Agent scope and the Runtime Adapter copies the immutable snapshot into its execution environment.
 
 Files are included only when newly uploaded or explicitly referenced.
 Previous file bytes are not resent merely to continue a Runtime-native conversation.
 
+For output, each Runtime Adapter consumes a typed native file reference and resolves it before crossing the Engine boundary.
+The Codex app-server Adapter exposes `csgclaw_publish_file` as a typed dynamic tool with a workspace-relative path; a direct Responses Adapter should consume native generated-file references and tool outputs.
+The Runtime Adapter opens the resolved local path through workspace-rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot with authoritative name, MIME type, size, and SHA-256 metadata.
+Engine assigns an opaque random ID independent from SHA-256 and returns metadata in a successful `TurnResult.Files` without exposing the host path.
+Channel Adapters call `Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent snapshot stream, and Turn replay preserves both ID and content.
+They may upload only files from a successful `TurnResult`.
+They never download `resource_link`; ordinary HTTP(S) resource links remain Markdown links.
+
 ### 6.3 Structured Output and Interactions
 
-One shared decoder owns the `::csgclaw-output::` grammar.
-It validates `resource_link` and detached `request_user_input` payloads before they cross the Engine boundary.
+One shared decoder owns the `::csgclaw-output::` grammar for `resource_link` and detached `request_user_input` only.
+Runtime file output uses typed native Runtime events and never relies on parsing assistant text or command stdout.
 Raw control lines never reach public text or Channel renderers.
 
 A blocking Runtime Permission or User Input keeps the same Turn open and uses `Resolve`.
@@ -526,11 +547,11 @@ Starting in Phase 2, the Agent Engine interface is the only boundary between Eng
 
 - Implement the complete `agentengine.Interface` and provide the concurrency-safe, stateful `enginetest.MemoryClient` implementing the same contract.
 - The interface is not an immutable protocol; when implementation exposes an omission or mistake, it may change through joint review, with the real Engine, Mock Client, contract tests, and affected Adapter call sites updated in the same change.
-- Implement `Agents()`, `Run`, `Cancel`, atomic `Reset`, claimed `Resolve`, explicit admission policies, Turn retry idempotency, TurnID event envelopes, file input, interactions, Structured Output, `Dispatched`, and stable errors.
+- Implement `Agents()`, `Run`, `Cancel`, atomic `Reset`, claimed `Resolve`, explicit admission policies, Turn retry idempotency, TurnID event envelopes, file input, authorized Runtime file output, interactions, Structured Output, `Dispatched`, and stable errors.
 - Let the Agent Engine Facade first wrap the existing Agent Service, Codex Session, brokers, Structured Output, and Runtime provisioning code instead of making internal refactoring a prerequisite for a complete Engine.
 - Coordinate Agent mutation, admission, active Turns, drain, and pinned Runtime handles through one shared Lifecycle Gate.
 - Migrate the anonymous Session API to `agentengine.Interface` while preserving its HTTP contract and zero IM entity creation.
-- Prove a test-only Feishu ingress harness through `MemoryClient`, with Feishu credentials remaining exclusively in the current Channel binding owner.
+- Prove test-only Feishu ingress and output-delivery harnesses through `MemoryClient`, including Feishu image upload, file upload, and message OpenAPI calls, with Feishu credentials remaining exclusively in the current Channel binding owner.
 - Keep production Channel Adapter implementation, integration, and atomic switching in Phase 3.
 - Materialize Codex `RuntimeSpec.Credentials` as workspace-relative files and run `RuntimeSpec.InitShell` after the files are available.
 
@@ -572,17 +593,20 @@ The two Phase 2 sides can be developed and verified independently, Phase 3 owns 
 ### 8.2 Target Architecture
 
 - `internal/agentengine` imports no IM, Participant, Channel, Team, or concrete Runtime package.
-- `Interface` exposes `Agents()` and Agent-scoped `Conversations(agentID)`.
+- `Interface` exposes `Agents()` and Agent-scoped `Conversations(agentID)`; files are a nested Conversation resource selected with `Conversations(agentID).Files()`.
 - Conversation requests do not repeat Agent ID.
 - Conversation keys remain opaque and caller-owned.
 - Every Run carries a caller-generated opaque Turn ID, and Cancel targets one Turn with its Conversation Key and Turn ID.
-- Engine persists no Agent, Conversation, transcript, file, or delivery state.
+- Engine durably persists no Agent, Conversation, transcript, file, or delivery state; its Artifact Store is process-local and bounded by explicit deletion or Turn-cache eviction.
 - Agent resource implementations, Agent Engine, and Runtime Adapters have no Channel Event Worker dependency and do not access IM message persistence.
 - Channel Event Workers are keyed by stable Binding identity, not Runtime ID or native Session ID.
 - Runtime-native conversation mapping has one owner.
 - After Phase 2, external callers depend only on `AgentInterface`, and `Conversations()` accesses Agent availability and Runtime selection only through the internal Engine Facade.
 - After Phase 4, the `AgentInterface` implementation is the only Agent persistence and Runtime lifecycle owner, and Engine internals no longer depend on the broad `internal/agent.Service`.
 - Runtime credential file layouts and initialization remain owned by each Runtime Adapter.
+- Runtime file output crosses Engine only in successful `TurnResult.Files` as metadata for an immutable snapshot with opaque ID, MIME type, size, SHA-256, and no host path.
+- Input file parts contain only Agent-scoped FileIDs; public request and response types contain no local source paths or Reader capabilities.
+- Public resource and event values use stable JSON field names, while `Files.Create` and `Files.Get` map to HTTP request and response bodies.
 - Missing Runtime Adapters fail explicitly with no fallback path.
 - The Go contract and both language documents remain synchronized.
 
@@ -603,13 +627,15 @@ The two Phase 2 sides can be developed and verified independently, Phase 3 owns 
 - Create, Update, Get, and List results omit Runtime credential values.
 - Recreate and Delete report missing strict-continuation mappings honestly.
 - CSGClaw Structured Output never leaks raw control lines.
+- Ordinary `resource_link` output is never downloaded or promoted to an uploadable file.
 - Secret answers enter neither logs nor transcripts.
 
 ### 8.4 Target Verification
 
 - Contract tests cover Run, Cancel, atomic Reset, claimed Resolve, event envelopes, terminal results, and stable errors.
 - Tests cover Turn retry idempotency, different-Conversation concurrency, reject, wait, supersede, sink failure, and cancellation behavior.
-- Tests cover no MCP, local MCP, remote MCP, text input, and file input.
+- Tests cover no MCP, local MCP, remote MCP, text input, file input, authorized Runtime file output, and workspace-escape rejection.
+- A Feishu OpenAPI end-to-end harness verifies image upload, file upload, message delivery, failed-Turn non-delivery, and the no-download rule for `resource_link`.
 - Anonymous tests verify that IM entity counts do not change and Session Binding scope is Agent-specific.
 - Channel tests verify deduplication, replay, superseding, rendering, Binding-driven Event Worker lifecycle, and idempotent reconciliation.
 - Lifecycle tests verify that Agent Stop, Recreate, and Runtime restart do not start or stop Channel Event Workers.

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -454,15 +454,20 @@ Engine 进程重启会中断等待中和运行中的 Turn，并清空进程内�
 调用 `Run` 前，调用方通过 `Conversations(agentID).Files().Create` 上传内容，并获得带 opaque FileID 的不可变 Metadata。
 `InputFile` 只携带该 FileID，因此调用方和 Engine 不需要共享文件系统或 `SourcePath`。
 Engine 在选定 Agent Scope 内解析 ID，Runtime Adapter 再把不可变快照复制到执行环境。
+解析会在 Admission 前取得 Lease，因此无效的 Supersede Request 不会取消 Active Turn，并发 Delete 也不能使已准入的 Input 失效。
 
 只有新上传或明确再次引用时才把 File 加入 Input。
 不能仅为继续 Runtime 原生 Conversation 而重发之前的 File Byte。
 
 对于输出，每个 Runtime Adapter 消费 typed 原生文件引用，并在跨过 Engine 边界前完成解析。
-Codex app-server Adapter 把 `csgclaw_publish_file` 暴露为接收 workspace 相对路径的 typed dynamic tool；直接使用 Responses 的 Adapter 应消费原生生成文件引用和工具输出。
+Codex app-server Adapter 只在 Engine 创建的 Thread 上暴露接收 workspace 相对路径的 typed dynamic tool `csgclaw_publish_file`；Legacy Bridge Thread 不发布无法投递的能力。
+当前 app-server Protocol 不能在 cold `thread/resume` 时附加 Dynamic Tool，因此恢复出的 Engine Mapping 对严格续接会如实报告不可续接，create-or-resume 则用新的 file-capable Thread 替换它。
+直接使用 Responses 的 Adapter 应消费原生生成文件引用和工具输出。
 Runtime Adapter 通过受 workspace 根目录约束的文件访问打开解析后的本地路径，拒绝越界路径和最终为 symlink 的非普通文件，并注册包含权威名称、MIME type、大小与 SHA-256 元数据的唯一不可变快照。
 Engine 分配与 SHA-256 无关的随机 opaque ID，并在成功的 `TurnResult.Files` 中返回 Metadata，但不暴露宿主路径。
 Channel Adapter 调用 `Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和独立快照流，Turn Replay 会保留相同 ID 和内容。
+单文件限制为 25 MiB，每个 Agent 最多保留 256 MiB 物理快照，包括仍被 Active Lease 持有的已删除快照。
+`Get` 会原地校验不可变快照并返回 Leased Descriptor；Delete 会立即撤销新访问，并在最后一个 Active Lease 关闭后删除实际字节。
 它只能上传成功 `TurnResult` 中的文件。
 Channel Adapter 不得下载 `resource_link`；普通 HTTP(S) 资源链接始终只是 Markdown 链接。
 

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -461,7 +461,7 @@ Engine 在选定 Agent Scope 内解析 ID，Runtime Adapter 再把不可变快�
 
 对于输出，每个 Runtime Adapter 消费 typed 原生文件引用，并在跨过 Engine 边界前完成解析。
 Codex app-server Adapter 只在 Engine 创建的 Thread 上暴露接收 workspace 相对路径的 typed dynamic tool `csgclaw_publish_file`；Legacy Bridge Thread 不发布无法投递的能力。
-当前 app-server Protocol 不能在 cold `thread/resume` 时附加 Dynamic Tool，因此恢复出的 Engine Mapping 对严格续接会如实报告不可续接，create-or-resume 则用新的 file-capable Thread 替换它。
+当前 app-server Protocol 不能在 cold `thread/resume` 时附加 Dynamic Tool，因此恢复出的 Engine Mapping 会续接同一个原生 Thread 以保留 Conversation Context，但在协议支持重新附加前不会发布 File Capability。
 直接使用 Responses 的 Adapter 应消费原生生成文件引用和工具输出。
 Runtime Adapter 通过受 workspace 根目录约束的文件访问打开解析后的本地路径，拒绝越界路径和最终为 symlink 的非普通文件，并注册包含权威名称、MIME type、大小与 SHA-256 元数据的唯一不可变快照。
 Engine 分配与 SHA-256 无关的随机 opaque ID，并在成功的 `TurnResult.Files` 中返回 Metadata，但不暴露宿主路径。

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -24,10 +24,10 @@ CSGClaw 需要一条 Runtime 中立的执行路径，供匿名 Session、内置 
 Channel Adapter 或 Session API -> Agent Engine -> Runtime Adapter
 ```
 
-设计提供两个公共 Resource Interface：
+设计提供两个顶层公共 Resource Interface：
 
 - `Agents()` 管理持久化 Agent Resource 和 Runtime 生命周期。
-- `Conversations(agentID)` 为一个已选择的 Agent 执行 Conversation。
+- `Conversations(agentID)` 为一个已选择的 Agent 执行 Conversation 并管理不可变文件。
 
 接口采用 Kubernetes Client 风格，先选择 Resource Scope，再暴露聚焦的操作。
 它不引入 Kubernetes Controller、API Server、Object Metadata Model 或 Reconciliation Framework。
@@ -217,15 +217,30 @@ Runtime Adapter 只管理 Runtime 特有的 Mapping、Protocol Translation、Cre
 | Resource | 操作 | 用途 |
 |---|---|---|
 | `Agents()` | Create、Get、List、Update、Delete、Start、Stop、Recreate | Agent 期望配置和 Runtime 生命周期 |
-| `Conversations(agentID)` | Run、Cancel、Reset、Resolve | 限定到一个 Agent 的 Conversation 执行 |
+| `Conversations(agentID)` | Files、Run、Cancel、Reset、Resolve | 限定到一个 Agent 的 Conversation 执行 |
+| `Conversations(agentID).Files()` | Create、Get、Delete | 由已选择 Agent 限定的不可变文件 |
 | `ConversationRuntime` | Run、Cancel、Reset、Resolve | Engine 后面的 Runtime 特有直接执行 |
+
+公共 Contract 已具备 Transport-ready 形态，但本阶段不定义远程 Engine Protocol：
+
+| Engine Operation | HTTP Mapping |
+|---|---|
+| `Agents().Create/Get/List/Update/Delete` | Agent Collection 与 Resource 的 POST、GET、PUT、DELETE |
+| `Agents().Start/Stop/Recreate` | Agent Action POST Endpoint |
+| `Conversations(agentID).Run` | 使用 JSON Request 和 JSON 或 SSE Result Stream 的 Turn POST |
+| `Cancel/Reset/Resolve` | 使用 typed JSON Body 的 Conversation Action POST Endpoint |
+| `Conversations(agentID).Files().Create` | File Metadata 加 Streaming HTTP Request Body |
+| `Conversations(agentID).Files().Get/Delete` | 带 Metadata Header 的 Content GET 和 DELETE |
+
+`context.Context`、`io.Reader`、`io.ReadCloser` 和 `EventSink` 属于 Go Client 与 Server Adapter 边界。
+跨过该边界的 Request、Resource、Event、Result 和 Error Value 都具有稳定 JSON 表示，并且不包含 Runtime Path 或进程内 Capability。
 
 `AgentInterface` 是 Agent Resource 的 Collection-scoped API，调用方不能依赖当前 `internal/agent.Service`。
 阶段 2 的 Engine Facade 可以通过私有 Backend 包装当前 Agent Service，以优先复用已经验证的 Agent 持久化和 Runtime 生命周期代码。
 该包装只是 Engine 内部实现，不进入公共 Contract，也不阻止阶段 4 把宽泛的 Service 拆成明确的 Storage、Lifecycle 和 Runtime 组件。
 Conversation Execution 不保存重复的 Agent Record，并协调 Active Turn 和生命周期变更。
 阶段 1 的 Conversation 实现只能通过 Composition Root 注入的私有 Adapter 访问当前 Agent Service。
-阶段 2 扩展这个边界，让完整 Engine 通过同一个私有 Facade 实现 `Agents()` 和 `Conversations()`，而不是先重写现有 Agent 组件。
+阶段 2 扩展这个边界，让完整 Engine 在不先重写现有 Agent 组件的前提下实现 `Agents()`、`Conversations(agentID)` 及其嵌套 `Files()` Resource。
 阶段 4 再在保持外部行为的前提下替换临时 Facade，并收敛 Agent State 与 Runtime 生命周期的内部 Owner。
 如果内部重构确实需要调整公共 Interface，该调整继续通过共同 Review 完成，并同步所有实现、Mock Client 和 Contract Test。
 
@@ -307,7 +322,7 @@ Turn 生命周期结束后，`TurnID` 只在有界的进程内幂等窗口中保
 
 `TurnRequest.Input` 是一个有序 `InputPart` List。
 Text Part 包含 `Text`。
-File Part 包含一个调用方已授权的 `InputFile`。
+File Part 包含一个仅携带 FileID 的 Agent-scoped `InputFile` 引用。
 不存在并行 File List，也不存在 Engine File Preparation 步骤。
 增量实现不会把这个 Contract 缩窄为 String。
 阶段 1 的 Session HTTP Adapter 创建一个 Text Part，私有 Codex Runtime Adapter 则在调用当前 Runtime API 前按顺序合并 Text Part。
@@ -319,13 +334,14 @@ Event Sink 接收一个逻辑 Turn 的有序进度：
 - Thought Delta。
 - Activity Update。
 - Interaction Request。
-- 已验证的 Output Item。
+- 已验证的非文件 Output Item。
 
 Sink 不是 Event Bus、Transcript Store 或 Channel Renderer。
 每个 Event 都携带 `TurnID` 和单调递增的 `Sequence`。
 Adapter 可以使用 `(TurnID, Sequence)` 对重试后回放的 Envelope 去重。
 
 `Run` 只返回一个 `TurnResult`，没有第二套裸 Runtime Error。
+成功 Result 通过 `Files` 携带 JSON-safe 不可变文件 Metadata；失败或取消 Result 不包含可投递文件。
 `Dispatched=false` 表示原生 Turn 尚未提交。
 这包括 Engine 拒绝 Admission，以及创建、解析或持久化必要的 Runtime 原生 Conversation Mapping 失败。
 `Dispatched=true` 表示 Continuation Policy 已成功满足，必要的 Mapping 已经持久化或解析，并且原生 Turn 已提交。
@@ -340,9 +356,9 @@ Adapter 可以使用 `(TurnID, Sequence)` 对重试后回放的 Envelope 去重�
 | 组件 | 负责 | 不负责 |
 |---|---|---|
 | Agent Resource 实现 | Agent 持久化、包含 Runtime Credential 和 `InitShell` 的期望配置、Runtime 生命周期、Workspace 和 Runtime Provision | Turn Input、Transcript、Runtime 原生 Conversation Mapping、Channel Event Worker 生命周期 |
-| Agent Engine | Admission、每 Conversation 串行化、Dispatch、Active Turn、Pending Interaction、Event 顺序、规范化 Result | 持久化 Agent 或 Conversation State、File、Channel 行为 |
-| Runtime Adapter | Runtime Credential 序列化、`InitShell` 执行、原生 Conversation Mapping、直接 Runtime 协议、Runtime Event 转换、向 Runtime 暴露 File | Channel Subscription、Transcript、Agent 持久化 |
-| Channel Adapter | Ingress、Identity、Binding 和 Channel Event Worker 生命周期、Host 侧 Channel Credential、Deduplication、Hidden Context、File Authorization、Transcript、Rendering、Ack | Runtime 原生 Mapping、Engine Admission |
+| Agent Engine | Admission、每 Conversation 串行化、Dispatch、Active Turn、Pending Interaction、Event 顺序、规范化 Result、进程内不可变 Artifact Store | 持久化 Agent 或 Conversation State、外部文件传输、Channel 行为 |
+| Runtime Adapter | Runtime Credential 序列化、`InitShell` 执行、原生 Conversation Mapping、直接 Runtime 协议、Runtime Event 转换、Input File 暴露、Output File 授权 | Channel Subscription、Transcript、Agent 持久化 |
+| Channel Adapter | Ingress、Identity、Binding 和 Channel Event Worker 生命周期、Host 侧 Channel Credential、Deduplication、Hidden Context、Input File 授权、已授权 Output File 投递、Transcript、Rendering、Ack | Runtime 原生 Mapping、Engine Admission |
 | Session HTTP Adapter | HTTP Validation、Session Binding、SSE 和 Error Mapping | IM Room、Message、Participant、Transcript |
 
 阶段 1 的最小 Session 实现没有生命周期协调。
@@ -434,21 +450,26 @@ Engine 进程重启会中断等待中和运行中的 Turn，并清空进程内�
 
 ### 6.2 文件
 
-内置 IM 继续拥有 Attachment Metadata、Blob、Download Token 和 GC。
-调用 Engine 前，受信任调用方授权文件，并解析包含 ID、Source Path、Name、Media Type、Size 和 Hash 的 `InputFile`。
-
-Engine 校验 Input Shape，但把 `SourcePath` 视为不透明值。
-它不调用 IM API、不读取 File Byte、不写 Workspace File、不管理 Blob，也不 Mount Sandbox。
-Runtime Adapter 决定如何 Mount、Copy 或暴露 File，并保留 Path、Symlink、Size 和 Hash 校验。
-调用方保证已解析 Source 在 `Run` 返回前持续有效。
+内置 IM 继续拥有其持久化 Attachment Metadata、Blob、Download Token 和 GC。
+调用 `Run` 前，调用方通过 `Conversations(agentID).Files().Create` 上传内容，并获得带 opaque FileID 的不可变 Metadata。
+`InputFile` 只携带该 FileID，因此调用方和 Engine 不需要共享文件系统或 `SourcePath`。
+Engine 在选定 Agent Scope 内解析 ID，Runtime Adapter 再把不可变快照复制到执行环境。
 
 只有新上传或明确再次引用时才把 File 加入 Input。
 不能仅为继续 Runtime 原生 Conversation 而重发之前的 File Byte。
 
+对于输出，每个 Runtime Adapter 消费 typed 原生文件引用，并在跨过 Engine 边界前完成解析。
+Codex app-server Adapter 把 `csgclaw_publish_file` 暴露为接收 workspace 相对路径的 typed dynamic tool；直接使用 Responses 的 Adapter 应消费原生生成文件引用和工具输出。
+Runtime Adapter 通过受 workspace 根目录约束的文件访问打开解析后的本地路径，拒绝越界路径和最终为 symlink 的非普通文件，并注册包含权威名称、MIME type、大小与 SHA-256 元数据的唯一不可变快照。
+Engine 分配与 SHA-256 无关的随机 opaque ID，并在成功的 `TurnResult.Files` 中返回 Metadata，但不暴露宿主路径。
+Channel Adapter 调用 `Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和独立快照流，Turn Replay 会保留相同 ID 和内容。
+它只能上传成功 `TurnResult` 中的文件。
+Channel Adapter 不得下载 `resource_link`；普通 HTTP(S) 资源链接始终只是 Markdown 链接。
+
 ### 6.3 Structured Output 和 Interaction
 
-唯一共享 Decoder 拥有 `::csgclaw-output::` Grammar。
-它在 Payload 跨过 Engine 边界前验证 `resource_link` 和 Detached `request_user_input`。
+唯一共享 Decoder 只拥有 `resource_link` 和 Detached `request_user_input` 的 `::csgclaw-output::` Grammar。
+Runtime File Output 使用 typed 原生 Runtime Event，不依赖解析 Assistant Text 或 Command Stdout。
 原始控制行不能进入公开 Text 或 Channel Renderer。
 
 Blocking Runtime Permission 或 User Input 保持同一个 Turn 打开，并使用 `Resolve`。
@@ -526,11 +547,11 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 
 - 实现完整 `agentengine.Interface`，并提供实现同一 Contract 的并发安全、有状态 `enginetest.MemoryClient`。
 - Interface 不是不可修改的冻结协议；实现中发现遗漏或错误时，可以通过共同 Review 调整，并在同一次变更中同步真实 Engine、Mock Client、Contract Test 和受影响的 Adapter 调用代码。
-- 实现 `Agents()`、`Run`、`Cancel`、原子 `Reset`、Claimed `Resolve`、显式 Admission Policy、Turn 重试幂等、TurnID Event Envelope、File Input、Interaction、Structured Output、`Dispatched` 和稳定 Error。
+- 实现 `Agents()`、`Run`、`Cancel`、原子 `Reset`、Claimed `Resolve`、显式 Admission Policy、Turn 重试幂等、TurnID Event Envelope、File Input、已授权 Runtime File Output、Interaction、Structured Output、`Dispatched` 和稳定 Error。
 - Agent Engine Facade 优先包装现有 Agent Service、Codex Session、Broker、Structured Output 和 Runtime Provision 代码，不把内部重构作为完成 Engine 的前置条件。
 - Agent Engine 通过共享 Lifecycle Gate 协调 Agent Mutation、Admission、Active Turn、Drain 和固定 Runtime Handle。
 - 把匿名 Session API 迁移到 `agentengine.Interface`，同时保留其 HTTP Contract 和零 IM Entity 创建。
-- 通过 `MemoryClient` 证明 Test-only 飞书 Ingress Harness，并让飞书 Credential 只存在于当前 Channel Binding Owner。
+- 通过 `MemoryClient` 证明 Test-only 飞书 Ingress 和 Output Delivery Harness，包括飞书图片上传、文件上传和消息 OpenAPI 调用，并让飞书 Credential 只存在于当前 Channel Binding Owner。
 - 生产 Channel Adapter 的实现、融合和原子切换保留在阶段 3。
 - 将 Codex `RuntimeSpec.Credentials` 物化为 Workspace 相对文件，并在 File 可用后运行 `RuntimeSpec.InitShell`。
 
@@ -572,17 +593,20 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 ### 8.2 目标架构
 
 - `internal/agentengine` 不 Import IM、Participant、Channel、Team 或具体 Runtime Package。
-- `Interface` 暴露 `Agents()` 和按 Agent 限定的 `Conversations(agentID)`。
+- `Interface` 暴露 `Agents()` 和按 Agent 限定的 `Conversations(agentID)`；文件是通过 `Conversations(agentID).Files()` 选择的嵌套 Conversation Resource。
 - Conversation Request 不重复携带 Agent ID。
 - Conversation Key 保持不透明并由调用方拥有。
 - 每次 Run 都携带调用方生成的不透明 Turn ID，Cancel 使用 Conversation Key 和 Turn ID 定位一个 Turn。
-- Engine 不持久化 Agent、Conversation、Transcript、File 或 Delivery State。
+- Engine 不持久化 Agent、Conversation、Transcript、File 或 Delivery State；Artifact Store 仅存在于进程内，并由显式删除或 Turn Cache 淘汰限制生命周期。
 - Agent Resource 实现、Agent Engine 和 Runtime Adapter 不依赖 Channel Event Worker，也不访问 IM Message 持久化。
 - Channel Event Worker 按稳定的 Binding Identity 建立索引，不使用 Runtime ID 或原生 Session ID。
 - Runtime 原生 Conversation Mapping 只有一个 Owner。
 - 阶段 2 完成后，外部调用方只依赖 `AgentInterface`，`Conversations()` 只通过 Engine 内部 Facade 访问 Agent 可用性和 Runtime 选择。
 - 阶段 4 完成后，`AgentInterface` 实现是唯一的 Agent 持久化和 Runtime 生命周期 Owner，并且 Engine 内部不再依赖宽泛的 `internal/agent.Service`。
 - Runtime Credential File Layout 和初始化由各 Runtime Adapter 负责。
+- Runtime File Output 只能通过成功的 `TurnResult.Files` 跨过 Engine，其中 Metadata 指向包含 opaque ID、MIME type、大小和 SHA-256 且不含宿主路径的不可变快照。
+- Input File Part 只包含 Agent-scoped FileID；公共 Request 和 Result 不包含本地 Source Path 或 Reader 能力。
+- 公共 Resource 与 Event Value 使用稳定 JSON Field Name，`Files.Create` 和 `Files.Get` 分别映射 HTTP Request 与 Response Body。
 - 缺少 Runtime Adapter 时明确失败，不启动 Fallback Path。
 - Go Contract 和两种语言文档保持同步。
 
@@ -603,13 +627,15 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 - Create、Update、Get 和 List Result 省略 Runtime Credential Value。
 - Recreate 和 Delete 如实报告严格续接 Mapping 缺失。
 - CSGClaw Structured Output 不泄漏原始控制行。
+- 普通 `resource_link` Output 不得被下载或提升为可上传文件。
 - Secret Answer 不进入 Log 或 Transcript。
 
 ### 8.4 目标验证
 
 - Contract Test 覆盖 Run、Cancel、原子 Reset、Claimed Resolve、Event Envelope、终态 Result 和稳定 Error。
 - 测试覆盖 Turn 重试幂等、不同 Conversation 并发、Reject、Wait、Supersede、Sink Failure 和 Cancel 行为。
-- 测试覆盖无 MCP、本地 MCP、远程 MCP、Text Input 和 File Input。
+- 测试覆盖无 MCP、本地 MCP、远程 MCP、Text Input、File Input、已授权 Runtime File Output 和 Workspace 越界拒绝。
+- 飞书 OpenAPI 端到端 Harness 验证图片上传、文件上传、消息投递、失败 Turn 不投递以及 `resource_link` 不下载规则。
 - 匿名测试验证 IM Entity 数量不变，并且 Session Binding Scope 按 Agent 隔离。
 - Channel 测试验证 Deduplication、Replay、Superseding、Rendering、Binding 驱动的 Event Worker 生命周期和幂等协调。
 - Lifecycle 测试验证 Agent Stop、Recreate 和 Runtime Restart 不启动或停止 Channel Event Worker。

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -466,7 +466,6 @@ Codex app-server Adapter 只在 Engine 创建的 Thread 上暴露接收 workspac
 Runtime Adapter 通过受 workspace 根目录约束的文件访问打开解析后的本地路径，拒绝越界路径和最终为 symlink 的非普通文件，并注册包含权威名称、MIME type、大小与 SHA-256 元数据的唯一不可变快照。
 Engine 分配与 SHA-256 无关的随机 opaque ID，并在成功的 `TurnResult.Files` 中返回 Metadata，但不暴露宿主路径。
 Channel Adapter 调用 `Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和独立快照流，Turn Replay 会保留相同 ID 和内容。
-单文件限制为 25 MiB，每个 Agent 最多保留 256 MiB 物理快照，包括仍被 Active Lease 持有的已删除快照。
 `Get` 会原地校验不可变快照并返回 Leased Descriptor；Delete 会立即撤销新访问，并在最后一个 Active Lease 关闭后删除实际字节。
 它只能上传成功 `TurnResult` 中的文件。
 Channel Adapter 不得下载 `resource_link`；普通 HTTP(S) 资源链接始终只是 Markdown 链接。

--- a/docs/tech/structured-output.md
+++ b/docs/tech/structured-output.md
@@ -304,12 +304,13 @@ A minimal link needs only `type`, `name`, and `uri`:
 ## File output
 
 Runtime-local file delivery is deliberately not encoded in this line protocol.
-The Codex app-server adapter registers the typed dynamic tool `csgclaw_publish_file` with `path`, optional `name`, and optional `mimeType` arguments.
+The Codex app-server adapter registers the typed dynamic tool `csgclaw_publish_file` only for Engine-created threads, with `path`, optional `name`, and optional `mimeType` arguments.
 The tool produces a reliable Runtime file event rather than text that must be reparsed.
 The Runtime Adapter opens the workspace-relative path through rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot in the Agent-scoped Engine Artifact Store before the Turn completes.
 Agent Engine assigns an opaque random file ID independent from the content SHA-256 and returns JSON-safe metadata in `TurnResult.Files` only when the Turn succeeds.
 The visible name must be a valid UTF-8 basename with no path components or control characters and at most 255 bytes.
 Channel Adapters call `Engine.Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent reader over the same snapshot without accessing the Runtime workspace.
+Files are limited to 25 MiB each and 256 MiB of retained physical snapshots per Agent.
 They may upload only files from a successful `TurnResult` and must never download a `resource_link`.
 
 A direct OpenAI Responses adapter should translate native generated-file references and tool outputs into the same Engine `OutputFile` contract instead of asking the model to print a CSGClaw control record.

--- a/docs/tech/structured-output.md
+++ b/docs/tech/structured-output.md
@@ -301,6 +301,21 @@ A minimal link needs only `type`, `name`, and `uri`:
 ::csgclaw-output::resource_link {"type":"resource_link","name":"docs","uri":"https://example.com/docs"}
 ```
 
+## File output
+
+Runtime-local file delivery is deliberately not encoded in this line protocol.
+The Codex app-server adapter registers the typed dynamic tool `csgclaw_publish_file` with `path`, optional `name`, and optional `mimeType` arguments.
+The tool produces a reliable Runtime file event rather than text that must be reparsed.
+The Runtime Adapter opens the workspace-relative path through rooted access, rejects escapes and non-regular final symlinks, and registers one immutable snapshot in the Agent-scoped Engine Artifact Store before the Turn completes.
+Agent Engine assigns an opaque random file ID independent from the content SHA-256 and returns JSON-safe metadata in `TurnResult.Files` only when the Turn succeeds.
+The visible name must be a valid UTF-8 basename with no path components or control characters and at most 255 bytes.
+Channel Adapters call `Engine.Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent reader over the same snapshot without accessing the Runtime workspace.
+They may upload only files from a successful `TurnResult` and must never download a `resource_link`.
+
+A direct OpenAI Responses adapter should translate native generated-file references and tool outputs into the same Engine `OutputFile` contract instead of asking the model to print a CSGClaw control record.
+Responses output text can carry file annotations, while OpenAI-managed container files remain addressable through their container and file IDs.
+See the [Responses API reference](https://developers.openai.com/api/reference/cli/resources/beta/subresources/responses) and [Container Files API](https://developers.openai.com/api/reference/resources/containers/subresources/files).
+
 ## Limits and compatibility
 
 - Each control record is limited to 256 KiB.

--- a/docs/tech/structured-output.md
+++ b/docs/tech/structured-output.md
@@ -310,7 +310,6 @@ The Runtime Adapter opens the workspace-relative path through rooted access, rej
 Agent Engine assigns an opaque random file ID independent from the content SHA-256 and returns JSON-safe metadata in `TurnResult.Files` only when the Turn succeeds.
 The visible name must be a valid UTF-8 basename with no path components or control characters and at most 255 bytes.
 Channel Adapters call `Engine.Conversations(agentID).Files().Get(fileID)` to receive authoritative metadata and an independent reader over the same snapshot without accessing the Runtime workspace.
-Files are limited to 25 MiB each and 256 MiB of retained physical snapshots per Agent.
 They may upload only files from a successful `TurnResult` and must never download a `resource_link`.
 
 A direct OpenAI Responses adapter should translate native generated-file references and tool outputs into the same Engine `OutputFile` contract instead of asking the model to print a CSGClaw control record.

--- a/docs/tech/structured-output.zh.md
+++ b/docs/tech/structured-output.zh.md
@@ -301,6 +301,21 @@ CSGClaw 会在 Markdown 链接旁渲染第一个使用绝对 HTTP(S) `src` 的�
 ::csgclaw-output::resource_link {"type":"resource_link","name":"docs","uri":"https://example.com/docs"}
 ```
 
+## 文件输出
+
+Runtime 本地文件投递明确不使用该行式协议编码。
+Codex app-server Adapter 注册 typed dynamic tool `csgclaw_publish_file`，参数为 `path`、可选 `name` 和可选 `mimeType`。
+该工具产生可靠的 Runtime File Event，而不是需要再次解析的文本。
+Runtime Adapter 通过受 workspace 根目录约束的文件访问打开相对路径，拒绝越界路径和最终为 symlink 的非普通文件，并在 Turn 完成前把唯一不可变快照注册到 Agent-scoped Engine Artifact Store。
+Agent Engine 分配与内容 SHA-256 无关的随机 opaque File ID，并且只在 Turn 成功时通过 `TurnResult.Files` 返回 JSON-safe Metadata。
+可见名称必须是有效 UTF-8 basename，不含路径成分或控制字符，并且最多为 255 bytes。
+Channel Adapter 调用 `Engine.Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和同一个快照上的独立 Reader，不再访问 Runtime workspace。
+它只能上传成功 `TurnResult` 中的文件，并且不得下载 `resource_link`。
+
+直接使用 OpenAI Responses 的 Adapter 应把原生生成文件引用和工具输出转换成同一个 Engine `OutputFile` Contract，而不是要求模型输出 CSGClaw 控制记录。
+Responses Output Text 可以携带 File Annotation，OpenAI 托管的 Container File 则继续通过 Container ID 和 File ID 寻址。
+参见 [Responses API Reference](https://developers.openai.com/api/reference/cli/resources/beta/subresources/responses) 和 [Container Files API](https://developers.openai.com/api/reference/resources/containers/subresources/files)。
+
 ## 限制与兼容性
 
 - 每条控制记录最大为 256 KiB。

--- a/docs/tech/structured-output.zh.md
+++ b/docs/tech/structured-output.zh.md
@@ -304,12 +304,13 @@ CSGClaw 会在 Markdown 链接旁渲染第一个使用绝对 HTTP(S) `src` 的�
 ## 文件输出
 
 Runtime 本地文件投递明确不使用该行式协议编码。
-Codex app-server Adapter 注册 typed dynamic tool `csgclaw_publish_file`，参数为 `path`、可选 `name` 和可选 `mimeType`。
+Codex app-server Adapter 只为 Engine 创建的 Thread 注册 typed dynamic tool `csgclaw_publish_file`，参数为 `path`、可选 `name` 和可选 `mimeType`。
 该工具产生可靠的 Runtime File Event，而不是需要再次解析的文本。
 Runtime Adapter 通过受 workspace 根目录约束的文件访问打开相对路径，拒绝越界路径和最终为 symlink 的非普通文件，并在 Turn 完成前把唯一不可变快照注册到 Agent-scoped Engine Artifact Store。
 Agent Engine 分配与内容 SHA-256 无关的随机 opaque File ID，并且只在 Turn 成功时通过 `TurnResult.Files` 返回 JSON-safe Metadata。
 可见名称必须是有效 UTF-8 basename，不含路径成分或控制字符，并且最多为 255 bytes。
 Channel Adapter 调用 `Engine.Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和同一个快照上的独立 Reader，不再访问 Runtime workspace。
+单文件限制为 25 MiB，每个 Agent 最多保留 256 MiB 物理快照。
 它只能上传成功 `TurnResult` 中的文件，并且不得下载 `resource_link`。
 
 直接使用 OpenAI Responses 的 Adapter 应把原生生成文件引用和工具输出转换成同一个 Engine `OutputFile` Contract，而不是要求模型输出 CSGClaw 控制记录。

--- a/docs/tech/structured-output.zh.md
+++ b/docs/tech/structured-output.zh.md
@@ -310,7 +310,6 @@ Runtime Adapter 通过受 workspace 根目录约束的文件访问打开相对�
 Agent Engine 分配与内容 SHA-256 无关的随机 opaque File ID，并且只在 Turn 成功时通过 `TurnResult.Files` 返回 JSON-safe Metadata。
 可见名称必须是有效 UTF-8 basename，不含路径成分或控制字符，并且最多为 255 bytes。
 Channel Adapter 调用 `Engine.Conversations(agentID).Files().Get(fileID)` 获取权威 Metadata 和同一个快照上的独立 Reader，不再访问 Runtime workspace。
-单文件限制为 25 MiB，每个 Agent 最多保留 256 MiB 物理快照。
 它只能上传成功 `TurnResult` 中的文件，并且不得下载 `resource_link`。
 
 直接使用 OpenAI Responses 的 Adapter 应把原生生成文件引用和工具输出转换成同一个 Engine `OutputFile` Contract，而不是要求模型输出 CSGClaw 控制记录。

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -139,6 +139,15 @@ type ResourceLink struct {
 	Icons       []map[string]any `json:"icons,omitempty"`
 }
 
+// RuntimeFile is a typed request from a Runtime to expose one local workspace
+// file. The Runtime Adapter authorizes the path and replaces this record with
+// an Agent Engine OutputFile before it crosses the Engine boundary.
+type RuntimeFile struct {
+	Path     string `json:"path"`
+	Name     string `json:"name,omitempty"`
+	MIMEType string `json:"mimeType,omitempty"`
+}
+
 // StructuredOutputArtifact is the normalized result of decoding CSGClaw
 // control records from one completed runtime output.
 type StructuredOutputArtifact struct {
@@ -207,6 +216,7 @@ const (
 	RuntimeEventUserInputRequest  RuntimeEventKind = "user_input_request"
 	RuntimeEventUserInputResolved RuntimeEventKind = "user_input_resolved"
 	RuntimeEventStructuredOutput  RuntimeEventKind = "structured_output"
+	RuntimeEventFileOutput        RuntimeEventKind = "file_output"
 	RuntimeEventPromptCompleted   RuntimeEventKind = "prompt_completed"
 	RuntimeEventPromptFailed      RuntimeEventKind = "prompt_failed"
 )
@@ -254,7 +264,7 @@ func RuntimeEventRequiresReliableDelivery(event RuntimeEvent) bool {
 	case RuntimeEventTextDelta,
 		RuntimeEventActionRequest, RuntimeEventActionDecision,
 		RuntimeEventUserInputRequest, RuntimeEventUserInputResolved,
-		RuntimeEventStructuredOutput:
+		RuntimeEventStructuredOutput, RuntimeEventFileOutput:
 		return true
 	case RuntimeEventPromptCompleted, RuntimeEventPromptFailed:
 		return true

--- a/internal/agentengine/agent.go
+++ b/internal/agentengine/agent.go
@@ -40,25 +40,25 @@ type AgentInterface interface {
 // Spec is desired state with Runtime credentials omitted; Status is the latest
 // observed state.
 type Agent struct {
-	ID        string
-	Spec      AgentSpec
-	Status    AgentStatus
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID        string      `json:"id"`
+	Spec      AgentSpec   `json:"spec"`
+	Status    AgentStatus `json:"status"`
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
 }
 
 // AgentSpec is the complete desired configuration reconciled by Agent Engine.
 // Updating it atomically replaces Skills and MCP configuration together
 // with the rest of the desired state.
 type AgentSpec struct {
-	Name         string
-	Description  string
-	Instructions string
-	Role         AgentRole
-	Runtime      RuntimeSpec
-	Model        ModelSpec
-	Skills       []string
-	MCPServers   map[string]MCPServerConfig
+	Name         string                     `json:"name"`
+	Description  string                     `json:"description,omitempty"`
+	Instructions string                     `json:"instructions,omitempty"`
+	Role         AgentRole                  `json:"role"`
+	Runtime      RuntimeSpec                `json:"runtime"`
+	Model        ModelSpec                  `json:"model"`
+	Skills       []string                   `json:"skills,omitempty"`
+	MCPServers   map[string]MCPServerConfig `json:"mcp_servers,omitempty"`
 }
 
 // AgentRole selects orchestration behavior. Agent is the resource kind, so a
@@ -73,41 +73,44 @@ const (
 // RuntimeSpec selects a registered Runtime Adapter and its desired execution
 // environment. Credential names and Options remain adapter-specific.
 type RuntimeSpec struct {
-	Adapter   string
-	Sandboxed bool
-	Image     string
+	Adapter   string `json:"adapter"`
+	Sandboxed bool   `json:"sandboxed,omitempty"`
+	Image     string `json:"image,omitempty"`
 
 	// Credentials maps Runtime-workspace-relative file paths to complete secret
 	// file contents. It is write-only on Create and Update: returned Agent values
 	// omit it, and its values must not be logged.
-	Credentials map[string]string
+	Credentials map[string]string `json:"credentials,omitempty"`
 
 	// InitShell is an idempotent shell program run with the Runtime workspace as
 	// its working directory after credentials are materialized.
-	InitShell string
+	InitShell string `json:"init_shell,omitempty"`
 
-	Options map[string]any
+	// Options must contain only JSON-compatible values so the same Spec can cross
+	// an HTTP transport without Runtime-specific Go types.
+	Options map[string]any `json:"options,omitempty"`
 }
 
 // ModelSpec selects model behavior without embedding provider credentials.
 type ModelSpec struct {
-	ProviderID      string
-	ModelID         string
-	ReasoningEffort string
-	FastMode        bool
-	Options         map[string]any
+	ProviderID      string `json:"provider_id,omitempty"`
+	ModelID         string `json:"model_id,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	FastMode        bool   `json:"fast_mode,omitempty"`
+	// Options must contain only JSON-compatible values.
+	Options map[string]any `json:"options,omitempty"`
 }
 
 // MCPServerConfig is one MCP server's schema-neutral desired configuration.
-// Values may contain secrets and must not be logged.
+// Values must be JSON-compatible, may contain secrets, and must not be logged.
 type MCPServerConfig map[string]any
 
 // AgentStatus is observed lifecycle state and is never desired configuration.
 type AgentStatus struct {
-	State     AgentState
-	RuntimeID string
-	Ready     bool
-	Message   string
+	State     AgentState `json:"state"`
+	RuntimeID string     `json:"runtime_id,omitempty"`
+	Ready     bool       `json:"ready"`
+	Message   string     `json:"message,omitempty"`
 }
 
 // AgentState is the observed lifecycle state.

--- a/internal/agentengine/agent_facade.go
+++ b/internal/agentengine/agent_facade.go
@@ -40,6 +40,7 @@ func (unavailableAgents) Recreate(context.Context, string) (Agent, error) {
 
 type agentFacade struct {
 	service *agent.Service
+	files   *FileStore
 }
 
 func (f agentFacade) Create(ctx context.Context, spec AgentSpec) (Agent, error) {
@@ -155,7 +156,17 @@ func (f agentFacade) Update(ctx context.Context, agentID string, spec AgentSpec)
 }
 
 func (f agentFacade) Delete(ctx context.Context, agentID string) error {
-	return f.service.Delete(ctx, agentID)
+	canonicalID := strings.TrimSpace(agentID)
+	if selected, ok := f.service.Agent(canonicalID); ok {
+		canonicalID = selected.ID
+	}
+	if err := f.service.Delete(ctx, agentID); err != nil {
+		return err
+	}
+	if f.files != nil {
+		f.files.DeleteAgent(canonicalID)
+	}
+	return nil
 }
 
 func (f agentFacade) Start(ctx context.Context, agentID string) (Agent, error) {

--- a/internal/agentengine/conversation.go
+++ b/internal/agentengine/conversation.go
@@ -5,6 +5,7 @@ import "context"
 // ConversationInterface executes conversations for the Agent selected by
 // Conversations.
 type ConversationInterface interface {
+	Files() FileInterface
 	Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult
 	Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error
 	Reset(ctx context.Context, key ConversationKey) error
@@ -67,31 +68,27 @@ const (
 
 // InputPart is text or a caller-authorized file.
 type InputPart struct {
-	Kind InputPartKind
-	Text string
-	File *InputFile
+	Kind InputPartKind `json:"kind"`
+	Text string        `json:"text,omitempty"`
+	File *InputFile    `json:"file,omitempty"`
 }
 
-// InputFile is a caller-authorized file source.
-// Engine validates only this neutral shape. Runtime Adapters own file access,
-// copying, and Runtime-specific input conversion.
+// InputFile references one immutable Agent-scoped Conversation file resource.
+// Runtime Adapters receive the resolved snapshot only after Engine admission.
 type InputFile struct {
-	ID         string
-	SourcePath string
-	Name       string
-	MediaType  string
-	SizeBytes  int64
-	SHA256     string
+	ID string `json:"id"`
+
+	file *OutputFile
 }
 
 // TurnRequest contains conversation identity and caller-normalized input.
 type TurnRequest struct {
-	ID              TurnID
-	ConversationKey ConversationKey
-	Input           []InputPart
-	Admission       AdmissionPolicy
-	Continuation    ContinuationPolicy
-	Interaction     InteractionPolicy
+	ID              TurnID             `json:"id"`
+	ConversationKey ConversationKey    `json:"conversation_key"`
+	Input           []InputPart        `json:"input"`
+	Admission       AdmissionPolicy    `json:"admission,omitempty"`
+	Continuation    ContinuationPolicy `json:"continuation,omitempty"`
+	Interaction     InteractionPolicy  `json:"interaction,omitempty"`
 }
 
 // TurnEventKind identifies progress emitted during a turn.
@@ -110,35 +107,36 @@ const (
 // TurnEvent is the replay-safe envelope for one normalized Runtime event.
 // Sequence starts at one and increases monotonically for each TurnID.
 type TurnEvent struct {
-	TurnID      TurnID
-	Sequence    uint64
-	Kind        TurnEventKind
-	Text        string
-	Thought     string
-	Tool        *ToolActivity
-	Activity    *ActivityUpdate
-	Interaction *InteractionRequest
-	Output      *OutputItem
+	TurnID      TurnID              `json:"turn_id"`
+	Sequence    uint64              `json:"sequence"`
+	Kind        TurnEventKind       `json:"kind"`
+	Text        string              `json:"text,omitempty"`
+	Thought     string              `json:"thought,omitempty"`
+	Tool        *ToolActivity       `json:"tool,omitempty"`
+	Activity    *ActivityUpdate     `json:"activity,omitempty"`
+	Interaction *InteractionRequest `json:"interaction,omitempty"`
+	Output      *OutputItem         `json:"output,omitempty"`
 }
 
-// ToolActivity contains normalized tool progress.
+// ToolActivity contains normalized tool progress. Payload must be JSON-compatible.
 type ToolActivity struct {
-	ID            string
-	Kind          string
-	Title         string
-	Status        string
-	InputSummary  string
-	OutputSummary string
-	Payload       any
+	ID            string `json:"id"`
+	Kind          string `json:"kind"`
+	Title         string `json:"title,omitempty"`
+	Status        string `json:"status,omitempty"`
+	InputSummary  string `json:"input_summary,omitempty"`
+	OutputSummary string `json:"output_summary,omitempty"`
+	Payload       any    `json:"payload,omitempty"`
 }
 
 // ActivityUpdate carries Runtime-neutral progress not represented by a tool.
+// Payload must be JSON-compatible.
 type ActivityUpdate struct {
-	ID      string
-	Kind    string
-	Title   string
-	Status  string
-	Payload any
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`
+	Title   string `json:"title,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Payload any    `json:"payload,omitempty"`
 }
 
 // InteractionKind identifies a blocking Runtime request.
@@ -150,26 +148,27 @@ const (
 )
 
 // InteractionRequest is one pending interaction addressable through Resolve.
+// Payload must be JSON-compatible.
 type InteractionRequest struct {
-	ID      string
-	Kind    InteractionKind
-	Title   string
-	Payload any
+	ID      string          `json:"id"`
+	Kind    InteractionKind `json:"kind"`
+	Title   string          `json:"title,omitempty"`
+	Payload any             `json:"payload,omitempty"`
 }
 
 // InteractionResolution resolves exactly one pending interaction.
 type InteractionResolution struct {
-	ConversationKey ConversationKey
-	InteractionID   string
-	OptionID        string
-	Answers         map[string]InteractionAnswer
-	ResponderID     string
+	ConversationKey ConversationKey              `json:"conversation_key"`
+	InteractionID   string                       `json:"interaction_id"`
+	OptionID        string                       `json:"option_id,omitempty"`
+	Answers         map[string]InteractionAnswer `json:"answers,omitempty"`
+	ResponderID     string                       `json:"responder_id,omitempty"`
 }
 
 // InteractionAnswer is a normalized answer for one Runtime question.
 type InteractionAnswer struct {
-	Values  []string
-	Skipped bool
+	Values  []string `json:"values,omitempty"`
+	Skipped bool     `json:"skipped,omitempty"`
 }
 
 // OutputItemKind identifies a detached, non-blocking output record.
@@ -180,10 +179,11 @@ const (
 	OutputItemResourceLink     OutputItemKind = "resource_link"
 )
 
-// OutputItem contains an already validated Runtime output record.
+// OutputItem contains an already validated Runtime output record. Payload must
+// be JSON-compatible and is decoded according to Kind by an HTTP client.
 type OutputItem struct {
-	Kind    OutputItemKind
-	Payload any
+	Kind    OutputItemKind `json:"kind"`
+	Payload any            `json:"payload"`
 }
 
 // TurnStatus is the terminal state of one turn.
@@ -205,6 +205,7 @@ const (
 	ErrorConversationBusy            ErrorCode = "conversation_busy"
 	ErrorConversationNotResumable    ErrorCode = "conversation_not_resumable"
 	ErrorFileUnavailable             ErrorCode = "file_unavailable"
+	ErrorFileNotFound                ErrorCode = "file_not_found"
 	ErrorInteractionNotFound         ErrorCode = "interaction_not_found"
 	ErrorInteractionUnsupported      ErrorCode = "interaction_unsupported"
 	ErrorCanceled                    ErrorCode = "canceled"
@@ -214,8 +215,8 @@ const (
 
 // TurnError is a normalized failure returned by Engine operations.
 type TurnError struct {
-	Code    ErrorCode
-	Message string
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
 }
 
 func (e *TurnError) Error() string {
@@ -229,6 +230,9 @@ func (e *TurnError) Error() string {
 func ErrorCodeOf(err error) ErrorCode {
 	for err != nil {
 		if turnErr, ok := err.(*TurnError); ok {
+			if turnErr == nil {
+				return ""
+			}
 			return turnErr.Code
 		}
 		type unwrapper interface{ Unwrap() error }
@@ -241,10 +245,15 @@ func ErrorCodeOf(err error) ErrorCode {
 	return ""
 }
 
-// TurnResult is the terminal outcome of one turn.
+// TurnResult is the JSON-safe terminal outcome of one turn. Files contains
+// metadata only; callers retrieve metadata and content through
+// Conversations(agentID).Files().Get(fileID).
 type TurnResult struct {
-	Status     TurnStatus
-	Output     string
-	Dispatched bool
-	Error      *TurnError
+	Status     TurnStatus   `json:"status"`
+	Output     string       `json:"output,omitempty"`
+	Files      []OutputFile `json:"files,omitempty"`
+	Dispatched bool         `json:"dispatched"`
+	Error      *TurnError   `json:"error,omitempty"`
+
+	files []*OutputFile
 }

--- a/internal/agentengine/engine.go
+++ b/internal/agentengine/engine.go
@@ -131,6 +131,19 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	}
 
 	identity := conversationIdentity{agentID: c.agentID, key: request.ConversationKey}
+	if replay, existing, preflightResult := c.engine.preflightTurn(identity, request); replay != nil {
+		return replayCompleted(ctx, sink, *replay)
+	} else if existing != nil {
+		return awaitActiveTurn(ctx, sink, existing)
+	} else if preflightResult != nil {
+		return *preflightResult
+	}
+	runtimeRequest, releaseInputs, inputErr := c.engine.resolveInputFiles(c.agentID, request)
+	if inputErr != nil {
+		return TurnResult{Status: TurnFailed, Error: inputErr}
+	}
+	defer releaseInputs()
+
 	turn, replay, existing, admissionResult := c.engine.admit(ctx, identity, request)
 	if replay != nil {
 		return replayCompleted(ctx, sink, *replay)
@@ -141,14 +154,6 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	if admissionResult != nil {
 		return *admissionResult
 	}
-	runtimeRequest, inputErr := c.engine.resolveInputFiles(c.agentID, request)
-	if inputErr != nil {
-		result := TurnResult{Status: TurnFailed, Error: inputErr}
-		turn.cancel()
-		c.engine.complete(identity, turn, result)
-		return result
-	}
-
 	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(turn.ctx, c.agentID)
 	if resolveErr != nil {
 		result := TurnResult{Status: TurnFailed, Error: resolveErr}
@@ -166,10 +171,19 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	})
 	result := runtimeAdapter.Run(turn.ctx, runtimeRequest, orderedSink)
 	if result.Status != TurnSucceeded {
+		cleanupOutputFiles(result.files)
 		result.Files = nil
 		result.files = nil
 	} else if len(result.files) > 0 {
-		result.Files = c.engine.files.registerTurnFiles(c.agentID, request.ConversationKey, request.ID, result.files)
+		files, fileErr := c.engine.files.registerTurnFiles(c.agentID, request.ConversationKey, request.ID, result.files)
+		if fileErr != nil {
+			result.Status = TurnFailed
+			result.Output = ""
+			result.Files = nil
+			result.Error = fileErr
+		} else {
+			result.Files = files
+		}
 		result.files = nil
 	}
 	turn.cancel()
@@ -178,20 +192,57 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	return result
 }
 
-func (e *Engine) resolveInputFiles(agentID string, request TurnRequest) (TurnRequest, *TurnError) {
+func (e *Engine) preflightTurn(identity conversationIdentity, request TurnRequest) (*completedTurn, *activeTurn, *TurnResult) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ensureState()
+	turnKey := turnIdentity{conversationIdentity: identity, id: request.ID}
+	if completed, ok := e.completed[turnKey]; ok {
+		if !sameTurnRequest(completed.request, request) {
+			result := failedResult(ErrorInvalidRequest, "turn ID was already used with a different request")
+			return nil, nil, &result
+		}
+		copy := cloneCompletedTurn(completed)
+		return &copy, nil, nil
+	}
+	if current := e.active[identity]; current != nil && current.request.ID == request.ID {
+		if !sameTurnRequest(current.request, request) {
+			result := failedResult(ErrorInvalidRequest, "turn ID is active with a different request")
+			return nil, nil, &result
+		}
+		return nil, current, nil
+	}
+	return nil, nil, nil
+}
+
+func (e *Engine) resolveInputFiles(agentID string, request TurnRequest) (TurnRequest, func(), *TurnError) {
 	resolved := cloneTurnRequest(request)
+	var releases []func()
+	release := func() {
+		for _, releaseFile := range releases {
+			releaseFile()
+		}
+	}
 	for index := range resolved.Input {
 		part := &resolved.Input[index]
 		if part.Kind != InputPartFile {
 			continue
 		}
-		file, err := e.files.resolve(agentID, part.File.ID)
+		file, releaseFile, err := e.files.resolve(agentID, part.File.ID)
 		if err != nil {
-			return TurnRequest{}, err
+			release()
+			return TurnRequest{}, func() {}, err
 		}
+		releases = append(releases, releaseFile)
 		part.File.file = file
 	}
-	return resolved, nil
+	return resolved, release, nil
+}
+
+func cleanupOutputFiles(files []*OutputFile) {
+	for _, file := range files {
+		file.cleanup()
+	}
 }
 
 func (c *conversations) Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error {

--- a/internal/agentengine/engine.go
+++ b/internal/agentengine/engine.go
@@ -26,6 +26,7 @@ type conversationRuntimeAdapter interface {
 type Engine struct {
 	agents   AgentInterface
 	runtimes conversationRuntimeResolver
+	files    *FileStore
 
 	mu             sync.Mutex
 	active         map[conversationIdentity]*activeTurn
@@ -89,6 +90,13 @@ func (e *Engine) Conversations(agentID string) ConversationInterface {
 	return &conversations{engine: e, agentID: strings.TrimSpace(agentID)}
 }
 
+func (c *conversations) Files() FileInterface {
+	if c == nil || c.engine == nil || c.engine.files == nil {
+		return unavailableFiles{}
+	}
+	return c.engine.files.Scope(c.agentID)
+}
+
 type conversations struct {
 	engine  *Engine
 	agentID string
@@ -133,6 +141,13 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	if admissionResult != nil {
 		return *admissionResult
 	}
+	runtimeRequest, inputErr := c.engine.resolveInputFiles(c.agentID, request)
+	if inputErr != nil {
+		result := TurnResult{Status: TurnFailed, Error: inputErr}
+		turn.cancel()
+		c.engine.complete(identity, turn, result)
+		return result
+	}
 
 	runtimeAdapter, releaseRuntime, resolveErr := c.engine.runtimes.conversationRuntime(turn.ctx, c.agentID)
 	if resolveErr != nil {
@@ -149,11 +164,34 @@ func (c *conversations) Run(ctx context.Context, request TurnRequest, sink Event
 	orderedSink := EventSinkFunc(func(eventCtx context.Context, event TurnEvent) error {
 		return c.engine.recordAndEmit(eventCtx, turn, sink, event)
 	})
-	result := runtimeAdapter.Run(turn.ctx, request, orderedSink)
+	result := runtimeAdapter.Run(turn.ctx, runtimeRequest, orderedSink)
+	if result.Status != TurnSucceeded {
+		result.Files = nil
+		result.files = nil
+	} else if len(result.files) > 0 {
+		result.Files = c.engine.files.registerTurnFiles(c.agentID, request.ConversationKey, request.ID, result.files)
+		result.files = nil
+	}
 	turn.cancel()
 	releaseRuntime()
 	c.engine.complete(identity, turn, result)
 	return result
+}
+
+func (e *Engine) resolveInputFiles(agentID string, request TurnRequest) (TurnRequest, *TurnError) {
+	resolved := cloneTurnRequest(request)
+	for index := range resolved.Input {
+		part := &resolved.Input[index]
+		if part.Kind != InputPartFile {
+			continue
+		}
+		file, err := e.files.resolve(agentID, part.File.ID)
+		if err != nil {
+			return TurnRequest{}, err
+		}
+		part.File.file = file
+	}
+	return resolved, nil
 }
 
 func (c *conversations) Cancel(ctx context.Context, key ConversationKey, turnID TurnID) error {
@@ -352,6 +390,9 @@ func (e *Engine) ensureState() {
 	if e.completed == nil {
 		e.completed = make(map[turnIdentity]completedTurn)
 	}
+	if e.files == nil {
+		e.files = NewFileStore()
+	}
 }
 
 func (e *Engine) setRuntime(identity conversationIdentity, turn *activeTurn, runtimeAdapter conversationRuntimeAdapter) {
@@ -433,6 +474,7 @@ func (e *Engine) complete(identity conversationIdentity, turn *activeTurn, resul
 			oldest := e.completedOrder[0]
 			e.completedOrder = e.completedOrder[1:]
 			delete(e.completed, oldest)
+			e.files.deleteTurn(oldest.agentID, oldest.key, oldest.id)
 		}
 	}
 	close(turn.done)
@@ -531,11 +573,24 @@ func cloneTurnEvent(input TurnEvent) TurnEvent {
 }
 
 func cloneTurnResult(input TurnResult) TurnResult {
+	input.Files = cloneOutputFiles(input.Files)
+	input.files = nil
 	if input.Error != nil {
 		errorCopy := *input.Error
 		input.Error = &errorCopy
 	}
 	return input
+}
+
+func cloneOutputFiles(input []OutputFile) []OutputFile {
+	if input == nil {
+		return nil
+	}
+	output := make([]OutputFile, len(input))
+	for index, file := range input {
+		output[index] = file.metadata()
+	}
+	return output
 }
 
 func normalizedAdmission(policy AdmissionPolicy) AdmissionPolicy {
@@ -570,8 +625,8 @@ func validateInput(input []InputPart) *TurnError {
 			if part.File == nil || strings.TrimSpace(part.Text) != "" {
 				return &TurnError{Code: ErrorInvalidRequest, Message: "file input must include only a file"}
 			}
-			if strings.TrimSpace(part.File.ID) == "" || strings.TrimSpace(part.File.SourcePath) == "" || strings.TrimSpace(part.File.Name) == "" || strings.TrimSpace(part.File.MediaType) == "" || part.File.SizeBytes < 0 || len(strings.TrimSpace(part.File.SHA256)) != 64 {
-				return &TurnError{Code: ErrorInvalidRequest, Message: "file ID, source path, name, media type, non-negative size, and SHA-256 are required"}
+			if strings.TrimSpace(part.File.ID) == "" {
+				return &TurnError{Code: ErrorInvalidRequest, Message: "file ID is required"}
 			}
 		default:
 			return &TurnError{Code: ErrorInvalidRequest, Message: fmt.Sprintf("unsupported input kind %q", part.Kind)}

--- a/internal/agentengine/engine_test.go
+++ b/internal/agentengine/engine_test.go
@@ -1,10 +1,12 @@
 package agentengine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,6 +201,121 @@ func (f *fakeConversationRuntime) publish(event activity.RuntimeEvent) {
 	f.mu.Unlock()
 	for _, subscriber := range subscribers {
 		subscriber <- event
+	}
+}
+
+func TestConversationRunAuthorizesRuntimeOutputFile(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "reports"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0}, 64)...)
+	outputPath := filepath.Join(workspace, "reports", "result.png")
+	if err := os.WriteFile(outputPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
+	promptCalls := 0
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		promptCalls++
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventStructuredOutput,
+			Payload: activity.StructuredOutputArtifact{ResourceLinks: []activity.ResourceLink{{Type: "resource_link", Name: "docs", URI: "https://example.com/docs"}}},
+		})
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventFileOutput,
+			Payload: activity.RuntimeFile{Path: filepath.Join("reports", "result.png"), Name: "result.png", MIMEType: "image/png"},
+		})
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	var outputs []*OutputItem
+	request := TurnRequest{ID: "turn-output", ConversationKey: "conversation-output", Input: textInput("create an image")}
+	result := engine.Conversations("agent-a").Run(context.Background(), request, EventSinkFunc(func(_ context.Context, event TurnEvent) error {
+		if event.Output != nil {
+			outputs = append(outputs, event.Output)
+		}
+		return nil
+	}))
+	if result.Status != TurnSucceeded || !result.Dispatched || len(outputs) != 1 || len(result.Files) != 1 {
+		t.Fatalf("Run() = %+v, outputs = %+v", result, outputs)
+	}
+	if outputs[0].Kind != OutputItemResourceLink {
+		t.Fatalf("first output = %+v, want ordinary resource link", outputs[0])
+	}
+	file := result.Files[0]
+	if file.Name != "result.png" || file.MediaType != "image/png" || file.SizeBytes != int64(len(content)) || len(file.SHA256) != 64 || !strings.HasPrefix(file.ID, "file-") || file.ID == "sha256:"+file.SHA256 {
+		t.Fatalf("OutputFile = %+v", file.OutputFileMetadata)
+	}
+	if err := os.WriteFile(outputPath, bytes.Repeat([]byte{1}, len(content)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		download, err := engine.Conversations("agent-a").Files().Get(context.Background(), file.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, readErr := io.ReadAll(download.Content)
+		closeErr := download.Content.Close()
+		if download.Metadata != file.OutputFileMetadata || readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+			t.Fatalf("attempt %d authorized file: metadata=%+v bytes=%d read=%v close=%v", attempt, download.Metadata, len(got), readErr, closeErr)
+		}
+	}
+	replacedWorkspace := workspace + "-replaced"
+	if err := os.Rename(workspace, replacedWorkspace); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(replacedWorkspace) })
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outputPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	download, err := engine.Conversations("agent-a").Files().Get(context.Background(), file.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, readErr := io.ReadAll(download.Content)
+	closeErr := download.Content.Close()
+	if download.Metadata != file.OutputFileMetadata || readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+		t.Fatalf("replaced workspace metadata=%+v content=%q read=%v close=%v", download.Metadata, got, readErr, closeErr)
+	}
+	replayed := engine.Conversations("agent-a").Run(context.Background(), request, nil)
+	if replayed.Status != TurnSucceeded || len(replayed.Files) != 1 || replayed.Files[0].ID != file.ID || promptCalls != 1 {
+		t.Fatalf("replayed result=%+v promptCalls=%d", replayed, promptCalls)
+	}
+}
+
+func TestConversationRunRejectsRuntimeOutputOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventFileOutput,
+			Payload: activity.RuntimeFile{Path: filepath.Join("escape", "secret.txt")},
+		})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-output", ConversationKey: "conversation-output", Input: textInput("read outside")}, nil)
+	if result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorFileUnavailable || !result.Dispatched {
+		t.Fatalf("Run() = %+v", result)
 	}
 }
 
@@ -541,11 +658,7 @@ func TestConversationRunRetainsDispatchedWhenFailureRacesAcceptance(t *testing.T
 }
 
 func TestConversationRunCopiesCodexFileInput(t *testing.T) {
-	sourcePath := filepath.Join(t.TempDir(), "report.txt")
 	content := []byte("report")
-	if err := os.WriteFile(sourcePath, content, 0o600); err != nil {
-		t.Fatal(err)
-	}
 	runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
 	var runtimePath string
 	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, prompt string) error {
@@ -564,16 +677,14 @@ func TestConversationRunCopiesCodexFileInput(t *testing.T) {
 		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
 		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
 	}}, runtimeImpl))
+	file := createEngineTestFile(t, engine, "agent-a", "report.txt", "text/plain", content)
 
 	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
 		ID:              "turn-1",
 		ConversationKey: "conversation-1",
 		Input: []InputPart{{
 			Kind: InputPartFile,
-			File: &InputFile{
-				ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain",
-				SizeBytes: int64(len(content)), SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917",
-			},
+			File: &InputFile{ID: file.ID},
 		}},
 	}, nil)
 	if result.Status != TurnSucceeded || result.Error != nil || !result.Dispatched {
@@ -590,49 +701,21 @@ func TestConversationRunCopiesCodexFileInput(t *testing.T) {
 	}
 }
 
-func TestConversationRunRejectsUnsafeOrInvalidFileBeforeDispatch(t *testing.T) {
-	sourcePath := filepath.Join(t.TempDir(), "report.txt")
-	if err := os.WriteFile(sourcePath, []byte("report"), 0o600); err != nil {
-		t.Fatal(err)
+func TestConversationRunRejectsUnknownFileBeforeDispatch(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-1", ConversationKey: "conversation-1",
+		Input: []InputPart{{Kind: InputPartFile, File: &InputFile{ID: "missing-file"}}},
+	}, nil)
+	if result.Error == nil || result.Error.Code != ErrorFileNotFound || result.Dispatched {
+		t.Fatalf("result = %+v", result)
 	}
-	symlinkPath := filepath.Join(t.TempDir(), "report-link.txt")
-	if err := os.Symlink(sourcePath, symlinkPath); err != nil {
-		t.Fatal(err)
-	}
-	for _, testCase := range []struct {
-		name string
-		file InputFile
-	}{
-		{
-			name: "symlink",
-			file: InputFile{ID: "file-1", SourcePath: symlinkPath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 6, SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917"},
-		},
-		{
-			name: "hash mismatch",
-			file: InputFile{ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 6, SHA256: strings.Repeat("0", 64)},
-		},
-		{
-			name: "size mismatch",
-			file: InputFile{ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain", SizeBytes: 7, SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917"},
-		},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
-			engine := New(newTestAgentService(t, []agent.Agent{{
-				ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
-				RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
-			}}, runtimeImpl))
-			result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
-				ID: "turn-1", ConversationKey: "conversation-1",
-				Input: []InputPart{{Kind: InputPartFile, File: &testCase.file}},
-			}, nil)
-			if result.Error == nil || result.Error.Code != ErrorFileUnavailable || result.Dispatched {
-				t.Fatalf("result = %+v", result)
-			}
-			if runtimeImpl.conversationKey != "" {
-				t.Fatalf("Runtime mapping was touched before file validation: %q", runtimeImpl.conversationKey)
-			}
-		})
+	if runtimeImpl.conversationKey != "" {
+		t.Fatalf("Runtime mapping was touched before file resolution: %q", runtimeImpl.conversationKey)
 	}
 }
 
@@ -649,22 +732,16 @@ func TestConversationRunRejectsRuntimeInputDestinationSymlink(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(workspace, ".csgclaw")); err != nil {
 		t.Fatal(err)
 	}
-	sourcePath := filepath.Join(root, "report.txt")
 	content := []byte("report")
-	if err := os.WriteFile(sourcePath, content, 0o600); err != nil {
-		t.Fatal(err)
-	}
 	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
 	engine := New(newTestAgentService(t, []agent.Agent{{
 		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
 		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
 	}}, runtimeImpl))
+	file := createEngineTestFile(t, engine, "agent-a", "report.txt", "text/plain", content)
 	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
 		ID: "turn-1", ConversationKey: "conversation-1",
-		Input: []InputPart{{Kind: InputPartFile, File: &InputFile{
-			ID: "file-1", SourcePath: sourcePath, Name: "report.txt", MediaType: "text/plain",
-			SizeBytes: int64(len(content)), SHA256: "845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917",
-		}}},
+		Input: []InputPart{{Kind: InputPartFile, File: &InputFile{ID: file.ID}}},
 	}, nil)
 	if result.Error == nil || result.Error.Code != ErrorFileUnavailable || result.Dispatched {
 		t.Fatalf("Run() = %+v", result)
@@ -676,15 +753,6 @@ func TestConversationRunRejectsRuntimeInputDestinationSymlink(t *testing.T) {
 }
 
 func TestCodexInputPreservesOrderedTextImageAndFileBlocks(t *testing.T) {
-	root := t.TempDir()
-	imagePath := filepath.Join(root, "image.png")
-	filePath := filepath.Join(root, "notes.txt")
-	if err := os.WriteFile(imagePath, []byte("image"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filePath, []byte("notes"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	runtimeImpl := &fakeConversationRuntime{workspace: t.TempDir()}
 	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
 		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
@@ -694,12 +762,14 @@ func TestCodexInputPreservesOrderedTextImageAndFileBlocks(t *testing.T) {
 		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
 		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
 	}}, runtimeImpl))
+	image := createEngineTestFile(t, engine, "agent-a", "image.png", "image/png", []byte("image"))
+	notes := createEngineTestFile(t, engine, "agent-a", "notes.txt", "text/plain", []byte("notes"))
 	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
 		ID: "caller-turn", ConversationKey: "conversation-1",
 		Input: []InputPart{
 			{Kind: InputPartText, Text: "before"},
-			{Kind: InputPartFile, File: &InputFile{ID: "image", SourcePath: imagePath, Name: "image.png", MediaType: "image/png", SizeBytes: 5, SHA256: "6105d6cc76af400325e94d588ce511be5bfdbb73b437dc51eca43917d7a43e3d"}},
-			{Kind: InputPartFile, File: &InputFile{ID: "notes", SourcePath: filePath, Name: "notes.txt", MediaType: "text/plain", SizeBytes: 5, SHA256: "ab5aa97074c454a0632057e704220d9a6678fbf773a0a5806fc09b8173b07309"}},
+			{Kind: InputPartFile, File: &InputFile{ID: image.ID}},
+			{Kind: InputPartFile, File: &InputFile{ID: notes.ID}},
 			{Kind: InputPartText, Text: "after"},
 		},
 	}, nil)
@@ -1040,6 +1110,17 @@ func textInput(values ...string) []InputPart {
 		parts = append(parts, InputPart{Kind: InputPartText, Text: value})
 	}
 	return parts
+}
+
+func createEngineTestFile(t testing.TB, engine Interface, agentID, name, mediaType string, content []byte) OutputFile {
+	t.Helper()
+	file, err := engine.Conversations(agentID).Files().Create(context.Background(), FileCreateRequest{
+		Name: name, MIMEType: mediaType, SizeBytes: int64(len(content)),
+	}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
 }
 
 func newTestAgentService(t *testing.T, agents []agent.Agent, runtimeImpl runtime.Runtime) *agent.Service {

--- a/internal/agentengine/engine_test.go
+++ b/internal/agentengine/engine_test.go
@@ -86,7 +86,7 @@ func (f *fakeConversationRuntime) Provision(ctx context.Context, request runtime
 	}
 	return nil
 }
-func (f *fakeConversationRuntime) EnsureSession(_ context.Context, _, conversationKey string) (string, error) {
+func (f *fakeConversationRuntime) EnsureEngineSession(_ context.Context, _, conversationKey string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.conversationKey = conversationKey
@@ -96,7 +96,7 @@ func (f *fakeConversationRuntime) EnsureSession(_ context.Context, _, conversati
 	f.conversations[conversationKey] = "codex-thread"
 	return "codex-thread", nil
 }
-func (f *fakeConversationRuntime) ExistingSession(_ context.Context, _, conversationKey string) (string, bool, error) {
+func (f *fakeConversationRuntime) ExistingEngineSession(_ context.Context, _, conversationKey string) (string, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	sessionID := f.conversations[conversationKey]
@@ -316,6 +316,79 @@ func TestConversationRunRejectsRuntimeOutputOutsideWorkspace(t *testing.T) {
 		ID: "turn-output", ConversationKey: "conversation-output", Input: textInput("read outside")}, nil)
 	if result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorFileUnavailable || !result.Dispatched {
 		t.Fatalf("Run() = %+v", result)
+	}
+	if strings.Contains(result.Error.Message, workspace) || strings.Contains(result.Error.Message, outside) {
+		t.Fatalf("public error leaked workspace path: %q", result.Error.Message)
+	}
+}
+
+func TestConversationRunCleansOutputSnapshotWhenLaterEventFails(t *testing.T) {
+	snapshotDir := t.TempDir()
+	t.Setenv("TMPDIR", snapshotDir)
+	workspace := t.TempDir()
+	content := []byte("temporary output")
+	if err := os.WriteFile(filepath.Join(workspace, "result.txt"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventFileOutput,
+			Payload: activity.RuntimeFile{Path: "result.txt", MIMEType: "text/plain"},
+		})
+		runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptFailed, Error: "later failure"})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-output", ConversationKey: "conversation-output", Input: textInput("create then fail"),
+	}, nil)
+	if result.Status != TurnFailed || result.Error == nil {
+		t.Fatalf("Run() = %+v", result)
+	}
+	paths, err := filepath.Glob(filepath.Join(snapshotDir, "csgclaw-output-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("failed Turn retained snapshots: %v", paths)
+	}
+}
+
+func TestConversationRunRejectsMismatchedRuntimeOutputMIMEAndCleansSnapshot(t *testing.T) {
+	snapshotDir := t.TempDir()
+	t.Setenv("TMPDIR", snapshotDir)
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "not-image.png"), []byte("plain text"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeImpl := &fakeConversationRuntime{workspace: workspace}
+	runtimeImpl.prompt = func(_ context.Context, runtimeID, sessionID, _ string) error {
+		runtimeImpl.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventFileOutput,
+			Payload: activity.RuntimeFile{Path: "not-image.png", MIMEType: "image/png"},
+		})
+		return nil
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	result := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-output", ConversationKey: "conversation-output", Input: textInput("publish image"),
+	}, nil)
+	if result.Status != TurnFailed || result.Error == nil || result.Error.Code != ErrorFileUnavailable {
+		t.Fatalf("Run() = %+v", result)
+	}
+	paths, err := filepath.Glob(filepath.Join(snapshotDir, "csgclaw-output-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("MIME rejection retained snapshots: %v", paths)
 	}
 }
 
@@ -820,6 +893,49 @@ func TestConversationRunRejectsSameConversationOverlap(t *testing.T) {
 	close(release)
 	if result := <-firstDone; result.Status != TurnSucceeded {
 		t.Fatalf("first result = %+v", result)
+	}
+}
+
+func TestConversationRunRejectsMissingSupersedeFileWithoutCancelingActiveTurn(t *testing.T) {
+	runtimeImpl := &fakeConversationRuntime{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var canceled atomic.Bool
+	runtimeImpl.prompt = func(ctx context.Context, runtimeID, sessionID, _ string) error {
+		close(started)
+		select {
+		case <-ctx.Done():
+			canceled.Store(true)
+			return ctx.Err()
+		case <-release:
+			runtimeImpl.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
+			return nil
+		}
+	}
+	engine := New(newTestAgentService(t, []agent.Agent{{
+		ID: "agent-a", Name: "A", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeID: "runtime-a", Status: string(runtime.StateRunning),
+	}}, runtimeImpl))
+	firstDone := make(chan TurnResult, 1)
+	go func() {
+		firstDone <- engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+			ID: "turn-active", ConversationKey: "conversation-1", Input: textInput("active"),
+		}, nil)
+	}()
+	<-started
+	invalid := engine.Conversations("agent-a").Run(context.Background(), TurnRequest{
+		ID: "turn-invalid", ConversationKey: "conversation-1", Admission: AdmissionSupersede,
+		Input: []InputPart{{Kind: InputPartFile, File: &InputFile{ID: "missing-file"}}},
+	}, nil)
+	if invalid.Error == nil || invalid.Error.Code != ErrorFileNotFound || invalid.Dispatched {
+		t.Fatalf("invalid supersede result = %+v", invalid)
+	}
+	if canceled.Load() {
+		t.Fatal("invalid supersede canceled the active turn")
+	}
+	close(release)
+	if result := <-firstDone; result.Status != TurnSucceeded {
+		t.Fatalf("active result = %+v", result)
 	}
 }
 

--- a/internal/agentengine/enginetest/contract.go
+++ b/internal/agentengine/enginetest/contract.go
@@ -1,8 +1,10 @@
 package enginetest
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -87,12 +89,13 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 	})
 
 	t.Run("run events result and recording", func(t *testing.T) {
+		var publishedFile agentengine.OutputFile
 		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
 			events := []agentengine.TurnEvent{
 				{Kind: agentengine.TurnEventThoughtDelta, Thought: "thinking"},
 				{Kind: agentengine.TurnEventToolCallStart, Tool: &agentengine.ToolActivity{ID: "tool-1", Kind: "exec_command", InputSummary: "pwd"}},
 				{Kind: agentengine.TurnEventActivityUpdate, Activity: &agentengine.ActivityUpdate{ID: "plan-1", Kind: "plan_update", Status: "running"}},
-				{Kind: agentengine.TurnEventOutputItem, Output: &agentengine.OutputItem{Kind: agentengine.OutputItemResourceLink, Payload: activity.ResourceLink{Name: "report", URI: "file:///report"}}},
+				{Kind: agentengine.TurnEventOutputItem, Output: &agentengine.OutputItem{Kind: agentengine.OutputItemResourceLink, Payload: activity.ResourceLink{Name: "report", URI: "https://example.com/report"}}},
 				{Kind: agentengine.TurnEventTextDelta, Text: "answer"},
 			}
 			for _, event := range events {
@@ -100,15 +103,16 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 					return contractFailure(agentengine.ErrorRuntimeFailed, err)
 				}
 			}
-			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Dispatched: true}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Files: []agentengine.OutputFile{publishedFile}, Dispatched: true}
 		}
 		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		publishedFile = contractCreateFile(t, client, "agent-a")
 		var events []agentengine.TurnEvent
 		result := client.Conversations("agent-a").Run(context.Background(), contractTurn("turn-1", "conversation-1"), agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
 			events = append(events, event)
 			return nil
 		}))
-		if result.Status != agentengine.TurnSucceeded || result.Output != "answer" || !result.Dispatched || result.Error != nil {
+		if result.Status != agentengine.TurnSucceeded || result.Output != "answer" || len(result.Files) != 1 || !result.Dispatched || result.Error != nil {
 			t.Fatalf("Run() = %+v", result)
 		}
 		if len(events) != 5 {
@@ -121,6 +125,16 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		}
 		if events[0].Thought != "thinking" || events[1].Tool == nil || events[2].Activity == nil || events[3].Output == nil || events[4].Text != "answer" {
 			t.Fatalf("normalized events = %+v", events)
+		}
+		file := result.Files[0]
+		download, err := client.Conversations("agent-a").Files().Get(context.Background(), file.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content, readErr := io.ReadAll(download.Content)
+		closeErr := download.Content.Close()
+		if download.Metadata != file.OutputFileMetadata || readErr != nil || closeErr != nil || string(content) != "contract-output" {
+			t.Fatalf("file = %+v content = %q, read=%v close=%v", download.Metadata, content, readErr, closeErr)
 		}
 	})
 
@@ -144,6 +158,55 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		managerUpdate.Spec.Role = agentengine.AgentRoleWorker
 		if _, err := client.Agents().Update(context.Background(), manager.ID, managerUpdate.Spec); agentengine.ErrorCodeOf(err) != agentengine.ErrorInvalidRequest {
 			t.Fatalf("manager-to-worker Update error = %v", err)
+		}
+	})
+
+	t.Run("file resources and file input", func(t *testing.T) {
+		client := factory(t, []agentengine.Agent{
+			contractAgent("agent-a", agentengine.AgentStateRunning, "codex"),
+			contractAgent("agent-b", agentengine.AgentStateRunning, "codex"),
+		}, nil)
+		content := []byte("contract file input")
+		created, err := client.Conversations("agent-a").Files().Create(context.Background(), agentengine.FileCreateRequest{
+			Name: "input.txt", MIMEType: "text/plain", SizeBytes: int64(len(content)),
+		}, bytes.NewReader(content))
+		if err != nil || created.ID == "" || created.Name != "input.txt" || created.SizeBytes != int64(len(content)) || len(created.SHA256) != 64 {
+			t.Fatalf("Create file = %+v, %v", created, err)
+		}
+		if _, err := client.Conversations("agent-b").Files().Get(context.Background(), created.ID); agentengine.ErrorCodeOf(err) != agentengine.ErrorFileNotFound {
+			t.Fatalf("cross-Agent Get error = %v", err)
+		}
+		download, err := client.Conversations("agent-a").Files().Get(context.Background(), created.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, readErr := io.ReadAll(download.Content)
+		closeErr := download.Content.Close()
+		if download.Metadata != created.OutputFileMetadata || readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+			t.Fatalf("file = %+v content = %q, read=%v close=%v", download.Metadata, got, readErr, closeErr)
+		}
+		request := contractTurn("turn-file-input", "conversation-file-input")
+		request.Input = []agentengine.InputPart{{Kind: agentengine.InputPartFile, File: &agentengine.InputFile{ID: created.ID}}}
+		if result := client.Conversations("agent-a").Run(context.Background(), request, nil); result.Status != agentengine.TurnSucceeded {
+			t.Fatalf("file input Run = %+v", result)
+		}
+		if err := client.Conversations("agent-a").Files().Delete(context.Background(), created.ID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := client.Conversations("agent-a").Files().Get(context.Background(), created.ID); agentengine.ErrorCodeOf(err) != agentengine.ErrorFileNotFound {
+			t.Fatalf("Get deleted error = %v", err)
+		}
+		owned, err := client.Conversations("agent-a").Files().Create(context.Background(), agentengine.FileCreateRequest{
+			Name: "owned.txt", MIMEType: "text/plain", SizeBytes: int64(len(content)),
+		}, bytes.NewReader(content))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Agents().Delete(context.Background(), "agent-a"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := client.Conversations("agent-a").Files().Get(context.Background(), owned.ID); agentengine.ErrorCodeOf(err) != agentengine.ErrorFileNotFound {
+			t.Fatalf("Get deleted-Agent file error = %v", err)
 		}
 	})
 
@@ -179,14 +242,16 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 
 	t.Run("turn retries are idempotent", func(t *testing.T) {
 		var executions int
+		var publishedFile agentengine.OutputFile
 		behavior := func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
 			executions++
 			if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventTextDelta, Text: "answer"}); err != nil {
 				return contractFailure(agentengine.ErrorRuntimeFailed, err)
 			}
-			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Dispatched: true}
+			return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Output: "answer", Files: []agentengine.OutputFile{publishedFile}, Dispatched: true}
 		}
 		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, behavior)
+		publishedFile = contractCreateFile(t, client, "agent-a")
 		request := contractTurn("turn-1", "conversation-1")
 		var firstEvents []agentengine.TurnEvent
 		first := client.Conversations("agent-a").Run(context.Background(), request, agentengine.EventSinkFunc(func(_ context.Context, event agentengine.TurnEvent) error {
@@ -201,7 +266,7 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		if executions != 1 {
 			t.Fatalf("Runtime executions = %d, want 1", executions)
 		}
-		if first.Status != agentengine.TurnSucceeded || retried != first {
+		if first.Status != agentengine.TurnSucceeded || retried.Status != first.Status || retried.Output != first.Output || len(first.Files) != 1 || len(retried.Files) != 1 || retried.Files[0].ID != first.Files[0].ID || retried.Dispatched != first.Dispatched || agentengine.ErrorCodeOf(retried.Error) != agentengine.ErrorCodeOf(first.Error) {
 			t.Fatalf("first = %+v, retried = %+v", first, retried)
 		}
 		if len(retriedEvents) != len(firstEvents) {
@@ -646,7 +711,7 @@ func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 		}
 		invalidFile := contractTurn("turn-invalid-file", "conversation-invalid-file")
 		invalidFile.Input = []agentengine.InputPart{{Kind: agentengine.InputPartFile, File: &agentengine.InputFile{ID: "file"}}}
-		if result := client.Conversations("agent-running").Run(context.Background(), invalidFile, nil); result.Error == nil || result.Error.Code != agentengine.ErrorInvalidRequest || result.Dispatched {
+		if result := client.Conversations("agent-running").Run(context.Background(), invalidFile, nil); result.Error == nil || result.Error.Code != agentengine.ErrorFileNotFound || result.Dispatched {
 			t.Fatalf("invalid file Run() = %+v", result)
 		}
 		invalidContinuation := contractTurn("turn-invalid-continuation", "conversation-invalid-continuation")
@@ -710,4 +775,16 @@ func contractTurn(id agentengine.TurnID, key agentengine.ConversationKey) agente
 
 func contractFailure(code agentengine.ErrorCode, err error) agentengine.TurnResult {
 	return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: true, Error: &agentengine.TurnError{Code: code, Message: err.Error()}}
+}
+
+func contractCreateFile(t testing.TB, client agentengine.Interface, agentID string) agentengine.OutputFile {
+	t.Helper()
+	content := []byte("contract-output")
+	file, err := client.Conversations(agentID).Files().Create(context.Background(), agentengine.FileCreateRequest{
+		Name: "contract.txt", MIMEType: "text/plain", SizeBytes: int64(len(content)),
+	}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
 }

--- a/internal/agentengine/enginetest/feishu_adapter_test.go
+++ b/internal/agentengine/enginetest/feishu_adapter_test.go
@@ -1,13 +1,27 @@
 package enginetest
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"csgclaw/internal/activity"
 	"csgclaw/internal/agentengine"
 	"csgclaw/internal/channel/feishu"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
 
 // feishuAdapterHarness is deliberately test-only. It accepts only the Engine
@@ -76,4 +90,256 @@ func TestFeishuAdapterHarnessUsesEngineWithoutLeakingChannelSecrets(t *testing.T
 	if strings.Contains(string(encoded), appID) || strings.Contains(string(encoded), appSecret) {
 		t.Fatalf("Feishu channel credentials leaked into Engine data: %s", encoded)
 	}
+}
+
+type feishuDeliveryHarness struct {
+	engine agentengine.Interface
+	client *lark.Client
+}
+
+func (h feishuDeliveryHarness) IngressAndDeliver(ctx context.Context, agentID, roomID string) agentengine.TurnResult {
+	var links []string
+	result := h.engine.Conversations(agentID).Run(ctx, agentengine.TurnRequest{
+		ID: "feishu-event-file", ConversationKey: agentengine.ConversationKey(roomID),
+		Admission: agentengine.AdmissionSupersede, Interaction: agentengine.InteractionSkipUserInput,
+		Input: []agentengine.InputPart{{Kind: agentengine.InputPartText, Text: "create files"}},
+	}, agentengine.EventSinkFunc(func(ctx context.Context, event agentengine.TurnEvent) error {
+		if event.Output == nil {
+			return nil
+		}
+		switch event.Output.Kind {
+		case agentengine.OutputItemResourceLink:
+			link, ok := event.Output.Payload.(activity.ResourceLink)
+			if !ok {
+				return fmt.Errorf("resource link output has invalid payload")
+			}
+			links = append(links, fmt.Sprintf("[%s](<%s>)", link.Name, link.URI))
+		}
+		return nil
+	}))
+	if result.Status != agentengine.TurnSucceeded {
+		return result
+	}
+	for _, file := range result.Files {
+		if err := h.uploadAndSend(ctx, agentID, roomID, file); err != nil {
+			return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: result.Dispatched, Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()}}
+		}
+	}
+	if len(links) > 0 {
+		content, _ := json.Marshal(map[string]any{
+			"config":   map[string]bool{"wide_screen_mode": true},
+			"elements": []map[string]string{{"tag": "markdown", "content": strings.Join(links, "\n")}},
+		})
+		if err := h.send(ctx, roomID, larkim.MsgTypeInteractive, string(content), "runtime-links"); err != nil {
+			return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: result.Dispatched, Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()}}
+		}
+	}
+	return result
+}
+
+func (h feishuDeliveryHarness) uploadAndSend(ctx context.Context, agentID, roomID string, file agentengine.OutputFile) error {
+	download, err := h.engine.Conversations(agentID).Files().Get(ctx, file.ID)
+	if err != nil {
+		return err
+	}
+	defer download.Content.Close()
+	metadata := download.Metadata
+	if strings.HasPrefix(metadata.MediaType, "image/") {
+		response, err := h.client.Im.V1.Image.Create(ctx, larkim.NewCreateImageReqBuilder().
+			Body(larkim.NewCreateImageReqBodyBuilder().ImageType("message").Image(download.Content).Build()).Build())
+		if err != nil {
+			return err
+		}
+		if !response.Success() || response.Data == nil || strings.TrimSpace(larkcore.StringValue(response.Data.ImageKey)) == "" {
+			return fmt.Errorf("Feishu image upload failed: code=%d msg=%s", response.Code, response.Msg)
+		}
+		content, _ := json.Marshal(map[string]string{"image_key": larkcore.StringValue(response.Data.ImageKey)})
+		return h.send(ctx, roomID, larkim.MsgTypeImage, string(content), metadata.ID)
+	}
+	response, err := h.client.Im.V1.File.Create(ctx, larkim.NewCreateFileReqBuilder().
+		Body(larkim.NewCreateFileReqBodyBuilder().FileType("stream").FileName(metadata.Name).File(download.Content).Build()).Build())
+	if err != nil {
+		return err
+	}
+	if !response.Success() || response.Data == nil || strings.TrimSpace(larkcore.StringValue(response.Data.FileKey)) == "" {
+		return fmt.Errorf("Feishu file upload failed: code=%d msg=%s", response.Code, response.Msg)
+	}
+	content, _ := json.Marshal(map[string]string{"file_key": larkcore.StringValue(response.Data.FileKey)})
+	return h.send(ctx, roomID, larkim.MsgTypeFile, string(content), metadata.ID)
+}
+
+func (h feishuDeliveryHarness) send(ctx context.Context, roomID, messageType, content, uuid string) error {
+	response, err := h.client.Im.V1.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().ReceiveIdType("chat_id").
+		Body(larkim.NewCreateMessageReqBodyBuilder().ReceiveId(roomID).MsgType(messageType).Content(content).Uuid(uuid).Build()).Build())
+	if err != nil {
+		return err
+	}
+	if !response.Success() || response.Data == nil || strings.TrimSpace(larkcore.StringValue(response.Data.MessageId)) == "" {
+		return fmt.Errorf("Feishu message send failed: code=%d msg=%s", response.Code, response.Msg)
+	}
+	return nil
+}
+
+func TestFeishuAdapterUploadsOnlyAuthorizedEngineFilesThroughOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	imageContent := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0}, 64)...)
+	fileContent := []byte("%PDF-1.7\ncontract report\n")
+	var mu sync.Mutex
+	var calls []string
+	resourceLinkFetched := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			writeFeishuJSON(w, map[string]any{"code": 0, "msg": "ok", "tenant_access_token": "tenant-test", "expire": 7200})
+			return
+		}
+		if r.URL.Path == "/forbidden-resource-link" {
+			mu.Lock()
+			resourceLinkFetched = true
+			mu.Unlock()
+			http.Error(w, "resource_link must not be downloaded", http.StatusInternalServerError)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer tenant-test" {
+			http.Error(w, "missing tenant token", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/open-apis/im/v1/images":
+			if err := assertMultipartFile(r, "image", imageContent); err != nil || r.FormValue("image_type") != "message" {
+				http.Error(w, fmt.Sprintf("invalid image upload: %v", err), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			calls = append(calls, "upload:image")
+			mu.Unlock()
+			writeFeishuJSON(w, map[string]any{"code": 0, "msg": "ok", "data": map[string]string{"image_key": "img-test"}})
+		case "/open-apis/im/v1/files":
+			if err := assertMultipartFile(r, "file", fileContent); err != nil || r.FormValue("file_type") != "stream" || r.FormValue("file_name") != "report.pdf" {
+				http.Error(w, fmt.Sprintf("invalid file upload: %v", err), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			calls = append(calls, "upload:file")
+			mu.Unlock()
+			writeFeishuJSON(w, map[string]any{"code": 0, "msg": "ok", "data": map[string]string{"file_key": "file-test"}})
+		case "/open-apis/im/v1/messages":
+			var body struct {
+				ReceiveID string `json:"receive_id"`
+				MsgType   string `json:"msg_type"`
+				Content   string `json:"content"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ReceiveID != "chat-test" || body.Content == "" || r.URL.Query().Get("receive_id_type") != "chat_id" {
+				http.Error(w, fmt.Sprintf("invalid message: %v", err), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			calls = append(calls, "send:"+body.MsgType)
+			mu.Unlock()
+			writeFeishuJSON(w, map[string]any{"code": 0, "msg": "ok", "data": map[string]string{"message_id": "message-test"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	seed := runningAgent("agent-feishu-files")
+	client := NewMemoryClient(seed)
+	image := memoryOutputFile(t, client, seed.ID, "result.png", "image/png", imageContent)
+	report := memoryOutputFile(t, client, seed.ID, "report.pdf", "application/pdf", fileContent)
+	client.SetTurnBehavior(func(ctx context.Context, _ string, _ agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
+		if err := sink.Emit(ctx, agentengine.TurnEvent{Kind: agentengine.TurnEventOutputItem, Output: &agentengine.OutputItem{
+			Kind: agentengine.OutputItemResourceLink, Payload: activity.ResourceLink{Type: "resource_link", Name: "docs", URI: server.URL + "/forbidden-resource-link"},
+		}}); err != nil {
+			return agentengine.TurnResult{Status: agentengine.TurnFailed, Dispatched: true, Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: err.Error()}}
+		}
+		return agentengine.TurnResult{Status: agentengine.TurnSucceeded, Files: []agentengine.OutputFile{image, report}, Dispatched: true}
+	})
+	harness := feishuDeliveryHarness{
+		engine: client,
+		client: lark.NewClient("app-test", "secret-test", lark.WithOpenBaseUrl(server.URL)),
+	}
+	result := harness.IngressAndDeliver(context.Background(), seed.ID, "chat-test")
+	if result.Status != agentengine.TurnSucceeded || len(result.Files) != 2 || !result.Dispatched {
+		t.Fatalf("delivery result = %+v", result)
+	}
+	if result.Files[0].ID == result.Files[1].ID || !strings.HasPrefix(result.Files[0].ID, "file-") || !strings.HasPrefix(result.Files[1].ID, "file-") {
+		t.Fatalf("delivery file IDs = %q, %q", result.Files[0].ID, result.Files[1].ID)
+	}
+	mu.Lock()
+	gotCalls := append([]string(nil), calls...)
+	linkFetched := resourceLinkFetched
+	mu.Unlock()
+	wantCalls := []string{"upload:image", "send:image", "upload:file", "send:file", "send:interactive"}
+	if fmt.Sprint(gotCalls) != fmt.Sprint(wantCalls) {
+		t.Fatalf("Feishu OpenAPI calls = %v, want %v", gotCalls, wantCalls)
+	}
+	if linkFetched {
+		t.Fatal("ordinary resource_link was downloaded")
+	}
+}
+
+func TestFeishuAdapterDoesNotUploadFilesFromFailedTurn(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected Feishu request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	seed := runningAgent("agent-feishu-failed-file")
+	client := NewMemoryClient(seed)
+	file := memoryOutputFile(t, client, seed.ID, "failed.pdf", "application/pdf", []byte("failed turn output"))
+	client.SetTurnBehavior(func(context.Context, string, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		return agentengine.TurnResult{
+			Status: agentengine.TurnFailed, Files: []agentengine.OutputFile{file}, Dispatched: true,
+			Error: &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: "turn failed"},
+		}
+	})
+	harness := feishuDeliveryHarness{
+		engine: client,
+		client: lark.NewClient("app-test", "secret-test", lark.WithOpenBaseUrl(server.URL)),
+	}
+	result := harness.IngressAndDeliver(context.Background(), seed.ID, "chat-test")
+	if result.Status != agentengine.TurnFailed || len(result.Files) != 0 || requests.Load() != 0 {
+		t.Fatalf("result=%+v Feishu requests=%d", result, requests.Load())
+	}
+}
+
+func memoryOutputFile(t testing.TB, client agentengine.Interface, agentID, name, mediaType string, content []byte) agentengine.OutputFile {
+	t.Helper()
+	digest := sha256.Sum256(content)
+	file, err := client.Conversations(agentID).Files().Create(context.Background(), agentengine.FileCreateRequest{
+		Name: name, MIMEType: mediaType, SizeBytes: int64(len(content)), SHA256: hex.EncodeToString(digest[:]),
+	}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
+}
+
+func assertMultipartFile(r *http.Request, field string, want []byte) error {
+	if err := r.ParseMultipartForm(int64(len(want) + 1<<20)); err != nil {
+		return err
+	}
+	file, _, err := r.FormFile(field)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	got, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("%s bytes = %d, want %d", field, len(got), len(want))
+	}
+	return nil
+}
+
+func writeFeishuJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
 }

--- a/internal/agentengine/enginetest/memory_client.go
+++ b/internal/agentengine/enginetest/memory_client.go
@@ -333,8 +333,12 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 			return failed(agentengine.ErrorInvalidRequest, "file ID is required")
 		}
 		if part.Kind == agentengine.InputPartFile {
-			if _, err := c.client.files.Scope(c.agentID).Get(ctx, part.File.ID); err != nil {
+			download, err := c.client.files.Scope(c.agentID).Get(ctx, part.File.ID)
+			if err != nil {
 				return failed(agentengine.ErrorFileNotFound, err.Error())
+			}
+			if err := download.Content.Close(); err != nil {
+				return failed(agentengine.ErrorFileUnavailable, "file content is unavailable")
 			}
 		}
 		if part.Kind != agentengine.InputPartText && part.Kind != agentengine.InputPartFile {

--- a/internal/agentengine/enginetest/memory_client.go
+++ b/internal/agentengine/enginetest/memory_client.go
@@ -47,6 +47,7 @@ type MemoryClient struct {
 	behavior       TurnBehavior
 	calls          []TurnCall
 	resolutions    []Resolution
+	files          *agentengine.FileStore
 	nextAgentID    atomic.Uint64
 }
 
@@ -105,6 +106,7 @@ func NewMemoryClient(agents ...agentengine.Agent) *MemoryClient {
 		active:        make(map[memoryConversation]*memoryTurn),
 		controls:      make(map[memoryConversation]*memoryControl),
 		completed:     make(map[memoryTurnIdentity]memoryCompletedTurn),
+		files:         agentengine.NewFileStore(),
 	}
 	for _, item := range agents {
 		client.provisions[item.ID] = memoryProvision{credentials: cloneStringMap(item.Spec.Runtime.Credentials), initShell: item.Spec.Runtime.InitShell}
@@ -239,6 +241,7 @@ func (a *memoryAgents) Delete(ctx context.Context, agentID string) error {
 		}
 	}
 	a.client.mu.Unlock()
+	a.client.files.DeleteAgent(strings.TrimSpace(agentID))
 	return nil
 }
 
@@ -303,6 +306,10 @@ type memoryConversations struct {
 	agentID string
 }
 
+func (c *memoryConversations) Files() agentengine.FileInterface {
+	return c.client.files.Scope(c.agentID)
+}
+
 func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
 	if ctx == nil {
 		ctx = context.Background()
@@ -322,8 +329,13 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 		if part.Kind == agentengine.InputPartFile && (part.File == nil || strings.TrimSpace(part.Text) != "") {
 			return failed(agentengine.ErrorInvalidRequest, "file input must include only a file")
 		}
-		if part.Kind == agentengine.InputPartFile && (strings.TrimSpace(part.File.ID) == "" || strings.TrimSpace(part.File.SourcePath) == "" || strings.TrimSpace(part.File.Name) == "" || strings.TrimSpace(part.File.MediaType) == "" || part.File.SizeBytes < 0 || len(strings.TrimSpace(part.File.SHA256)) != 64) {
-			return failed(agentengine.ErrorInvalidRequest, "file ID, source path, name, media type, non-negative size, and SHA-256 are required")
+		if part.Kind == agentengine.InputPartFile && strings.TrimSpace(part.File.ID) == "" {
+			return failed(agentengine.ErrorInvalidRequest, "file ID is required")
+		}
+		if part.Kind == agentengine.InputPartFile {
+			if _, err := c.client.files.Scope(c.agentID).Get(ctx, part.File.ID); err != nil {
+				return failed(agentengine.ErrorFileNotFound, err.Error())
+			}
 		}
 		if part.Kind != agentengine.InputPartText && part.Kind != agentengine.InputPartFile {
 			return failed(agentengine.ErrorInvalidRequest, "unsupported input kind")
@@ -437,6 +449,9 @@ func (c *memoryConversations) Run(ctx context.Context, request agentengine.TurnR
 		result = *policyResult
 	}
 	policyMu.Unlock()
+	if result.Status != agentengine.TurnSucceeded {
+		result.Files = nil
+	}
 	turn.cancel()
 	c.completeMemoryTurn(key, turn, result)
 	return result
@@ -729,11 +744,23 @@ func cloneMemoryCompleted(input memoryCompletedTurn) memoryCompletedTurn {
 }
 
 func cloneMemoryResult(input agentengine.TurnResult) agentengine.TurnResult {
+	input.Files = cloneMemoryFiles(input.Files)
 	if input.Error != nil {
 		errorCopy := *input.Error
 		input.Error = &errorCopy
 	}
 	return input
+}
+
+func cloneMemoryFiles(input []agentengine.OutputFile) []agentengine.OutputFile {
+	if input == nil {
+		return nil
+	}
+	output := make([]agentengine.OutputFile, len(input))
+	for index, file := range input {
+		output[index] = file
+	}
+	return output
 }
 
 func validateSpec(spec agentengine.AgentSpec) error {

--- a/internal/agentengine/file_store.go
+++ b/internal/agentengine/file_store.go
@@ -36,10 +36,8 @@ type FileCreateRequest struct {
 // FileStore owns process-local immutable snapshots indexed by Agent and FileID.
 // It is reusable by the real Engine and contract-compatible test clients.
 type FileStore struct {
-	mu            sync.RWMutex
-	byAgent       map[string]map[string]storedFile
-	bytesByAgent  map[string]int64
-	maxAgentBytes int64
+	mu      sync.RWMutex
+	byAgent map[string]map[string]storedFile
 }
 
 type storedFile struct {
@@ -50,7 +48,7 @@ type storedFile struct {
 
 // NewFileStore creates an empty process-local Artifact Store.
 func NewFileStore() *FileStore {
-	return &FileStore{byAgent: make(map[string]map[string]storedFile), bytesByAgent: make(map[string]int64), maxAgentBytes: maxAgentFileBytes}
+	return &FileStore{byAgent: make(map[string]map[string]storedFile)}
 }
 
 // Scope returns file operations for one Agent.
@@ -135,17 +133,6 @@ func (s *FileStore) put(agentID string, file storedFile) *TurnError {
 	if s.byAgent == nil {
 		s.byAgent = make(map[string]map[string]storedFile)
 	}
-	if s.bytesByAgent == nil {
-		s.bytesByAgent = make(map[string]int64)
-	}
-	limit := s.maxAgentBytes
-	if limit <= 0 {
-		limit = maxAgentFileBytes
-	}
-	if file.file.SizeBytes > limit-s.bytesByAgent[agentID] {
-		s.mu.Unlock()
-		return &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("Agent file storage exceeds %d bytes", limit)}
-	}
 	files := s.byAgent[agentID]
 	if files == nil {
 		files = make(map[string]storedFile)
@@ -154,21 +141,6 @@ func (s *FileStore) put(agentID string, file storedFile) *TurnError {
 	if _, exists := files[file.file.ID]; exists {
 		s.mu.Unlock()
 		return &TurnError{Code: ErrorFileUnavailable, Message: "file ID collision"}
-	}
-	s.bytesByAgent[agentID] += file.file.SizeBytes
-	size := file.file.SizeBytes
-	if !file.file.snapshot.setOnRemove(func() { s.releaseBytes(agentID, size) }) {
-		remaining := s.bytesByAgent[agentID] - size
-		if remaining > 0 {
-			s.bytesByAgent[agentID] = remaining
-		} else {
-			delete(s.bytesByAgent, agentID)
-		}
-		if len(files) == 0 {
-			delete(s.byAgent, agentID)
-		}
-		s.mu.Unlock()
-		return &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
 	}
 	files[file.file.ID] = file
 	s.mu.Unlock()
@@ -260,17 +232,6 @@ func (s *FileStore) DeleteAgent(agentID string) {
 	for _, file := range files {
 		file.file.cleanup()
 	}
-}
-
-func (s *FileStore) releaseBytes(agentID string, size int64) {
-	s.mu.Lock()
-	remaining := s.bytesByAgent[agentID] - size
-	if remaining > 0 {
-		s.bytesByAgent[agentID] = remaining
-	} else {
-		delete(s.bytesByAgent, agentID)
-	}
-	s.mu.Unlock()
 }
 
 type unavailableFiles struct{}

--- a/internal/agentengine/file_store.go
+++ b/internal/agentengine/file_store.go
@@ -1,0 +1,207 @@
+package agentengine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// FileInterface manages immutable files scoped to one Agent. Create and Get
+// map directly to HTTP upload and download bodies.
+type FileInterface interface {
+	Create(ctx context.Context, request FileCreateRequest, content io.Reader) (OutputFile, error)
+	Get(ctx context.Context, fileID string) (FileContent, error)
+	Delete(ctx context.Context, fileID string) error
+}
+
+// FileContent combines authoritative metadata with an independent content
+// stream. An HTTP adapter maps Metadata to response headers and Content to the
+// response body.
+type FileContent struct {
+	Metadata OutputFileMetadata
+	Content  io.ReadCloser
+}
+
+// FileCreateRequest declares metadata for one uploaded immutable file.
+type FileCreateRequest struct {
+	Name      string `json:"name"`
+	MIMEType  string `json:"mime_type"`
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256,omitempty"`
+}
+
+// FileStore owns process-local immutable snapshots indexed by Agent and FileID.
+// It is reusable by the real Engine and contract-compatible test clients.
+type FileStore struct {
+	mu      sync.RWMutex
+	byAgent map[string]map[string]storedFile
+}
+
+type storedFile struct {
+	file            *OutputFile
+	conversationKey ConversationKey
+	turnID          TurnID
+}
+
+// NewFileStore creates an empty process-local Artifact Store.
+func NewFileStore() *FileStore {
+	return &FileStore{byAgent: make(map[string]map[string]storedFile)}
+}
+
+// Scope returns file operations for one Agent.
+func (s *FileStore) Scope(agentID string) FileInterface {
+	return &agentFiles{store: s, agentID: strings.TrimSpace(agentID)}
+}
+
+type agentFiles struct {
+	store   *FileStore
+	agentID string
+}
+
+func (f *agentFiles) Create(ctx context.Context, request FileCreateRequest, content io.Reader) (OutputFile, error) {
+	if f == nil || f.store == nil || f.agentID == "" {
+		return OutputFile{}, &TurnError{Code: ErrorInvalidRequest, Message: "agent ID is required"}
+	}
+	file, err := newOutputFile(ctx, OutputFileMetadata{
+		Name: request.Name, MediaType: request.MIMEType, SizeBytes: request.SizeBytes, SHA256: request.SHA256,
+	}, content)
+	if err != nil {
+		return OutputFile{}, &TurnError{Code: ErrorInvalidRequest, Message: err.Error()}
+	}
+	f.store.put(f.agentID, storedFile{file: file})
+	return file.metadata(), nil
+}
+
+func (f *agentFiles) Get(ctx context.Context, fileID string) (FileContent, error) {
+	file, err := f.stored(fileID)
+	if err != nil {
+		return FileContent{}, err
+	}
+	content, err := file.file.open(ctx)
+	if err != nil {
+		return FileContent{}, err
+	}
+	return FileContent{Metadata: file.file.OutputFileMetadata, Content: content}, nil
+}
+
+func (f *agentFiles) Delete(_ context.Context, fileID string) error {
+	fileID = strings.TrimSpace(fileID)
+	if f == nil || f.store == nil || f.agentID == "" || fileID == "" {
+		return &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and file ID are required"}
+	}
+	file, ok := f.store.delete(f.agentID, fileID)
+	if !ok {
+		return &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
+	}
+	file.file.cleanup()
+	return nil
+}
+
+func (f *agentFiles) stored(fileID string) (storedFile, error) {
+	fileID = strings.TrimSpace(fileID)
+	if f == nil || f.store == nil || f.agentID == "" || fileID == "" {
+		return storedFile{}, &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and file ID are required"}
+	}
+	file, ok := f.store.get(f.agentID, fileID)
+	if !ok {
+		return storedFile{}, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
+	}
+	return file, nil
+}
+
+func (s *FileStore) put(agentID string, file storedFile) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	files := s.byAgent[agentID]
+	if files == nil {
+		files = make(map[string]storedFile)
+		s.byAgent[agentID] = files
+	}
+	files[file.file.ID] = file
+}
+
+func (s *FileStore) get(agentID, fileID string) (storedFile, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	file, ok := s.byAgent[agentID][fileID]
+	return file, ok
+}
+
+func (s *FileStore) delete(agentID, fileID string) (storedFile, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	files := s.byAgent[agentID]
+	file, ok := files[fileID]
+	if !ok {
+		return storedFile{}, false
+	}
+	delete(files, fileID)
+	if len(files) == 0 {
+		delete(s.byAgent, agentID)
+	}
+	return file, true
+}
+
+func (s *FileStore) registerTurnFiles(agentID string, conversationKey ConversationKey, turnID TurnID, files []*OutputFile) []OutputFile {
+	result := make([]OutputFile, 0, len(files))
+	for _, file := range files {
+		if file == nil || file.snapshot == nil {
+			continue
+		}
+		s.put(agentID, storedFile{file: file, conversationKey: conversationKey, turnID: turnID})
+		result = append(result, file.metadata())
+	}
+	return result
+}
+
+func (s *FileStore) resolve(agentID, fileID string) (*OutputFile, *TurnError) {
+	file, ok := s.get(strings.TrimSpace(agentID), strings.TrimSpace(fileID))
+	if !ok {
+		return nil, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
+	}
+	return file.file, nil
+}
+
+func (s *FileStore) deleteTurn(agentID string, conversationKey ConversationKey, turnID TurnID) {
+	var removed []*OutputFile
+	s.mu.Lock()
+	files := s.byAgent[agentID]
+	for fileID, file := range files {
+		if file.conversationKey == conversationKey && file.turnID == turnID {
+			removed = append(removed, file.file)
+			delete(files, fileID)
+		}
+	}
+	if len(files) == 0 {
+		delete(s.byAgent, agentID)
+	}
+	s.mu.Unlock()
+	for _, file := range removed {
+		file.cleanup()
+	}
+}
+
+// DeleteAgent removes every snapshot owned by one Agent.
+func (s *FileStore) DeleteAgent(agentID string) {
+	s.mu.Lock()
+	files := s.byAgent[agentID]
+	delete(s.byAgent, agentID)
+	s.mu.Unlock()
+	for _, file := range files {
+		file.file.cleanup()
+	}
+}
+
+type unavailableFiles struct{}
+
+func (unavailableFiles) Create(context.Context, FileCreateRequest, io.Reader) (OutputFile, error) {
+	return OutputFile{}, &TurnError{Code: ErrorAgentUnavailable, Message: "file store is unavailable"}
+}
+func (unavailableFiles) Get(context.Context, string) (FileContent, error) {
+	return FileContent{}, &TurnError{Code: ErrorAgentUnavailable, Message: "file store is unavailable"}
+}
+func (unavailableFiles) Delete(context.Context, string) error {
+	return &TurnError{Code: ErrorAgentUnavailable, Message: "file store is unavailable"}
+}

--- a/internal/agentengine/file_store.go
+++ b/internal/agentengine/file_store.go
@@ -2,6 +2,7 @@ package agentengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,8 +36,10 @@ type FileCreateRequest struct {
 // FileStore owns process-local immutable snapshots indexed by Agent and FileID.
 // It is reusable by the real Engine and contract-compatible test clients.
 type FileStore struct {
-	mu      sync.RWMutex
-	byAgent map[string]map[string]storedFile
+	mu            sync.RWMutex
+	byAgent       map[string]map[string]storedFile
+	bytesByAgent  map[string]int64
+	maxAgentBytes int64
 }
 
 type storedFile struct {
@@ -47,7 +50,7 @@ type storedFile struct {
 
 // NewFileStore creates an empty process-local Artifact Store.
 func NewFileStore() *FileStore {
-	return &FileStore{byAgent: make(map[string]map[string]storedFile)}
+	return &FileStore{byAgent: make(map[string]map[string]storedFile), bytesByAgent: make(map[string]int64), maxAgentBytes: maxAgentFileBytes}
 }
 
 // Scope returns file operations for one Agent.
@@ -68,20 +71,45 @@ func (f *agentFiles) Create(ctx context.Context, request FileCreateRequest, cont
 		Name: request.Name, MediaType: request.MIMEType, SizeBytes: request.SizeBytes, SHA256: request.SHA256,
 	}, content)
 	if err != nil {
-		return OutputFile{}, &TurnError{Code: ErrorInvalidRequest, Message: err.Error()}
+		var invalid *invalidOutputFileError
+		if errors.As(err, &invalid) {
+			return OutputFile{}, &TurnError{Code: ErrorInvalidRequest, Message: invalid.Error()}
+		}
+		if ctx != nil && ctx.Err() != nil {
+			return OutputFile{}, &TurnError{Code: ErrorCanceled, Message: "file upload was canceled"}
+		}
+		return OutputFile{}, &TurnError{Code: ErrorFileUnavailable, Message: "file content could not be stored"}
 	}
-	f.store.put(f.agentID, storedFile{file: file})
+	if storeErr := f.store.put(f.agentID, storedFile{file: file}); storeErr != nil {
+		file.cleanup()
+		return OutputFile{}, storeErr
+	}
 	return file.metadata(), nil
 }
 
 func (f *agentFiles) Get(ctx context.Context, fileID string) (FileContent, error) {
-	file, err := f.stored(fileID)
-	if err != nil {
-		return FileContent{}, err
+	fileID = strings.TrimSpace(fileID)
+	if f == nil || f.store == nil || f.agentID == "" || fileID == "" {
+		return FileContent{}, &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and file ID are required"}
+	}
+	f.store.mu.RLock()
+	file, ok := f.store.byAgent[f.agentID][fileID]
+	if !ok {
+		f.store.mu.RUnlock()
+		return FileContent{}, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
+	}
+	release, retained := file.file.snapshot.retain()
+	f.store.mu.RUnlock()
+	if !retained {
+		return FileContent{}, &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
 	}
 	content, err := file.file.open(ctx)
+	release()
 	if err != nil {
-		return FileContent{}, err
+		if ctx != nil && ctx.Err() != nil {
+			return FileContent{}, &TurnError{Code: ErrorCanceled, Message: "file download was canceled"}
+		}
+		return FileContent{}, &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
 	}
 	return FileContent{Metadata: file.file.OutputFileMetadata, Content: content}, nil
 }
@@ -99,34 +127,52 @@ func (f *agentFiles) Delete(_ context.Context, fileID string) error {
 	return nil
 }
 
-func (f *agentFiles) stored(fileID string) (storedFile, error) {
-	fileID = strings.TrimSpace(fileID)
-	if f == nil || f.store == nil || f.agentID == "" || fileID == "" {
-		return storedFile{}, &TurnError{Code: ErrorInvalidRequest, Message: "agent ID and file ID are required"}
+func (s *FileStore) put(agentID string, file storedFile) *TurnError {
+	if file.file == nil || file.file.snapshot == nil {
+		return &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
 	}
-	file, ok := f.store.get(f.agentID, fileID)
-	if !ok {
-		return storedFile{}, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
-	}
-	return file, nil
-}
-
-func (s *FileStore) put(agentID string, file storedFile) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.byAgent == nil {
+		s.byAgent = make(map[string]map[string]storedFile)
+	}
+	if s.bytesByAgent == nil {
+		s.bytesByAgent = make(map[string]int64)
+	}
+	limit := s.maxAgentBytes
+	if limit <= 0 {
+		limit = maxAgentFileBytes
+	}
+	if file.file.SizeBytes > limit-s.bytesByAgent[agentID] {
+		s.mu.Unlock()
+		return &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("Agent file storage exceeds %d bytes", limit)}
+	}
 	files := s.byAgent[agentID]
 	if files == nil {
 		files = make(map[string]storedFile)
 		s.byAgent[agentID] = files
 	}
+	if _, exists := files[file.file.ID]; exists {
+		s.mu.Unlock()
+		return &TurnError{Code: ErrorFileUnavailable, Message: "file ID collision"}
+	}
+	s.bytesByAgent[agentID] += file.file.SizeBytes
+	size := file.file.SizeBytes
+	if !file.file.snapshot.setOnRemove(func() { s.releaseBytes(agentID, size) }) {
+		remaining := s.bytesByAgent[agentID] - size
+		if remaining > 0 {
+			s.bytesByAgent[agentID] = remaining
+		} else {
+			delete(s.bytesByAgent, agentID)
+		}
+		if len(files) == 0 {
+			delete(s.byAgent, agentID)
+		}
+		s.mu.Unlock()
+		return &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
+	}
 	files[file.file.ID] = file
-}
-
-func (s *FileStore) get(agentID, fileID string) (storedFile, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	file, ok := s.byAgent[agentID][fileID]
-	return file, ok
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *FileStore) delete(agentID, fileID string) (storedFile, bool) {
@@ -144,24 +190,46 @@ func (s *FileStore) delete(agentID, fileID string) (storedFile, bool) {
 	return file, true
 }
 
-func (s *FileStore) registerTurnFiles(agentID string, conversationKey ConversationKey, turnID TurnID, files []*OutputFile) []OutputFile {
+func (s *FileStore) registerTurnFiles(agentID string, conversationKey ConversationKey, turnID TurnID, files []*OutputFile) ([]OutputFile, *TurnError) {
 	result := make([]OutputFile, 0, len(files))
+	registered := make([]string, 0, len(files))
 	for _, file := range files {
 		if file == nil || file.snapshot == nil {
 			continue
 		}
-		s.put(agentID, storedFile{file: file, conversationKey: conversationKey, turnID: turnID})
+		if err := s.put(agentID, storedFile{file: file, conversationKey: conversationKey, turnID: turnID}); err != nil {
+			for _, fileID := range registered {
+				stored, ok := s.delete(agentID, fileID)
+				if ok {
+					stored.file.cleanup()
+				}
+			}
+			for _, pending := range files {
+				pending.cleanup()
+			}
+			return nil, err
+		}
+		registered = append(registered, file.ID)
 		result = append(result, file.metadata())
 	}
-	return result
+	return result, nil
 }
 
-func (s *FileStore) resolve(agentID, fileID string) (*OutputFile, *TurnError) {
-	file, ok := s.get(strings.TrimSpace(agentID), strings.TrimSpace(fileID))
+func (s *FileStore) resolve(agentID, fileID string) (*OutputFile, func(), *TurnError) {
+	agentID = strings.TrimSpace(agentID)
+	fileID = strings.TrimSpace(fileID)
+	s.mu.RLock()
+	file, ok := s.byAgent[agentID][fileID]
 	if !ok {
-		return nil, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
+		s.mu.RUnlock()
+		return nil, nil, &TurnError{Code: ErrorFileNotFound, Message: fmt.Sprintf("file %q was not found", fileID)}
 	}
-	return file.file, nil
+	release, retained := file.file.snapshot.retain()
+	s.mu.RUnlock()
+	if !retained {
+		return nil, nil, &TurnError{Code: ErrorFileUnavailable, Message: "file content is unavailable"}
+	}
+	return file.file, release, nil
 }
 
 func (s *FileStore) deleteTurn(agentID string, conversationKey ConversationKey, turnID TurnID) {
@@ -192,6 +260,17 @@ func (s *FileStore) DeleteAgent(agentID string) {
 	for _, file := range files {
 		file.file.cleanup()
 	}
+}
+
+func (s *FileStore) releaseBytes(agentID string, size int64) {
+	s.mu.Lock()
+	remaining := s.bytesByAgent[agentID] - size
+	if remaining > 0 {
+		s.bytesByAgent[agentID] = remaining
+	} else {
+		delete(s.bytesByAgent, agentID)
+	}
+	s.mu.Unlock()
 }
 
 type unavailableFiles struct{}

--- a/internal/agentengine/http_contract_test.go
+++ b/internal/agentengine/http_contract_test.go
@@ -1,0 +1,81 @@
+package agentengine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFileInterfaceMapsToHTTPContentEndpoint(t *testing.T) {
+	content := []byte("HTTP file content")
+	files := NewFileStore().Scope("agent-a")
+	file, err := files.Create(context.Background(), FileCreateRequest{
+		Name: "报告.txt", MIMEType: "text/plain", SizeBytes: int64(len(content)),
+	}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/agents/agent-a/files/"+file.ID+"/content" {
+			http.NotFound(w, r)
+			return
+		}
+		download, err := files.Get(r.Context(), file.ID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		defer download.Content.Close()
+		w.Header().Set("Content-Type", download.Metadata.MediaType)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", download.Metadata.SizeBytes))
+		w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": download.Metadata.Name}))
+		w.Header().Set("ETag", `"`+download.Metadata.SHA256+`"`)
+		_, _ = io.Copy(w, download.Content)
+	}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "/api/v1/agents/agent-a/files/" + file.ID + "/content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	got, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disposition, dispositionParams, dispositionErr := mime.ParseMediaType(response.Header.Get("Content-Disposition"))
+	if response.StatusCode != http.StatusOK || !bytes.Equal(got, content) ||
+		response.Header.Get("Content-Type") != file.MediaType || response.ContentLength != file.SizeBytes ||
+		response.Header.Get("ETag") != `"`+file.SHA256+`"` || dispositionErr != nil ||
+		disposition != "attachment" || dispositionParams["filename"] != file.Name {
+		t.Fatalf("HTTP file response status=%d headers=%v content=%q", response.StatusCode, response.Header, got)
+	}
+}
+
+func TestAgentEngineWireTypesUseStableJSONShapes(t *testing.T) {
+	now := time.Date(2026, 8, 21, 3, 0, 0, 0, time.UTC)
+	values := []any{
+		Agent{ID: "agent-a", Spec: AgentSpec{Name: "A", Role: AgentRoleWorker, Runtime: RuntimeSpec{Adapter: "codex"}}, Status: AgentStatus{State: AgentStateRunning, Ready: true}, CreatedAt: now, UpdatedAt: now},
+		TurnRequest{ID: "turn-1", ConversationKey: "conversation-1", Input: []InputPart{{Kind: InputPartFile, File: &InputFile{ID: "file-1"}}}, Admission: AdmissionRejectIfBusy},
+		TurnEvent{TurnID: "turn-1", Sequence: 1, Kind: TurnEventActivityUpdate, Activity: &ActivityUpdate{ID: "plan", Kind: "plan_update", Payload: map[string]any{"step": 1}}},
+		TurnResult{Status: TurnSucceeded, Output: "done", Files: []OutputFile{{OutputFileMetadata: OutputFileMetadata{ID: "file-1", Name: "report.txt", MediaType: "text/plain", SizeBytes: 3, SHA256: strings.Repeat("0", 64)}}}, Dispatched: true},
+		InteractionResolution{ConversationKey: "conversation-1", InteractionID: "interaction-1", Answers: map[string]InteractionAnswer{"choice": {Values: []string{"yes"}}}},
+	}
+	for _, value := range values {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal %T: %v", value, err)
+		}
+		if bytes.Contains(encoded, []byte("snapshot")) || bytes.Contains(encoded, []byte("SourcePath")) || bytes.Contains(encoded, []byte("source_path")) {
+			t.Fatalf("%T leaked implementation detail: %s", value, encoded)
+		}
+	}
+}

--- a/internal/agentengine/interface_contract_test.go
+++ b/internal/agentengine/interface_contract_test.go
@@ -112,7 +112,7 @@ func (*contractRuntime) ReconcileMCPServers(context.Context, runtime.Handle, run
 	return nil
 }
 
-func (r *contractRuntime) EnsureSession(_ context.Context, _ string, conversationKey string) (string, error) {
+func (r *contractRuntime) EnsureEngineSession(_ context.Context, _ string, conversationKey string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if sessionID := r.conversations[conversationKey]; sessionID != "" {
@@ -124,7 +124,7 @@ func (r *contractRuntime) EnsureSession(_ context.Context, _ string, conversatio
 	return sessionID, nil
 }
 
-func (r *contractRuntime) ExistingSession(_ context.Context, _ string, conversationKey string) (string, bool, error) {
+func (r *contractRuntime) ExistingEngineSession(_ context.Context, _ string, conversationKey string) (string, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	sessionID := r.conversations[conversationKey]

--- a/internal/agentengine/interface_contract_test.go
+++ b/internal/agentengine/interface_contract_test.go
@@ -3,7 +3,9 @@ package agentengine_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +37,7 @@ type contractRuntime struct {
 	workspace     string
 	permission    *codex.MemoryPermissionBroker
 	userInput     *codex.MemoryUserInputBroker
+	openFile      func(context.Context, string) (io.ReadCloser, error)
 }
 
 func newContractRuntime(kind, workspace string, behavior enginetest.TurnBehavior) *contractRuntime {
@@ -158,6 +161,31 @@ func (r *contractRuntime) PromptTurn(ctx context.Context, runtimeID, sessionID, 
 		}
 		r.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptFailed, Error: message})
 		return nil
+	}
+	for _, file := range result.Files {
+		if r.openFile == nil {
+			return fmt.Errorf("contract file opener is unavailable")
+		}
+		reader, err := r.openFile(context.Background(), file.ID)
+		if err != nil {
+			return err
+		}
+		content, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		if readErr != nil || closeErr != nil {
+			return errors.Join(readErr, closeErr)
+		}
+		relativePath := filepath.Join("contract-outputs", file.Name)
+		if err := os.MkdirAll(filepath.Join(r.workspace, filepath.Dir(relativePath)), 0o700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(r.workspace, relativePath), content, 0o600); err != nil {
+			return err
+		}
+		r.publish(activity.RuntimeEvent{
+			RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventFileOutput,
+			Payload: activity.RuntimeFile{Path: relativePath, Name: file.Name, MIMEType: file.MediaType},
+		})
 	}
 	r.publish(activity.RuntimeEvent{RuntimeID: runtimeID, SessionID: sessionID, Kind: activity.RuntimeEventPromptCompleted})
 	return nil
@@ -294,8 +322,15 @@ func (r *contractRuntime) setState(runtimeID string, state runtime.State) {
 func newRealContractEngine(t testing.TB, seeded []agentengine.Agent, behavior enginetest.TurnBehavior) agentengine.Interface {
 	t.Helper()
 	root := t.TempDir()
-	codexRuntime := newContractRuntime(runtime.KindCodex, filepath.Join(root, "workspace"), behavior)
-	openClawRuntime := newContractRuntime(runtime.KindOpenClawSandbox, filepath.Join(root, "openclaw-workspace"), behavior)
+	codexWorkspace := filepath.Join(root, "workspace")
+	openClawWorkspace := filepath.Join(root, "openclaw-workspace")
+	for _, workspace := range []string{codexWorkspace, openClawWorkspace} {
+		if err := os.MkdirAll(workspace, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	codexRuntime := newContractRuntime(runtime.KindCodex, codexWorkspace, behavior)
+	openClawRuntime := newContractRuntime(runtime.KindOpenClawSandbox, openClawWorkspace, behavior)
 	stored := make([]agent.Agent, 0, len(seeded))
 	for _, item := range seeded {
 		runtimeKind := strings.TrimSpace(item.Spec.Runtime.Adapter)
@@ -336,5 +371,13 @@ func newRealContractEngine(t testing.TB, seeded []agentengine.Agent, behavior en
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = service.Close() })
-	return agentengine.New(service)
+	engine := agentengine.New(service)
+	codexRuntime.openFile = func(ctx context.Context, fileID string) (io.ReadCloser, error) {
+		download, err := engine.Conversations("agent-a").Files().Get(ctx, fileID)
+		if err != nil {
+			return nil, err
+		}
+		return download.Content, nil
+	}
+	return engine
 }

--- a/internal/agentengine/output_file.go
+++ b/internal/agentengine/output_file.go
@@ -17,11 +17,7 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	maxOutputFileNameBytes = 255
-	maxFileSizeBytes       = 25 * 1024 * 1024
-	maxAgentFileBytes      = 256 * 1024 * 1024
-)
+const maxOutputFileNameBytes = 255
 
 type invalidOutputFileError struct {
 	message string
@@ -70,9 +66,6 @@ func newOutputFile(ctx context.Context, metadata OutputFileMetadata, source io.R
 	}
 	if metadata.SizeBytes < 0 {
 		return nil, invalidOutputFile("output file size must be non-negative")
-	}
-	if metadata.SizeBytes > maxFileSizeBytes {
-		return nil, invalidOutputFile(fmt.Sprintf("output file exceeds %d bytes", maxFileSizeBytes))
 	}
 	expectedHash := strings.ToLower(strings.TrimSpace(metadata.SHA256))
 	if expectedHash != "" {
@@ -155,16 +148,15 @@ func newOutputFileID() (string, error) {
 }
 
 type outputFileSnapshot struct {
-	mu       sync.Mutex
-	path     string
-	removed  bool
-	leases   int
-	onRemove func()
+	mu      sync.Mutex
+	path    string
+	removed bool
+	leases  int
 }
 
 func createOutputFileSnapshot(ctx context.Context, source io.Reader, expectedSize int64) (*outputFileSnapshot, string, error) {
-	if expectedSize < 0 || expectedSize > maxFileSizeBytes {
-		return nil, "", invalidOutputFile(fmt.Sprintf("output file must contain at most %d bytes", maxFileSizeBytes))
+	if expectedSize < 0 {
+		return nil, "", invalidOutputFile("output file size must be non-negative")
 	}
 	snapshot, err := os.CreateTemp("", "csgclaw-output-")
 	if err != nil {
@@ -175,18 +167,13 @@ func createOutputFileSnapshot(ctx context.Context, source io.Reader, expectedSiz
 		_ = snapshot.Close()
 		_ = os.Remove(path)
 	}
-	limit := expectedSize + 1
-	if limit <= 0 {
-		cleanup()
-		return nil, "", fmt.Errorf("output file size is too large")
-	}
 	hash := sha256.New()
-	written, err := io.Copy(io.MultiWriter(snapshot, hash), io.LimitReader(contextReader{ctx: ctx, reader: source}, limit))
+	written, extra, err := copyExactOutputFile(ctx, io.MultiWriter(snapshot, hash), source, expectedSize)
 	if err != nil {
 		cleanup()
 		return nil, "", fmt.Errorf("snapshot output file: %w", err)
 	}
-	if written != expectedSize {
+	if written != expectedSize || extra {
 		cleanup()
 		return nil, "", fmt.Errorf("output file size changed: got %d, want %d", written, expectedSize)
 	}
@@ -215,9 +202,9 @@ func (s *outputFileSnapshot) cleanup() {
 	}
 	s.mu.Lock()
 	s.removed = true
-	path, onRemove := s.takeRemovalLocked()
+	path := s.takeRemovalLocked()
 	s.mu.Unlock()
-	removeOutputFileSnapshot(path, onRemove)
+	removeOutputFileSnapshot(path)
 }
 
 func (s *outputFileSnapshot) retain() (func(), bool) {
@@ -231,19 +218,6 @@ func (s *outputFileSnapshot) retain() (func(), bool) {
 	}
 	s.leases++
 	return s.release, true
-}
-
-func (s *outputFileSnapshot) setOnRemove(onRemove func()) bool {
-	if s == nil || onRemove == nil {
-		return false
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.removed || s.path == "" || s.onRemove != nil {
-		return false
-	}
-	s.onRemove = onRemove
-	return true
 }
 
 func (s *outputFileSnapshot) openVerified(ctx context.Context, expectedSize int64, expectedHash string) (io.ReadCloser, error) {
@@ -272,12 +246,12 @@ func (s *outputFileSnapshot) openVerified(ctx context.Context, expectedSize int6
 		return nil, fmt.Errorf("output file snapshot metadata changed")
 	}
 	hash := sha256.New()
-	written, err := io.Copy(hash, io.LimitReader(contextReader{ctx: ctx, reader: source}, expectedSize+1))
+	written, extra, err := copyExactOutputFile(ctx, hash, source, expectedSize)
 	if err != nil {
 		closeWithRelease()
 		return nil, fmt.Errorf("read output file snapshot: %w", err)
 	}
-	if written != expectedSize || hex.EncodeToString(hash.Sum(nil)) != expectedHash {
+	if written != expectedSize || extra || hex.EncodeToString(hash.Sum(nil)) != expectedHash {
 		closeWithRelease()
 		return nil, fmt.Errorf("output file snapshot content changed")
 	}
@@ -296,31 +270,39 @@ func (s *outputFileSnapshot) release() {
 	if s.leases > 0 {
 		s.leases--
 	}
-	path, onRemove := s.takeRemovalLocked()
+	path := s.takeRemovalLocked()
 	s.mu.Unlock()
-	removeOutputFileSnapshot(path, onRemove)
+	removeOutputFileSnapshot(path)
 }
 
-func (s *outputFileSnapshot) takeRemovalLocked() (string, func()) {
+func (s *outputFileSnapshot) takeRemovalLocked() string {
 	if !s.removed || s.leases != 0 || s.path == "" {
-		return "", nil
+		return ""
 	}
 	path := s.path
 	s.path = ""
-	onRemove := s.onRemove
-	s.onRemove = nil
-	return path, onRemove
+	return path
 }
 
-func removeOutputFileSnapshot(path string, onRemove func()) {
+func removeOutputFileSnapshot(path string) {
 	if path == "" {
 		return
 	}
 	_ = os.Chmod(path, 0o600)
 	_ = os.Remove(path)
-	if onRemove != nil {
-		onRemove()
+}
+
+func copyExactOutputFile(ctx context.Context, destination io.Writer, source io.Reader, expectedSize int64) (int64, bool, error) {
+	reader := contextReader{ctx: ctx, reader: source}
+	written, err := io.CopyN(destination, reader, expectedSize)
+	if err != nil {
+		return written, false, err
 	}
+	extra, err := io.ReadAll(io.LimitReader(reader, 1))
+	if err != nil {
+		return written, false, err
+	}
+	return written, len(extra) != 0, nil
 }
 
 type leasedOutputFile struct {

--- a/internal/agentengine/output_file.go
+++ b/internal/agentengine/output_file.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -13,11 +12,28 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
 
-const maxOutputFileNameBytes = 255
+const (
+	maxOutputFileNameBytes = 255
+	maxFileSizeBytes       = 25 * 1024 * 1024
+	maxAgentFileBytes      = 256 * 1024 * 1024
+)
+
+type invalidOutputFileError struct {
+	message string
+}
+
+func (e *invalidOutputFileError) Error() string {
+	return e.message
+}
+
+func invalidOutputFile(message string) error {
+	return &invalidOutputFileError{message: message}
+}
 
 // OutputFileMetadata describes one Runtime file authorized for delivery by a
 // Channel Adapter. It deliberately contains no host or Runtime path.
@@ -42,7 +58,7 @@ func newOutputFile(ctx context.Context, metadata OutputFileMetadata, source io.R
 		ctx = context.Background()
 	}
 	if source == nil {
-		return nil, fmt.Errorf("output file source is required")
+		return nil, invalidOutputFile("output file source is required")
 	}
 	name, err := normalizeOutputFileName(metadata.Name)
 	if err != nil {
@@ -50,16 +66,19 @@ func newOutputFile(ctx context.Context, metadata OutputFileMetadata, source io.R
 	}
 	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(metadata.MediaType))
 	if err != nil || strings.TrimSpace(mediaType) == "" {
-		return nil, fmt.Errorf("output file media type is invalid")
+		return nil, invalidOutputFile("output file media type is invalid")
 	}
 	if metadata.SizeBytes < 0 {
-		return nil, fmt.Errorf("output file size must be non-negative")
+		return nil, invalidOutputFile("output file size must be non-negative")
+	}
+	if metadata.SizeBytes > maxFileSizeBytes {
+		return nil, invalidOutputFile(fmt.Sprintf("output file exceeds %d bytes", maxFileSizeBytes))
 	}
 	expectedHash := strings.ToLower(strings.TrimSpace(metadata.SHA256))
 	if expectedHash != "" {
 		digest, err := hex.DecodeString(expectedHash)
 		if err != nil || len(digest) != sha256.Size {
-			return nil, fmt.Errorf("output file SHA-256 is invalid")
+			return nil, invalidOutputFile("output file SHA-256 is invalid")
 		}
 	}
 
@@ -69,7 +88,7 @@ func newOutputFile(ctx context.Context, metadata OutputFileMetadata, source io.R
 	}
 	if expectedHash != "" && actualHash != expectedHash {
 		snapshot.cleanup()
-		return nil, fmt.Errorf("output file SHA-256 does not match")
+		return nil, invalidOutputFile("output file SHA-256 does not match")
 	}
 	id, err := newOutputFileID()
 	if err != nil {
@@ -109,20 +128,19 @@ func (f *OutputFile) cleanup() {
 		return
 	}
 	f.snapshot.cleanup()
-	f.snapshot = nil
 }
 
 func normalizeOutputFileName(value string) (string, error) {
 	name := strings.TrimSpace(value)
 	if name == "" || !utf8.ValidString(name) || len([]byte(name)) > maxOutputFileNameBytes {
-		return "", fmt.Errorf("output file name must be valid UTF-8 with 1 to %d bytes", maxOutputFileNameBytes)
+		return "", invalidOutputFile(fmt.Sprintf("output file name must be valid UTF-8 with 1 to %d bytes", maxOutputFileNameBytes))
 	}
 	if name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, "/\\\x00") {
-		return "", fmt.Errorf("output file name must be a basename without path components")
+		return "", invalidOutputFile("output file name must be a basename without path components")
 	}
 	for _, character := range name {
 		if unicode.IsControl(character) {
-			return "", fmt.Errorf("output file name must not contain control characters")
+			return "", invalidOutputFile("output file name must not contain control characters")
 		}
 	}
 	return name, nil
@@ -137,10 +155,17 @@ func newOutputFileID() (string, error) {
 }
 
 type outputFileSnapshot struct {
-	path string
+	mu       sync.Mutex
+	path     string
+	removed  bool
+	leases   int
+	onRemove func()
 }
 
 func createOutputFileSnapshot(ctx context.Context, source io.Reader, expectedSize int64) (*outputFileSnapshot, string, error) {
+	if expectedSize < 0 || expectedSize > maxFileSizeBytes {
+		return nil, "", invalidOutputFile(fmt.Sprintf("output file must contain at most %d bytes", maxFileSizeBytes))
+	}
 	snapshot, err := os.CreateTemp("", "csgclaw-output-")
 	if err != nil {
 		return nil, "", fmt.Errorf("create output file snapshot: %w", err)
@@ -188,79 +213,132 @@ func (s *outputFileSnapshot) cleanup() {
 	if s == nil {
 		return
 	}
-	if s.path != "" {
-		_ = os.Chmod(s.path, 0o600)
-		_ = os.Remove(s.path)
-		s.path = ""
+	s.mu.Lock()
+	s.removed = true
+	path, onRemove := s.takeRemovalLocked()
+	s.mu.Unlock()
+	removeOutputFileSnapshot(path, onRemove)
+}
+
+func (s *outputFileSnapshot) retain() (func(), bool) {
+	if s == nil {
+		return nil, false
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.removed || s.path == "" {
+		return nil, false
+	}
+	s.leases++
+	return s.release, true
+}
+
+func (s *outputFileSnapshot) setOnRemove(onRemove func()) bool {
+	if s == nil || onRemove == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.removed || s.path == "" || s.onRemove != nil {
+		return false
+	}
+	s.onRemove = onRemove
+	return true
 }
 
 func (s *outputFileSnapshot) openVerified(ctx context.Context, expectedSize int64, expectedHash string) (io.ReadCloser, error) {
+	if s == nil {
+		return nil, fmt.Errorf("output file is unavailable")
+	}
+	s.mu.Lock()
+	if s.path == "" {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("output file is unavailable")
+	}
 	source, err := os.Open(s.path)
 	if err != nil {
+		s.mu.Unlock()
 		return nil, fmt.Errorf("open output file snapshot: %w", err)
 	}
-	defer source.Close()
+	s.leases++
+	s.mu.Unlock()
+	closeWithRelease := func() {
+		_ = source.Close()
+		s.release()
+	}
 	info, err := source.Stat()
 	if err != nil || !info.Mode().IsRegular() || info.Size() != expectedSize {
+		closeWithRelease()
 		return nil, fmt.Errorf("output file snapshot metadata changed")
 	}
-	delivery, err := os.CreateTemp("", "csgclaw-delivery-")
-	if err != nil {
-		return nil, fmt.Errorf("create output file delivery reader: %w", err)
-	}
-	deliveryPath := delivery.Name()
-	cleanup := func() {
-		_ = delivery.Close()
-		_ = os.Remove(deliveryPath)
-	}
 	hash := sha256.New()
-	written, err := io.Copy(io.MultiWriter(delivery, hash), io.LimitReader(contextReader{ctx: ctx, reader: source}, expectedSize+1))
+	written, err := io.Copy(hash, io.LimitReader(contextReader{ctx: ctx, reader: source}, expectedSize+1))
 	if err != nil {
-		cleanup()
+		closeWithRelease()
 		return nil, fmt.Errorf("read output file snapshot: %w", err)
 	}
 	if written != expectedSize || hex.EncodeToString(hash.Sum(nil)) != expectedHash {
-		cleanup()
+		closeWithRelease()
 		return nil, fmt.Errorf("output file snapshot content changed")
 	}
-	if err := delivery.Chmod(0o400); err != nil {
-		cleanup()
-		return nil, fmt.Errorf("protect output file delivery reader: %w", err)
-	}
-	if _, err := delivery.Seek(0, io.SeekStart); err != nil {
-		cleanup()
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		closeWithRelease()
 		return nil, fmt.Errorf("rewind output file delivery reader: %w", err)
 	}
-	result := &temporaryOutputFile{File: delivery, path: deliveryPath, snapshot: s}
-	if err := os.Remove(deliveryPath); err == nil {
-		result.path = ""
-	}
-	return result, nil
+	return &leasedOutputFile{File: source, snapshot: s}, nil
 }
 
-type temporaryOutputFile struct {
+func (s *outputFileSnapshot) release() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.leases > 0 {
+		s.leases--
+	}
+	path, onRemove := s.takeRemovalLocked()
+	s.mu.Unlock()
+	removeOutputFileSnapshot(path, onRemove)
+}
+
+func (s *outputFileSnapshot) takeRemovalLocked() (string, func()) {
+	if !s.removed || s.leases != 0 || s.path == "" {
+		return "", nil
+	}
+	path := s.path
+	s.path = ""
+	onRemove := s.onRemove
+	s.onRemove = nil
+	return path, onRemove
+}
+
+func removeOutputFileSnapshot(path string, onRemove func()) {
+	if path == "" {
+		return
+	}
+	_ = os.Chmod(path, 0o600)
+	_ = os.Remove(path)
+	if onRemove != nil {
+		onRemove()
+	}
+}
+
+type leasedOutputFile struct {
 	*os.File
-	path     string
 	snapshot *outputFileSnapshot
 }
 
-func (f *temporaryOutputFile) Close() error {
+func (f *leasedOutputFile) Close() error {
 	if f == nil || f.File == nil {
 		return nil
 	}
 	closeErr := f.File.Close()
-	var removeErr error
-	if f.path != "" {
-		_ = os.Chmod(f.path, 0o600)
-		removeErr = os.Remove(f.path)
-		if errors.Is(removeErr, os.ErrNotExist) {
-			removeErr = nil
-		}
-	}
 	f.File = nil
+	if f.snapshot != nil {
+		f.snapshot.release()
+	}
 	f.snapshot = nil
-	return errors.Join(closeErr, removeErr)
+	return closeErr
 }
 
 type contextReader struct {

--- a/internal/agentengine/output_file.go
+++ b/internal/agentengine/output_file.go
@@ -1,0 +1,276 @@
+package agentengine
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const maxOutputFileNameBytes = 255
+
+// OutputFileMetadata describes one Runtime file authorized for delivery by a
+// Channel Adapter. It deliberately contains no host or Runtime path.
+type OutputFileMetadata struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256"`
+}
+
+// OutputFile is JSON-safe metadata for one immutable Engine file resource.
+// Snapshot access stays behind FileInterface and never exposes a host path.
+type OutputFile struct {
+	OutputFileMetadata
+
+	snapshot *outputFileSnapshot
+}
+
+func newOutputFile(ctx context.Context, metadata OutputFileMetadata, source io.Reader) (*OutputFile, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if source == nil {
+		return nil, fmt.Errorf("output file source is required")
+	}
+	name, err := normalizeOutputFileName(metadata.Name)
+	if err != nil {
+		return nil, err
+	}
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(metadata.MediaType))
+	if err != nil || strings.TrimSpace(mediaType) == "" {
+		return nil, fmt.Errorf("output file media type is invalid")
+	}
+	if metadata.SizeBytes < 0 {
+		return nil, fmt.Errorf("output file size must be non-negative")
+	}
+	expectedHash := strings.ToLower(strings.TrimSpace(metadata.SHA256))
+	if expectedHash != "" {
+		digest, err := hex.DecodeString(expectedHash)
+		if err != nil || len(digest) != sha256.Size {
+			return nil, fmt.Errorf("output file SHA-256 is invalid")
+		}
+	}
+
+	snapshot, actualHash, err := createOutputFileSnapshot(ctx, source, metadata.SizeBytes)
+	if err != nil {
+		return nil, err
+	}
+	if expectedHash != "" && actualHash != expectedHash {
+		snapshot.cleanup()
+		return nil, fmt.Errorf("output file SHA-256 does not match")
+	}
+	id, err := newOutputFileID()
+	if err != nil {
+		snapshot.cleanup()
+		return nil, err
+	}
+	return &OutputFile{
+		OutputFileMetadata: OutputFileMetadata{
+			ID: id, Name: name, MediaType: strings.ToLower(mediaType), SizeBytes: metadata.SizeBytes, SHA256: actualHash,
+		},
+		snapshot: snapshot,
+	}, nil
+}
+
+func (f *OutputFile) open(ctx context.Context) (io.ReadCloser, error) {
+	if f == nil || f.snapshot == nil || f.snapshot.path == "" {
+		return nil, fmt.Errorf("output file is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return f.snapshot.openVerified(ctx, f.SizeBytes, f.SHA256)
+}
+
+func (f *OutputFile) metadata() OutputFile {
+	if f == nil {
+		return OutputFile{}
+	}
+	return OutputFile{OutputFileMetadata: f.OutputFileMetadata}
+}
+
+func (f *OutputFile) cleanup() {
+	if f == nil || f.snapshot == nil {
+		return
+	}
+	f.snapshot.cleanup()
+	f.snapshot = nil
+}
+
+func normalizeOutputFileName(value string) (string, error) {
+	name := strings.TrimSpace(value)
+	if name == "" || !utf8.ValidString(name) || len([]byte(name)) > maxOutputFileNameBytes {
+		return "", fmt.Errorf("output file name must be valid UTF-8 with 1 to %d bytes", maxOutputFileNameBytes)
+	}
+	if name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, "/\\\x00") {
+		return "", fmt.Errorf("output file name must be a basename without path components")
+	}
+	for _, character := range name {
+		if unicode.IsControl(character) {
+			return "", fmt.Errorf("output file name must not contain control characters")
+		}
+	}
+	return name, nil
+}
+
+func newOutputFileID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate output file ID: %w", err)
+	}
+	return "file-" + hex.EncodeToString(value), nil
+}
+
+type outputFileSnapshot struct {
+	path string
+}
+
+func createOutputFileSnapshot(ctx context.Context, source io.Reader, expectedSize int64) (*outputFileSnapshot, string, error) {
+	snapshot, err := os.CreateTemp("", "csgclaw-output-")
+	if err != nil {
+		return nil, "", fmt.Errorf("create output file snapshot: %w", err)
+	}
+	path := snapshot.Name()
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = os.Remove(path)
+	}
+	limit := expectedSize + 1
+	if limit <= 0 {
+		cleanup()
+		return nil, "", fmt.Errorf("output file size is too large")
+	}
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(snapshot, hash), io.LimitReader(contextReader{ctx: ctx, reader: source}, limit))
+	if err != nil {
+		cleanup()
+		return nil, "", fmt.Errorf("snapshot output file: %w", err)
+	}
+	if written != expectedSize {
+		cleanup()
+		return nil, "", fmt.Errorf("output file size changed: got %d, want %d", written, expectedSize)
+	}
+	if err := snapshot.Sync(); err != nil {
+		cleanup()
+		return nil, "", fmt.Errorf("sync output file snapshot: %w", err)
+	}
+	if err := snapshot.Chmod(0o400); err != nil {
+		cleanup()
+		return nil, "", fmt.Errorf("protect output file snapshot: %w", err)
+	}
+	if err := snapshot.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, "", fmt.Errorf("close output file snapshot: %w", err)
+	}
+	result := &outputFileSnapshot{path: path}
+	runtime.SetFinalizer(result, func(snapshot *outputFileSnapshot) {
+		snapshot.cleanup()
+	})
+	return result, hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func (s *outputFileSnapshot) cleanup() {
+	if s == nil {
+		return
+	}
+	if s.path != "" {
+		_ = os.Chmod(s.path, 0o600)
+		_ = os.Remove(s.path)
+		s.path = ""
+	}
+}
+
+func (s *outputFileSnapshot) openVerified(ctx context.Context, expectedSize int64, expectedHash string) (io.ReadCloser, error) {
+	source, err := os.Open(s.path)
+	if err != nil {
+		return nil, fmt.Errorf("open output file snapshot: %w", err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() != expectedSize {
+		return nil, fmt.Errorf("output file snapshot metadata changed")
+	}
+	delivery, err := os.CreateTemp("", "csgclaw-delivery-")
+	if err != nil {
+		return nil, fmt.Errorf("create output file delivery reader: %w", err)
+	}
+	deliveryPath := delivery.Name()
+	cleanup := func() {
+		_ = delivery.Close()
+		_ = os.Remove(deliveryPath)
+	}
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(delivery, hash), io.LimitReader(contextReader{ctx: ctx, reader: source}, expectedSize+1))
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("read output file snapshot: %w", err)
+	}
+	if written != expectedSize || hex.EncodeToString(hash.Sum(nil)) != expectedHash {
+		cleanup()
+		return nil, fmt.Errorf("output file snapshot content changed")
+	}
+	if err := delivery.Chmod(0o400); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("protect output file delivery reader: %w", err)
+	}
+	if _, err := delivery.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("rewind output file delivery reader: %w", err)
+	}
+	result := &temporaryOutputFile{File: delivery, path: deliveryPath, snapshot: s}
+	if err := os.Remove(deliveryPath); err == nil {
+		result.path = ""
+	}
+	return result, nil
+}
+
+type temporaryOutputFile struct {
+	*os.File
+	path     string
+	snapshot *outputFileSnapshot
+}
+
+func (f *temporaryOutputFile) Close() error {
+	if f == nil || f.File == nil {
+		return nil
+	}
+	closeErr := f.File.Close()
+	var removeErr error
+	if f.path != "" {
+		_ = os.Chmod(f.path, 0o600)
+		removeErr = os.Remove(f.path)
+		if errors.Is(removeErr, os.ErrNotExist) {
+			removeErr = nil
+		}
+	}
+	f.File = nil
+	f.snapshot = nil
+	return errors.Join(closeErr, removeErr)
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r contextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}

--- a/internal/agentengine/output_file_test.go
+++ b/internal/agentengine/output_file_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -70,8 +72,16 @@ func TestFileStoreTurnCleanupUsesConversationIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstMetadata := store.registerTurnFiles("agent-a", "conversation-a", "turn-1", []*OutputFile{first})[0]
-	secondMetadata := store.registerTurnFiles("agent-a", "conversation-b", "turn-1", []*OutputFile{second})[0]
+	firstFiles, firstStoreErr := store.registerTurnFiles("agent-a", "conversation-a", "turn-1", []*OutputFile{first})
+	if firstStoreErr != nil {
+		t.Fatal(firstStoreErr)
+	}
+	secondFiles, secondStoreErr := store.registerTurnFiles("agent-a", "conversation-b", "turn-1", []*OutputFile{second})
+	if secondStoreErr != nil {
+		t.Fatal(secondStoreErr)
+	}
+	firstMetadata := firstFiles[0]
+	secondMetadata := secondFiles[0]
 	store.deleteTurn("agent-a", "conversation-a", "turn-1")
 	if _, err := store.Scope("agent-a").Get(context.Background(), firstMetadata.ID); ErrorCodeOf(err) != ErrorFileNotFound {
 		t.Fatalf("first Get error = %v", err)
@@ -81,6 +91,171 @@ func TestFileStoreTurnCleanupUsesConversationIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = download.Content.Close()
+}
+
+func TestFileStoreGetLeaseSurvivesDelete(t *testing.T) {
+	store := NewFileStore()
+	files := store.Scope("agent-a")
+	content := []byte("leased content")
+	created, err := files.Create(context.Background(), outputFileTestRequest("lease.txt", content), bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	download, err := files.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Delete(context.Background(), created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := files.Get(context.Background(), created.ID); ErrorCodeOf(err) != ErrorFileNotFound {
+		t.Fatalf("Get after Delete error = %v", err)
+	}
+	got, readErr := io.ReadAll(download.Content)
+	closeErr := download.Content.Close()
+	if readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+		t.Fatalf("leased content = %q, read=%v close=%v", got, readErr, closeErr)
+	}
+	store.mu.RLock()
+	remaining := store.bytesByAgent["agent-a"]
+	store.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("remaining bytes = %d, want 0", remaining)
+	}
+}
+
+func TestFileStoreConcurrentGetAndDelete(t *testing.T) {
+	store := NewFileStore()
+	files := store.Scope("agent-a")
+	content := bytes.Repeat([]byte("x"), 4096)
+	for iteration := 0; iteration < 50; iteration++ {
+		created, err := files.Create(context.Background(), outputFileTestRequest("race.txt", content), bytes.NewReader(content))
+		if err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		getErr := make(chan error, 1)
+		deleteErr := make(chan error, 1)
+		go func() {
+			<-start
+			download, err := files.Get(context.Background(), created.ID)
+			if err != nil {
+				if code := ErrorCodeOf(err); code != ErrorFileNotFound && code != ErrorFileUnavailable {
+					getErr <- err
+					return
+				}
+				getErr <- nil
+				return
+			}
+			got, readErr := io.ReadAll(download.Content)
+			closeErr := download.Content.Close()
+			if readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+				getErr <- errors.Join(readErr, closeErr, errors.New("content changed"))
+				return
+			}
+			getErr <- nil
+		}()
+		go func() {
+			<-start
+			deleteErr <- files.Delete(context.Background(), created.ID)
+		}()
+		close(start)
+		if err := <-getErr; err != nil {
+			t.Fatalf("iteration %d Get error = %v", iteration, err)
+		}
+		if err := <-deleteErr; err != nil {
+			t.Fatalf("iteration %d Delete error = %v", iteration, err)
+		}
+	}
+}
+
+func TestFileStoreResolvedInputSurvivesDelete(t *testing.T) {
+	store := NewFileStore()
+	files := store.Scope("agent-a")
+	content := []byte("resolved input")
+	created, err := files.Create(context.Background(), outputFileTestRequest("input.txt", content), bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, release, resolveErr := store.resolve("agent-a", created.ID)
+	if resolveErr != nil {
+		t.Fatal(resolveErr)
+	}
+	if err := files.Delete(context.Background(), created.ID); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := file.open(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	release()
+	if readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+		t.Fatalf("resolved content = %q, read=%v close=%v", got, readErr, closeErr)
+	}
+}
+
+func TestFileStoreEnforcesFileAndAgentLimits(t *testing.T) {
+	store := NewFileStore()
+	store.maxAgentBytes = 8
+	files := store.Scope("agent-a")
+	content := []byte("12345678")
+	first, err := files.Create(context.Background(), outputFileTestRequest("first.txt", content), bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := files.Create(context.Background(), outputFileTestRequest("second.txt", []byte("x")), strings.NewReader("x")); ErrorCodeOf(err) != ErrorFileUnavailable {
+		t.Fatalf("aggregate quota error = %v", err)
+	}
+	if err := files.Delete(context.Background(), first.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := files.Create(context.Background(), outputFileTestRequest("second.txt", []byte("x")), strings.NewReader("x")); err != nil {
+		t.Fatalf("Create after quota release error = %v", err)
+	}
+	tooLarge := FileCreateRequest{Name: "large.bin", MIMEType: "application/octet-stream", SizeBytes: maxFileSizeBytes + 1}
+	if _, err := files.Create(context.Background(), tooLarge, strings.NewReader("")); ErrorCodeOf(err) != ErrorInvalidRequest {
+		t.Fatalf("per-file quota error = %v", err)
+	}
+}
+
+func TestFileStoreNormalizesStorageAndContentErrors(t *testing.T) {
+	files := NewFileStore().Scope("agent-a")
+	request := FileCreateRequest{Name: "failed.txt", MIMEType: "text/plain", SizeBytes: 1}
+	if _, err := files.Create(context.Background(), request, errorReader{err: errors.New("read /private/secret")}); ErrorCodeOf(err) != ErrorFileUnavailable || strings.Contains(err.Error(), "/private/secret") {
+		t.Fatalf("storage error = %v", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := files.Create(canceled, request, strings.NewReader("x")); ErrorCodeOf(err) != ErrorCanceled {
+		t.Fatalf("canceled Create error = %v", err)
+	}
+
+	store := NewFileStore()
+	storedFiles := store.Scope("agent-a")
+	content := []byte("content")
+	created, err := storedFiles.Create(context.Background(), outputFileTestRequest("content.txt", content), bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.mu.RLock()
+	path := store.byAgent["agent-a"][created.ID].file.snapshot.path
+	store.mu.RUnlock()
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := storedFiles.Get(context.Background(), created.ID); ErrorCodeOf(err) != ErrorFileUnavailable || strings.Contains(err.Error(), path) {
+		t.Fatalf("content error = %v", err)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 func outputFileTestRequest(name string, content []byte) FileCreateRequest {

--- a/internal/agentengine/output_file_test.go
+++ b/internal/agentengine/output_file_test.go
@@ -1,0 +1,91 @@
+package agentengine
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestOutputFileSnapshotsOnceAndUsesOpaqueIdentity(t *testing.T) {
+	content := []byte("immutable output")
+	store := NewFileStore()
+	files := store.Scope("agent-a")
+	request := outputFileTestRequest("报告.pdf", content)
+	first, err := files.Create(context.Background(), request, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := files.Create(context.Background(), request, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(first.ID, "file-") || len(first.ID) != len("file-")+32 || first.ID == second.ID || first.ID == "sha256:"+first.SHA256 {
+		t.Fatalf("file IDs = %q, %q", first.ID, second.ID)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		download, err := files.Get(context.Background(), first.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, readErr := io.ReadAll(download.Content)
+		closeErr := download.Content.Close()
+		if download.Metadata != first.OutputFileMetadata || readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
+			t.Fatalf("attempt %d metadata=%+v content=%q read=%v close=%v", attempt, download.Metadata, got, readErr, closeErr)
+		}
+	}
+}
+
+func TestOutputFileRejectsUnsafeNames(t *testing.T) {
+	content := []byte("content")
+	files := NewFileStore().Scope("agent-a")
+	invalidNames := []string{
+		"", ".", "..", "nested/report.pdf", `nested\report.pdf`, "line\nbreak.pdf", "tab\tname.pdf", string([]byte{0xff, 0xfe}), strings.Repeat("a", 256),
+	}
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			request := outputFileTestRequest(name, content)
+			if _, err := files.Create(context.Background(), request, bytes.NewReader(content)); err == nil {
+				t.Fatalf("Create(%q) error = nil", name)
+			}
+		})
+	}
+	request := outputFileTestRequest("报告 2026.pdf", content)
+	if _, err := files.Create(context.Background(), request, bytes.NewReader(content)); err != nil {
+		t.Fatalf("valid Unicode name error = %v", err)
+	}
+}
+
+func TestFileStoreTurnCleanupUsesConversationIdentity(t *testing.T) {
+	store := NewFileStore()
+	content := []byte("same turn ID")
+	first, err := newOutputFile(context.Background(), OutputFileMetadata{Name: "first.txt", MediaType: "text/plain", SizeBytes: int64(len(content))}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newOutputFile(context.Background(), OutputFileMetadata{Name: "second.txt", MediaType: "text/plain", SizeBytes: int64(len(content))}, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstMetadata := store.registerTurnFiles("agent-a", "conversation-a", "turn-1", []*OutputFile{first})[0]
+	secondMetadata := store.registerTurnFiles("agent-a", "conversation-b", "turn-1", []*OutputFile{second})[0]
+	store.deleteTurn("agent-a", "conversation-a", "turn-1")
+	if _, err := store.Scope("agent-a").Get(context.Background(), firstMetadata.ID); ErrorCodeOf(err) != ErrorFileNotFound {
+		t.Fatalf("first Get error = %v", err)
+	}
+	download, err := store.Scope("agent-a").Get(context.Background(), secondMetadata.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = download.Content.Close()
+}
+
+func outputFileTestRequest(name string, content []byte) FileCreateRequest {
+	digest := sha256.Sum256(content)
+	return FileCreateRequest{
+		Name: name, MIMEType: "application/pdf", SizeBytes: int64(len(content)), SHA256: hex.EncodeToString(digest[:]),
+	}
+}

--- a/internal/agentengine/output_file_test.go
+++ b/internal/agentengine/output_file_test.go
@@ -116,12 +116,6 @@ func TestFileStoreGetLeaseSurvivesDelete(t *testing.T) {
 	if readErr != nil || closeErr != nil || !bytes.Equal(got, content) {
 		t.Fatalf("leased content = %q, read=%v close=%v", got, readErr, closeErr)
 	}
-	store.mu.RLock()
-	remaining := store.bytesByAgent["agent-a"]
-	store.mu.RUnlock()
-	if remaining != 0 {
-		t.Fatalf("remaining bytes = %d, want 0", remaining)
-	}
 }
 
 func TestFileStoreConcurrentGetAndDelete(t *testing.T) {
@@ -196,27 +190,20 @@ func TestFileStoreResolvedInputSurvivesDelete(t *testing.T) {
 	}
 }
 
-func TestFileStoreEnforcesFileAndAgentLimits(t *testing.T) {
-	store := NewFileStore()
-	store.maxAgentBytes = 8
-	files := store.Scope("agent-a")
-	content := []byte("12345678")
-	first, err := files.Create(context.Background(), outputFileTestRequest("first.txt", content), bytes.NewReader(content))
+func TestFileStoreAcceptsFileAboveFormerSizeLimit(t *testing.T) {
+	const size = int64(25*1024*1024 + 1)
+	files := NewFileStore().Scope("agent-a")
+	created, err := files.Create(context.Background(), FileCreateRequest{
+		Name: "large.bin", MIMEType: "application/octet-stream", SizeBytes: size,
+	}, io.LimitReader(zeroReader{}, size))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := files.Create(context.Background(), outputFileTestRequest("second.txt", []byte("x")), strings.NewReader("x")); ErrorCodeOf(err) != ErrorFileUnavailable {
-		t.Fatalf("aggregate quota error = %v", err)
+	if created.SizeBytes != size {
+		t.Fatalf("SizeBytes = %d, want %d", created.SizeBytes, size)
 	}
-	if err := files.Delete(context.Background(), first.ID); err != nil {
+	if err := files.Delete(context.Background(), created.ID); err != nil {
 		t.Fatal(err)
-	}
-	if _, err := files.Create(context.Background(), outputFileTestRequest("second.txt", []byte("x")), strings.NewReader("x")); err != nil {
-		t.Fatalf("Create after quota release error = %v", err)
-	}
-	tooLarge := FileCreateRequest{Name: "large.bin", MIMEType: "application/octet-stream", SizeBytes: maxFileSizeBytes + 1}
-	if _, err := files.Create(context.Background(), tooLarge, strings.NewReader("")); ErrorCodeOf(err) != ErrorInvalidRequest {
-		t.Fatalf("per-file quota error = %v", err)
 	}
 }
 
@@ -252,6 +239,15 @@ func TestFileStoreNormalizesStorageAndContentErrors(t *testing.T) {
 
 type errorReader struct {
 	err error
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(buffer []byte) (int, error) {
+	for index := range buffer {
+		buffer[index] = 0
+	}
+	return len(buffer), nil
 }
 
 func (r errorReader) Read([]byte) (int, error) {

--- a/internal/agentengine/runtime_adapter.go
+++ b/internal/agentengine/runtime_adapter.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -28,7 +30,8 @@ type agentServiceAdapter struct {
 // New wires the existing Agent Service through private Engine facades.
 func New(service *agent.Service) *Engine {
 	adapter := agentServiceAdapter{service: service}
-	return &Engine{agents: agentFacade{service: service}, runtimes: adapter}
+	files := NewFileStore()
+	return &Engine{agents: agentFacade{service: service, files: files}, runtimes: adapter, files: files}
 }
 
 func (a agentServiceAdapter) conversationRuntime(ctx context.Context, agentID string) (conversationRuntimeAdapter, func(), *TurnError) {
@@ -78,7 +81,7 @@ type codexRuntimeAdapter struct {
 }
 
 func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink EventSink) TurnResult {
-	blocks, cleanup, inputErr := a.prepareInput(request.ID, request.Input)
+	blocks, cleanup, inputErr := a.prepareInput(ctx, request.ID, request.Input)
 	if inputErr != nil {
 		return TurnResult{Status: TurnFailed, Error: inputErr}
 	}
@@ -109,6 +112,7 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 	runtimeDone := false
 	eventStreamClosed := false
 	var output strings.Builder
+	var files []*OutputFile
 	stopPrompt := func(result TurnResult) TurnResult {
 		cancel()
 		if !promptReturned {
@@ -125,7 +129,7 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 				result.Dispatched = dispatched
 				return result
 			}
-			return TurnResult{Status: TurnSucceeded, Output: output.String(), Dispatched: dispatched}
+			return TurnResult{Status: TurnSucceeded, Output: output.String(), Dispatched: dispatched, files: files}
 		}
 		select {
 		case <-accepted:
@@ -151,7 +155,7 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 			if strings.TrimSpace(event.RuntimeID) != strings.TrimSpace(a.runtimeID) || strings.TrimSpace(event.SessionID) != strings.TrimSpace(sessionID) {
 				continue
 			}
-			if result := a.handleEvent(runCtx, request, sink, event, &output); result != nil {
+			if result := a.handleEvent(runCtx, request, sink, event, &output, &files); result != nil {
 				return stopPrompt(*result)
 			}
 			if event.Kind == activity.RuntimeEventPromptCompleted {
@@ -179,7 +183,7 @@ func (a *codexRuntimeAdapter) session(ctx context.Context, request TurnRequest) 
 	return sessionID, nil
 }
 
-func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnRequest, sink EventSink, event activity.RuntimeEvent, output *strings.Builder) *TurnResult {
+func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnRequest, sink EventSink, event activity.RuntimeEvent, output *strings.Builder, files *[]*OutputFile) *TurnResult {
 	emit := func(turnEvent TurnEvent) *TurnResult {
 		if err := emitTurnEvent(ctx, sink, turnEvent); err != nil {
 			result := resultFromContext(ctx, err)
@@ -216,6 +220,19 @@ func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnReque
 				return result
 			}
 		}
+	case activity.RuntimeEventFileOutput:
+		runtimeFile, ok := event.Payload.(activity.RuntimeFile)
+		if !ok {
+			result := failedResult(ErrorRuntimeFailed, "Codex returned invalid file output")
+			return &result
+		}
+		file, fileErr := a.authorizeOutputFile(ctx, runtimeFile)
+		if fileErr != nil {
+			result := TurnResult{Status: TurnFailed, Error: fileErr}
+			return &result
+		}
+		*files = append(*files, file)
+		return nil
 	case activity.RuntimeEventTextDelta:
 		phase := runtimeEventPhase(event)
 		if phase != "" && phase != "final_answer" {
@@ -237,6 +254,106 @@ func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnReque
 		}})
 	}
 	return nil
+}
+
+func (a *codexRuntimeAdapter) authorizeOutputFile(ctx context.Context, request activity.RuntimeFile) (*OutputFile, *TurnError) {
+	workspace, err := a.runtime.WorkspaceDir(a.runtimeID)
+	if err != nil {
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+	}
+	workspace = strings.TrimSpace(workspace)
+	relativePath, err := cleanRuntimeOutputPath(request.Path)
+	if err != nil {
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("open Runtime workspace: %v", err)}
+	}
+	source, info, err := openRuntimeOutputSource(root, relativePath)
+	if err != nil {
+		_ = root.Close()
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+	}
+	prefix := make([]byte, 512)
+	prefixBytes, readErr := io.ReadFull(contextReader{ctx: ctx, reader: source}, prefix)
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		_ = source.Close()
+		_ = root.Close()
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("read Runtime output file: %v", readErr)}
+	}
+	prefix = prefix[:prefixBytes]
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		_ = source.Close()
+		_ = root.Close()
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("rewind Runtime output file: %v", err)}
+	}
+	name := strings.TrimSpace(request.Name)
+	if name == "" {
+		name = filepath.Base(relativePath)
+	}
+	mediaType, err := runtimeOutputMediaType(request.MIMEType, name, prefix)
+	if err != nil {
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+	}
+	file, snapshotErr := newOutputFile(ctx, OutputFileMetadata{Name: name, MediaType: mediaType, SizeBytes: info.Size()}, source)
+	closeErr := source.Close()
+	rootCloseErr := root.Close()
+	if snapshotErr != nil || closeErr != nil || rootCloseErr != nil {
+		err := errors.Join(snapshotErr, closeErr, rootCloseErr)
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("snapshot Runtime output file: %v", err)}
+	}
+	return file, nil
+}
+
+func cleanRuntimeOutputPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	cleaned := filepath.Clean(path)
+	if path == "" || cleaned == "." || filepath.IsAbs(cleaned) || filepath.VolumeName(cleaned) != "" || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("Runtime output path must stay within the Runtime workspace")
+	}
+	return cleaned, nil
+}
+
+func openRuntimeOutputSource(root *os.Root, relativePath string) (*os.File, os.FileInfo, error) {
+	info, err := root.Lstat(relativePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect Runtime output file: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("Runtime output must be a regular non-symlink file")
+	}
+	file, err := root.Open(relativePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open Runtime output file: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("Runtime output file changed before it could be opened")
+	}
+	return file, openedInfo, nil
+}
+
+func runtimeOutputMediaType(requested, name string, prefix []byte) (string, error) {
+	detected := http.DetectContentType(prefix)
+	mediaType := strings.TrimSpace(requested)
+	if mediaType != "" {
+		parsed, _, err := mime.ParseMediaType(mediaType)
+		if err != nil || strings.TrimSpace(parsed) == "" {
+			return "", fmt.Errorf("Runtime output MIME type is invalid")
+		}
+		mediaType = strings.ToLower(parsed)
+	} else if byExtension := mime.TypeByExtension(filepath.Ext(name)); byExtension != "" {
+		parsed, _, _ := mime.ParseMediaType(byExtension)
+		mediaType = strings.ToLower(parsed)
+	} else {
+		mediaType = strings.ToLower(detected)
+	}
+	if strings.HasPrefix(mediaType, "image/") && !strings.HasPrefix(strings.ToLower(detected), "image/") {
+		return "", fmt.Errorf("Runtime output content does not match image MIME type %q", mediaType)
+	}
+	return mediaType, nil
 }
 
 func (a *codexRuntimeAdapter) handleInteraction(ctx context.Context, policy InteractionPolicy, interaction InteractionRequest, sink EventSink) *TurnResult {
@@ -347,7 +464,7 @@ func runtimeEventPhase(event activity.RuntimeEvent) string {
 
 var safeInputNamePattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
-func (a *codexRuntimeAdapter) prepareInput(turnID TurnID, input []InputPart) ([]codex.PromptContentBlock, func(), *TurnError) {
+func (a *codexRuntimeAdapter) prepareInput(ctx context.Context, turnID TurnID, input []InputPart) ([]codex.PromptContentBlock, func(), *TurnError) {
 	needsFiles := false
 	for _, part := range input {
 		needsFiles = needsFiles || part.Kind == InputPartFile
@@ -390,66 +507,55 @@ func (a *codexRuntimeAdapter) prepareInput(turnID TurnID, input []InputPart) ([]
 			blocks = append(blocks, codex.TextBlock(part.Text))
 			continue
 		}
-		path, err := copyVerifiedInput(workspaceRoot, workspace, turnDir, index, *part.File)
+		path, err := copyVerifiedInput(ctx, workspaceRoot, workspace, turnDir, index, *part.File)
 		if err != nil {
 			cleanup()
 			return nil, func() {}, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
 		}
-		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(part.File.MediaType)), "image/") {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(part.File.file.MediaType)), "image/") {
 			blocks = append(blocks, codex.LocalImageBlock(path))
 		} else {
-			blocks = append(blocks, codex.TextBlock(fmt.Sprintf("Attached file %q is available in the Runtime workspace at %s", part.File.Name, path)))
+			blocks = append(blocks, codex.TextBlock(fmt.Sprintf("Attached file %q is available in the Runtime workspace at %s", part.File.file.Name, path)))
 		}
 	}
 	return blocks, cleanup, nil
 }
 
-func copyVerifiedInput(root *os.Root, workspace, turnDir string, index int, input InputFile) (string, error) {
-	info, err := os.Lstat(input.SourcePath)
-	if err != nil {
-		return "", fmt.Errorf("inspect input file %q: %w", input.Name, err)
+func copyVerifiedInput(ctx context.Context, root *os.Root, workspace, turnDir string, index int, input InputFile) (string, error) {
+	if input.file == nil {
+		return "", fmt.Errorf("input file %q is unresolved", input.ID)
 	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return "", fmt.Errorf("input file %q must be a regular non-symlink file", input.Name)
-	}
-	source, err := os.Open(input.SourcePath)
+	source, err := input.file.open(ctx)
 	if err != nil {
-		return "", fmt.Errorf("open input file %q: %w", input.Name, err)
+		return "", fmt.Errorf("open input file %q: %w", input.file.Name, err)
 	}
 	defer source.Close()
-	openedInfo, err := source.Stat()
-	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
-		return "", fmt.Errorf("input file %q changed before it could be copied", input.Name)
-	}
-	if openedInfo.Size() != input.SizeBytes {
-		return "", fmt.Errorf("input file %q size does not match", input.Name)
-	}
-	name := fmt.Sprintf("%03d-%s-%s", index, safeInputName(input.ID), safeInputName(filepath.Base(input.Name)))
+	name := fmt.Sprintf("%03d-%s-%s", index, safeInputName(input.ID), safeInputName(filepath.Base(input.file.Name)))
 	destination := filepath.Join(turnDir, name)
 	suffix, err := randomInputSuffix()
 	if err != nil {
-		return "", fmt.Errorf("create Runtime-local input name %q: %w", input.Name, err)
+		return "", fmt.Errorf("create Runtime-local input name %q: %w", input.file.Name, err)
 	}
 	temporary := destination + ".tmp-" + suffix
 	target, err := root.OpenFile(temporary, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		return "", fmt.Errorf("create Runtime-local input %q: %w", input.Name, err)
+		return "", fmt.Errorf("create Runtime-local input %q: %w", input.file.Name, err)
 	}
 	hash := sha256.New()
 	_, copyErr := io.Copy(io.MultiWriter(target, hash), source)
 	closeErr := target.Close()
 	if copyErr != nil || closeErr != nil {
 		_ = root.Remove(temporary)
-		return "", fmt.Errorf("copy input file %q: %v", input.Name, errors.Join(copyErr, closeErr))
+		return "", fmt.Errorf("copy input file %q: %v", input.file.Name, errors.Join(copyErr, closeErr))
 	}
 	actualHash := fmt.Sprintf("%x", hash.Sum(nil))
-	if !strings.EqualFold(actualHash, strings.TrimSpace(input.SHA256)) {
+	if !strings.EqualFold(actualHash, strings.TrimSpace(input.file.SHA256)) {
 		_ = root.Remove(temporary)
-		return "", fmt.Errorf("input file %q SHA-256 does not match", input.Name)
+		return "", fmt.Errorf("input file %q SHA-256 does not match", input.file.Name)
 	}
 	if err := root.Rename(temporary, destination); err != nil {
 		_ = root.Remove(temporary)
-		return "", fmt.Errorf("activate Runtime-local input %q: %w", input.Name, err)
+		return "", fmt.Errorf("activate Runtime-local input %q: %w", input.file.Name, err)
 	}
 	return filepath.Join(workspace, destination), nil
 }

--- a/internal/agentengine/runtime_adapter.go
+++ b/internal/agentengine/runtime_adapter.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"os"
@@ -61,8 +62,8 @@ func (a agentServiceAdapter) conversationRuntime(ctx context.Context, agentID st
 }
 
 type codexConversationRuntime interface {
-	EnsureSession(ctx context.Context, runtimeID, conversationKey string) (string, error)
-	ExistingSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error)
+	EnsureEngineSession(ctx context.Context, runtimeID, conversationKey string) (string, error)
+	ExistingEngineSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error)
 	PromptTurn(ctx context.Context, runtimeID, sessionID, turnID string, blocks []codex.PromptContentBlock, accepted func()) error
 	SubscribeSession(runtimeID, sessionID string) (<-chan activity.RuntimeEvent, func())
 	ResetConversation(ctx context.Context, runtimeID, conversationKey string) error
@@ -113,6 +114,12 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 	eventStreamClosed := false
 	var output strings.Builder
 	var files []*OutputFile
+	filesOwned := true
+	defer func() {
+		if filesOwned {
+			cleanupOutputFiles(files)
+		}
+	}()
 	stopPrompt := func(result TurnResult) TurnResult {
 		cancel()
 		if !promptReturned {
@@ -129,6 +136,7 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 				result.Dispatched = dispatched
 				return result
 			}
+			filesOwned = false
 			return TurnResult{Status: TurnSucceeded, Output: output.String(), Dispatched: dispatched, files: files}
 		}
 		select {
@@ -167,7 +175,7 @@ func (a *codexRuntimeAdapter) Run(ctx context.Context, request TurnRequest, sink
 
 func (a *codexRuntimeAdapter) session(ctx context.Context, request TurnRequest) (string, *TurnError) {
 	if request.Continuation == ContinuationRequireExisting {
-		sessionID, ok, err := a.runtime.ExistingSession(ctx, a.runtimeID, string(request.ConversationKey))
+		sessionID, ok, err := a.runtime.ExistingEngineSession(ctx, a.runtimeID, string(request.ConversationKey))
 		if err != nil {
 			return "", &TurnError{Code: ErrorRuntimeFailed, Message: err.Error()}
 		}
@@ -176,7 +184,7 @@ func (a *codexRuntimeAdapter) session(ctx context.Context, request TurnRequest) 
 		}
 		return sessionID, nil
 	}
-	sessionID, err := a.runtime.EnsureSession(ctx, a.runtimeID, string(request.ConversationKey))
+	sessionID, err := a.runtime.EnsureEngineSession(ctx, a.runtimeID, string(request.ConversationKey))
 	if err != nil {
 		return "", &TurnError{Code: ErrorRuntimeFailed, Message: fmt.Sprintf("ensure Codex conversation: %v", err)}
 	}
@@ -259,7 +267,7 @@ func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnReque
 func (a *codexRuntimeAdapter) authorizeOutputFile(ctx context.Context, request activity.RuntimeFile) (*OutputFile, *TurnError) {
 	workspace, err := a.runtime.WorkspaceDir(a.runtimeID)
 	if err != nil {
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		return nil, a.runtimeFileUnavailable("resolve_workspace", err)
 	}
 	workspace = strings.TrimSpace(workspace)
 	relativePath, err := cleanRuntimeOutputPath(request.Path)
@@ -268,42 +276,55 @@ func (a *codexRuntimeAdapter) authorizeOutputFile(ctx context.Context, request a
 	}
 	root, err := os.OpenRoot(workspace)
 	if err != nil {
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("open Runtime workspace: %v", err)}
+		return nil, a.runtimeFileUnavailable("open_workspace", err)
 	}
 	source, info, err := openRuntimeOutputSource(root, relativePath)
 	if err != nil {
 		_ = root.Close()
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+		return nil, a.runtimeFileUnavailable("open_source", err)
 	}
-	prefix := make([]byte, 512)
-	prefixBytes, readErr := io.ReadFull(contextReader{ctx: ctx, reader: source}, prefix)
-	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+	if info.Size() > maxFileSizeBytes {
 		_ = source.Close()
 		_ = root.Close()
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("read Runtime output file: %v", readErr)}
-	}
-	prefix = prefix[:prefixBytes]
-	if _, err := source.Seek(0, io.SeekStart); err != nil {
-		_ = source.Close()
-		_ = root.Close()
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("rewind Runtime output file: %v", err)}
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("Runtime output file exceeds %d bytes", maxFileSizeBytes)}
 	}
 	name := strings.TrimSpace(request.Name)
 	if name == "" {
 		name = filepath.Base(relativePath)
 	}
-	mediaType, err := runtimeOutputMediaType(request.MIMEType, name, prefix)
-	if err != nil {
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
-	}
-	file, snapshotErr := newOutputFile(ctx, OutputFileMetadata{Name: name, MediaType: mediaType, SizeBytes: info.Size()}, source)
+	file, snapshotErr := newOutputFile(ctx, OutputFileMetadata{Name: name, MediaType: "application/octet-stream", SizeBytes: info.Size()}, source)
 	closeErr := source.Close()
 	rootCloseErr := root.Close()
 	if snapshotErr != nil || closeErr != nil || rootCloseErr != nil {
-		err := errors.Join(snapshotErr, closeErr, rootCloseErr)
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("snapshot Runtime output file: %v", err)}
+		if file != nil {
+			file.cleanup()
+		}
+		return nil, a.runtimeFileUnavailable("snapshot_source", errors.Join(snapshotErr, closeErr, rootCloseErr))
 	}
+	download, err := file.open(ctx)
+	if err != nil {
+		file.cleanup()
+		return nil, a.runtimeFileUnavailable("verify_snapshot", err)
+	}
+	prefix := make([]byte, 512)
+	prefixBytes, readErr := io.ReadFull(contextReader{ctx: ctx, reader: download}, prefix)
+	downloadCloseErr := download.Close()
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) || downloadCloseErr != nil {
+		file.cleanup()
+		return nil, a.runtimeFileUnavailable("read_snapshot_prefix", errors.Join(readErr, downloadCloseErr))
+	}
+	mediaType, err := runtimeOutputMediaType(request.MIMEType, name, prefix[:prefixBytes])
+	if err != nil {
+		file.cleanup()
+		return nil, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+	}
+	file.MediaType = mediaType
 	return file, nil
+}
+
+func (a *codexRuntimeAdapter) runtimeFileUnavailable(stage string, err error) *TurnError {
+	slog.Warn("Runtime output file unavailable", "runtime_id", strings.TrimSpace(a.runtimeID), "stage", stage, "error", err)
+	return &TurnError{Code: ErrorFileUnavailable, Message: "Runtime output file is unavailable"}
 }
 
 func cleanRuntimeOutputPath(path string) (string, error) {
@@ -477,21 +498,21 @@ func (a *codexRuntimeAdapter) prepareInput(ctx context.Context, turnID TurnID, i
 		var err error
 		workspace, err = a.runtime.WorkspaceDir(a.runtimeID)
 		if err != nil {
-			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+			return nil, cleanup, a.runtimeInputFileUnavailable("resolve_workspace", err)
 		}
 		workspaceRoot, err = os.OpenRoot(workspace)
 		if err != nil {
-			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+			return nil, cleanup, a.runtimeInputFileUnavailable("open_workspace", err)
 		}
 		inputRoot := filepath.Join(".csgclaw", "engine-inputs")
 		if err := workspaceRoot.MkdirAll(inputRoot, 0o700); err != nil {
 			_ = workspaceRoot.Close()
-			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+			return nil, cleanup, a.runtimeInputFileUnavailable("prepare_input_root", err)
 		}
 		turnDir, err = makeRootTempDir(workspaceRoot, inputRoot, safeInputName(string(turnID))+"-")
 		if err != nil {
 			_ = workspaceRoot.Close()
-			return nil, cleanup, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+			return nil, cleanup, a.runtimeInputFileUnavailable("prepare_turn_directory", err)
 		}
 		var cleanupOnce sync.Once
 		cleanup = func() {
@@ -510,7 +531,7 @@ func (a *codexRuntimeAdapter) prepareInput(ctx context.Context, turnID TurnID, i
 		path, err := copyVerifiedInput(ctx, workspaceRoot, workspace, turnDir, index, *part.File)
 		if err != nil {
 			cleanup()
-			return nil, func() {}, &TurnError{Code: ErrorFileUnavailable, Message: err.Error()}
+			return nil, func() {}, a.runtimeInputFileUnavailable("copy_input", err)
 		}
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(part.File.file.MediaType)), "image/") {
 			blocks = append(blocks, codex.LocalImageBlock(path))
@@ -519,6 +540,11 @@ func (a *codexRuntimeAdapter) prepareInput(ctx context.Context, turnID TurnID, i
 		}
 	}
 	return blocks, cleanup, nil
+}
+
+func (a *codexRuntimeAdapter) runtimeInputFileUnavailable(stage string, err error) *TurnError {
+	slog.Warn("Runtime input file unavailable", "runtime_id", strings.TrimSpace(a.runtimeID), "stage", stage, "error", err)
+	return &TurnError{Code: ErrorFileUnavailable, Message: "Runtime input file is unavailable"}
 }
 
 func copyVerifiedInput(ctx context.Context, root *os.Root, workspace, turnDir string, index int, input InputFile) (string, error) {

--- a/internal/agentengine/runtime_adapter.go
+++ b/internal/agentengine/runtime_adapter.go
@@ -283,11 +283,6 @@ func (a *codexRuntimeAdapter) authorizeOutputFile(ctx context.Context, request a
 		_ = root.Close()
 		return nil, a.runtimeFileUnavailable("open_source", err)
 	}
-	if info.Size() > maxFileSizeBytes {
-		_ = source.Close()
-		_ = root.Close()
-		return nil, &TurnError{Code: ErrorFileUnavailable, Message: fmt.Sprintf("Runtime output file exceeds %d bytes", maxFileSizeBytes)}
-	}
 	name := strings.TrimSpace(request.Name)
 	if name == "" {
 		name = filepath.Base(relativePath)

--- a/internal/api/agent_sessions_test.go
+++ b/internal/api/agent_sessions_test.go
@@ -41,6 +41,10 @@ type fakeSessionConversations struct {
 	delegate agentengine.ConversationInterface
 }
 
+func (c fakeSessionConversations) Files() agentengine.FileInterface {
+	return c.delegate.Files()
+}
+
 func (c fakeSessionConversations) Run(ctx context.Context, request agentengine.TurnRequest, sink agentengine.EventSink) agentengine.TurnResult {
 	if c.engine.beforeRun != nil {
 		c.engine.beforeRun(ctx)

--- a/internal/runtime/codex/appserver_events.go
+++ b/internal/runtime/codex/appserver_events.go
@@ -933,6 +933,16 @@ func (s *liveSession) appServerTracksThread(threadID string) bool {
 	return ok
 }
 
+func (s *liveSession) appServerPublishesFilesForThread(threadID string) bool {
+	threadID = strings.TrimSpace(threadID)
+	if s == nil || threadID == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.filePublishingThreads[threadID]
+}
+
 func (m *appServerManager) appServerPrimaryThreadID(live *liveSession) string {
 	if live == nil || live.session == nil {
 		return ""

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -183,7 +183,7 @@ func (m *appServerManager) Start(ctx context.Context, spec SessionSpec) (*Sessio
 		}
 	}
 
-	threadID, err := m.startOrResumeThread(ctx, live, m.persistedThreadID(spec), false)
+	threadID, _, err := m.startOrResumeThread(ctx, live, m.persistedThreadID(spec), false)
 	if err != nil {
 		_ = m.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID})
 		return nil, m.wrapStartupError(spec, "initialize codex app-server thread", err)
@@ -420,7 +420,7 @@ func (m *appServerManager) ensureSession(ctx context.Context, handle SessionHand
 	}
 
 	live.mu.Lock()
-	if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID] == publishFiles {
+	if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] {
 		live.mu.Unlock()
 		return threadID, nil
 	}
@@ -433,14 +433,14 @@ func (m *appServerManager) ensureSession(ctx context.Context, handle SessionHand
 		defer live.conversationPersistMu.Unlock()
 
 		live.mu.Lock()
-		if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID] == publishFiles {
+		if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] {
 			live.mu.Unlock()
 			return threadID, nil
 		}
 		restoredThreadID = strings.TrimSpace(live.conversationSessions[conversationKey])
 		live.mu.Unlock()
 
-		threadID, err := m.startOrResumeThread(ctx, live, restoredThreadID, publishFiles)
+		threadID, filePublishing, err := m.startOrResumeThread(ctx, live, restoredThreadID, publishFiles)
 		if err != nil {
 			return "", err
 		}
@@ -450,7 +450,7 @@ func (m *appServerManager) ensureSession(ctx context.Context, handle SessionHand
 		previousFilePublishing := live.filePublishingThreads[previous]
 		live.conversationSessions[conversationKey] = threadID
 		live.loadedConversations[conversationKey] = true
-		live.filePublishingThreads[threadID] = publishFiles
+		live.filePublishingThreads[threadID] = filePublishing
 		conversations := cloneConversationSessions(live.conversationSessions)
 		live.mu.Unlock()
 		if err := m.persistConversationSessions(live, conversations); err != nil {
@@ -512,12 +512,16 @@ func (m *appServerManager) ExistingEngineSession(ctx context.Context, handle Ses
 	conversationKey = strings.TrimSpace(conversationKey)
 	live.mu.Lock()
 	threadID := strings.TrimSpace(live.conversationSessions[conversationKey])
-	available := threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID]
+	available := threadID != ""
 	live.mu.Unlock()
 	if !available {
 		return "", false, nil
 	}
-	return threadID, true, nil
+	resolved, err := m.ensureSession(ctx, handle, conversationKey, true)
+	if err != nil {
+		return "", false, err
+	}
+	return resolved, true, nil
 }
 
 func (m *appServerManager) ExistingSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, bool, error) {
@@ -660,21 +664,22 @@ func (m *appServerManager) initializeHandshake(ctx context.Context, live *liveSe
 	return nil
 }
 
-func (m *appServerManager) startOrResumeThread(ctx context.Context, live *liveSession, threadID string, publishFiles bool) (string, error) {
+func (m *appServerManager) startOrResumeThread(ctx context.Context, live *liveSession, threadID string, publishFiles bool) (string, bool, error) {
 	threadID = strings.TrimSpace(threadID)
-	if threadID != "" && !publishFiles {
+	if threadID != "" {
 		resumed, err := m.resumeThread(ctx, live, threadID)
 		if err == nil {
 			if strings.TrimSpace(resumed) != "" {
-				return resumed, nil
+				return resumed, false, nil
 			}
-			return threadID, nil
+			return threadID, false, nil
 		}
 		if live.appClient != nil {
 			live.appClient.logDebug("codex app-server thread resume failed; starting a new thread", "thread_id", threadID, "error", err)
 		}
 	}
-	return m.startThread(ctx, live, publishFiles)
+	started, err := m.startThread(ctx, live, publishFiles)
+	return started, publishFiles && err == nil, err
 }
 
 func (m *appServerManager) startThread(ctx context.Context, live *liveSession, publishFiles bool) (string, error) {

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"csgclaw/internal/activity"
 	"csgclaw/internal/codexcli"
@@ -22,8 +25,10 @@ import (
 )
 
 const (
-	appServerTurnInterruptTimeout = 5 * time.Second
-	appServerTrackedTurnLimit     = 256
+	appServerTurnInterruptTimeout      = 5 * time.Second
+	appServerTrackedTurnLimit          = 256
+	appServerPublishFileToolName       = "csgclaw_publish_file"
+	appServerMaxPublishedFileNameBytes = 255
 )
 
 var (
@@ -657,6 +662,7 @@ func appServerThreadStartParams(spec SessionSpec) map[string]any {
 	spec.Profile = spec.Profile.Normalized()
 	params := map[string]any{
 		"cwd":                    spec.WorkspaceDir,
+		"dynamicTools":           []map[string]any{appServerPublishFileToolSpec()},
 		"persistExtendedHistory": true,
 		"experimentalRawEvents":  false,
 	}
@@ -671,6 +677,32 @@ func appServerThreadStartParams(spec SessionSpec) map[string]any {
 		params["permissions"] = readOnlyPermissionsProfile
 	}
 	return params
+}
+
+func appServerPublishFileToolSpec() map[string]any {
+	return map[string]any{
+		"name":        appServerPublishFileToolName,
+		"description": "Publish an existing file from the current Runtime workspace to the user. Call this only after the file is complete. The path must be relative to the workspace; do not pass a URL or an absolute path.",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Workspace-relative path of the completed file.",
+				},
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Optional UTF-8 delivery filename with at most 255 bytes, no directory components, and no control characters.",
+				},
+				"mimeType": map[string]any{
+					"type":        "string",
+					"description": "Optional expected MIME type. The Runtime Adapter validates or derives it from the file.",
+				},
+			},
+			"required":             []string{"path"},
+			"additionalProperties": false,
+		},
+	}
 }
 
 func appServerThreadResumeParams(spec SessionSpec, threadID string) map[string]any {
@@ -779,8 +811,96 @@ func (m *appServerManager) handleAppServerServerRequest(runtimeID string, live *
 		}, nil
 	case "item/tool/requestUserInput":
 		return m.handleAppServerUserInputRequest(runtimeID, live, req)
+	case "item/tool/call":
+		return m.handleAppServerDynamicToolCall(runtimeID, live, req)
 	default:
 		return nil, fmt.Errorf("unhandled server request: %s", strings.TrimSpace(req.Method))
+	}
+}
+
+type appServerDynamicToolCallParams struct {
+	ThreadID  string                   `json:"threadId"`
+	TurnID    string                   `json:"turnId"`
+	CallID    string                   `json:"callId"`
+	Tool      string                   `json:"tool"`
+	Arguments appServerPublishFileArgs `json:"arguments"`
+}
+
+type appServerPublishFileArgs struct {
+	Path     string `json:"path"`
+	Name     string `json:"name"`
+	MIMEType string `json:"mimeType"`
+}
+
+func (m *appServerManager) handleAppServerDynamicToolCall(runtimeID string, _ *liveSession, req appServerServerRequest) (any, error) {
+	var params appServerDynamicToolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, fmt.Errorf("decode dynamic tool call: %w", err)
+	}
+	params.ThreadID = strings.TrimSpace(params.ThreadID)
+	params.TurnID = strings.TrimSpace(params.TurnID)
+	params.CallID = strings.TrimSpace(params.CallID)
+	params.Tool = strings.TrimSpace(params.Tool)
+	if params.ThreadID == "" || params.TurnID == "" || params.CallID == "" {
+		return nil, fmt.Errorf("dynamic tool thread ID, turn ID, and call ID are required")
+	}
+	if params.Tool != appServerPublishFileToolName {
+		return nil, fmt.Errorf("unsupported dynamic tool %q", params.Tool)
+	}
+	file, err := normalizeAppServerPublishFileArgs(params.Arguments)
+	if err != nil {
+		return appServerDynamicToolResponse(false, err.Error()), nil
+	}
+	if m == nil || m.deps.EventSink == nil {
+		return appServerDynamicToolResponse(false, "file delivery is unavailable"), nil
+	}
+	m.publishAppServerEvent(SessionEvent{
+		RuntimeID:  runtimeID,
+		SessionID:  params.ThreadID,
+		TurnID:     params.TurnID,
+		Kind:       SessionEventFileOutput,
+		ToolCallID: params.CallID,
+		ToolKind:   appServerPublishFileToolName,
+		ToolTitle:  "Publish file",
+		ToolStatus: "completed",
+		Payload:    file,
+	})
+	return appServerDynamicToolResponse(true, "File publication requested."), nil
+}
+
+func normalizeAppServerPublishFileArgs(args appServerPublishFileArgs) (activity.RuntimeFile, error) {
+	path := strings.TrimSpace(args.Path)
+	cleaned := filepath.Clean(path)
+	if path == "" || cleaned == "." || filepath.IsAbs(cleaned) || filepath.VolumeName(cleaned) != "" || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return activity.RuntimeFile{}, fmt.Errorf("path must stay within the Runtime workspace")
+	}
+	name := strings.TrimSpace(args.Name)
+	if name == "" {
+		name = filepath.Base(cleaned)
+	}
+	if !utf8.ValidString(name) || len([]byte(name)) > appServerMaxPublishedFileNameBytes || name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, "/\\\x00") {
+		return activity.RuntimeFile{}, fmt.Errorf("name must be a valid UTF-8 basename with 1 to %d bytes", appServerMaxPublishedFileNameBytes)
+	}
+	for _, character := range name {
+		if unicode.IsControl(character) {
+			return activity.RuntimeFile{}, fmt.Errorf("name must not contain control characters")
+		}
+	}
+	mediaType := strings.TrimSpace(args.MIMEType)
+	if mediaType != "" {
+		parsed, _, err := mime.ParseMediaType(mediaType)
+		if err != nil || strings.TrimSpace(parsed) == "" {
+			return activity.RuntimeFile{}, fmt.Errorf("mimeType is invalid")
+		}
+		mediaType = strings.ToLower(parsed)
+	}
+	return activity.RuntimeFile{Path: cleaned, Name: name, MIMEType: mediaType}, nil
+}
+
+func appServerDynamicToolResponse(success bool, message string) map[string]any {
+	return map[string]any{
+		"contentItems": []map[string]any{{"type": "inputText", "text": strings.TrimSpace(message)}},
+		"success":      success,
 	}
 }
 

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -146,6 +146,7 @@ func (m *appServerManager) Start(ctx context.Context, spec SessionSpec) (*Sessio
 		appClient:             appClient,
 		conversationSessions:  conversationSessions,
 		loadedConversations:   make(map[string]bool),
+		filePublishingThreads: make(map[string]bool),
 		turnWaiters:           make(map[string]*appServerTurnWaiter),
 		turnThreads:           make(map[string]string),
 		commandOutputs:        make(map[string]*appServerCommandOutputState),
@@ -182,7 +183,7 @@ func (m *appServerManager) Start(ctx context.Context, spec SessionSpec) (*Sessio
 		}
 	}
 
-	threadID, err := m.startOrResumeThread(ctx, live, m.persistedThreadID(spec))
+	threadID, err := m.startOrResumeThread(ctx, live, m.persistedThreadID(spec), false)
 	if err != nil {
 		_ = m.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID})
 		return nil, m.wrapStartupError(spec, "initialize codex app-server thread", err)
@@ -400,6 +401,14 @@ func (m *appServerManager) Prompt(ctx context.Context, handle SessionHandle, req
 }
 
 func (m *appServerManager) EnsureSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, error) {
+	return m.ensureSession(ctx, handle, conversationKey, false)
+}
+
+func (m *appServerManager) EnsureEngineSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, error) {
+	return m.ensureSession(ctx, handle, conversationKey, true)
+}
+
+func (m *appServerManager) ensureSession(ctx context.Context, handle SessionHandle, conversationKey string, publishFiles bool) (string, error) {
 	live, err := m.ensureLiveSession(ctx, handle)
 	if err != nil {
 		return "", err
@@ -411,7 +420,7 @@ func (m *appServerManager) EnsureSession(ctx context.Context, handle SessionHand
 	}
 
 	live.mu.Lock()
-	if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] {
+	if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID] == publishFiles {
 		live.mu.Unlock()
 		return threadID, nil
 	}
@@ -424,34 +433,39 @@ func (m *appServerManager) EnsureSession(ctx context.Context, handle SessionHand
 		defer live.conversationPersistMu.Unlock()
 
 		live.mu.Lock()
-		if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] {
+		if threadID := strings.TrimSpace(live.conversationSessions[conversationKey]); threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID] == publishFiles {
 			live.mu.Unlock()
 			return threadID, nil
 		}
 		restoredThreadID = strings.TrimSpace(live.conversationSessions[conversationKey])
 		live.mu.Unlock()
 
-		threadID, err := m.startOrResumeThread(ctx, live, restoredThreadID)
+		threadID, err := m.startOrResumeThread(ctx, live, restoredThreadID, publishFiles)
 		if err != nil {
 			return "", err
 		}
 		live.mu.Lock()
 		previous := live.conversationSessions[conversationKey]
+		previousLoaded := live.loadedConversations[conversationKey]
+		previousFilePublishing := live.filePublishingThreads[previous]
 		live.conversationSessions[conversationKey] = threadID
 		live.loadedConversations[conversationKey] = true
+		live.filePublishingThreads[threadID] = publishFiles
 		conversations := cloneConversationSessions(live.conversationSessions)
 		live.mu.Unlock()
 		if err := m.persistConversationSessions(live, conversations); err != nil {
 			live.mu.Lock()
 			live.conversationSessions[conversationKey] = previous
-			delete(live.loadedConversations, conversationKey)
+			live.loadedConversations[conversationKey] = previousLoaded
+			live.filePublishingThreads[previous] = previousFilePublishing
+			delete(live.filePublishingThreads, threadID)
 			live.mu.Unlock()
 			return "", err
 		}
 		return threadID, nil
 	}
 
-	threadID, err := m.startThread(ctx, live)
+	threadID, err := m.startThread(ctx, live, publishFiles)
 	if err != nil {
 		return "", err
 	}
@@ -459,24 +473,51 @@ func (m *appServerManager) EnsureSession(ctx context.Context, handle SessionHand
 	live.conversationPersistMu.Lock()
 	defer live.conversationPersistMu.Unlock()
 	live.mu.Lock()
-	if existing := strings.TrimSpace(live.conversationSessions[conversationKey]); existing != "" {
+	existing := strings.TrimSpace(live.conversationSessions[conversationKey])
+	if existing != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[existing] == publishFiles {
 		live.mu.Unlock()
 		return existing, nil
 	}
+	previousLoaded := live.loadedConversations[conversationKey]
+	previousFilePublishing := live.filePublishingThreads[existing]
 	live.conversationSessions[conversationKey] = threadID
 	live.loadedConversations[conversationKey] = true
+	live.filePublishingThreads[threadID] = publishFiles
 	conversations := cloneConversationSessions(live.conversationSessions)
 	live.mu.Unlock()
 	if err := m.persistConversationSessions(live, conversations); err != nil {
 		live.mu.Lock()
 		if live.conversationSessions[conversationKey] == threadID {
-			delete(live.conversationSessions, conversationKey)
-			delete(live.loadedConversations, conversationKey)
+			if existing == "" {
+				delete(live.conversationSessions, conversationKey)
+				delete(live.loadedConversations, conversationKey)
+			} else {
+				live.conversationSessions[conversationKey] = existing
+				live.loadedConversations[conversationKey] = previousLoaded
+				live.filePublishingThreads[existing] = previousFilePublishing
+			}
+			delete(live.filePublishingThreads, threadID)
 		}
 		live.mu.Unlock()
 		return "", err
 	}
 	return threadID, nil
+}
+
+func (m *appServerManager) ExistingEngineSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, bool, error) {
+	live, err := m.ensureLiveSession(ctx, handle)
+	if err != nil {
+		return "", false, err
+	}
+	conversationKey = strings.TrimSpace(conversationKey)
+	live.mu.Lock()
+	threadID := strings.TrimSpace(live.conversationSessions[conversationKey])
+	available := threadID != "" && live.loadedConversations[conversationKey] && live.filePublishingThreads[threadID]
+	live.mu.Unlock()
+	if !available {
+		return "", false, nil
+	}
+	return threadID, true, nil
 }
 
 func (m *appServerManager) ExistingSession(ctx context.Context, handle SessionHandle, conversationKey string) (string, bool, error) {
@@ -523,6 +564,8 @@ func (m *appServerManager) ResetConversationHistory(ctx context.Context, handle 
 	delete(live.conversationSessions, conversationKey)
 	wasLoaded := live.loadedConversations[conversationKey]
 	delete(live.loadedConversations, conversationKey)
+	wasFilePublishing := live.filePublishingThreads[sessionID]
+	delete(live.filePublishingThreads, sessionID)
 	conversations := cloneConversationSessions(live.conversationSessions)
 	live.mu.Unlock()
 	if err := m.persistConversationSessions(live, conversations); err != nil {
@@ -530,6 +573,7 @@ func (m *appServerManager) ResetConversationHistory(ctx context.Context, handle 
 		if sessionID != "" {
 			live.conversationSessions[conversationKey] = sessionID
 			live.loadedConversations[conversationKey] = wasLoaded
+			live.filePublishingThreads[sessionID] = wasFilePublishing
 		}
 		live.mu.Unlock()
 		return err
@@ -616,9 +660,9 @@ func (m *appServerManager) initializeHandshake(ctx context.Context, live *liveSe
 	return nil
 }
 
-func (m *appServerManager) startOrResumeThread(ctx context.Context, live *liveSession, threadID string) (string, error) {
+func (m *appServerManager) startOrResumeThread(ctx context.Context, live *liveSession, threadID string, publishFiles bool) (string, error) {
 	threadID = strings.TrimSpace(threadID)
-	if threadID != "" {
+	if threadID != "" && !publishFiles {
 		resumed, err := m.resumeThread(ctx, live, threadID)
 		if err == nil {
 			if strings.TrimSpace(resumed) != "" {
@@ -630,11 +674,11 @@ func (m *appServerManager) startOrResumeThread(ctx context.Context, live *liveSe
 			live.appClient.logDebug("codex app-server thread resume failed; starting a new thread", "thread_id", threadID, "error", err)
 		}
 	}
-	return m.startThread(ctx, live)
+	return m.startThread(ctx, live, publishFiles)
 }
 
-func (m *appServerManager) startThread(ctx context.Context, live *liveSession) (string, error) {
-	params := appServerThreadStartParams(live.spec)
+func (m *appServerManager) startThread(ctx context.Context, live *liveSession, publishFiles bool) (string, error) {
+	params := appServerThreadStartParams(live.spec, publishFiles)
 	raw, err := live.appClient.request(ctx, "thread/start", params)
 	if err != nil {
 		return "", err
@@ -658,13 +702,15 @@ func (m *appServerManager) resumeThread(ctx context.Context, live *liveSession, 
 	return resumed, nil
 }
 
-func appServerThreadStartParams(spec SessionSpec) map[string]any {
+func appServerThreadStartParams(spec SessionSpec, publishFiles bool) map[string]any {
 	spec.Profile = spec.Profile.Normalized()
 	params := map[string]any{
 		"cwd":                    spec.WorkspaceDir,
-		"dynamicTools":           []map[string]any{appServerPublishFileToolSpec()},
 		"persistExtendedHistory": true,
 		"experimentalRawEvents":  false,
+	}
+	if publishFiles {
+		params["dynamicTools"] = []map[string]any{appServerPublishFileToolSpec()}
 	}
 	if spec.Profile.ModelID != "" {
 		params["model"] = spec.Profile.ModelID
@@ -832,7 +878,7 @@ type appServerPublishFileArgs struct {
 	MIMEType string `json:"mimeType"`
 }
 
-func (m *appServerManager) handleAppServerDynamicToolCall(runtimeID string, _ *liveSession, req appServerServerRequest) (any, error) {
+func (m *appServerManager) handleAppServerDynamicToolCall(runtimeID string, live *liveSession, req appServerServerRequest) (any, error) {
 	var params appServerDynamicToolCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return nil, fmt.Errorf("decode dynamic tool call: %w", err)
@@ -846,6 +892,9 @@ func (m *appServerManager) handleAppServerDynamicToolCall(runtimeID string, _ *l
 	}
 	if params.Tool != appServerPublishFileToolName {
 		return nil, fmt.Errorf("unsupported dynamic tool %q", params.Tool)
+	}
+	if live == nil || !live.appServerPublishesFilesForThread(params.ThreadID) {
+		return nil, fmt.Errorf("dynamic file tool references unknown or unsupported thread %q", params.ThreadID)
 	}
 	file, err := normalizeAppServerPublishFileArgs(params.Arguments)
 	if err != nil {

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -150,8 +150,8 @@ func TestAppServerManagerRestoresConversationThreadMapping(t *testing.T) {
 	}
 }
 
-func TestAppServerManagerReplacesColdEngineMappingWithFileCapableThread(t *testing.T) {
-	withAppServerHelperCommand(t, "engine-conversation-thread")
+func TestAppServerManagerPreservesColdEngineConversationContext(t *testing.T) {
+	withAppServerHelperCommand(t, "resume-success")
 	spec := testAppServerSessionSpec(t.TempDir())
 	spec.ConversationSessions = map[string]string{"conversation-1": "cold-thread"}
 	var persisted map[string]string
@@ -165,18 +165,22 @@ func TestAppServerManagerReplacesColdEngineMappingWithFileCapableThread(t *testi
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
-	if _, ok, err := manager.ExistingEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1"); err != nil || ok {
-		t.Fatalf("cold ExistingEngineSession ok=%v err=%v", ok, err)
-	}
 	threadID, err := manager.EnsureEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("cold EnsureEngineSession error=%v", err)
 	}
-	if threadID != "engine-thread" || persisted["conversation-1"] != threadID {
-		t.Fatalf("Engine thread=%q persisted=%v", threadID, persisted)
+	if threadID != "resumed-thread" || persisted["conversation-1"] != threadID {
+		t.Fatalf("resumed Engine thread=%q persisted=%v", threadID, persisted)
 	}
 	if got, ok, err := manager.ExistingEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1"); err != nil || !ok || got != threadID {
 		t.Fatalf("loaded ExistingEngineSession=%q ok=%v err=%v", got, ok, err)
+	}
+	live := manager.liveSession(spec.RuntimeID)
+	live.mu.Lock()
+	filePublishing := live.filePublishingThreads[threadID]
+	live.mu.Unlock()
+	if filePublishing {
+		t.Fatal("cold resumed thread was incorrectly marked file-capable")
 	}
 }
 
@@ -2543,29 +2547,6 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
 			}
 			return rpcResult(msg["id"], map[string]any{"threadId": fmt.Sprintf("conversation-thread-%d", index)}), true
-		})
-	case "engine-conversation-thread":
-		threadStarts := 0
-		runAppServerHelper(t, func(_ int, msg map[string]any) (map[string]any, bool) {
-			if msg["method"] != "thread/start" {
-				if msg["method"] == "thread/resume" {
-					t.Fatalf("Engine conversation unexpectedly resumed cold thread")
-				}
-				return nil, false
-			}
-			threadStarts++
-			params, _ := msg["params"].(map[string]any)
-			tools, _ := params["dynamicTools"].([]any)
-			if threadStarts == 1 {
-				if len(tools) != 0 {
-					t.Fatalf("primary dynamicTools = %#v", params["dynamicTools"])
-				}
-				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
-			}
-			if len(tools) != 1 {
-				t.Fatalf("Engine dynamicTools = %#v", params["dynamicTools"])
-			}
-			return rpcResult(msg["id"], map[string]any{"threadId": "engine-thread"}), true
 		})
 	case "conversation-thread-notification-before-result":
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -150,6 +150,36 @@ func TestAppServerManagerRestoresConversationThreadMapping(t *testing.T) {
 	}
 }
 
+func TestAppServerManagerReplacesColdEngineMappingWithFileCapableThread(t *testing.T) {
+	withAppServerHelperCommand(t, "engine-conversation-thread")
+	spec := testAppServerSessionSpec(t.TempDir())
+	spec.ConversationSessions = map[string]string{"conversation-1": "cold-thread"}
+	var persisted map[string]string
+	deps := testAppServerManagerDeps()
+	deps.OnConversationSessionsChange = func(_ *Session, conversations map[string]string) error {
+		persisted = cloneConversationSessions(conversations)
+		return nil
+	}
+	manager := newAppServerManager(deps)
+	if _, err := manager.Start(context.Background(), spec); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
+	if _, ok, err := manager.ExistingEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1"); err != nil || ok {
+		t.Fatalf("cold ExistingEngineSession ok=%v err=%v", ok, err)
+	}
+	threadID, err := manager.EnsureEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if threadID != "engine-thread" || persisted["conversation-1"] != threadID {
+		t.Fatalf("Engine thread=%q persisted=%v", threadID, persisted)
+	}
+	if got, ok, err := manager.ExistingEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "conversation-1"); err != nil || !ok || got != threadID {
+		t.Fatalf("loaded ExistingEngineSession=%q ok=%v err=%v", got, ok, err)
+	}
+}
+
 func TestAppServerManagerSerializesConversationPersistence(t *testing.T) {
 	withAppServerHelperCommand(t, "conversation-thread")
 	dir := t.TempDir()
@@ -339,14 +369,18 @@ func TestAppServerManagerPublishFileDynamicToolEndToEnd(t *testing.T) {
 	spec := testAppServerSessionSpec(dir)
 	sink := &recordingSink{}
 	manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
-	session, err := manager.Start(context.Background(), spec)
+	_, err := manager.Start(context.Background(), spec)
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
 	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
+	engineThread, err := manager.EnsureEngineSession(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, "engine-files")
+	if err != nil {
+		t.Fatalf("EnsureEngineSession() error = %v", err)
+	}
 
 	resp, err := manager.Prompt(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
-		SessionID: session.SessionID,
+		SessionID: engineThread,
 		Prompt:    []PromptContentBlock{TextBlock("publish the report")},
 	})
 	if err != nil {
@@ -2205,7 +2239,7 @@ func TestAppServerParamsMapOffToCodexNone(t *testing.T) {
 	spec := testAppServerSessionSpec(t.TempDir())
 	spec.Profile.ReasoningEffort = "off"
 
-	threadConfig := appServerThreadStartParams(spec)["config"].(map[string]any)
+	threadConfig := appServerThreadStartParams(spec, false)["config"].(map[string]any)
 	if got, want := threadConfig["model_reasoning_effort"], "none"; got != want {
 		t.Fatalf("model_reasoning_effort = %v, want %v", got, want)
 	}
@@ -2219,7 +2253,7 @@ func TestAppServerParamsOmitReasoningForModelDefault(t *testing.T) {
 	spec := testAppServerSessionSpec(t.TempDir())
 	spec.Profile.ReasoningEffort = "auto"
 
-	if config, ok := appServerThreadStartParams(spec)["config"]; ok {
+	if config, ok := appServerThreadStartParams(spec, false)["config"]; ok {
 		t.Fatalf("thread config = %v, want omitted", config)
 	}
 	turn := appServerTurnStartParams(spec, "thread-1", "hello")
@@ -2232,7 +2266,7 @@ func TestAppServerReadOnlyParamsAndOverrides(t *testing.T) {
 	spec := testAppServerSessionSpec(t.TempDir())
 	spec.ExecutionMode = ExecutionModeReadOnly
 
-	thread := appServerThreadStartParams(spec)
+	thread := appServerThreadStartParams(spec, false)
 	if thread["approvalPolicy"] != "never" || thread["permissions"] != readOnlyPermissionsProfile {
 		t.Fatalf("thread params = %#v", thread)
 	}
@@ -2262,7 +2296,7 @@ func TestAppServerReadOnlyParamsAndOverrides(t *testing.T) {
 
 func TestAppServerThreadStartRegistersPublishFileDynamicTool(t *testing.T) {
 	spec := testAppServerSessionSpec(t.TempDir())
-	params := appServerThreadStartParams(spec)
+	params := appServerThreadStartParams(spec, true)
 	tools, ok := params["dynamicTools"].([]map[string]any)
 	if !ok || len(tools) != 1 {
 		t.Fatalf("dynamicTools = %#v, want one typed tool", params["dynamicTools"])
@@ -2279,10 +2313,17 @@ func TestAppServerThreadStartRegistersPublishFileDynamicTool(t *testing.T) {
 	}
 }
 
+func TestAppServerThreadStartOmitsPublishFileToolForLegacyThread(t *testing.T) {
+	params := appServerThreadStartParams(testAppServerSessionSpec(t.TempDir()), false)
+	if tools, ok := params["dynamicTools"]; ok {
+		t.Fatalf("legacy dynamicTools = %#v, want omitted", tools)
+	}
+}
+
 func TestAppServerPublishFileDynamicToolEmitsTypedFileEvent(t *testing.T) {
 	sink := &recordingSink{}
 	manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
-	live := &liveSession{spec: testAppServerSessionSpec(t.TempDir())}
+	live := &liveSession{spec: testAppServerSessionSpec(t.TempDir()), filePublishingThreads: map[string]bool{"thread-1": true}}
 	response, err := manager.handleAppServerServerRequest("runtime-1", live, appServerServerRequest{
 		Method: "item/tool/call",
 		Params: mustJSONRaw(t, map[string]any{
@@ -2330,7 +2371,7 @@ func TestAppServerPublishFileDynamicToolRejectsUnsafeArguments(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			sink := &recordingSink{}
 			manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
-			response, err := manager.handleAppServerServerRequest("runtime-1", &liveSession{}, appServerServerRequest{
+			response, err := manager.handleAppServerServerRequest("runtime-1", &liveSession{filePublishingThreads: map[string]bool{"thread-1": true}}, appServerServerRequest{
 				Method: "item/tool/call",
 				Params: mustJSONRaw(t, map[string]any{
 					"threadId": "thread-1", "turnId": "turn-1", "callId": "call-1", "tool": appServerPublishFileToolName,
@@ -2348,6 +2389,21 @@ func TestAppServerPublishFileDynamicToolRejectsUnsafeArguments(t *testing.T) {
 				t.Fatalf("unsafe file events = %#v", events)
 			}
 		})
+	}
+}
+
+func TestAppServerPublishFileDynamicToolRejectsUnownedThread(t *testing.T) {
+	manager := newAppServerManager(testAppServerManagerDepsWithSink(&recordingSink{}))
+	live := &liveSession{filePublishingThreads: map[string]bool{"owned-thread": true}}
+	_, err := manager.handleAppServerServerRequest("runtime-1", live, appServerServerRequest{
+		Method: "item/tool/call",
+		Params: mustJSONRaw(t, map[string]any{
+			"threadId": "other-thread", "turnId": "turn-1", "callId": "call-1", "tool": appServerPublishFileToolName,
+			"arguments": map[string]any{"path": "report.txt"},
+		}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown or unsupported thread") {
+		t.Fatalf("unowned dynamic tool error = %v", err)
 	}
 }
 
@@ -2488,6 +2544,29 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 			}
 			return rpcResult(msg["id"], map[string]any{"threadId": fmt.Sprintf("conversation-thread-%d", index)}), true
 		})
+	case "engine-conversation-thread":
+		threadStarts := 0
+		runAppServerHelper(t, func(_ int, msg map[string]any) (map[string]any, bool) {
+			if msg["method"] != "thread/start" {
+				if msg["method"] == "thread/resume" {
+					t.Fatalf("Engine conversation unexpectedly resumed cold thread")
+				}
+				return nil, false
+			}
+			threadStarts++
+			params, _ := msg["params"].(map[string]any)
+			tools, _ := params["dynamicTools"].([]any)
+			if threadStarts == 1 {
+				if len(tools) != 0 {
+					t.Fatalf("primary dynamicTools = %#v", params["dynamicTools"])
+				}
+				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+			}
+			if len(tools) != 1 {
+				t.Fatalf("Engine dynamicTools = %#v", params["dynamicTools"])
+			}
+			return rpcResult(msg["id"], map[string]any{"threadId": "engine-thread"}), true
+		})
 	case "conversation-thread-notification-before-result":
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
 			if msg["method"] != "thread/start" {
@@ -2524,6 +2603,7 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 		})
 	case "prompt-publish-file":
 		awaitingTool := false
+		threadStarts := 0
 		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
 			if awaitingTool {
 				assertServerRequestResponse(t, msg, 9010, func(result map[string]any) {
@@ -2536,14 +2616,21 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 					}
 				})
 				awaitingTool = false
-				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "message-1", "type": "agentMessage", "text": "published"}})
-				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-publish", "status": "completed"}})
+				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "engine-thread", "item": map[string]any{"id": "message-1", "type": "agentMessage", "text": "published"}})
+				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "engine-thread", "turn": map[string]any{"id": "turn-publish", "status": "completed"}})
 				return nil, false
 			}
 			switch msg["method"] {
 			case "thread/start":
 				params, _ := msg["params"].(map[string]any)
 				tools, _ := params["dynamicTools"].([]any)
+				if threadStarts == 0 {
+					threadStarts++
+					if len(tools) != 0 {
+						t.Fatalf("primary thread dynamicTools = %#v, want none", params["dynamicTools"])
+					}
+					return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+				}
 				if len(tools) != 1 {
 					t.Fatalf("thread/start dynamicTools = %#v", params["dynamicTools"])
 				}
@@ -2551,11 +2638,11 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				if tool["name"] != appServerPublishFileToolName {
 					t.Fatalf("thread/start publish tool = %#v", tool)
 				}
-				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+				return rpcResult(msg["id"], map[string]any{"threadId": "engine-thread"}), true
 			case "turn/start":
 				awaitingTool = true
 				writeRPCServerRequest(t, 9010, "item/tool/call", map[string]any{
-					"threadId": "main-thread", "turnId": "turn-publish", "callId": "call-publish", "tool": appServerPublishFileToolName,
+					"threadId": "engine-thread", "turnId": "turn-publish", "callId": "call-publish", "tool": appServerPublishFileToolName,
 					"arguments": map[string]any{"path": "reports/result.pdf", "name": "result.pdf", "mimeType": "application/pdf"},
 				})
 				return rpcResult(msg["id"], map[string]any{"turnId": "turn-publish"}), true

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -333,6 +333,40 @@ func TestAppServerManagerPromptCompletesTurn(t *testing.T) {
 	}
 }
 
+func TestAppServerManagerPublishFileDynamicToolEndToEnd(t *testing.T) {
+	withAppServerHelperCommand(t, "prompt-publish-file")
+	dir := t.TempDir()
+	spec := testAppServerSessionSpec(dir)
+	sink := &recordingSink{}
+	manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
+	session, err := manager.Start(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Stop(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}) })
+
+	resp, err := manager.Prompt(context.Background(), SessionHandle{RuntimeID: spec.RuntimeID}, PromptRequest{
+		SessionID: session.SessionID,
+		Prompt:    []PromptContentBlock{TextBlock("publish the report")},
+	})
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+	if resp.StopReason != StopReasonEndTurn {
+		t.Fatalf("StopReason = %q, want %q", resp.StopReason, StopReasonEndTurn)
+	}
+
+	waitForRuntime(t, func() bool { return len(sink.snapshot()) >= 3 })
+	events := sink.snapshot()
+	if len(events) != 3 || events[0].Kind != SessionEventFileOutput || events[1].Kind != SessionEventTextDelta || events[2].Kind != SessionEventPromptCompleted {
+		t.Fatalf("events = %#v, want file output, text, and prompt completion", events)
+	}
+	file, ok := events[0].Payload.(activity.RuntimeFile)
+	if !ok || file.Path != filepath.Join("reports", "result.pdf") || file.Name != "result.pdf" || file.MIMEType != "application/pdf" {
+		t.Fatalf("file output = %#v", events[0])
+	}
+}
+
 func TestAppServerManagerQuestionRoundTripForManagerAndWorker(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -2226,6 +2260,97 @@ func TestAppServerReadOnlyParamsAndOverrides(t *testing.T) {
 	}
 }
 
+func TestAppServerThreadStartRegistersPublishFileDynamicTool(t *testing.T) {
+	spec := testAppServerSessionSpec(t.TempDir())
+	params := appServerThreadStartParams(spec)
+	tools, ok := params["dynamicTools"].([]map[string]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("dynamicTools = %#v, want one typed tool", params["dynamicTools"])
+	}
+	tool := tools[0]
+	if tool["name"] != "csgclaw_publish_file" || strings.TrimSpace(fmt.Sprint(tool["description"])) == "" {
+		t.Fatalf("publish file tool = %#v", tool)
+	}
+	schema, _ := tool["inputSchema"].(map[string]any)
+	properties, _ := schema["properties"].(map[string]any)
+	required, _ := schema["required"].([]string)
+	if schema["type"] != "object" || properties["path"] == nil || properties["name"] == nil || properties["mimeType"] == nil || len(required) != 1 || required[0] != "path" || schema["additionalProperties"] != false {
+		t.Fatalf("publish file input schema = %#v", schema)
+	}
+}
+
+func TestAppServerPublishFileDynamicToolEmitsTypedFileEvent(t *testing.T) {
+	sink := &recordingSink{}
+	manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
+	live := &liveSession{spec: testAppServerSessionSpec(t.TempDir())}
+	response, err := manager.handleAppServerServerRequest("runtime-1", live, appServerServerRequest{
+		Method: "item/tool/call",
+		Params: mustJSONRaw(t, map[string]any{
+			"threadId": "thread-1",
+			"turnId":   "turn-1",
+			"callId":   "call-1",
+			"tool":     "csgclaw_publish_file",
+			"arguments": map[string]any{
+				"path": "reports/result.pdf", "mimeType": "application/pdf",
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, _ := response.(map[string]any)
+	items, _ := result["contentItems"].([]map[string]any)
+	if result["success"] != true || len(items) != 1 || items[0]["type"] != "inputText" {
+		t.Fatalf("dynamic tool response = %#v", response)
+	}
+	events := sink.snapshot()
+	if len(events) != 1 || events[0].Kind != activity.RuntimeEventFileOutput || events[0].RuntimeID != "runtime-1" || events[0].SessionID != "thread-1" || events[0].TurnID != "turn-1" || events[0].ToolCallID != "call-1" {
+		t.Fatalf("file events = %#v", events)
+	}
+	file, ok := events[0].Payload.(activity.RuntimeFile)
+	if !ok || file.Path != filepath.Join("reports", "result.pdf") || file.Name != "result.pdf" || file.MIMEType != "application/pdf" {
+		t.Fatalf("file event payload = %#v", events[0].Payload)
+	}
+}
+
+func TestAppServerPublishFileDynamicToolRejectsUnsafeArguments(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "absolute path", arguments: map[string]any{"path": "/etc/passwd"}},
+		{name: "path traversal", arguments: map[string]any{"path": "../secret.txt"}},
+		{name: "nested delivery name", arguments: map[string]any{"path": "report.txt", "name": "nested/report.txt"}},
+		{name: "dot delivery name", arguments: map[string]any{"path": "report.txt", "name": ".."}},
+		{name: "control character", arguments: map[string]any{"path": "report.txt", "name": "line\nbreak.txt"}},
+		{name: "oversized name", arguments: map[string]any{"path": "report.txt", "name": strings.Repeat("a", 256)}},
+		{name: "invalid MIME type", arguments: map[string]any{"path": "report.txt", "mimeType": "not a mime"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sink := &recordingSink{}
+			manager := newAppServerManager(testAppServerManagerDepsWithSink(sink))
+			response, err := manager.handleAppServerServerRequest("runtime-1", &liveSession{}, appServerServerRequest{
+				Method: "item/tool/call",
+				Params: mustJSONRaw(t, map[string]any{
+					"threadId": "thread-1", "turnId": "turn-1", "callId": "call-1", "tool": appServerPublishFileToolName,
+					"arguments": test.arguments,
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, _ := response.(map[string]any)
+			if result["success"] != false {
+				t.Fatalf("response = %#v, want typed failure", response)
+			}
+			if events := sink.snapshot(); len(events) != 0 {
+				t.Fatalf("unsafe file events = %#v", events)
+			}
+		})
+	}
+}
+
 func TestAppServerReadOnlyDeclinesMutationApprovals(t *testing.T) {
 	manager := newAppServerManager(testAppServerManagerDeps())
 	live := &liveSession{spec: SessionSpec{ExecutionMode: ExecutionModeReadOnly}}
@@ -2393,6 +2518,47 @@ func TestAppServerManagerHelperProcess(t *testing.T) {
 				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "item-1", "type": "agentMessage", "text": "done"}})
 				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-1", "status": "completed"}})
 				return rpcResult(msg["id"], map[string]any{"turnId": "turn-1"}), true
+			default:
+				return nil, false
+			}
+		})
+	case "prompt-publish-file":
+		awaitingTool := false
+		runAppServerHelper(t, func(index int, msg map[string]any) (map[string]any, bool) {
+			if awaitingTool {
+				assertServerRequestResponse(t, msg, 9010, func(result map[string]any) {
+					if result["success"] != true {
+						t.Fatalf("publish file result = %#v", result)
+					}
+					items, _ := result["contentItems"].([]any)
+					if len(items) != 1 {
+						t.Fatalf("publish file contentItems = %#v", result["contentItems"])
+					}
+				})
+				awaitingTool = false
+				writeRPCNotification(t, "item/completed", map[string]any{"threadId": "main-thread", "item": map[string]any{"id": "message-1", "type": "agentMessage", "text": "published"}})
+				writeRPCNotification(t, "turn/completed", map[string]any{"threadId": "main-thread", "turn": map[string]any{"id": "turn-publish", "status": "completed"}})
+				return nil, false
+			}
+			switch msg["method"] {
+			case "thread/start":
+				params, _ := msg["params"].(map[string]any)
+				tools, _ := params["dynamicTools"].([]any)
+				if len(tools) != 1 {
+					t.Fatalf("thread/start dynamicTools = %#v", params["dynamicTools"])
+				}
+				tool, _ := tools[0].(map[string]any)
+				if tool["name"] != appServerPublishFileToolName {
+					t.Fatalf("thread/start publish tool = %#v", tool)
+				}
+				return rpcResult(msg["id"], map[string]any{"threadId": "main-thread"}), true
+			case "turn/start":
+				awaitingTool = true
+				writeRPCServerRequest(t, 9010, "item/tool/call", map[string]any{
+					"threadId": "main-thread", "turnId": "turn-publish", "callId": "call-publish", "tool": appServerPublishFileToolName,
+					"arguments": map[string]any{"path": "reports/result.pdf", "name": "result.pdf", "mimeType": "application/pdf"},
+				})
+				return rpcResult(msg["id"], map[string]any{"turnId": "turn-publish"}), true
 			default:
 				return nil, false
 			}

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -247,6 +247,16 @@ func (r *Runtime) EnsureSession(ctx context.Context, runtimeID, conversationKey 
 	return ensurer.EnsureSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
 }
 
+func (r *Runtime) EnsureEngineSession(ctx context.Context, runtimeID, conversationKey string) (string, error) {
+	ensurer, ok := r.SessionManager().(interface {
+		EnsureEngineSession(context.Context, SessionHandle, string) (string, error)
+	})
+	if !ok {
+		return "", fmt.Errorf("codex session manager does not support Engine conversation sessions")
+	}
+	return ensurer.EnsureEngineSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
+}
+
 func (r *Runtime) ExistingSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error) {
 	resolver, ok := r.SessionManager().(interface {
 		ExistingSession(context.Context, SessionHandle, string) (string, bool, error)
@@ -255,6 +265,16 @@ func (r *Runtime) ExistingSession(ctx context.Context, runtimeID, conversationKe
 		return "", false, fmt.Errorf("codex session manager does not support strict conversation lookup")
 	}
 	return resolver.ExistingSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
+}
+
+func (r *Runtime) ExistingEngineSession(ctx context.Context, runtimeID, conversationKey string) (string, bool, error) {
+	resolver, ok := r.SessionManager().(interface {
+		ExistingEngineSession(context.Context, SessionHandle, string) (string, bool, error)
+	})
+	if !ok {
+		return "", false, fmt.Errorf("codex session manager does not support strict Engine conversation lookup")
+	}
+	return resolver.ExistingEngineSession(ctx, SessionHandle{RuntimeID: runtimeID}, conversationKey)
 }
 
 func (r *Runtime) Prompt(ctx context.Context, runtimeID, sessionID, prompt string) error {

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -122,6 +122,7 @@ const (
 	SessionEventUserInputRequest   = activity.RuntimeEventUserInputRequest
 	SessionEventUserInputResolved  = activity.RuntimeEventUserInputResolved
 	SessionEventStructuredOutput   = activity.RuntimeEventStructuredOutput
+	SessionEventFileOutput         = activity.RuntimeEventFileOutput
 	SessionEventPromptCompleted    = activity.RuntimeEventPromptCompleted
 	SessionEventPromptFailed       = activity.RuntimeEventPromptFailed
 )

--- a/internal/runtime/codex/session_manager.go
+++ b/internal/runtime/codex/session_manager.go
@@ -21,6 +21,7 @@ type liveSession struct {
 	spec                  SessionSpec
 	conversationSessions  map[string]string
 	loadedConversations   map[string]bool
+	filePublishingThreads map[string]bool
 	turnWaiters           map[string]*appServerTurnWaiter
 	turnThreads           map[string]string
 	turnThreadOrder       []string

--- a/internal/runtime/codex/structured_output_test.go
+++ b/internal/runtime/codex/structured_output_test.go
@@ -65,6 +65,16 @@ func TestDecodeStructuredCommandOutputAcceptsAssistantLineBreakVariant(t *testin
 	}
 }
 
+func TestDecodeStructuredCommandOutputDoesNotTreatFileTextAsProtocol(t *testing.T) {
+	t.Parallel()
+
+	record := `::csgclaw-output::runtime_file {"type":"runtime_file","path":"reports/result.pdf"}`
+	cleaned, artifact, errs := decodeStructuredCommandOutput(record)
+	if cleaned != record || !structuredOutputArtifactEmpty(artifact) || len(errs) != 0 {
+		t.Fatalf("cleaned=%q artifact=%+v errors=%v", cleaned, artifact, errs)
+	}
+}
+
 func TestDecodeStructuredCommandOutputRejectsMalformedDuplicateAndUnsafeRecords(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add typed Runtime file publication and immutable Agent-scoped input/output snapshots
- expose HTTP-ready conversation file retrieval and verify Feishu image/file delivery end to end