### PR TITLE
fix(im): prevent duplicate message sends

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -744,14 +744,15 @@ func bootstrapRuntimeKind(runtime string) string {
 }
 
 type createMessageRequest struct {
-	RoomID      string                       `json:"room_id"`
-	SenderID    string                       `json:"sender_id"`
-	Content     string                       `json:"content"`
-	Locale      string                       `json:"locale,omitempty"`
-	MentionID   string                       `json:"mention_id,omitempty"`
-	Metadata    map[string]any               `json:"metadata,omitempty"`
-	RelatesTo   *im.MessageRelation          `json:"relates_to,omitempty"`
-	Attachments []im.MessageAttachmentUpload `json:"attachments,omitempty"`
+	RoomID          string                       `json:"room_id"`
+	ClientMessageID string                       `json:"client_message_id,omitempty"`
+	SenderID        string                       `json:"sender_id"`
+	Content         string                       `json:"content"`
+	Locale          string                       `json:"locale,omitempty"`
+	MentionID       string                       `json:"mention_id,omitempty"`
+	Metadata        map[string]any               `json:"metadata,omitempty"`
+	RelatesTo       *im.MessageRelation          `json:"relates_to,omitempty"`
+	Attachments     []im.MessageAttachmentUpload `json:"attachments,omitempty"`
 }
 
 type addRoomMembersRequest struct {
@@ -2703,14 +2704,16 @@ func (h *Handler) handleCreateMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	serviceReq = h.resolveCSGClawParticipantMessageRequest(serviceReq)
 
-	message, err := channel.SendMessage(serviceReq)
+	message, created, err := channel.SendMessageOnce(serviceReq)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	h.publishMessageCreated(serviceReq.RoomID, message.SenderID, message)
-	h.publishThreadUpdated(serviceReq.RoomID, message)
-	h.handleTeamRoomCommand(r.Context(), serviceReq.RoomID, message.SenderID, message.Content)
+	if created {
+		h.publishMessageCreated(serviceReq.RoomID, message.SenderID, message)
+		h.publishThreadUpdated(serviceReq.RoomID, message)
+		h.handleTeamRoomCommand(r.Context(), serviceReq.RoomID, message.SenderID, message.Content)
+	}
 	writeJSON(w, http.StatusCreated, message)
 }
 
@@ -3471,14 +3474,15 @@ func (r createMessageRequest) toServiceRequest() (im.CreateMessageRequest, error
 	}
 
 	return im.CreateMessageRequest{
-		RoomID:      roomID,
-		SenderID:    r.SenderID,
-		Content:     r.Content,
-		Locale:      r.Locale,
-		MentionID:   r.MentionID,
-		Metadata:    r.Metadata,
-		RelatesTo:   r.RelatesTo,
-		Attachments: r.Attachments,
+		RoomID:          roomID,
+		ClientMessageID: strings.TrimSpace(r.ClientMessageID),
+		SenderID:        r.SenderID,
+		Content:         r.Content,
+		Locale:          r.Locale,
+		MentionID:       r.MentionID,
+		Metadata:        r.Metadata,
+		RelatesTo:       r.RelatesTo,
+		Attachments:     r.Attachments,
 	}, nil
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -6199,6 +6199,41 @@ func TestHandleMessagesPostCreatesMessage(t *testing.T) {
 	}
 }
 
