### PR TITLE
fix(web): align human avatar and identity layout

### DIFF
--- a/web/app/src/components/business/AgentAvatar/AgentAvatar.tsx
+++ b/web/app/src/components/business/AgentAvatar/AgentAvatar.tsx
@@ -45,6 +45,7 @@ export function AgentAvatarContent({
 
 export function AgentAvatarPicker({
   disabled = false,
+  fallback,
   value,
   t,
   onChange,
@@ -52,6 +53,7 @@ export function AgentAvatarPicker({
   portalContainer = null,
 }: {
   disabled?: boolean;
+  fallback?: ReactNode;
   value?: string | null;
   t: TranslateFn;
   onChange: (value: string) => void;
@@ -292,16 +294,16 @@ export function AgentAvatarPicker({
         >
           {selected ? (
             <img className="agent-avatar-trigger-image" src={selected} alt="" draggable={false} />
+          ) : fallback ? (
+            <span className="agent-avatar-trigger-fallback">{fallback}</span>
           ) : (
             <ImagePlus aria-hidden="true" size={16} strokeWidth={1.8} />
           )}
           {mode === "edit" ? (
             <>
-              {selected ? (
-                <span className="agent-avatar-edit-overlay" aria-hidden="true">
-                  <Edit3 size={20} strokeWidth={1.8} />
-                </span>
-              ) : null}
+              <span className="agent-avatar-edit-overlay" aria-hidden="true">
+                <Edit3 size={20} strokeWidth={1.8} />
+              </span>
               <span className="agent-avatar-edit-tooltip" role="tooltip">
                 {t("editAvatar")}
               </span>

--- a/web/app/src/pages/HumanPage/components/HumanDetailPane/HumanDetailPane.tsx
+++ b/web/app/src/pages/HumanPage/components/HumanDetailPane/HumanDetailPane.tsx
@@ -1,6 +1,7 @@
 import { Check, CheckCircle2, Edit3, Link2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { AgentAvatarPicker } from "@/components/business/AgentAvatar";
+import { avatarFallbackText } from "@/shared/avatar";
 import { localizeRole } from "@/shared/i18n";
 import { feishuHumanParticipant } from "@/models/conversations";
 import type { IMUser, LocaleCode, TranslateFn } from "@/models/conversations";
@@ -83,6 +84,7 @@ export function HumanDetailPane({
           <div className="entity-avatar human-detail-avatar agent-header-avatar-picker" aria-busy={avatarBusy}>
             <AgentAvatarPicker
               disabled={avatarBusy}
+              fallback={avatarFallbackText(user.avatar, displayName, user.id)}
               value={user.avatar}
               t={t}
               mode="edit"

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -698,6 +698,20 @@
   object-fit: cover;
 }
 
+.agent-avatar-trigger-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--avatar-default-bg);
+  color: var(--avatar-default-fg);
+  font-size: 16px;
+  font-weight: var(--avatar-default-weight);
+  line-height: 1;
+}
+
 .agent-avatar-edit-overlay {
   position: absolute;
   inset: 0;
@@ -3511,7 +3525,7 @@ select,
 
 .human-identity-fields {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
   gap: 10px;
 }
 
@@ -3576,6 +3590,7 @@ select,
 .human-field {
   display: grid;
   gap: 4px;
+  min-width: 0;
   padding: 10px 12px;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -3587,6 +3602,7 @@ select,
   font-size: 14px;
   font-weight: 720;
   line-height: 18px;
+  overflow-wrap: anywhere;
 }
 
 .human-description-field {
@@ -3721,12 +3737,6 @@ select,
 
   .computer-summary-strip {
     grid-template-columns: repeat(2, minmax(0, 170px));
-  }
-}
-
-@media (max-width: 780px) {
-  .human-identity-fields {
-    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceComponents.css
@@ -3663,8 +3663,10 @@ select,
 
 .human-channel-icon img {
   display: block;
-  width: 22px;
-  height: 22px;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
 }
 
 .human-channel-main {

--- a/web/app/tests/components/HumanDetailPane.test.tsx
+++ b/web/app/tests/components/HumanDetailPane.test.tsx
@@ -94,6 +94,26 @@ describe("HumanDetailPane", () => {
     expect(onAvatarChange).toHaveBeenCalledWith("avatar/cartoon-2.png");
   });
 
+  it("uses the same initial fallback for an unconfigured human avatar", () => {
+    const localUser = { ...admin, avatar: "", name: "Local User" };
+    const { container } = render(<HumanDetailPane locale="en" t={t} user={localUser} />);
+
+    const editAvatar = screen.getByRole("button", { name: "Edit avatar" });
+    expect(editAvatar).toBeInTheDocument();
+    expect(container.querySelector(".agent-avatar-trigger-fallback")).toHaveTextContent("L");
+    expect(container.querySelector(".agent-avatar-edit-overlay")).toBeInTheDocument();
+
+    fireEvent.click(editAvatar);
+    expect(screen.getByRole("dialog", { name: "Edit avatar" })).toBeInTheDocument();
+  });
+
+  it("preserves a legacy initial avatar as the detail fallback", () => {
+    const localUser = { ...admin, avatar: "A" };
+    const { container } = render(<HumanDetailPane locale="en" t={t} user={localUser} />);
+
+    expect(container.querySelector(".agent-avatar-trigger-fallback")).toHaveTextContent("A");
+  });
+
   it("shows Feishu channel status without bound user detail", () => {
     const { container } = render(<HumanDetailPane locale="en" t={t} user={admin} />);
 


### PR DESCRIPTION
## Summary
- show the same fallback initial avatar in the human list and detail header
- keep fallback avatars editable with the existing avatar picker
- make role and user ID cards adapt to the available container width
- wrap long user IDs safely inside their card
