### PR TITLE
feat(feishu): support file transmission

### DIFF
--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -626,7 +626,7 @@ The two Phase 2 sides can be developed and verified independently, Phase 3 owns 
 - Anonymous Sessions create no IM entities and preserve their public API contract.
 - Different Conversations can run concurrently while one Conversation remains serialized.
 - Built-in IM preserves Room, Thread, Mention, file, Activity, Stop, Work, interaction, and `/new` behavior.
-- Feishu preserves its currently supported text behavior without claiming file support.
+- Feishu preserves its text behavior and delivers successful Engine output files through Agent-scoped snapshots. Supported images use Feishu image messages; larger images and other artifacts use file messages within Feishu upload limits.
 - Binding creation, update, and deletion reconcile exactly one Channel Event Worker through idempotent operations.
 - Agent Stop, Recreate, and Runtime restart neither restart Channel Event Workers nor delete bindings or transcripts.
 - Agent API deletion removes or deactivates referenced bindings, stops their Event Workers, and preserves saved transcripts.

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -624,7 +624,7 @@ Agent 删除由 Application 和 Binding 边界协调：删除或停用关联 Bin
 - 匿名 Session 不创建 IM Entity，并保留公共 API Contract。
 - 不同 Conversation 可以并发，一个 Conversation 内保持串行。
 - 内置 IM 保留 Room、Thread、Mention、File、Activity、Stop、Work、Interaction 和 `/new` 行为。
-- 飞书保留当前支持的 Text 行为，不声称支持 File。
+- 飞书保留已有 Text 行为，并通过 Agent-scoped 快照投递成功 Turn 的 Engine Output File。受支持图片使用飞书 Image Message；较大图片和其他产物在飞书上传限制内使用 File Message。
 - Binding 创建、更新和删除通过幂等操作协调唯一的 Channel Event Worker。
 - Agent Stop、Recreate 和 Runtime Restart 既不重启 Channel Event Worker，也不删除 Binding 或 Transcript。
 - Agent API 删除会删除或停用关联 Binding、停止对应 Event Worker，并保留已保存的 Transcript。

--- a/internal/agent/agents_instructions.go
+++ b/internal/agent/agents_instructions.go
@@ -54,12 +54,19 @@ func RenderAgentsInstructionsBlock(instructions string) string {
 }
 
 func RenderRuntimeAgentsInstructionsBlock(agentID, instructions string) string {
-	managedInstructions := ""
+	managedInstructions := strings.TrimSpace(runtimeFilePublishingInstructions)
 	if strings.TrimSpace(agentID) == ManagerUserID {
-		managedInstructions = strings.TrimSpace(managerRuntimeConnectorInstructions)
+		managedInstructions += "\n\n" + strings.TrimSpace(managerRuntimeConnectorInstructions)
 	}
 	return renderAgentsInstructionsBlock(instructions, managedInstructions)
 }