+func TestHandleMessagesPostDeduplicatesClientMessageID(t *testing.T) {
+	srv := &Handler{
+		im: im.NewServiceFromBootstrap(im.Bootstrap{
+			CurrentUserID: "u-admin",
+			Users:         []im.User{{ID: "u-admin", Name: "admin"}},
+			Rooms:         []im.Room{{ID: "room-1", Title: "Room One", Members: []string{"u-admin"}}},
+		}),
+	}
+	body := `{"room_id":"room-1","sender_id":"u-admin","content":"send once","client_message_id":"client-1"}`
+	var ids []string
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/messages", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+		}
+		var got im.Message
+		if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		ids = append(ids, got.ID)
+	}
+	if ids[0] != ids[1] {
+		t.Fatalf("message ids = %v, want the same id for duplicate requests", ids)
+	}
+	messages, err := srv.im.ListMessages("room-1")
+	if err != nil {
+		t.Fatalf("ListMessages() error = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want one idempotent message", len(messages))
+	}
+}
+
 func TestHandleMessagesPostNormalizesCanonicalSlashCommand(t *testing.T) {
 	srv := &Handler{
 		im: im.NewServiceFromBootstrap(im.Bootstrap{

--- a/internal/apitypes/types.go
+++ b/internal/apitypes/types.go
@@ -63,17 +63,18 @@ type Mention struct {
 }
 
 type Message struct {
-	ID          string              `json:"id"`
-	SenderID    string              `json:"sender_id"`
-	Kind        string              `json:"kind,omitempty"`
-	Content     string              `json:"content"`
-	Event       *EventPayload       `json:"event,omitempty"`
-	Metadata    map[string]any      `json:"metadata,omitempty"`
-	CreatedAt   time.Time           `json:"created_at"`
-	Mentions    []Mention           `json:"mentions"`
-	RelatesTo   *MessageRelation    `json:"relates_to,omitempty"`
-	Thread      *ThreadSummary      `json:"thread,omitempty"`
-	Attachments []MessageAttachment `json:"attachments,omitempty"`
+	ID              string              `json:"id"`
+	ClientMessageID string              `json:"client_message_id,omitempty"`
+	SenderID        string              `json:"sender_id"`
+	Kind            string              `json:"kind,omitempty"`
+	Content         string              `json:"content"`
+	Event           *EventPayload       `json:"event,omitempty"`
+	Metadata        map[string]any      `json:"metadata,omitempty"`
+	CreatedAt       time.Time           `json:"created_at"`
+	Mentions        []Mention           `json:"mentions"`
+	RelatesTo       *MessageRelation    `json:"relates_to,omitempty"`
+	Thread          *ThreadSummary      `json:"thread,omitempty"`
+	Attachments     []MessageAttachment `json:"attachments,omitempty"`
 }
 
 type MessageAttachment struct {
@@ -98,14 +99,15 @@ type MessageAttachmentUpload struct {
 }
 
 type CreateMessageRequest struct {
-	RoomID      string                    `json:"room_id"`
-	SenderID    string                    `json:"sender_id"`
-	Content     string                    `json:"content"`
-	Locale      string                    `json:"locale,omitempty"`
-	MentionID   string                    `json:"mention_id,omitempty"`
-	Metadata    map[string]any            `json:"metadata,omitempty"`
-	RelatesTo   *MessageRelation          `json:"relates_to,omitempty"`
-	Attachments []MessageAttachmentUpload `json:"attachments,omitempty"`
+	RoomID          string                    `json:"room_id"`
+	ClientMessageID string                    `json:"client_message_id,omitempty"`
+	SenderID        string                    `json:"sender_id"`
+	Content         string                    `json:"content"`
+	Locale          string                    `json:"locale,omitempty"`
+	MentionID       string                    `json:"mention_id,omitempty"`
+	Metadata        map[string]any            `json:"metadata,omitempty"`
+	RelatesTo       *MessageRelation          `json:"relates_to,omitempty"`
+	Attachments     []MessageAttachmentUpload `json:"attachments,omitempty"`
 }
 
 type MessageRelation struct {

--- a/internal/channel/csgclaw/service.go
+++ b/internal/channel/csgclaw/service.go
@@ -65,9 +65,14 @@ func (s *Service) ListMessagesWithOptions(roomID string, opts im.ListMessagesOpt
 }
 
 func (s *Service) SendMessage(req apitypes.CreateMessageRequest) (im.Message, error) {
+	message, _, err := s.SendMessageOnce(req)
+	return message, err
+}
+
+func (s *Service) SendMessageOnce(req apitypes.CreateMessageRequest) (im.Message, bool, error) {
 	content, err := normalizeSlashContent(req.Content)
 	if err != nil {
-		return im.Message{}, err
+		return im.Message{}, false, err
 	}
 	req.Content = content
 	req.SenderID = botIDToUserID(req.SenderID)
@@ -75,7 +80,7 @@ func (s *Service) SendMessage(req apitypes.CreateMessageRequest) (im.Message, er
 	if req.RelatesTo != nil {
 		req.RelatesTo.EventID = botIDToUserID(req.RelatesTo.EventID)
 	}
-	return s.im.CreateMessage(req)
+	return s.im.CreateMessageOnce(req)
 }
 
 func normalizeSlashContent(content string) (string, error) {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1974,11 +1974,20 @@ func (s *Service) CreateMessageOnce(req CreateMessageRequest) (Message, bool, er
 			}
 		}
 	}
+	previousLocale := room.Locale
+	messageCount := len(room.Messages)
+	threadCount := len(room.Threads)
+	rollbackRoom := func() {
+		room.Locale = previousLocale
+		room.Messages = room.Messages[:messageCount]
+		room.Threads = room.Threads[:threadCount]
+	}
 	if locale := messagePresentationLocale(req.Locale); strings.TrimSpace(req.Locale) != "" {
 		room.Locale = locale
 	}
 	relatesTo, err := s.normalizeMessageRelationLocked(*room, req.RelatesTo)
 	if err != nil {
+		rollbackRoom()
 		return Message{}, false, err
 	}
 	if relatesTo != nil && relatesTo.RelType == RelationTypeThread {
@@ -1991,11 +2000,16 @@ func (s *Service) CreateMessageOnce(req CreateMessageRequest) (Message, bool, er
 	message.RelatesTo = relatesTo
 	attachments, err := s.storeMessageAttachmentsLocked(roomID, message.ID, senderID, req.Attachments)
 	if err != nil {
+		rollbackRoom()
 		return Message{}, false, err
 	}
 	message.Attachments = attachments
 	room.Messages = append(room.Messages, message)
 	if err := s.saveLocked(); err != nil {
+		rollbackRoom()
+		if rollbackErr := s.saveLocked(); rollbackErr != nil {
+			return Message{}, false, errors.Join(err, fmt.Errorf("restore IM state after failed message save: %w", rollbackErr))
+		}
 		return Message{}, false, err
 	}
 	return s.presentMessageLocked(*room, message, ""), true, nil

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1929,17 +1929,25 @@ func (s *Service) UpdateUser(req UpdateUserRequest) (User, bool, error) {
 }
 
 func (s *Service) CreateMessage(req CreateMessageRequest) (Message, error) {
+	message, _, err := s.CreateMessageOnce(req)
+	return message, err
+}
+
+// CreateMessageOnce creates a message or returns the message previously created
+// for the same sender and client-generated idempotency key.
+func (s *Service) CreateMessageOnce(req CreateMessageRequest) (Message, bool, error) {
 	content := strings.TrimSpace(req.Content)
 	roomID := strings.TrimSpace(req.RoomID)
 	senderID := strings.TrimSpace(req.SenderID)
+	clientMessageID := strings.TrimSpace(req.ClientMessageID)
 	if roomID == "" {
-		return Message{}, fmt.Errorf("room_id is required")
+		return Message{}, false, fmt.Errorf("room_id is required")
 	}
 	if senderID == "" {
-		return Message{}, fmt.Errorf("sender_id is required")
+		return Message{}, false, fmt.Errorf("sender_id is required")
 	}
 	if content == "" && len(req.Attachments) == 0 {
-		return Message{}, fmt.Errorf("content is required")
+		return Message{}, false, fmt.Errorf("content is required")
 	}
 
 	s.mu.Lock()
@@ -1947,42 +1955,50 @@ func (s *Service) CreateMessage(req CreateMessageRequest) (Message, error) {
 
 	senderUserID := s.resolveUserIDLocked(senderID)
 	if _, ok := s.users[senderUserID]; !ok {
-		return Message{}, fmt.Errorf("sender not found")
+		return Message{}, false, fmt.Errorf("sender not found")
 	}
 	senderID = senderUserID
 	content, err := s.contentWithMentionPrefixLocked(content, req.MentionID, false)
 	if err != nil {
-		return Message{}, err
+		return Message{}, false, err
 	}
 
 	room, ok := s.rooms[roomID]
 	if !ok {
-		return Message{}, fmt.Errorf("room not found")
+		return Message{}, false, fmt.Errorf("room not found")
+	}
+	if clientMessageID != "" {
+		for _, existing := range room.Messages {
+			if existing.SenderID == senderID && existing.ClientMessageID == clientMessageID {
+				return s.presentMessageLocked(*room, existing, ""), false, nil
+			}
+		}
 	}
 	if locale := messagePresentationLocale(req.Locale); strings.TrimSpace(req.Locale) != "" {
 		room.Locale = locale
 	}
 	relatesTo, err := s.normalizeMessageRelationLocked(*room, req.RelatesTo)
 	if err != nil {
-		return Message{}, err
+		return Message{}, false, err
 	}
 	if relatesTo != nil && relatesTo.RelType == RelationTypeThread {
 		s.ensureThreadStateLocked(room, relatesTo.EventID)
 	}
 
 	message := s.newMessage("", senderID, MessageKindMessage, content)
+	message.ClientMessageID = clientMessageID
 	message.Metadata = utils.CloneAnyMap(req.Metadata)
 	message.RelatesTo = relatesTo
 	attachments, err := s.storeMessageAttachmentsLocked(roomID, message.ID, senderID, req.Attachments)
 	if err != nil {
-		return Message{}, err
+		return Message{}, false, err
 	}
 	message.Attachments = attachments
 	room.Messages = append(room.Messages, message)
 	if err := s.saveLocked(); err != nil {
-		return Message{}, err
+		return Message{}, false, err
 	}
-	return s.presentMessageLocked(*room, message, ""), nil
+	return s.presentMessageLocked(*room, message, ""), true, nil
 }
 
 func (s *Service) DeliverMessage(req DeliverMessageRequest) (Message, error) {

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -110,6 +110,51 @@ func TestCreateMessagePersistsUserIDsAndMentionNames(t *testing.T) {
 	}
 }
 
+func TestCreateMessageOnceDeduplicatesClientMessageID(t *testing.T) {
+	svc := NewService()
+	room, err := svc.CreateRoom(CreateRoomRequest{
+		Title:     "Idempotency",
+		CreatorID: "user-admin",
+	})
+	if err != nil {
+		t.Fatalf("CreateRoom() error = %v", err)
+	}
+	before, err := svc.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(before) error = %v", err)
+	}
+	req := CreateMessageRequest{
+		RoomID:          room.ID,
+		SenderID:        "user-admin",
+		Content:         "send once",
+		ClientMessageID: "client-message-1",
+	}
+	first, created, err := svc.CreateMessageOnce(req)
+	if err != nil {
+		t.Fatalf("CreateMessageOnce(first) error = %v", err)
+	}
+	if !created {
+		t.Fatal("CreateMessageOnce(first) created = false, want true")
+	}
+	second, created, err := svc.CreateMessageOnce(req)
+	if err != nil {
+		t.Fatalf("CreateMessageOnce(second) error = %v", err)
+	}
+	if created {
+		t.Fatal("CreateMessageOnce(second) created = true, want false")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("duplicate message id = %q, want %q", second.ID, first.ID)
+	}
+	messages, err := svc.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages() error = %v", err)
+	}
+	if len(messages) != len(before)+1 {
+		t.Fatalf("messages = %d, want %d after one idempotent message", len(messages), len(before)+1)
+	}
+}
+
 func TestUpdateRoomPersistsNotifyAllAgentsAndPublishesEvent(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "im", "state.json")
 	bus := NewBus()

--- a/internal/im/service_test.go
+++ b/internal/im/service_test.go
@@ -155,6 +155,138 @@ func TestCreateMessageOnceDeduplicatesClientMessageID(t *testing.T) {
 	}
 }
 
+func TestCreateMessageOnceRetriesAfterPersistenceFailure(t *testing.T) {
+	svc := NewService()
+	room, err := svc.CreateRoom(CreateRoomRequest{
+		Title:     "Idempotency retry",
+		CreatorID: "user-admin",
+	})
+	if err != nil {
+		t.Fatalf("CreateRoom() error = %v", err)
+	}
+	before, err := svc.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(before) error = %v", err)
+	}
+
+	dir := t.TempDir()
+	blockedParent := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(blockedParent, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocked parent) error = %v", err)
+	}
+	svc.statePath = filepath.Join(blockedParent, "state.json")
+	req := CreateMessageRequest{
+		RoomID:          room.ID,
+		SenderID:        "user-admin",
+		Content:         "retry me",
+		ClientMessageID: "client-message-retry",
+	}
+	if _, _, err := svc.CreateMessageOnce(req); err == nil {
+		t.Fatal("CreateMessageOnce(first) error = nil, want persistence error")
+	}
+	afterFailure, err := svc.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(after failure) error = %v", err)
+	}
+	if len(afterFailure) != len(before) {
+		t.Fatalf("messages after failure = %d, want %d", len(afterFailure), len(before))
+	}
+
+	svc.statePath = filepath.Join(dir, "im", "state.json")
+	createdMessage, created, err := svc.CreateMessageOnce(req)
+	if err != nil {
+		t.Fatalf("CreateMessageOnce(retry) error = %v", err)
+	}
+	if !created {
+		t.Fatal("CreateMessageOnce(retry) created = false, want true")
+	}
+	if createdMessage.ClientMessageID != req.ClientMessageID {
+		t.Fatalf("client message id = %q, want %q", createdMessage.ClientMessageID, req.ClientMessageID)
+	}
+	reloaded, err := NewServiceFromPath(svc.statePath)
+	if err != nil {
+		t.Fatalf("NewServiceFromPath() error = %v", err)
+	}
+	persisted, err := reloaded.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(reloaded) error = %v", err)
+	}
+	if len(persisted) != len(before)+1 {
+		t.Fatalf("persisted messages = %d, want %d", len(persisted), len(before)+1)
+	}
+}
+
+func TestCreateMessageOnceRestoresPersistedStateAfterPartialSave(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "im", "state.json")
+	svc, err := NewServiceFromPath(statePath)
+	if err != nil {
+		t.Fatalf("NewServiceFromPath() error = %v", err)
+	}
+	room, err := svc.CreateRoom(CreateRoomRequest{
+		Title:     "Partial save retry",
+		CreatorID: "user-admin",
+	})
+	if err != nil {
+		t.Fatalf("CreateRoom() error = %v", err)
+	}
+	root, err := svc.CreateMessage(CreateMessageRequest{
+		RoomID:   room.ID,
+		SenderID: "user-admin",
+		Content:  "thread root",
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage(root) error = %v", err)
+	}
+	before, err := svc.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(before) error = %v", err)
+	}
+
+	blockedThreadDir := filepath.Join(filepath.Dir(statePath), threadsDirName, room.ID)
+	if err := os.WriteFile(blockedThreadDir, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocked thread dir) error = %v", err)
+	}
+	req := CreateMessageRequest{
+		RoomID:          room.ID,
+		SenderID:        "user-admin",
+		Content:         "retry thread reply",
+		ClientMessageID: "client-partial-save-retry",
+		RelatesTo: &MessageRelation{
+			RelType: RelationTypeThread,
+			EventID: root.ID,
+		},
+	}
+	if _, _, err := svc.CreateMessageOnce(req); err == nil {
+		t.Fatal("CreateMessageOnce(first) error = nil, want thread persistence error")
+	}
+
+	reloaded, err := NewServiceFromPath(statePath)
+	if err != nil {
+		t.Fatalf("NewServiceFromPath(reload after failure) error = %v", err)
+	}
+	afterReload, err := reloaded.ListMessages(room.ID)
+	if err != nil {
+		t.Fatalf("ListMessages(after reload) error = %v", err)
+	}
+	if len(afterReload) != len(before) {
+		t.Fatalf("messages after reload = %d, want %d", len(afterReload), len(before))
+	}
+
+	if err := os.Remove(blockedThreadDir); err != nil {
+		t.Fatalf("Remove(blocked thread dir) error = %v", err)
+	}
+	createdMessage, created, err := svc.CreateMessageOnce(req)
+	if err != nil {
+		t.Fatalf("CreateMessageOnce(retry) error = %v", err)
+	}
+	if !created {
+		t.Fatal("CreateMessageOnce(retry) created = false, want true")
+	}
+	if createdMessage.ClientMessageID != req.ClientMessageID {
+		t.Fatalf("client message id = %q, want %q", createdMessage.ClientMessageID, req.ClientMessageID)
+	}
+}
+
 func TestUpdateRoomPersistsNotifyAllAgentsAndPublishesEvent(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "im", "state.json")
 	bus := NewBus()

--- a/internal/im/session_store.go
+++ b/internal/im/session_store.go
@@ -23,18 +23,19 @@ const (
 
 // sessionMessageLine is the on-disk jsonl shape. blob_ref points at spillover payload.
 type sessionMessageLine struct {
-	ID          string              `json:"id"`
-	SenderID    string              `json:"sender_id"`
-	Kind        string              `json:"kind,omitempty"`
-	Content     string              `json:"content"`
-	Event       *EventPayload       `json:"event,omitempty"`
-	Metadata    map[string]any      `json:"metadata,omitempty"`
-	CreatedAt   string              `json:"created_at"`
-	Mentions    []Mention           `json:"mentions"`
-	RelatesTo   *MessageRelation    `json:"relates_to,omitempty"`
-	Thread      *ThreadSummary      `json:"thread,omitempty"`
-	Attachments []MessageAttachment `json:"attachments,omitempty"`
-	BlobRef     string              `json:"blob_ref,omitempty"`
+	ID              string              `json:"id"`
+	ClientMessageID string              `json:"client_message_id,omitempty"`
+	SenderID        string              `json:"sender_id"`
+	Kind            string              `json:"kind,omitempty"`
+	Content         string              `json:"content"`
+	Event           *EventPayload       `json:"event,omitempty"`
+	Metadata        map[string]any      `json:"metadata,omitempty"`
+	CreatedAt       string              `json:"created_at"`
+	Mentions        []Mention           `json:"mentions"`
+	RelatesTo       *MessageRelation    `json:"relates_to,omitempty"`
+	Thread          *ThreadSummary      `json:"thread,omitempty"`
+	Attachments     []MessageAttachment `json:"attachments,omitempty"`
+	BlobRef         string              `json:"blob_ref,omitempty"`
 }
 
 type sessionMessageBlob struct {
@@ -46,17 +47,18 @@ type sessionMessageBlob struct {
 
 func messageToSessionLine(message Message) sessionMessageLine {
 	return sessionMessageLine{
-		ID:          message.ID,
-		SenderID:    message.SenderID,
-		Kind:        message.Kind,
-		Content:     message.Content,
-		Event:       message.Event,
-		Metadata:    message.Metadata,
-		CreatedAt:   message.CreatedAt.UTC().Format(timeRFC3339Nano),
-		Mentions:    message.Mentions,
-		RelatesTo:   message.RelatesTo,
-		Thread:      message.Thread,
-		Attachments: message.Attachments,
+		ID:              message.ID,
+		ClientMessageID: message.ClientMessageID,
+		SenderID:        message.SenderID,
+		Kind:            message.Kind,
+		Content:         message.Content,
+		Event:           message.Event,
+		Metadata:        message.Metadata,
+		CreatedAt:       message.CreatedAt.UTC().Format(timeRFC3339Nano),
+		Mentions:        message.Mentions,
+		RelatesTo:       message.RelatesTo,
+		Thread:          message.Thread,
+		Attachments:     message.Attachments,
 	}
 }
 
@@ -66,17 +68,18 @@ func sessionLineToMessage(line sessionMessageLine) (Message, error) {
 		return Message{}, err
 	}
 	return Message{
-		ID:          line.ID,
-		SenderID:    line.SenderID,
-		Kind:        line.Kind,
-		Content:     line.Content,
-		Event:       line.Event,
-		Metadata:    line.Metadata,
-		CreatedAt:   createdAt,
-		Mentions:    line.Mentions,
-		RelatesTo:   line.RelatesTo,
-		Thread:      line.Thread,
-		Attachments: cloneMessageAttachments(line.Attachments),
+		ID:              line.ID,
+		ClientMessageID: line.ClientMessageID,
+		SenderID:        line.SenderID,
+		Kind:            line.Kind,
+		Content:         line.Content,
+		Event:           line.Event,
+		Metadata:        line.Metadata,
+		CreatedAt:       createdAt,
+		Mentions:        line.Mentions,
+		RelatesTo:       line.RelatesTo,
+		Thread:          line.Thread,
+		Attachments:     cloneMessageAttachments(line.Attachments),
 	}, nil
 }
 

--- a/web/app/src/api/im.ts
+++ b/web/app/src/api/im.ts
@@ -10,6 +10,7 @@ import type {
 
 export type SendMessagePayload = {
   attachments?: File[];
+  client_message_id?: string;
   content: string;
   locale?: string;
   relates_to?: MessageRelation | null;

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -104,6 +104,10 @@ type ComposerSendState = {
   status: "failed" | "idle" | "sending";
 };
 type ComposerSendStatesByKey = Record<string, ComposerSendState>;
+type PendingClientMessage = {
+  fingerprint: string;
+  id: string;
+};
 type RemovedAttachment = {
   draft: AttachmentDraft;
   index: number;
@@ -119,6 +123,17 @@ const idleComposerSendState: ComposerSendState = {
   progress: 0,
   status: "idle",
 };
+
+function newClientMessageID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `client-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function messageFingerprint(content: string, attachments: readonly AttachmentDraft[]): string {
+  return JSON.stringify([content, attachments.map(({ file }) => [file.name, file.size, file.lastModified, file.type])]);
+}
 
 type OpenCreateRoomOptions = {
   description?: string;
@@ -307,6 +322,8 @@ export function useConversationController({
   const [attachmentErrorsByConversationId, setAttachmentErrorsByConversationId] = useState<ComposerErrorsByKey>({});
   const editorRef = useRef<HTMLDivElement | null>(null);
   const sendAbortControllersRef = useRef<Record<string, AbortController>>({});
+  const sendLocksRef = useRef<Record<string, boolean>>({});
+  const pendingClientMessagesRef = useRef<Record<string, PendingClientMessage>>({});
   const composerIsComposingRef = useRef(false);
   const composerJustEndedCompositionRef = useRef(false);
   const messageListRef = useRef<HTMLElement | null>(null);
@@ -913,9 +930,17 @@ export function useConversationController({
     const roomID = activeConversation.id;
     const senderID = data.current_user_id;
     const attachments = attachmentDrafts.map((draft) => draft.file);
-    setComposerError("", roomID);
     const serializedDraft = serializeComposerSegments(draftSegments);
     const content = normalizeSlashShorthandForPayload(serializedDraft);
+    const fingerprint = messageFingerprint(content, attachmentDrafts);
+    if (sendLocksRef.current[roomID]) {
+      return;
+    }
+    sendLocksRef.current[roomID] = true;
+    const pending = pendingClientMessagesRef.current[roomID];
+    const clientMessage = pending?.fingerprint === fingerprint ? pending : { fingerprint, id: newClientMessageID() };
+    pendingClientMessagesRef.current[roomID] = clientMessage;
+    setComposerError("", roomID);
     const abortController = new AbortController();
     sendAbortControllersRef.current[roomID]?.abort();
     sendAbortControllersRef.current[roomID] = abortController;
@@ -929,6 +954,7 @@ export function useConversationController({
           room_id: roomID,
           sender_id: senderID,
           content,
+          client_message_id: clientMessage.id,
           locale,
           attachments,
         },
@@ -948,6 +974,7 @@ export function useConversationController({
       setBootstrapData((current) => appendMessageToData(current, roomID, created));
       messageListAutoScroll.follow("smooth");
       clearComposer(roomID);
+      delete pendingClientMessagesRef.current[roomID];
       setComposerSendStatesByConversationId((current) => ({
         ...current,
         [roomID]: idleComposerSendState,
@@ -960,6 +987,7 @@ export function useConversationController({
         [roomID]: { error: message, progress: current[roomID]?.progress ?? 0, status: "failed" },
       }));
     } finally {
+      delete sendLocksRef.current[roomID];
       if (sendAbortControllersRef.current[roomID] === abortController) {
         delete sendAbortControllersRef.current[roomID];
       }
@@ -1078,12 +1106,22 @@ export function useConversationController({
       return;
     }
 
+    const threadSendKey = `thread:${activeThreadDraftKey}`;
+    if (sendLocksRef.current[threadSendKey]) {
+      return;
+    }
+    sendLocksRef.current[threadSendKey] = true;
+    const fingerprint = messageFingerprint(text, activeThreadAttachmentDrafts);
+    const pending = pendingClientMessagesRef.current[threadSendKey];
+    const clientMessage = pending?.fingerprint === fingerprint ? pending : { fingerprint, id: newClientMessageID() };
+    pendingClientMessagesRef.current[threadSendKey] = clientMessage;
     setThreadError("");
     try {
       const created = await sendMessageRequest({
         room_id: activeConversation.id,
         sender_id: data.current_user_id,
         content: text,
+        client_message_id: clientMessage.id,
         locale,
         attachments: activeThreadAttachmentDrafts.map((draft) => draft.file),
         relates_to: {
@@ -1093,11 +1131,14 @@ export function useConversationController({
       });
       setThreadDraftsByKey((current) => updateDrafts(current, activeThreadDraftKey, []));
       setThreadAttachmentDraftsByKey((current) => updateAttachmentDrafts(current, activeThreadDraftKey, []));
+      delete pendingClientMessagesRef.current[threadSendKey];
       setActiveThreadView((current) => appendReplyToThreadView(current, created) ?? null);
       setBootstrapData((current) => appendMessageToData(current, activeConversation.id, created));
       await refreshThreadView(activeConversation.id, activeThreadRootID);
     } catch (err) {
       setThreadError(errorMessage(err, t("sendFailed")));
+    } finally {
+      delete sendLocksRef.current[threadSendKey];
     }
   }
 

--- a/web/app/src/models/conversations.ts
+++ b/web/app/src/models/conversations.ts
@@ -101,6 +101,7 @@ export type ThreadState = {
 
 export type IMMessage = {
   attachments?: MessageAttachment[] | null;
+  client_message_id?: string;
   id?: string;
   content: string;
   created_at?: string;


### PR DESCRIPTION
## Summary
- add a synchronous per-conversation send lock to block rapid repeated clicks
- attach a stable client message ID to normal messages and thread replies
- deduplicate repeated message requests server-side and suppress duplicate events