+
+const runtimeFilePublishingInstructions = `### Output File Delivery
+
+- When ` + "`csgclaw_publish_file`" + ` is available and the user asks to receive a generated file, create the file in the Runtime workspace.
+- Call ` + "`csgclaw_publish_file`" + ` with the file's workspace-relative path immediately after creating it.
+- Do not search for or use ` + "`csgclaw-cli`" + `, ` + "`curl`" + `, HTTP APIs, channel-specific APIs, or other upload methods for output file delivery.
+- Calling the tool publishes the file through the active channel. Mention the file in the final answer only after the tool succeeds.`
 
 const managerRuntimeConnectorInstructions = `### GitHub Connector Access
 

--- a/internal/agent/agents_instructions_test.go
+++ b/internal/agent/agents_instructions_test.go
@@ -110,6 +110,28 @@ func TestRenderAgentsInstructionsBlockWithInstructions(t *testing.T) {
 	}
 }
 
+func TestRenderRuntimeAgentsInstructionsBlockAddsSharedFilePublishingRules(t *testing.T) {
+	for _, agentID := range []string{ManagerUserID, "agent-worker"} {
+		rendered := RenderRuntimeAgentsInstructionsBlock(agentID, "Stay concise.")
+		for _, want := range []string{
+			"Output File Delivery",
+			"When `csgclaw_publish_file` is available",
+			"workspace-relative path immediately after creating it",
+			"Do not search for or use `csgclaw-cli`, `curl`, HTTP APIs, channel-specific APIs, or other upload methods",
+			"Mention the file in the final answer only after the tool succeeds",
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("runtime instructions for %q missing %q in %q", agentID, want, rendered)
+			}
+		}
+	}
+
+	plain := RenderAgentsInstructionsBlock("Stay concise.")
+	if strings.Contains(plain, "Output File Delivery") || strings.Contains(plain, "csgclaw_publish_file") {
+		t.Fatalf("non-runtime instructions include file publishing guidance: %q", plain)
+	}
+}
+
 func TestRenderRuntimeAgentsInstructionsBlockAddsManagerConnectorRulesOnlyForManager(t *testing.T) {
 	manager := RenderRuntimeAgentsInstructionsBlock(ManagerUserID, "Stay concise.")
 	if !strings.Contains(manager, "# Managed Runtime Instructions") {

--- a/internal/channel/feishu/binding/worker.go
+++ b/internal/channel/feishu/binding/worker.go
@@ -117,7 +117,13 @@ func (w *pipelineWorker) Start(ctx context.Context) error {
 		return errors.Join(cause, cleanupFailedStart(cancel, adapter, intake, runner))
 	}
 	store := feishustate.NewStore()
-	dispatcher, err := delivery.NewDispatcher(delivery.DispatcherOptions{State: store, Adapter: adapter})
+	dispatcher, err := delivery.NewDispatcher(delivery.DispatcherOptions{
+		State:   store,
+		Adapter: adapter,
+		Files: delivery.NewEngineFileResolver(
+			w.factory.engine.Conversations(w.resolved.Binding.AgentID).Files(),
+		),
+	})
 	if err != nil {
 		return fail(err)
 	}

--- a/internal/channel/feishu/delivery/delivery.go
+++ b/internal/channel/feishu/delivery/delivery.go
@@ -30,6 +30,7 @@ var (
 type DispatcherOptions struct {
 	State         *feishustate.Store
 	Adapter       transport.Adapter
+	Files         FileResolver
 	RetryInterval time.Duration
 }
 
@@ -38,12 +39,16 @@ type DispatcherOptions struct {
 type Dispatcher struct {
 	state    *feishustate.Store
 	adapter  transport.Adapter
+	files    FileResolver
 	interval time.Duration
 	wake     chan struct{}
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
 	done   chan struct{}
+
+	uploadMu sync.Mutex
+	uploads  map[string]mediaUpload
 }
 
 func NewDispatcher(options DispatcherOptions) (*Dispatcher, error) {
@@ -60,6 +65,7 @@ func NewDispatcher(options DispatcherOptions) (*Dispatcher, error) {
 	return &Dispatcher{
 		state:    options.State,
 		adapter:  options.Adapter,
+		files:    options.Files,
 		interval: interval,
 		wake:     make(chan struct{}, 1),
 		done:     make(chan struct{}),
@@ -202,6 +208,8 @@ func (d *Dispatcher) drain(ctx context.Context) {
 				slog.Error("record Feishu delivery failure failed",
 					deliveryErrorLogAttrs(intent, err, "record_error", markErr)...)
 				blockedScopes[lane] = struct{}{}
+			} else if !retry && intent.Kind == channeltypes.DeliveryFile {
+				d.discardMediaUpload(intent.ID)
 			}
 			d.logDeliveryFailure(intent, err, retry, nextAttemptAt)
 			if retry {
@@ -213,6 +221,9 @@ func (d *Dispatcher) drain(ctx context.Context) {
 			slog.Error("record delivered Feishu intent failed", intentLogAttrs(delivered, "error", err)...)
 			blockedScopes[lane] = struct{}{}
 			continue
+		}
+		if intent.Kind == channeltypes.DeliveryFile {
+			d.discardMediaUpload(intent.ID)
 		}
 		slog.Debug("delivered Feishu intent", intentLogAttrs(delivered)...)
 	}
@@ -421,6 +432,7 @@ func retryableDelivery(intent channeltypes.DeliveryIntent, err error) bool {
 	// deduplication key, so an ambiguous outcome must not be repeated.
 	switch intent.Kind {
 	case channeltypes.DeliveryText, channeltypes.DeliveryMarkdown, channeltypes.DeliveryCard,
+		channeltypes.DeliveryFile,
 		channeltypes.DeliveryMarkdownUpdate, channeltypes.DeliveryCardUpdate, channeltypes.DeliveryReactionDelete:
 		return true
 	default:
@@ -435,6 +447,8 @@ func (d *Dispatcher) deliver(ctx context.Context, intent channeltypes.DeliveryIn
 			return intent, err
 		}
 		return deliverText(ctx, d.adapter, intent)
+	case channeltypes.DeliveryFile:
+		return d.deliverMedia(ctx, intent)
 	case channeltypes.DeliveryMarkdownUpdate:
 		return d.deliverMarkdownUpdate(ctx, intent)
 	case channeltypes.DeliveryCard:

--- a/internal/channel/feishu/delivery/delivery_test.go
+++ b/internal/channel/feishu/delivery/delivery_test.go
@@ -3,10 +3,13 @@ package delivery
 import (
 	"context"
 	"errors"
+	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"csgclaw/internal/agentengine"
 	channeltypes "csgclaw/internal/channel"
 	feishustate "csgclaw/internal/channel/feishu/state"
 	"csgclaw/internal/channel/feishu/transport"
@@ -14,12 +17,20 @@ import (
 
 type recordingAdapter struct {
 	transport.Adapter
-	mu        sync.Mutex
-	texts     []transport.SendTextRequest
-	updates   []transport.UpdateTextRequest
-	textErr   error
-	updateErr error
-	messageID string
+	mu           sync.Mutex
+	texts        []transport.SendTextRequest
+	updates      []transport.UpdateTextRequest
+	imageUploads []transport.UploadImageRequest
+	fileUploads  []transport.UploadFileRequest
+	images       []transport.SendImageRequest
+	files        []transport.SendFileRequest
+	imageBody    []string
+	fileBody     []string
+	textErr      error
+	updateErr    error
+	imageErr     error
+	fileErr      error
+	messageID    string
 }
 
 func (a *recordingAdapter) SendText(_ context.Context, req transport.SendTextRequest) (transport.SendResult, error) {
@@ -36,6 +47,44 @@ func (a *recordingAdapter) UpdateText(_ context.Context, req transport.UpdateTex
 	defer a.mu.Unlock()
 	a.updates = append(a.updates, req)
 	return a.updateErr
+}
+func (a *recordingAdapter) UploadImage(_ context.Context, req transport.UploadImageRequest) (transport.UploadResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.imageUploads = append(a.imageUploads, req)
+	if req.Content != nil {
+		body, _ := io.ReadAll(req.Content)
+		a.imageBody = append(a.imageBody, string(body))
+	}
+	return transport.UploadResult{Key: "image-key"}, nil
+}
+func (a *recordingAdapter) UploadFile(_ context.Context, req transport.UploadFileRequest) (transport.UploadResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.fileUploads = append(a.fileUploads, req)
+	if req.Content != nil {
+		body, _ := io.ReadAll(req.Content)
+		a.fileBody = append(a.fileBody, string(body))
+	}
+	return transport.UploadResult{Key: "file-key"}, nil
+}
+func (a *recordingAdapter) SendImage(_ context.Context, req transport.SendImageRequest) (transport.SendResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.images = append(a.images, req)
+	if a.imageErr != nil {
+		return transport.SendResult{}, a.imageErr
+	}
+	return transport.SendResult{MessageID: a.messageID}, nil
+}
+func (a *recordingAdapter) SendFile(_ context.Context, req transport.SendFileRequest) (transport.SendResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.files = append(a.files, req)
+	if a.fileErr != nil {
+		return transport.SendResult{}, a.fileErr
+	}
+	return transport.SendResult{MessageID: a.messageID}, nil
 }
 
 func TestDispatcherDeliversFromMemory(t *testing.T) {
@@ -56,6 +105,173 @@ func TestDispatcherDeliversFromMemory(t *testing.T) {
 	delivered, ok := store.Delivery(intent.ID)
 	if !ok || delivered.Status != channeltypes.DeliveryDelivered || delivered.MessageID != "message-1" {
 		t.Fatalf("delivery = %#v, found=%t", delivered, ok)
+	}
+}
+
+func TestDispatcherDeliversAgentEngineMedia(t *testing.T) {
+	store := feishustate.NewStore()
+	image := channeltypes.DeliveryIntent{
+		ID: "image", BindingID: "binding-1", TurnID: "turn-1",
+		Kind: channeltypes.DeliveryFile, ChatID: "chat-1", ReplyTo: "root-1", ThreadID: "thread-1",
+		FileID: "file-image",
+	}
+	file := channeltypes.DeliveryIntent{
+		ID: "file", BindingID: "binding-1", TurnID: "turn-1",
+		Kind: channeltypes.DeliveryFile, ChatID: "chat-1",
+		FileID: "file-report",
+	}
+	if err := store.Enqueue(image); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Enqueue(file); err != nil {
+		t.Fatal(err)
+	}
+	resolver := fileResolverFunc(func(_ context.Context, fileID string) (agentengine.FileContent, error) {
+		switch fileID {
+		case "file-image":
+			return agentengine.FileContent{
+				Metadata: agentengine.OutputFileMetadata{ID: fileID, Name: "result.png", MediaType: "image/png", SizeBytes: 3},
+				Content:  io.NopCloser(strings.NewReader("png")),
+			}, nil
+		case "file-report":
+			return agentengine.FileContent{
+				Metadata: agentengine.OutputFileMetadata{ID: fileID, Name: "report.pdf", MediaType: "application/pdf", SizeBytes: 3},
+				Content:  io.NopCloser(strings.NewReader("pdf")),
+			}, nil
+		default:
+			t.Fatalf("unexpected fileID = %q", fileID)
+			return agentengine.FileContent{}, nil
+		}
+	})
+	adapter := &recordingAdapter{messageID: "message-media"}
+	dispatcher, err := NewDispatcher(DispatcherOptions{State: store, Adapter: adapter, Files: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.drain(context.Background())
+
+	deliveredImage, _ := store.Delivery(image.ID)
+	deliveredFile, _ := store.Delivery(file.ID)
+	if deliveredImage.Status != channeltypes.DeliveryDelivered || deliveredImage.MessageID != "message-media" ||
+		deliveredFile.Status != channeltypes.DeliveryDelivered || deliveredFile.MessageID != "message-media" {
+		t.Fatalf("image=%#v file=%#v", deliveredImage, deliveredFile)
+	}
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if len(adapter.imageUploads) != 1 || len(adapter.images) != 1 || len(adapter.imageBody) != 1 ||
+		adapter.imageUploads[0].MediaType != "image/png" || adapter.images[0].ImageKey != "image-key" || adapter.images[0].ReplyTo != "root-1" ||
+		!adapter.images[0].ReplyInThread || adapter.images[0].ThreadID != "thread-1" || adapter.imageBody[0] != "png" {
+		t.Fatalf("image uploads=%#v sends=%#v bodies=%#v", adapter.imageUploads, adapter.images, adapter.imageBody)
+	}
+	if len(adapter.fileUploads) != 1 || len(adapter.files) != 1 || len(adapter.fileBody) != 1 ||
+		adapter.fileUploads[0].Name != "report.pdf" || adapter.files[0].FileKey != "file-key" || adapter.fileBody[0] != "pdf" {
+		t.Fatalf("file uploads=%#v sends=%#v bodies=%#v", adapter.fileUploads, adapter.files, adapter.fileBody)
+	}
+}
+
+func TestDispatcherSendsOversizedImageAsFile(t *testing.T) {
+	store := feishustate.NewStore()
+	intent := channeltypes.DeliveryIntent{
+		ID: "large-image", BindingID: "binding-1", TurnID: "turn-1",
+		Kind: channeltypes.DeliveryFile, ChatID: "chat-1", FileID: "file-large-image",
+	}
+	if err := store.Enqueue(intent); err != nil {
+		t.Fatal(err)
+	}
+	resolver := fileResolverFunc(func(_ context.Context, fileID string) (agentengine.FileContent, error) {
+		return agentengine.FileContent{
+			Metadata: agentengine.OutputFileMetadata{
+				ID: fileID, Name: "large.png", MediaType: "image/png", SizeBytes: transport.ImageUploadLimitBytes + 1,
+			},
+			Content: io.NopCloser(strings.NewReader("png")),
+		}, nil
+	})
+	adapter := &recordingAdapter{messageID: "message-large-image"}
+	dispatcher, err := NewDispatcher(DispatcherOptions{State: store, Adapter: adapter, Files: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.drain(context.Background())
+
+	delivered, _ := store.Delivery(intent.ID)
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if delivered.Status != channeltypes.DeliveryDelivered || len(adapter.imageUploads) != 0 ||
+		len(adapter.fileUploads) != 1 || adapter.fileUploads[0].Name != "large.png" || len(adapter.files) != 1 {
+		t.Fatalf("delivery=%#v image uploads=%d file uploads=%#v sends=%#v", delivered, len(adapter.imageUploads), adapter.fileUploads, adapter.files)
+	}
+}
+
+func TestDispatcherReusesUploadWhenMessageSendRetries(t *testing.T) {
+	store := feishustate.NewStore()
+	intent := channeltypes.DeliveryIntent{
+		ID: "retry-image", BindingID: "binding-1", TurnID: "turn-1",
+		Kind: channeltypes.DeliveryFile, ChatID: "chat-1", FileID: "file-image",
+	}
+	if err := store.Enqueue(intent); err != nil {
+		t.Fatal(err)
+	}
+	resolveCalls := 0
+	resolver := fileResolverFunc(func(_ context.Context, fileID string) (agentengine.FileContent, error) {
+		resolveCalls++
+		return agentengine.FileContent{
+			Metadata: agentengine.OutputFileMetadata{ID: fileID, Name: "result.png", MediaType: "image/png", SizeBytes: 3},
+			Content:  io.NopCloser(strings.NewReader("png")),
+		}, nil
+	})
+	adapter := &recordingAdapter{
+		messageID: "message-image",
+		imageErr:  &transport.APIError{Operation: "send image", HTTPStatus: 503},
+	}
+	dispatcher, err := NewDispatcher(DispatcherOptions{
+		State: store, Adapter: adapter, Files: resolver, RetryInterval: time.Nanosecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.drain(context.Background())
+	adapter.mu.Lock()
+	adapter.imageErr = nil
+	adapter.mu.Unlock()
+	time.Sleep(time.Millisecond)
+	dispatcher.drain(context.Background())
+
+	delivered, _ := store.Delivery(intent.ID)
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if delivered.Status != channeltypes.DeliveryDelivered || resolveCalls != 1 ||
+		len(adapter.imageUploads) != 1 || len(adapter.images) != 2 {
+		t.Fatalf("delivery=%#v resolve=%d uploads=%d sends=%d", delivered, resolveCalls, len(adapter.imageUploads), len(adapter.images))
+	}
+}
+
+func TestDispatcherRejectsIncompleteEngineMetadataWithoutFallback(t *testing.T) {
+	store := feishustate.NewStore()
+	intent := channeltypes.DeliveryIntent{
+		ID: "invalid-metadata", BindingID: "binding-1", TurnID: "turn-1",
+		Kind: channeltypes.DeliveryFile, ChatID: "chat-1", FileID: "file-invalid",
+	}
+	if err := store.Enqueue(intent); err != nil {
+		t.Fatal(err)
+	}
+	resolver := fileResolverFunc(func(context.Context, string) (agentengine.FileContent, error) {
+		return agentengine.FileContent{
+			Metadata: agentengine.OutputFileMetadata{Name: "result.png", MediaType: "image/png", SizeBytes: 3},
+			Content:  io.NopCloser(strings.NewReader("png")),
+		}, nil
+	})
+	adapter := &recordingAdapter{}
+	dispatcher, err := NewDispatcher(DispatcherOptions{State: store, Adapter: adapter, Files: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.drain(context.Background())
+
+	failed, _ := store.Delivery(intent.ID)
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if failed.Status != channeltypes.DeliveryFailed || len(adapter.imageUploads) != 0 || len(adapter.fileUploads) != 0 {
+		t.Fatalf("delivery=%#v image uploads=%d file uploads=%d", failed, len(adapter.imageUploads), len(adapter.fileUploads))
 	}
 }
 

--- a/internal/channel/feishu/delivery/media.go
+++ b/internal/channel/feishu/delivery/media.go
@@ -1,7 +1,192 @@
 package delivery
 
-// TODO(agent-engine): expose an authorized Runtime-owned output artifact (for
-// example a bounded local file/blob with MIME type, size, and digest) before
-// producing Feishu image/file deliveries. Engine resource_link output is an
-// external HTTP(S) URL; the channel must not fetch it as media because that
-// would add an SSRF/authorization fallback outside the Runtime boundary.
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"csgclaw/internal/agentengine"
+	channeltypes "csgclaw/internal/channel"
+	"csgclaw/internal/channel/feishu/transport"
+)
+
+// FileResolver returns file content from the Agent scope owned by this binding.
+type FileResolver interface {
+	GetFile(context.Context, string) (agentengine.FileContent, error)
+}
+
+type fileResolverFunc func(context.Context, string) (agentengine.FileContent, error)
+
+func (f fileResolverFunc) GetFile(ctx context.Context, fileID string) (agentengine.FileContent, error) {
+	return f(ctx, fileID)
+}
+
+// NewEngineFileResolver adapts one binding's Agent-scoped Engine file API.
+func NewEngineFileResolver(files agentengine.FileInterface) FileResolver {
+	if files == nil {
+		return nil
+	}
+	return engineFileResolver{files: files}
+}
+
+type engineFileResolver struct {
+	files agentengine.FileInterface
+}
+
+func (r engineFileResolver) GetFile(ctx context.Context, fileID string) (agentengine.FileContent, error) {
+	fileID = strings.TrimSpace(fileID)
+	if r.files == nil || fileID == "" {
+		return agentengine.FileContent{}, fmt.Errorf("Agent Engine file resolver requires a file ID")
+	}
+	return r.files.Get(ctx, fileID)
+}
+
+type mediaUpload struct {
+	image bool
+	key   string
+}
+
+func (d *Dispatcher) deliverMedia(ctx context.Context, intent channeltypes.DeliveryIntent) (channeltypes.DeliveryIntent, error) {
+	if d == nil || d.files == nil {
+		return intent, fmt.Errorf("Feishu file delivery is unavailable")
+	}
+	fileID := strings.TrimSpace(intent.FileID)
+	if fileID == "" {
+		return intent, fmt.Errorf("Feishu file delivery requires a file ID")
+	}
+
+	upload, ok := d.cachedMediaUpload(intent.ID)
+	if !ok {
+		var err error
+		upload, err = d.uploadMedia(ctx, intent, fileID)
+		if err != nil {
+			return intent, err
+		}
+		d.cacheMediaUpload(intent.ID, upload)
+	}
+
+	result, err := d.sendMedia(ctx, intent, upload)
+	if err != nil {
+		return intent, err
+	}
+	intent.MessageID = result.MessageID
+	return intent, nil
+}
+
+func (d *Dispatcher) uploadMedia(ctx context.Context, intent channeltypes.DeliveryIntent, fileID string) (mediaUpload, error) {
+	download, err := d.files.GetFile(ctx, fileID)
+	if err != nil {
+		return mediaUpload{}, fmt.Errorf("load Agent Engine file %q for Feishu delivery: %w", fileID, err)
+	}
+	if download.Content == nil {
+		return mediaUpload{}, fmt.Errorf("Agent Engine file %q content is unavailable", fileID)
+	}
+
+	metadata, metadataErr := authoritativeMediaMetadata(fileID, download.Metadata)
+	if metadataErr != nil {
+		_ = download.Content.Close()
+		return mediaUpload{}, metadataErr
+	}
+	upload, uploadErr := d.uploadMediaContent(ctx, metadata, download.Content)
+	closeErr := download.Content.Close()
+	if uploadErr != nil {
+		return mediaUpload{}, uploadErr
+	}
+	if closeErr != nil {
+		slog.Warn("close uploaded Agent Engine file content failed",
+			intentLogAttrs(intent, "file_id", fileID, "error", closeErr)...)
+	}
+	return upload, nil
+}
+
+func (d *Dispatcher) uploadMediaContent(ctx context.Context, metadata agentengine.OutputFileMetadata, content io.Reader) (mediaUpload, error) {
+	if transport.SupportsImageUpload(metadata.MediaType, metadata.SizeBytes) {
+		result, err := d.adapter.UploadImage(ctx, transport.UploadImageRequest{
+			MediaType: metadata.MediaType,
+			SizeBytes: metadata.SizeBytes,
+			Content:   content,
+		})
+		if err != nil {
+			return mediaUpload{}, err
+		}
+		if key := strings.TrimSpace(result.Key); key != "" {
+			return mediaUpload{image: true, key: key}, nil
+		}
+		return mediaUpload{}, fmt.Errorf("Feishu image upload returned no image key")
+	}
+
+	result, err := d.adapter.UploadFile(ctx, transport.UploadFileRequest{
+		Name:      metadata.Name,
+		SizeBytes: metadata.SizeBytes,
+		Content:   content,
+	})
+	if err != nil {
+		return mediaUpload{}, err
+	}
+	if key := strings.TrimSpace(result.Key); key != "" {
+		return mediaUpload{key: key}, nil
+	}
+	return mediaUpload{}, fmt.Errorf("Feishu file upload returned no file key")
+}
+
+func (d *Dispatcher) sendMedia(ctx context.Context, intent channeltypes.DeliveryIntent, upload mediaUpload) (transport.SendResult, error) {
+	request := transport.SendFileRequest{
+		ChatID:         intent.ChatID,
+		FileKey:        upload.key,
+		IdempotencyKey: intent.ID,
+		ReplyTo:        intent.ReplyTo,
+		ReplyInThread:  intent.ReplyTo != "" && intent.ThreadID != "",
+		ThreadID:       intent.ThreadID,
+	}
+	if upload.image {
+		return d.adapter.SendImage(ctx, transport.SendImageRequest{
+			ChatID:         request.ChatID,
+			ImageKey:       upload.key,
+			IdempotencyKey: request.IdempotencyKey,
+			ReplyTo:        request.ReplyTo,
+			ReplyInThread:  request.ReplyInThread,
+			ThreadID:       request.ThreadID,
+		})
+	}
+	return d.adapter.SendFile(ctx, request)
+}
+
+func authoritativeMediaMetadata(fileID string, metadata agentengine.OutputFileMetadata) (agentengine.OutputFileMetadata, error) {
+	metadata.ID = strings.TrimSpace(metadata.ID)
+	metadata.Name = strings.TrimSpace(metadata.Name)
+	metadata.MediaType = strings.TrimSpace(metadata.MediaType)
+	if metadata.ID != fileID {
+		return agentengine.OutputFileMetadata{}, fmt.Errorf("Agent Engine file ID %q did not match Feishu delivery file ID %q", metadata.ID, fileID)
+	}
+	if metadata.Name == "" || metadata.MediaType == "" || metadata.SizeBytes < 0 {
+		return agentengine.OutputFileMetadata{}, fmt.Errorf("Agent Engine file %q returned invalid delivery metadata", fileID)
+	}
+	return metadata, nil
+}
+
+func (d *Dispatcher) cachedMediaUpload(intentID string) (mediaUpload, bool) {
+	d.uploadMu.Lock()
+	defer d.uploadMu.Unlock()
+	upload, ok := d.uploads[strings.TrimSpace(intentID)]
+	return upload, ok
+}
+
+func (d *Dispatcher) cacheMediaUpload(intentID string, upload mediaUpload) {
+	d.uploadMu.Lock()
+	defer d.uploadMu.Unlock()
+	if d.uploads == nil {
+		d.uploads = make(map[string]mediaUpload)
+	}
+	d.uploads[strings.TrimSpace(intentID)] = upload
+}
+
+func (d *Dispatcher) discardMediaUpload(intentID string) {
+	if d == nil {
+		return
+	}
+	d.uploadMu.Lock()
+	delete(d.uploads, strings.TrimSpace(intentID))
+	d.uploadMu.Unlock()
+}

--- a/internal/channel/feishu/execution/runner.go
+++ b/internal/channel/feishu/execution/runner.go
@@ -14,10 +14,15 @@ import (
 	feishuctx "csgclaw/internal/channel/feishu/context"
 	"csgclaw/internal/channel/feishu/presentation"
 	feishustate "csgclaw/internal/channel/feishu/state"
+	"csgclaw/internal/channel/feishu/transport"
 	"csgclaw/internal/slashcommand"
 )
 
-const processingPinEmoji = "Pin"
+const (
+	processingPinEmoji       = "Pin"
+	maxFeishuOutputFileCount = 8
+	maxFeishuOutputFileTotal = int64(50 << 20)
+)
 
 type FilePreparer interface {
 	Prepare(context.Context, channeltypes.InboundMessage) ([]agentengine.InputPart, func(), error)
@@ -376,6 +381,9 @@ func (r *Runner) finalize(message channeltypes.InboundMessage, result agentengin
 			terminal = presentation.Terminal(mode, presentationResult(result))
 		}
 		intents = append(intents, r.presentationUpdateIntents(message, finalSequence, true, terminal)...)
+		if status == channeltypes.TurnSucceeded {
+			intents = append(intents, r.fileDeliveryIntents(message, result.Files, finalSequence+1)...)
+		}
 		if cleanup, ok := r.reactionCleanupIntent(message); ok {
 			intents = append(intents, cleanup)
 		}
@@ -460,6 +468,68 @@ func (r *Runner) textIntent(message channeltypes.InboundMessage, id string, sequ
 	intent.Kind = channeltypes.DeliveryText
 	intent.Text = text
 	return intent
+}
+
+func (r *Runner) fileDeliveryIntents(message channeltypes.InboundMessage, files []agentengine.OutputFile, startSequence uint64) []channeltypes.DeliveryIntent {
+	if len(files) == 0 {
+		return nil
+	}
+	intents := make([]channeltypes.DeliveryIntent, 0, len(files)+1)
+	var totalSize int64
+	rejected := 0
+	for index, file := range files {
+		fileID := strings.TrimSpace(file.ID)
+		if reason := outputFileRejection(file, len(intents), totalSize); reason != "" {
+			slog.Warn("skip unsupported Feishu output file delivery",
+				messageLogAttrs(message,
+					"file_id", fileID,
+					"file_name", file.Name,
+					"file_media_type", file.MediaType,
+					"file_size_bytes", file.SizeBytes,
+					"reason", reason,
+				)...)
+			rejected++
+			continue
+		}
+		intent := baseIntent(message, fileDeliveryID(message.TurnID, index), startSequence+uint64(len(intents)))
+		intent.Kind = channeltypes.DeliveryFile
+		intent.FileID = fileID
+		intents = append(intents, intent)
+		totalSize += file.SizeBytes
+	}
+	if rejected > 0 {
+		warning := baseIntent(message, strings.TrimSpace(message.TurnID)+":files:warning", startSequence+uint64(len(intents)))
+		warning.Kind = channeltypes.DeliveryText
+		warning.Text = fmt.Sprintf(
+			"Feishu could not send %d generated file(s) because their metadata or delivery limits were invalid (maximum %d files, %d MiB per file, %d MiB total).",
+			rejected, maxFeishuOutputFileCount, transport.FileUploadLimitBytes>>20, maxFeishuOutputFileTotal>>20,
+		)
+		intents = append(intents, warning)
+	}
+	return intents
+}
+
+func outputFileRejection(file agentengine.OutputFile, accepted int, acceptedBytes int64) string {
+	if strings.TrimSpace(file.ID) == "" {
+		return "Engine file ID is empty"
+	}
+	if file.SizeBytes < 0 {
+		return "file size is negative"
+	}
+	if file.SizeBytes > transport.FileUploadLimitBytes {
+		return "file exceeds Feishu's per-file upload limit"
+	}
+	if accepted >= maxFeishuOutputFileCount {
+		return "Turn exceeds the Feishu output file count limit"
+	}
+	if file.SizeBytes > maxFeishuOutputFileTotal-acceptedBytes {
+		return "Turn exceeds the Feishu output file total size limit"
+	}
+	return ""
+}
+
+func fileDeliveryID(turnID string, index int) string {
+	return strings.TrimSpace(turnID) + fmt.Sprintf(":file:%d", index+1)
 }
 
 func (r *Runner) enqueueInitialPresentation(message channeltypes.InboundMessage, mode presentation.Mode) error {

--- a/internal/channel/feishu/execution/runner.go
+++ b/internal/channel/feishu/execution/runner.go
@@ -513,8 +513,8 @@ func outputFileRejection(file agentengine.OutputFile, accepted int, acceptedByte
 	if strings.TrimSpace(file.ID) == "" {
 		return "Engine file ID is empty"
 	}
-	if file.SizeBytes < 0 {
-		return "file size is negative"
+	if file.SizeBytes <= 0 {
+		return "file size must be positive"
 	}
 	if file.SizeBytes > transport.FileUploadLimitBytes {
 		return "file exceeds Feishu's per-file upload limit"

--- a/internal/channel/feishu/execution/runner_test.go
+++ b/internal/channel/feishu/execution/runner_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	channeltypes "csgclaw/internal/channel"
 	"csgclaw/internal/channel/feishu/presentation"
 	feishustate "csgclaw/internal/channel/feishu/state"
+	"csgclaw/internal/channel/feishu/transport"
 )
 
 type fakeEngine struct{ conversation *fakeConversation }
@@ -316,6 +318,140 @@ func TestRunnerRendersEngineEventsIntoMemoryDelivery(t *testing.T) {
 	final, ok := store.Delivery(finalID)
 	if !ok || final.Kind != channeltypes.DeliveryMarkdownUpdate || !strings.Contains(final.Text, "answer") {
 		t.Fatalf("final delivery = %#v, found=%t", final, ok)
+	}
+}
+
+func TestRunnerQueuesOutputFilesForChatDelivery(t *testing.T) {
+	runFinished := make(chan struct{})
+	conversation := &fakeConversation{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		defer close(runFinished)
+		return agentengine.TurnResult{
+			Status: agentengine.TurnSucceeded,
+			Output: "done",
+			Files: []agentengine.OutputFile{
+				{OutputFileMetadata: agentengine.OutputFileMetadata{
+					ID: "file-image", Name: "result.png", MediaType: "image/png", SizeBytes: 3, SHA256: strings.Repeat("a", 64),
+				}},
+				{OutputFileMetadata: agentengine.OutputFileMetadata{
+					ID: "file-report", Name: "report.pdf", MediaType: "application/pdf", SizeBytes: 3, SHA256: strings.Repeat("b", 64),
+				}},
+				{OutputFileMetadata: agentengine.OutputFileMetadata{
+					ID: "file-svg", Name: "diagram.svg", MediaType: "image/svg+xml", SizeBytes: 3, SHA256: strings.Repeat("c", 64),
+				}},
+			},
+		}
+	}}
+	store := feishustate.NewStore()
+	runner, err := NewRunner(RunnerOptions{
+		Engine: fakeEngine{conversation}, State: store, Presentation: presentation.ModeMarkdown,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := runnerMessage("event-files", "turn-files", "conversation", "create a chart")
+	if err := runner.Submit(context.Background(), message); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-runFinished:
+	case <-time.After(time.Second):
+		t.Fatal("Engine run did not finish")
+	}
+	if err := runner.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	image, imageOK := store.Delivery(fileDeliveryID(message.TurnID, 0))
+	file, fileOK := store.Delivery(fileDeliveryID(message.TurnID, 1))
+	svg, svgOK := store.Delivery(fileDeliveryID(message.TurnID, 2))
+	if !imageOK || image.Kind != channeltypes.DeliveryFile || image.FileID != "file-image" {
+		t.Fatalf("image intent = %#v, found=%t", image, imageOK)
+	}
+	if !fileOK || file.Kind != channeltypes.DeliveryFile || file.FileID != "file-report" {
+		t.Fatalf("file intent = %#v, found=%t", file, fileOK)
+	}
+	if !svgOK || svg.Kind != channeltypes.DeliveryFile || svg.FileID != "file-svg" {
+		t.Fatalf("svg intent = %#v, found=%t", svg, svgOK)
+	}
+}
+
+func TestFileDeliveryIntentsEnforceOutboundPolicyAndWarnUser(t *testing.T) {
+	message := runnerMessage("event-file-policy", "turn-file-policy", "conversation", "create files")
+	files := make([]agentengine.OutputFile, 0, maxFeishuOutputFileCount+2)
+	for index := 0; index < maxFeishuOutputFileCount+1; index++ {
+		files = append(files, agentengine.OutputFile{OutputFileMetadata: agentengine.OutputFileMetadata{
+			ID: fmt.Sprintf("file-%d", index), Name: fmt.Sprintf("file-%d.txt", index), MediaType: "text/plain", SizeBytes: 1,
+		}})
+	}
+	files = append(files, agentengine.OutputFile{OutputFileMetadata: agentengine.OutputFileMetadata{
+		ID: "file-large", Name: "large.zip", MediaType: "application/zip", SizeBytes: transport.FileUploadLimitBytes + 1,
+	}})
+
+	intents := (&Runner{}).fileDeliveryIntents(message, files, 10)
+	if len(intents) != maxFeishuOutputFileCount+1 {
+		t.Fatalf("intent count = %d, want %d", len(intents), maxFeishuOutputFileCount+1)
+	}
+	for index, intent := range intents[:maxFeishuOutputFileCount] {
+		if intent.Kind != channeltypes.DeliveryFile || intent.FileID != fmt.Sprintf("file-%d", index) || intent.Sequence != uint64(10+index) {
+			t.Fatalf("file intent %d = %#v", index, intent)
+		}
+	}
+	warning := intents[len(intents)-1]
+	if warning.Kind != channeltypes.DeliveryText || warning.ID != message.TurnID+":files:warning" ||
+		warning.Sequence != 10+maxFeishuOutputFileCount || !strings.Contains(warning.Text, "could not send 2 generated file(s)") {
+		t.Fatalf("warning intent = %#v", warning)
+	}
+}
+
+func TestFileDeliveryIntentsEnforceAggregateSizeLimit(t *testing.T) {
+	message := runnerMessage("event-file-total", "turn-file-total", "conversation", "create files")
+	files := []agentengine.OutputFile{
+		{OutputFileMetadata: agentengine.OutputFileMetadata{
+			ID: "file-30", Name: "first.zip", MediaType: "application/zip", SizeBytes: transport.FileUploadLimitBytes,
+		}},
+		{OutputFileMetadata: agentengine.OutputFileMetadata{
+			ID: "file-21", Name: "second.zip", MediaType: "application/zip", SizeBytes: 21 << 20,
+		}},
+	}
+
+	intents := (&Runner{}).fileDeliveryIntents(message, files, 1)
+	if len(intents) != 2 || intents[0].Kind != channeltypes.DeliveryFile || intents[0].FileID != "file-30" ||
+		intents[1].Kind != channeltypes.DeliveryText || !strings.Contains(intents[1].Text, "could not send 1 generated file(s)") {
+		t.Fatalf("intents = %#v", intents)
+	}
+}
+
+func TestRunnerDoesNotQueueOutputFilesForFailedTurn(t *testing.T) {
+	runFinished := make(chan struct{})
+	conversation := &fakeConversation{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {
+		defer close(runFinished)
+		return agentengine.TurnResult{
+			Status: agentengine.TurnFailed,
+			Error:  &agentengine.TurnError{Code: agentengine.ErrorRuntimeFailed, Message: "failed"},
+			Files: []agentengine.OutputFile{{OutputFileMetadata: agentengine.OutputFileMetadata{
+				ID: "file-failed", Name: "failed.pdf", MediaType: "application/pdf", SizeBytes: 3,
+			}}},
+		}
+	}}
+	store := feishustate.NewStore()
+	runner, err := NewRunner(RunnerOptions{Engine: fakeEngine{conversation}, State: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := runnerMessage("event-failed-files", "turn-failed-files", "conversation", "fail")
+	if err := runner.Submit(context.Background(), message); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-runFinished:
+	case <-time.After(time.Second):
+		t.Fatal("Engine run did not finish")
+	}
+	if err := runner.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if intent, ok := store.Delivery(fileDeliveryID(message.TurnID, 0)); ok {
+		t.Fatalf("failed turn queued file delivery: %#v", intent)
 	}
 }
 

--- a/internal/channel/feishu/execution/runner_test.go
+++ b/internal/channel/feishu/execution/runner_test.go
@@ -421,6 +421,20 @@ func TestFileDeliveryIntentsEnforceAggregateSizeLimit(t *testing.T) {
 	}
 }
 
+func TestFileDeliveryIntentsRejectEmptyFileAndWarnUser(t *testing.T) {
+	message := runnerMessage("event-empty-file", "turn-empty-file", "conversation", "create an empty file")
+	files := []agentengine.OutputFile{{OutputFileMetadata: agentengine.OutputFileMetadata{
+		ID: "file-empty", Name: "empty.txt", MediaType: "text/plain", SizeBytes: 0,
+	}}}
+
+	intents := (&Runner{}).fileDeliveryIntents(message, files, 4)
+	if len(intents) != 1 || intents[0].Kind != channeltypes.DeliveryText ||
+		intents[0].ID != message.TurnID+":files:warning" || intents[0].Sequence != 4 ||
+		!strings.Contains(intents[0].Text, "could not send 1 generated file(s)") {
+		t.Fatalf("intents = %#v", intents)
+	}
+}
+
 func TestRunnerDoesNotQueueOutputFilesForFailedTurn(t *testing.T) {
 	runFinished := make(chan struct{})
 	conversation := &fakeConversation{run: func(context.Context, agentengine.TurnRequest, agentengine.EventSink) agentengine.TurnResult {

--- a/internal/channel/feishu/files/media.go
+++ b/internal/channel/feishu/files/media.go
@@ -25,13 +25,17 @@ const stagingFilePrefix = "feishu-attachment-"
 // Preparer downloads Feishu resources into a private channel-owned staging
 // directory, applies channel policy, and returns Engine-neutral file inputs.
 type Preparer struct {
-	Downloader transport.Adapter
+	Downloader Downloader
 	Files      agentengine.FileInterface
 	Root       string
 	Policy     Policy
 
 	quotaOnce sync.Once
 	quota     *bindingQuota
+}
+
+type Downloader interface {
+	DownloadResource(context.Context, transport.DownloadResourceRequest) (transport.DownloadResourceResult, error)
 }
 
 // Prepare returns inputs and a cleanup function. Cleanup is safe after

--- a/internal/channel/feishu/transport/adapter.go
+++ b/internal/channel/feishu/transport/adapter.go
@@ -25,6 +25,10 @@ type larkOperations interface {
 	UpdateText(context.Context, UpdateTextRequest) error
 	SendCard(context.Context, SendCardRequest) (SendResult, error)
 	UpdateCard(context.Context, UpdateCardRequest) error
+	UploadImage(context.Context, UploadImageRequest) (UploadResult, error)
+	UploadFile(context.Context, UploadFileRequest) (UploadResult, error)
+	SendImage(context.Context, SendImageRequest) (SendResult, error)
+	SendFile(context.Context, SendFileRequest) (SendResult, error)
 	AddReaction(context.Context, AddReactionRequest) (AddReactionResult, error)
 	DeleteReaction(context.Context, DeleteReactionRequest) error
 }
@@ -228,6 +232,54 @@ func (a *adapter) UpdateCard(ctx context.Context, req UpdateCardRequest) error {
 		return fmt.Errorf("update feishu card: %w", err)
 	}
 	return nil
+}
+
+func (a *adapter) UploadImage(ctx context.Context, req UploadImageRequest) (UploadResult, error) {
+	if err := a.ready(ctx); err != nil {
+		return UploadResult{}, err
+	}
+	result, err := a.oapi.UploadImage(ctx, req)
+	if err != nil {
+		return UploadResult{}, fmt.Errorf("upload feishu image: %w", err)
+	}
+	result.Key = strings.TrimSpace(result.Key)
+	return result, nil
+}
+
+func (a *adapter) UploadFile(ctx context.Context, req UploadFileRequest) (UploadResult, error) {
+	if err := a.ready(ctx); err != nil {
+		return UploadResult{}, err
+	}
+	result, err := a.oapi.UploadFile(ctx, req)
+	if err != nil {
+		return UploadResult{}, fmt.Errorf("upload feishu file: %w", err)
+	}
+	result.Key = strings.TrimSpace(result.Key)
+	return result, nil
+}
+
+func (a *adapter) SendImage(ctx context.Context, req SendImageRequest) (SendResult, error) {
+	if err := a.ready(ctx); err != nil {
+		return SendResult{}, err
+	}
+	result, err := a.oapi.SendImage(ctx, req)
+	if err != nil {
+		return SendResult{}, fmt.Errorf("send feishu image: %w", err)
+	}
+	result.MessageID = strings.TrimSpace(result.MessageID)
+	return result, nil
+}
+
+func (a *adapter) SendFile(ctx context.Context, req SendFileRequest) (SendResult, error) {
+	if err := a.ready(ctx); err != nil {
+		return SendResult{}, err
+	}
+	result, err := a.oapi.SendFile(ctx, req)
+	if err != nil {
+		return SendResult{}, fmt.Errorf("send feishu file: %w", err)
+	}
+	result.MessageID = strings.TrimSpace(result.MessageID)
+	return result, nil
 }
 
 func (a *adapter) AddReaction(ctx context.Context, req AddReactionRequest) (AddReactionResult, error) {

--- a/internal/channel/feishu/transport/adapter_test.go
+++ b/internal/channel/feishu/transport/adapter_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -62,6 +63,45 @@ func TestAdapterUsesBindingLifetimeContextAndDelegatesProtocolOperations(t *test
 	}
 	if oapi.updateCard.MessageID != " om_card " || oapi.updateCard.Card["updated"] != true {
 		t.Fatalf("UpdateCard request = %#v", oapi.updateCard)
+	}
+
+	imageUpload, err := adapter.UploadImage(ctx, UploadImageRequest{
+		MediaType: " image/png ", SizeBytes: 5, Content: strings.NewReader("image"),
+	})
+	if err != nil || imageUpload.Key != "image-key" {
+		t.Fatalf("UploadImage() = %#v, %v", imageUpload, err)
+	}
+	if oapi.uploadImage.MediaType != " image/png " || oapi.uploadImage.SizeBytes != 5 {
+		t.Fatalf("UploadImage request = %#v", oapi.uploadImage)
+	}
+	imageResult, err := adapter.SendImage(ctx, SendImageRequest{
+		ChatID: " oc_chat ", ImageKey: imageUpload.Key,
+		IdempotencyKey: " delivery-image ", ReplyTo: " om_root ", ReplyInThread: true, ThreadID: " omt_thread ",
+	})
+	if err != nil || imageResult.MessageID != "om_image" {
+		t.Fatalf("SendImage() = %#v, %v", imageResult, err)
+	}
+	if oapi.sendImage.ChatID != " oc_chat " || oapi.sendImage.ImageKey != "image-key" || oapi.sendImage.IdempotencyKey != " delivery-image " || oapi.sendImage.ThreadID != " omt_thread " {
+		t.Fatalf("SendImage request = %#v", oapi.sendImage)
+	}
+	fileUpload, err := adapter.UploadFile(ctx, UploadFileRequest{
+		Name: " report.pdf ", SizeBytes: 4, Content: strings.NewReader("file"),
+	})
+	if err != nil || fileUpload.Key != "file-key" {
+		t.Fatalf("UploadFile() = %#v, %v", fileUpload, err)
+	}
+	if oapi.uploadFile.Name != " report.pdf " || oapi.uploadFile.SizeBytes != 4 {
+		t.Fatalf("UploadFile request = %#v", oapi.uploadFile)
+	}
+	fileResult, err := adapter.SendFile(ctx, SendFileRequest{
+		ChatID: " oc_chat ", FileKey: fileUpload.Key,
+		IdempotencyKey: " delivery-file ", ReplyTo: " om_root ", ReplyInThread: true, ThreadID: " omt_thread ",
+	})
+	if err != nil || fileResult.MessageID != "om_file" {
+		t.Fatalf("SendFile() = %#v, %v", fileResult, err)
+	}
+	if oapi.sendFile.ChatID != " oc_chat " || oapi.sendFile.FileKey != "file-key" || oapi.sendFile.IdempotencyKey != " delivery-file " || oapi.sendFile.ThreadID != " omt_thread " {
+		t.Fatalf("SendFile request = %#v", oapi.sendFile)
 	}
 
 	reaction, err := adapter.AddReaction(ctx, AddReactionRequest{MessageID: " om_message ", EmojiType: " Pin "})
@@ -180,6 +220,10 @@ type fakeOperations struct {
 	updateText     UpdateTextRequest
 	sendCard       SendCardRequest
 	updateCard     UpdateCardRequest
+	uploadImage    UploadImageRequest
+	uploadFile     UploadFileRequest
+	sendImage      SendImageRequest
+	sendFile       SendFileRequest
 	addReaction    AddReactionRequest
 	deleteReaction DeleteReactionRequest
 	download       DownloadResourceRequest
@@ -203,6 +247,26 @@ func (f *fakeOperations) UpdateText(_ context.Context, req UpdateTextRequest) er
 func (f *fakeOperations) UpdateCard(_ context.Context, req UpdateCardRequest) error {
 	f.updateCard = req
 	return nil
+}
+
+func (f *fakeOperations) UploadImage(_ context.Context, req UploadImageRequest) (UploadResult, error) {
+	f.uploadImage = req
+	return UploadResult{Key: " image-key "}, nil
+}
+
+func (f *fakeOperations) UploadFile(_ context.Context, req UploadFileRequest) (UploadResult, error) {
+	f.uploadFile = req
+	return UploadResult{Key: " file-key "}, nil
+}
+
+func (f *fakeOperations) SendImage(_ context.Context, req SendImageRequest) (SendResult, error) {
+	f.sendImage = req
+	return SendResult{MessageID: " om_image "}, nil
+}
+
+func (f *fakeOperations) SendFile(_ context.Context, req SendFileRequest) (SendResult, error) {
+	f.sendFile = req
+	return SendResult{MessageID: " om_file "}, nil
 }
 
 func (f *fakeOperations) AddReaction(_ context.Context, req AddReactionRequest) (AddReactionResult, error) {
@@ -233,6 +297,18 @@ func (*fakePublicAdapter) SendCard(context.Context, SendCardRequest) (SendResult
 	return SendResult{}, nil
 }
 func (*fakePublicAdapter) UpdateCard(context.Context, UpdateCardRequest) error { return nil }
+func (*fakePublicAdapter) UploadImage(context.Context, UploadImageRequest) (UploadResult, error) {
+	return UploadResult{}, nil
+}
+func (*fakePublicAdapter) UploadFile(context.Context, UploadFileRequest) (UploadResult, error) {
+	return UploadResult{}, nil
+}
+func (*fakePublicAdapter) SendImage(context.Context, SendImageRequest) (SendResult, error) {
+	return SendResult{}, nil
+}
+func (*fakePublicAdapter) SendFile(context.Context, SendFileRequest) (SendResult, error) {
+	return SendResult{}, nil
+}
 func (*fakePublicAdapter) AddReaction(context.Context, AddReactionRequest) (AddReactionResult, error) {
 	return AddReactionResult{}, nil
 }

--- a/internal/channel/feishu/transport/ingress_lark.go
+++ b/internal/channel/feishu/transport/ingress_lark.go
@@ -38,11 +38,8 @@ func newOAPIIngress(appID, appSecret string, client *lark.Client) (*oapiIngress,
 	if strings.TrimSpace(appID) == "" || strings.TrimSpace(appSecret) == "" || client == nil {
 		return nil, ErrInvalidConfig
 	}
-	dispatcher := larkdispatcher.NewEventDispatcher("", "")
 	ingress := &oapiIngress{appID: appID, client: client}
-	dispatcher.OnP2MessageReceiveV1(ingress.handleMessage)
-	dispatcher.OnCustomizedEvent("drive.notice.comment_add_v1", ingress.handleComment)
-	dispatcher.OnP2CardActionTrigger(ingress.handleCardAction)
+	dispatcher := newOAPIEventDispatcher(ingress)
 	ingress.socket = larkws.NewClient(
 		appID,
 		appSecret,
@@ -50,6 +47,18 @@ func newOAPIIngress(appID, appSecret string, client *lark.Client) (*oapiIngress,
 		larkws.WithDomain(lark.FeishuBaseUrl),
 	)
 	return ingress, nil
+}
+
+func newOAPIEventDispatcher(ingress *oapiIngress) *larkdispatcher.EventDispatcher {
+	dispatcher := larkdispatcher.NewEventDispatcher("", "")
+	dispatcher.OnP2MessageReceiveV1(ingress.handleMessage)
+	dispatcher.OnCustomizedEvent("drive.notice.comment_add_v1", ingress.handleComment)
+	dispatcher.OnP2CardActionTrigger(ingress.handleCardAction)
+	// Processing reactions are outbound presentation state, not Agent input.
+	// Feishu may echo their lifecycle events back to this connection.
+	dispatcher.OnP2MessageReactionCreatedV1(func(context.Context, *larkim.P2MessageReactionCreatedV1) error { return nil })
+	dispatcher.OnP2MessageReactionDeletedV1(func(context.Context, *larkim.P2MessageReactionDeletedV1) error { return nil })
+	return dispatcher
 }
 
 func (i *oapiIngress) Connect(ctx context.Context, handler func(context.Context, Event) error) error {

--- a/internal/channel/feishu/transport/ingress_lark.go
+++ b/internal/channel/feishu/transport/ingress_lark.go
@@ -398,38 +398,60 @@ func parseMessageContent(kind, rawValue string) (string, json.RawMessage, []Reso
 }
 
 func preferredPostContent(raw json.RawMessage) string {
-	locales := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(raw, &locales); err != nil {
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
 		return string(raw)
+	}
+	if isPostBody(fields) {
+		return localizedPostContent("zh_cn", raw, raw)
 	}
 
 	selectedLocale := ""
 	selectedBody := json.RawMessage(nil)
-	for _, locale := range []string{"zh_cn", "en_us"} {
-		if body, ok := locales[locale]; ok && json.Valid(body) && strings.HasPrefix(strings.TrimSpace(string(body)), "{") {
-			selectedLocale, selectedBody = locale, body
-			break
+	selectedRank := 0
+	for locale, body := range fields {
+		bodyFields := make(map[string]json.RawMessage)
+		if json.Unmarshal(body, &bodyFields) != nil || !isPostBody(bodyFields) {
+			continue
 		}
-	}
-	if selectedLocale == "" {
-		for locale, body := range locales {
-			if !json.Valid(body) || !strings.HasPrefix(strings.TrimSpace(string(body)), "{") {
-				continue
-			}
-			if selectedLocale == "" || locale < selectedLocale {
-				selectedLocale, selectedBody = locale, body
-			}
+		rank := postLocaleRank(locale)
+		if selectedLocale == "" || rank < selectedRank || rank == selectedRank && locale < selectedLocale {
+			selectedLocale, selectedBody, selectedRank = locale, body, rank
 		}
 	}
 	if selectedLocale == "" {
 		return string(raw)
 	}
+	return localizedPostContent(selectedLocale, selectedBody, raw)
+}
 
-	selected, err := json.Marshal(map[string]json.RawMessage{selectedLocale: selectedBody})
+func localizedPostContent(locale string, body, fallback json.RawMessage) string {
+	selected, err := json.Marshal(map[string]json.RawMessage{locale: body})
 	if err != nil {
-		return string(raw)
+		return string(fallback)
 	}
 	return string(selected)
+}
+
+func isPostBody(fields map[string]json.RawMessage) bool {
+	for _, name := range []string{"content_v2", "content"} {
+		var paragraphs []json.RawMessage
+		if value, ok := fields[name]; ok && json.Unmarshal(value, &paragraphs) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func postLocaleRank(locale string) int {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(locale)), "-", "_") {
+	case "zh_cn":
+		return 0
+	case "en_us":
+		return 1
+	default:
+		return 2
+	}
 }
 
 func parseMillis(value string) time.Time {

--- a/internal/channel/feishu/transport/lark_test.go
+++ b/internal/channel/feishu/transport/lark_test.go
@@ -94,6 +94,22 @@ func TestHandleMessageExtractsImageFromDirectPostBody(t *testing.T) {
 	}
 }
 
+func TestIngressDispatcherAcceptsReactionLifecycleEvents(t *testing.T) {
+	dispatcher := newOAPIEventDispatcher(&oapiIngress{})
+	for _, eventType := range []string{"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"} {
+		t.Run(eventType, func(t *testing.T) {
+			payload := []byte(fmt.Sprintf(`{
+				"schema":"2.0",
+				"header":{"event_id":"event-1","event_type":%q,"create_time":"1787628112287"},
+				"event":{"message_id":"message-1","reaction_id":"reaction-1"}
+			}`, eventType))
+			if _, err := dispatcher.Do(context.Background(), payload); err != nil {
+				t.Fatalf("dispatch %s: %v", eventType, err)
+			}
+		})
+	}
+}
+
 func TestIngressRoutingHelpers(t *testing.T) {
 	if got := ingressChatMode("group", "thread"); got != ModeTopic {
 		t.Fatalf("mode = %q", got)

--- a/internal/channel/feishu/transport/lark_test.go
+++ b/internal/channel/feishu/transport/lark_test.go
@@ -53,6 +53,47 @@ func TestParseMessageContentPrefersChinesePostLocale(t *testing.T) {
 	}
 }
 
+func TestParseMessageContentAcceptsDirectPostBody(t *testing.T) {
+	text, raw, resources := parseMessageContent("post", `{
+		"title":"",
+		"content":[
+			[{"tag":"img","image_key":"img_screenshot"}],
+			[{"tag":"text","text":"你能看到这个图片么"}]
+		]
+	}`)
+	if text != "![image](img_screenshot)\n你能看到这个图片么" || len(raw) == 0 {
+		t.Fatalf("text=%q raw=%q", text, raw)
+	}
+	if len(resources) != 1 || resources[0].Kind != "image" || resources[0].ID != "img_screenshot" {
+		t.Fatalf("resources = %#v", resources)
+	}
+}
+
+func TestHandleMessageExtractsImageFromDirectPostBody(t *testing.T) {
+	var got Event
+	ingress := &oapiIngress{handler: func(_ context.Context, event Event) error {
+		got = event
+		return nil
+	}}
+	messageID, chatID, chatType := "message-1", "chat-1", "p2p"
+	messageType := "post"
+	content := `{"title":"","content":[[{"tag":"img","image_key":"img_screenshot"}],[{"tag":"text","text":"请查看图片"}]]}`
+	if err := ingress.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{Message: &larkim.EventMessage{
+			MessageId: &messageID, ChatId: &chatID, ChatType: &chatType,
+			MessageType: &messageType, Content: &content,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Message == nil || got.Message.Text != "![image](img_screenshot)\n请查看图片" {
+		t.Fatalf("message = %#v", got.Message)
+	}
+	if len(got.Message.Resources) != 1 || got.Message.Resources[0].ID != "img_screenshot" || got.Message.Resources[0].Kind != "image" {
+		t.Fatalf("resources = %#v", got.Message.Resources)
+	}
+}
+
 func TestIngressRoutingHelpers(t *testing.T) {
 	if got := ingressChatMode("group", "thread"); got != ModeTopic {
 		t.Fatalf("mode = %q", got)

--- a/internal/channel/feishu/transport/outbound.go
+++ b/internal/channel/feishu/transport/outbound.go
@@ -147,8 +147,8 @@ func (o *directOutbound) UploadImage(ctx context.Context, req UploadImageRequest
 	if req.Content == nil {
 		return UploadResult{}, errors.New("feishu image content is required")
 	}
-	if req.SizeBytes < 0 {
-		return UploadResult{}, errors.New("feishu image size must be non-negative")
+	if req.SizeBytes <= 0 {
+		return UploadResult{}, errors.New("feishu image size must be positive")
 	}
 	if req.SizeBytes > ImageUploadLimitBytes {
 		return UploadResult{}, fmt.Errorf("feishu image upload is %d bytes; limit is %d: %w", req.SizeBytes, ImageUploadLimitBytes, ErrPayloadTooLarge)
@@ -186,8 +186,8 @@ func (o *directOutbound) UploadFile(ctx context.Context, req UploadFileRequest) 
 	if fileName == "" {
 		return UploadResult{}, errors.New("feishu file name is required")
 	}
-	if req.SizeBytes < 0 {
-		return UploadResult{}, errors.New("feishu file size must be non-negative")
+	if req.SizeBytes <= 0 {
+		return UploadResult{}, errors.New("feishu file size must be positive")
 	}
 	if req.SizeBytes > FileUploadLimitBytes {
 		return UploadResult{}, fmt.Errorf("feishu file upload is %d bytes; limit is %d: %w", req.SizeBytes, FileUploadLimitBytes, ErrPayloadTooLarge)
@@ -480,7 +480,7 @@ func uploadedFileKey(resp *larkim.CreateFileResp) (string, error) {
 // SupportsImageUpload reports whether metadata can use Feishu's image endpoint.
 // Larger supported images should be sent through the generic file endpoint.
 func SupportsImageUpload(mediaType string, sizeBytes int64) bool {
-	if sizeBytes < 0 || sizeBytes > ImageUploadLimitBytes {
+	if sizeBytes <= 0 || sizeBytes > ImageUploadLimitBytes {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(mediaType)) {

--- a/internal/channel/feishu/transport/outbound.go
+++ b/internal/channel/feishu/transport/outbound.go
@@ -14,12 +14,22 @@ import (
 )
 
 type larkOpenAPI interface {
+	CreateImage(context.Context, createImageAPIRequest) (*larkim.CreateImageResp, error)
+	CreateFile(context.Context, createFileAPIRequest) (*larkim.CreateFileResp, error)
 	CreateMessage(context.Context, createMessageAPIRequest) (*larkim.CreateMessageResp, error)
 	ReplyMessage(context.Context, replyMessageAPIRequest) (*larkim.ReplyMessageResp, error)
 	UpdateMessage(context.Context, updateMessageAPIRequest) (*larkim.UpdateMessageResp, error)
 	PatchMessage(context.Context, patchMessageAPIRequest) (*larkim.PatchMessageResp, error)
 	CreateMessageReaction(context.Context, createReactionAPIRequest) (*larkim.CreateMessageReactionResp, error)
 	DeleteMessageReaction(context.Context, deleteReactionAPIRequest) (*larkim.DeleteMessageReactionResp, error)
+}
+
+type createImageAPIRequest struct {
+	Body *larkim.CreateImageReqBody
+}
+
+type createFileAPIRequest struct {
+	Body *larkim.CreateFileReqBody
 }
 
 type createMessageAPIRequest struct {
@@ -55,11 +65,14 @@ type deleteReactionAPIRequest struct {
 const (
 	feishuTextRequestBodyLimit = 150 << 10
 	feishuRichRequestBodyLimit = 30 << 10
+	// ImageUploadLimitBytes and FileUploadLimitBytes mirror Feishu's upload
+	// endpoint limits. Delivery policy may impose lower aggregate limits.
+	ImageUploadLimitBytes int64 = 10 << 20
+	FileUploadLimitBytes  int64 = 30 << 20
 )
 
-// directOutbound maps one delivery attempt to exactly one generated
-// OpenAPI method call. It never invokes the SDK channel Send helper, whose
-// retry, fallback, and chunking policy sits above the raw message APIs.
+// directOutbound maps one operation to exactly one raw OpenAPI call. Retry and
+// multi-step upload/send orchestration stay in the delivery dispatcher.
 type directOutbound struct {
 	api larkOpenAPI
 }
@@ -122,6 +135,108 @@ func (o *directOutbound) SendCard(ctx context.Context, req SendCardRequest) (Sen
 		return SendResult{}, fmt.Errorf("encode feishu card: %w", err)
 	}
 	return o.sendMessage(ctx, req.ChatID, req.ReplyTo, req.ReplyInThread, req.IdempotencyKey, "interactive", string(content))
+}
+
+func (o *directOutbound) UploadImage(ctx context.Context, req UploadImageRequest) (UploadResult, error) {
+	if ctx == nil {
+		return UploadResult{}, errNilContext
+	}
+	if o == nil || o.api == nil {
+		return UploadResult{}, ErrInvalidConfig
+	}
+	if req.Content == nil {
+		return UploadResult{}, errors.New("feishu image content is required")
+	}
+	if req.SizeBytes < 0 {
+		return UploadResult{}, errors.New("feishu image size must be non-negative")
+	}
+	if req.SizeBytes > ImageUploadLimitBytes {
+		return UploadResult{}, fmt.Errorf("feishu image upload is %d bytes; limit is %d: %w", req.SizeBytes, ImageUploadLimitBytes, ErrPayloadTooLarge)
+	}
+	if !SupportsImageUpload(req.MediaType, req.SizeBytes) {
+		return UploadResult{}, fmt.Errorf("feishu image media type %q is not supported for image upload", req.MediaType)
+	}
+	resp, err := o.api.CreateImage(ctx, createImageAPIRequest{
+		Body: larkim.NewCreateImageReqBodyBuilder().
+			ImageType("message").
+			Image(req.Content).
+			Build(),
+	})
+	if err != nil {
+		return UploadResult{}, requestAPIError("create image", err)
+	}
+	imageKey, err := uploadedImageKey(resp)
+	if err != nil {
+		return UploadResult{}, err
+	}
+	return UploadResult{Key: imageKey}, nil
+}
+
+func (o *directOutbound) UploadFile(ctx context.Context, req UploadFileRequest) (UploadResult, error) {
+	if ctx == nil {
+		return UploadResult{}, errNilContext
+	}
+	if o == nil || o.api == nil {
+		return UploadResult{}, ErrInvalidConfig
+	}
+	if req.Content == nil {
+		return UploadResult{}, errors.New("feishu file content is required")
+	}
+	fileName := strings.TrimSpace(req.Name)
+	if fileName == "" {
+		return UploadResult{}, errors.New("feishu file name is required")
+	}
+	if req.SizeBytes < 0 {
+		return UploadResult{}, errors.New("feishu file size must be non-negative")
+	}
+	if req.SizeBytes > FileUploadLimitBytes {
+		return UploadResult{}, fmt.Errorf("feishu file upload is %d bytes; limit is %d: %w", req.SizeBytes, FileUploadLimitBytes, ErrPayloadTooLarge)
+	}
+	resp, err := o.api.CreateFile(ctx, createFileAPIRequest{
+		Body: larkim.NewCreateFileReqBodyBuilder().
+			FileType("stream").
+			FileName(fileName).
+			File(req.Content).
+			Build(),
+	})
+	if err != nil {
+		return UploadResult{}, requestAPIError("create file", err)
+	}
+	fileKey, err := uploadedFileKey(resp)
+	if err != nil {
+		return UploadResult{}, err
+	}
+	return UploadResult{Key: fileKey}, nil
+}
+
+func (o *directOutbound) SendImage(ctx context.Context, req SendImageRequest) (SendResult, error) {
+	if err := validateDirectSend(ctx, req.ChatID, req.IdempotencyKey, req.ReplyTo, req.ReplyInThread, req.ThreadID); err != nil {
+		return SendResult{}, err
+	}
+	imageKey := strings.TrimSpace(req.ImageKey)
+	if imageKey == "" {
+		return SendResult{}, errors.New("feishu image key is required")
+	}
+	content, err := json.Marshal(map[string]string{"image_key": imageKey})
+	if err != nil {
+		return SendResult{}, fmt.Errorf("encode feishu image message: %w", err)
+	}
+	return o.sendMessage(ctx, req.ChatID, req.ReplyTo, req.ReplyInThread, req.IdempotencyKey, larkim.MsgTypeImage, string(content))
+}
+
+func (o *directOutbound) SendFile(ctx context.Context, req SendFileRequest) (SendResult, error) {
+	if err := validateDirectSend(ctx, req.ChatID, req.IdempotencyKey, req.ReplyTo, req.ReplyInThread, req.ThreadID); err != nil {
+		return SendResult{}, err
+	}
+	fileKey := strings.TrimSpace(req.FileKey)
+	if fileKey == "" {
+		return SendResult{}, errors.New("feishu file key is required")
+	}
+	content, err := json.Marshal(map[string]string{"file_key": fileKey})
+	if err != nil {
+		return SendResult{}, fmt.Errorf("encode feishu file message: %w", err)
+	}
+	return o.sendMessage(ctx, req.ChatID, req.ReplyTo, req.ReplyInThread, req.IdempotencyKey, larkim.MsgTypeFile, string(content))
 }
 
 func (o *directOutbound) UpdateText(ctx context.Context, req UpdateTextRequest) error {
@@ -336,6 +451,46 @@ func (o *directOutbound) sendMessage(ctx context.Context, chatID, replyTo string
 	return SendResult{MessageID: strings.TrimSpace(*resp.Data.MessageId)}, nil
 }
 
+func uploadedImageKey(resp *larkim.CreateImageResp) (string, error) {
+	if resp == nil {
+		return "", missingAPIResponse("create image")
+	}
+	if apiResponseFailed(resp.Success(), resp.ApiResp) {
+		return "", responseAPIError("create image", resp.Code, resp.Msg, resp.ApiResp)
+	}
+	if resp.Data == nil || resp.Data.ImageKey == nil || strings.TrimSpace(*resp.Data.ImageKey) == "" {
+		return "", missingAPIResult("create image", "image_key", resp.ApiResp)
+	}
+	return strings.TrimSpace(*resp.Data.ImageKey), nil
+}
+
+func uploadedFileKey(resp *larkim.CreateFileResp) (string, error) {
+	if resp == nil {
+		return "", missingAPIResponse("create file")
+	}
+	if apiResponseFailed(resp.Success(), resp.ApiResp) {
+		return "", responseAPIError("create file", resp.Code, resp.Msg, resp.ApiResp)
+	}
+	if resp.Data == nil || resp.Data.FileKey == nil || strings.TrimSpace(*resp.Data.FileKey) == "" {
+		return "", missingAPIResult("create file", "file_key", resp.ApiResp)
+	}
+	return strings.TrimSpace(*resp.Data.FileKey), nil
+}
+
+// SupportsImageUpload reports whether metadata can use Feishu's image endpoint.
+// Larger supported images should be sent through the generic file endpoint.
+func SupportsImageUpload(mediaType string, sizeBytes int64) bool {
+	if sizeBytes < 0 || sizeBytes > ImageUploadLimitBytes {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif", "image/tiff", "image/bmp", "image/x-icon", "image/vnd.microsoft.icon":
+		return true
+	default:
+		return false
+	}
+}
+
 // validateMessageRequestSize measures the exact JSON body handed to the SDK.
 // It rejects an invalid attempt instead of splitting, downgrading, or relying
 // on a remote 4xx. Feishu limits text bodies to 150 KiB and rich/card bodies to
@@ -428,6 +583,34 @@ func apiResponseFailed(success bool, response *larkcore.ApiResp) bool {
 type sdkLarkOpenAPI struct {
 	client *lark.Client
 	tokens tenantTokenSource
+}
+
+func (a *sdkLarkOpenAPI) CreateImage(ctx context.Context, req createImageAPIRequest) (*larkim.CreateImageResp, error) {
+	token, err := a.token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.client.Im.V1.Image.Create(ctx, larkim.NewCreateImageReqBuilder().
+		Body(req.Body).
+		Build(), larkcore.WithTenantAccessToken(token))
+	if resp != nil {
+		a.invalidateRejectedToken(token, resp.Code)
+	}
+	return resp, err
+}
+
+func (a *sdkLarkOpenAPI) CreateFile(ctx context.Context, req createFileAPIRequest) (*larkim.CreateFileResp, error) {
+	token, err := a.token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.client.Im.V1.File.Create(ctx, larkim.NewCreateFileReqBuilder().
+		Body(req.Body).
+		Build(), larkcore.WithTenantAccessToken(token))
+	if resp != nil {
+		a.invalidateRejectedToken(token, resp.Code)
+	}
+	return resp, err
 }
 
 func (a *sdkLarkOpenAPI) CreateMessage(ctx context.Context, req createMessageAPIRequest) (*larkim.CreateMessageResp, error) {

--- a/internal/channel/feishu/transport/outbound_test.go
+++ b/internal/channel/feishu/transport/outbound_test.go
@@ -140,6 +140,25 @@ func TestDirectOutboundRejectsUnsupportedImageMediaTypeBeforeUpload(t *testing.T
 	}
 }
 
+func TestDirectOutboundRejectsEmptyUploadsBeforeOpenAPI(t *testing.T) {
+	t.Parallel()
+	api := &fakeLarkOpenAPI{}
+	outbound := newDirectOutboundWithAPI(api)
+
+	_, imageErr := outbound.UploadImage(context.Background(), UploadImageRequest{
+		MediaType: "image/png", Content: strings.NewReader(""),
+	})
+	_, fileErr := outbound.UploadFile(context.Background(), UploadFileRequest{
+		Name: "empty.txt", Content: strings.NewReader(""),
+	})
+	if imageErr == nil || fileErr == nil || api.createImageCalls != 0 || api.createFileCalls != 0 {
+		t.Fatalf("image error=%v file error=%v image uploads=%d file uploads=%d", imageErr, fileErr, api.createImageCalls, api.createFileCalls)
+	}
+	if SupportsImageUpload("image/png", 0) {
+		t.Fatal("zero-byte image was considered uploadable")
+	}
+}
+
 func TestDirectOutboundUploadsFileThenRepliesWithMessage(t *testing.T) {
 	t.Parallel()
 	api := &fakeLarkOpenAPI{}

--- a/internal/channel/feishu/transport/outbound_test.go
+++ b/internal/channel/feishu/transport/outbound_test.go
@@ -86,6 +86,118 @@ func TestDirectOutboundCreateCardUsesStableUUIDAndExactJSON(t *testing.T) {
 	}
 }
 
+func TestDirectOutboundUploadsImageThenSendsMessage(t *testing.T) {
+	t.Parallel()
+	api := &fakeLarkOpenAPI{}
+	outbound := newDirectOutboundWithAPI(api)
+	key := "delivery-image-1"
+
+	upload, err := outbound.UploadImage(context.Background(), UploadImageRequest{
+		MediaType: "image/png", SizeBytes: 3, Content: strings.NewReader("png"),
+	})
+	if err != nil || upload.Key != "img-test" {
+		t.Fatalf("UploadImage() = %+v, %v", upload, err)
+	}
+	if api.createImageCalls != 1 || api.createCalls != 0 || api.replyCalls != 0 || api.createImageReq == nil || api.createImageReq.Body == nil {
+		t.Fatalf("OpenAPI calls after upload: image=%d create=%d reply=%d request=%#v", api.createImageCalls, api.createCalls, api.replyCalls, api.createImageReq)
+	}
+	result, err := outbound.SendImage(context.Background(), SendImageRequest{
+		ChatID: " chat-1 ", ImageKey: upload.Key, IdempotencyKey: key,
+	})
+	if err != nil || result.MessageID != "created-message" {
+		t.Fatalf("SendImage() = %+v, %v", result, err)
+	}
+	if api.createImageCalls != 1 || api.createCalls != 1 || api.replyCalls != 0 || api.createImageReq == nil || api.createImageReq.Body == nil {
+		t.Fatalf("OpenAPI calls: upload image=%d create=%d reply=%d request=%#v", api.createImageCalls, api.createCalls, api.replyCalls, api.createImageReq)
+	}
+	if api.createImageReq.Body.ImageType == nil || *api.createImageReq.Body.ImageType != "message" {
+		t.Fatalf("image upload body = %#v", api.createImageReq.Body)
+	}
+	uploaded, readErr := io.ReadAll(api.createImageReq.Body.Image)
+	if readErr != nil || string(uploaded) != "png" {
+		t.Fatalf("uploaded image = %q, error=%v", uploaded, readErr)
+	}
+	body := api.createReq.Body
+	if body.MsgType == nil || *body.MsgType != larkim.MsgTypeImage || body.Content == nil || body.Uuid == nil || *body.Uuid != feishuMessageUUID(key) {
+		t.Fatalf("image message body = %#v", body)
+	}
+	var content map[string]string
+	if err := json.Unmarshal([]byte(*body.Content), &content); err != nil || content["image_key"] != "img-test" {
+		t.Fatalf("image message content = %#v, error=%v", content, err)
+	}
+}
+
+func TestDirectOutboundRejectsUnsupportedImageMediaTypeBeforeUpload(t *testing.T) {
+	t.Parallel()
+	api := &fakeLarkOpenAPI{}
+	outbound := newDirectOutboundWithAPI(api)
+
+	_, err := outbound.UploadImage(context.Background(), UploadImageRequest{
+		MediaType: "image/svg+xml", SizeBytes: 3, Content: strings.NewReader("svg"),
+	})
+	if err == nil || api.createImageCalls != 0 || api.createCalls != 0 || api.replyCalls != 0 {
+		t.Fatalf("SendImage() error=%v upload=%d create=%d reply=%d", err, api.createImageCalls, api.createCalls, api.replyCalls)
+	}
+}
+
+func TestDirectOutboundUploadsFileThenRepliesWithMessage(t *testing.T) {
+	t.Parallel()
+	api := &fakeLarkOpenAPI{}
+	outbound := newDirectOutboundWithAPI(api)
+	key := "delivery-file-1"
+
+	upload, err := outbound.UploadFile(context.Background(), UploadFileRequest{
+		Name: " report.pdf ", SizeBytes: 3, Content: strings.NewReader("pdf"),
+	})
+	if err != nil || upload.Key != "file-test" {
+		t.Fatalf("UploadFile() = %+v, %v", upload, err)
+	}
+	if api.createFileCalls != 1 || api.replyCalls != 0 || api.createCalls != 0 || api.createFileReq == nil || api.createFileReq.Body == nil {
+		t.Fatalf("OpenAPI calls after upload: file=%d reply=%d create=%d request=%#v", api.createFileCalls, api.replyCalls, api.createCalls, api.createFileReq)
+	}
+	result, err := outbound.SendFile(context.Background(), SendFileRequest{
+		ChatID: "chat-1", FileKey: upload.Key, IdempotencyKey: key,
+		ReplyTo: "message-root", ReplyInThread: true, ThreadID: "thread-1",
+	})
+	if err != nil || result.MessageID != "reply-message" {
+		t.Fatalf("SendFile() = %+v, %v", result, err)
+	}
+	if api.createFileCalls != 1 || api.replyCalls != 1 || api.createCalls != 0 || api.createFileReq == nil || api.createFileReq.Body == nil {
+		t.Fatalf("OpenAPI calls: upload file=%d reply=%d create=%d request=%#v", api.createFileCalls, api.replyCalls, api.createCalls, api.createFileReq)
+	}
+	if api.createFileReq.Body.FileType == nil || *api.createFileReq.Body.FileType != "stream" ||
+		api.createFileReq.Body.FileName == nil || *api.createFileReq.Body.FileName != "report.pdf" {
+		t.Fatalf("file upload body = %#v", api.createFileReq.Body)
+	}
+	uploaded, readErr := io.ReadAll(api.createFileReq.Body.File)
+	if readErr != nil || string(uploaded) != "pdf" {
+		t.Fatalf("uploaded file = %q, error=%v", uploaded, readErr)
+	}
+	body := api.replyReq.Body
+	if api.replyReq.MessageID != "message-root" || body.MsgType == nil || *body.MsgType != larkim.MsgTypeFile ||
+		body.Content == nil || body.Uuid == nil || *body.Uuid != feishuMessageUUID(key) ||
+		body.ReplyInThread == nil || !*body.ReplyInThread {
+		t.Fatalf("file reply body = %#v request=%#v", body, api.replyReq)
+	}
+	var content map[string]string
+	if err := json.Unmarshal([]byte(*body.Content), &content); err != nil || content["file_key"] != "file-test" {
+		t.Fatalf("file message content = %#v, error=%v", content, err)
+	}
+}
+
+func TestDirectOutboundRejectsOversizedFileBeforeUpload(t *testing.T) {
+	t.Parallel()
+	api := &fakeLarkOpenAPI{}
+	outbound := newDirectOutboundWithAPI(api)
+
+	_, err := outbound.UploadFile(context.Background(), UploadFileRequest{
+		Name: "archive.zip", SizeBytes: FileUploadLimitBytes + 1, Content: strings.NewReader("zip"),
+	})
+	if !errors.Is(err, ErrPayloadTooLarge) || api.createFileCalls != 0 {
+		t.Fatalf("UploadFile() error=%v upload calls=%d", err, api.createFileCalls)
+	}
+}
+
 func TestDirectOutboundPatchAndReactionsEachCallOnce(t *testing.T) {
 	t.Parallel()
 	api := &fakeLarkOpenAPI{}
@@ -405,6 +517,8 @@ func (s *recordingTenantTokenSource) Invalidate(token string) {
 }
 
 type fakeLarkOpenAPI struct {
+	createImageCalls    int
+	createFileCalls     int
 	createCalls         int
 	replyCalls          int
 	updateCalls         int
@@ -412,6 +526,8 @@ type fakeLarkOpenAPI struct {
 	createReactionCalls int
 	deleteReactionCalls int
 
+	createImageReq    *createImageAPIRequest
+	createFileReq     *createFileAPIRequest
 	createReq         *createMessageAPIRequest
 	replyReq          *replyMessageAPIRequest
 	updateReq         *updateMessageAPIRequest
@@ -419,6 +535,10 @@ type fakeLarkOpenAPI struct {
 	createReactionReq *createReactionAPIRequest
 	deleteReactionReq *deleteReactionAPIRequest
 
+	createImageErr    error
+	createImageResp   *larkim.CreateImageResp
+	createFileErr     error
+	createFileResp    *larkim.CreateFileResp
 	createErr         error
 	createResp        *larkim.CreateMessageResp
 	replyErr          error
@@ -426,6 +546,30 @@ type fakeLarkOpenAPI struct {
 	patchErr          error
 	createReactionErr error
 	deleteReactionErr error
+}
+
+func (f *fakeLarkOpenAPI) CreateImage(_ context.Context, req createImageAPIRequest) (*larkim.CreateImageResp, error) {
+	f.createImageCalls++
+	f.createImageReq = &req
+	if f.createImageErr != nil {
+		return nil, f.createImageErr
+	}
+	if f.createImageResp != nil {
+		return f.createImageResp, nil
+	}
+	return &larkim.CreateImageResp{Data: &larkim.CreateImageRespData{ImageKey: testStringPointer("img-test")}}, nil
+}
+
+func (f *fakeLarkOpenAPI) CreateFile(_ context.Context, req createFileAPIRequest) (*larkim.CreateFileResp, error) {
+	f.createFileCalls++
+	f.createFileReq = &req
+	if f.createFileErr != nil {
+		return nil, f.createFileErr
+	}
+	if f.createFileResp != nil {
+		return f.createFileResp, nil
+	}
+	return &larkim.CreateFileResp{Data: &larkim.CreateFileRespData{FileKey: testStringPointer("file-test")}}, nil
 }
 
 func (f *fakeLarkOpenAPI) CreateMessage(_ context.Context, req createMessageAPIRequest) (*larkim.CreateMessageResp, error) {

--- a/internal/channel/feishu/transport/types.go
+++ b/internal/channel/feishu/transport/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -203,6 +204,44 @@ type SendCardRequest struct {
 	ThreadID       string
 }
 
+type UploadImageRequest struct {
+	MediaType string
+	SizeBytes int64
+	Content   io.Reader
+}
+
+type UploadFileRequest struct {
+	Name      string
+	SizeBytes int64
+	Content   io.Reader
+}
+
+type UploadResult struct {
+	Key string
+}
+
+type SendImageRequest struct {
+	ChatID   string
+	ImageKey string
+	// IdempotencyKey is a process-local delivery ID. It is hashed into the UUID
+	// sent to Feishu and is never sent verbatim.
+	IdempotencyKey string
+	ReplyTo        string
+	ReplyInThread  bool
+	ThreadID       string
+}
+
+type SendFileRequest struct {
+	ChatID  string
+	FileKey string
+	// IdempotencyKey is a process-local delivery ID. It is hashed into the UUID
+	// sent to Feishu and is never sent verbatim.
+	IdempotencyKey string
+	ReplyTo        string
+	ReplyInThread  bool
+	ThreadID       string
+}
+
 type UpdateCardRequest struct {
 	MessageID string
 	Card      map[string]any
@@ -263,6 +302,10 @@ type Adapter interface {
 	UpdateText(context.Context, UpdateTextRequest) error
 	SendCard(context.Context, SendCardRequest) (SendResult, error)
 	UpdateCard(context.Context, UpdateCardRequest) error
+	UploadImage(context.Context, UploadImageRequest) (UploadResult, error)
+	UploadFile(context.Context, UploadFileRequest) (UploadResult, error)
+	SendImage(context.Context, SendImageRequest) (SendResult, error)
+	SendFile(context.Context, SendFileRequest) (SendResult, error)
 	AddReaction(context.Context, AddReactionRequest) (AddReactionResult, error)
 	DeleteReaction(context.Context, DeleteReactionRequest) error
 	DownloadResource(context.Context, DownloadResourceRequest) (DownloadResourceResult, error)

--- a/internal/channel/types.go
+++ b/internal/channel/types.go
@@ -174,6 +174,7 @@ const (
 	DeliveryMarkdownUpdate DeliveryKind = "markdown_update"
 	DeliveryCard           DeliveryKind = "card"
 	DeliveryCardUpdate     DeliveryKind = "card_update"
+	DeliveryFile           DeliveryKind = "file"
 	DeliveryReactionAdd    DeliveryKind = "reaction_add"
 	DeliveryReactionDelete DeliveryKind = "reaction_delete"
 	DeliveryCommentReply   DeliveryKind = "comment_reply"
@@ -209,6 +210,7 @@ type DeliveryIntent struct {
 	TopLevel      bool           `json:"top_level,omitempty"`
 	Text          string         `json:"text,omitempty"`
 	Card          map[string]any `json:"card,omitempty"`
+	FileID        string         `json:"file_id,omitempty"`
 	EmojiType     string         `json:"emoji_type,omitempty"`
 	ReactionID    string         `json:"reaction_id,omitempty"`
 	Attempts      int            `json:"attempts,omitempty"`

--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -733,7 +733,7 @@ func appServerThreadStartParams(spec SessionSpec, publishFiles bool) map[string]
 func appServerPublishFileToolSpec() map[string]any {
 	return map[string]any{
 		"name":        appServerPublishFileToolName,
-		"description": "Publish an existing file from the current Runtime workspace to the user. Call this only after the file is complete. The path must be relative to the workspace; do not pass a URL or an absolute path.",
+		"description": "Publish a generated workspace file through the active channel. When the user asks to generate, send, return, or download a file, call this tool immediately after creating it. Do not search for or use csgclaw-cli, curl, Feishu APIs, or other upload methods. The path must be relative to the workspace; do not pass a URL or an absolute path.",
 		"inputSchema": map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -2306,8 +2306,14 @@ func TestAppServerThreadStartRegistersPublishFileDynamicTool(t *testing.T) {
 		t.Fatalf("dynamicTools = %#v, want one typed tool", params["dynamicTools"])
 	}
 	tool := tools[0]
-	if tool["name"] != "csgclaw_publish_file" || strings.TrimSpace(fmt.Sprint(tool["description"])) == "" {
+	description := strings.TrimSpace(fmt.Sprint(tool["description"]))
+	if tool["name"] != "csgclaw_publish_file" || description == "" {
 		t.Fatalf("publish file tool = %#v", tool)
+	}
+	for _, want := range []string{"generate, send, return, or download a file", "call this tool immediately after creating it", "Do not search for or use csgclaw-cli, curl, Feishu APIs, or other upload methods"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("publish file tool description missing %q in %q", want, description)
+		}
 	}
 	schema, _ := tool["inputSchema"].(map[string]any)
 	properties, _ := schema["properties"].(map[string]any)

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -470,6 +470,9 @@ func TestRefreshCodexHomeAgentsFileCreatesManagedFileWhenMissing(t *testing.T) {
 	if !strings.Contains(text, "Prefer targeted tests.") {
 		t.Fatalf("AGENTS.md = %q, want agent instructions", text)
 	}
+	if !strings.Contains(text, "Output File Delivery") || !strings.Contains(text, "`csgclaw_publish_file`") {
+		t.Fatalf("AGENTS.md = %q, want shared file publishing instructions", text)
+	}
 	if !strings.Contains(text, "END CSGCLAW-INSTRUCTIONS") {
 		t.Fatalf("AGENTS.md = %q, want instructions block end marker", text)
 	}


### PR DESCRIPTION
## Summary

- deliver successful Agent Engine output artifacts through Feishu image or file messages using Agent-scoped authoritative file snapshots
- normalize both direct and locale-wrapped Feishu rich-text bodies so inbound images retain their `image_key`, download through the message-resource API, and reach Codex as image inputs
- split media upload from message send and reuse uploaded keys when send retries, avoiding duplicate uploads
- enforce Feishu and per-turn size/count limits with user-visible warnings
- reject zero-byte output artifacts before queueing and at both raw upload boundaries, using the same warning path instead of a permanent remote failure
- accept Feishu processing-reaction lifecycle events without treating echoed presentation state as an ingress failure
- tell Codex to publish generated files immediately through the active channel using both the dynamic tool description and shared Runtime managed instructions, without searching for CLI, curl, HTTP, or channel-specific upload alternatives

## Validation

- `go test -count=1 ./internal/agent ./internal/channel/feishu/... ./internal/agentengine/... ./internal/runtime/codex`
- `go test -race -count=1 ./internal/agent ./internal/channel/feishu/transport ./internal/channel/feishu/ingress ./internal/channel/feishu/execution ./internal/runtime/codex ./internal/agentengine`
- `go vet ./internal/agent ./internal/channel/feishu/... ./internal/agentengine/... ./internal/runtime/codex`
- `git diff --check`

## Notes

- supported non-empty images up to 10 MiB use Feishu image messages; other non-empty artifacts up to 30 MiB use generic file messages
- Engine file metadata is the single source of truth; delivery does not fall back to intent metadata or cross-Agent lookup
- rich-text normalization accepts the two Feishu wire shapes used here (direct body and locale wrapper) without recursively guessing arbitrary payloads
- processing reactions are consumed only at the Feishu transport boundary; they do not enter Agent input
- shared output-delivery guidance applies to Manager and Worker Codex Runtimes when `csgclaw_publish_file` is available; Manager connector and historical-attachment rules remain Manager-only
- duplicate user requests keep the existing latest-turn-wins behavior
- this completes the Feishu channel integration for the Agent Engine file capability introduced by #509