### PR TITLE
fix(template): structure publishing and deployment errors

### DIFF
--- a/internal/api/community_instance.go
+++ b/internal/api/community_instance.go
@@ -19,11 +19,13 @@ import (
 const communityAgentInstancePath = "/api/v1/agent/instances"
 const communityInstanceTemplatePendingCode = "AGENT-ERR-22"
 const communityInstanceSensitiveCheckCode = "AGENT-ERR-23"
+const communityInstanceResourceUnavailableCode = "RESOURCE-ERR-1"
 const communityInstanceDeployRetries = 3
 const communityInstanceDeployRetryDelay = 3 * time.Second
 
 var errCommunityInstanceSensitiveCheck = errors.New("community template has not passed the sensitive-content check")
 var errCommunityInstanceTemplatePending = errors.New("community template is not ready for deployment")
+var errCommunityInstanceResourceUnavailable = errors.New("community deployment resource is temporarily unavailable")
 
 type communityAgentInstanceRequest struct {
 	Name        string         `json:"name"`
@@ -168,8 +170,17 @@ func createCommunityAgentInstanceOnce(req *http.Request) (bool, error) {
 		if message == "" {
 			message = communityInstanceSensitiveCheckCode
 		}
-		retryable := !strings.EqualFold(strings.TrimSpace(result.Context.SensitiveCheckStatus), "fail")
-		return retryable, fmt.Errorf("%w: %s", errCommunityInstanceSensitiveCheck, message)
+		if strings.EqualFold(strings.TrimSpace(result.Context.SensitiveCheckStatus), "pending") {
+			return true, fmt.Errorf("%w: %s", errCommunityInstanceTemplatePending, message)
+		}
+		return false, fmt.Errorf("%w: %s", errCommunityInstanceSensitiveCheck, message)
+	}
+	if result.Code == communityInstanceResourceUnavailableCode {
+		message := strings.TrimSpace(result.Msg)
+		if message == "" {
+			message = communityInstanceResourceUnavailableCode
+		}
+		return false, fmt.Errorf("%w: %s", errCommunityInstanceResourceUnavailable, message)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("create community instance: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
@@ -182,7 +193,11 @@ func createCommunityAgentInstanceOnce(req *http.Request) (bool, error) {
 
 func communityInstanceUpstreamMessage(err error) string {
 	message := err.Error()
-	for _, sentinel := range []error{errCommunityInstanceTemplatePending, errCommunityInstanceSensitiveCheck} {
+	for _, sentinel := range []error{
+		errCommunityInstanceTemplatePending,
+		errCommunityInstanceSensitiveCheck,
+		errCommunityInstanceResourceUnavailable,
+	} {
 		if errors.Is(err, sentinel) {
 			return strings.TrimPrefix(message, sentinel.Error()+": ")
 		}

--- a/internal/api/community_instance_test.go
+++ b/internal/api/community_instance_test.go
@@ -228,6 +228,46 @@ func TestCreateCommunityAgentInstanceDoesNotRetryFailedSensitiveCheck(t *testing
 	}
 }
 
+func TestCreateCommunityAgentInstanceTreatsNonPendingSensitiveCheckAsFailed(t *testing.T) {
+	for _, status := range []string{"", "Exception", "Unknown"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			attempts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = fmt.Fprintf(
+					w,
+					`{"code":"AGENT-ERR-23","msg":"sensitive-content review did not pass","context":{"sensitive_check_status":%q}}`,
+					status,
+				)
+			}))
+			defer server.Close()
+
+			previousCredentials := loadCommunityInstanceCredentials
+			loadCommunityInstanceCredentials = func() (string, string, bool, error) {
+				return server.URL, "hub-token", true, nil
+			}
+			t.Cleanup(func() { loadCommunityInstanceCredentials = previousCredentials })
+
+			err := createCommunityAgentInstanceRequest(context.Background(), hub.Template{
+				Namespace: "alice",
+				Name:      "ReviewBot",
+			}, auth.Status{UserID: "alice", UserUUID: "uuid-alice"})
+			if !errors.Is(err, errCommunityInstanceSensitiveCheck) {
+				t.Fatalf("error = %v, want errCommunityInstanceSensitiveCheck", err)
+			}
+			if errors.Is(err, errCommunityInstanceTemplatePending) {
+				t.Fatalf("error = %v, should not classify status %q as pending", err, status)
+			}
+			if got, want := attempts, 1; got != want {
+				t.Fatalf("attempts = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
 func TestCreateCommunityAgentInstanceRetriesPendingSensitiveCheck(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -262,6 +302,65 @@ func TestCreateCommunityAgentInstanceRetriesPendingSensitiveCheck(t *testing.T) 
 	}
 	if got, want := attempts, communityInstanceDeployRetries+1; got != want {
 		t.Fatalf("attempts = %d, want %d", got, want)
+	}
+}
+
+func TestCreateCommunityAgentInstanceReturnsPendingAfterSensitiveCheckRetries(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"code":"AGENT-ERR-23","msg":"sensitive-content review pending","context":{"sensitive_check_status":"Pending"}}`))
+	}))
+	defer server.Close()
+
+	previousCredentials := loadCommunityInstanceCredentials
+	previousWait := waitForCommunityInstanceRetry
+	loadCommunityInstanceCredentials = func() (string, string, bool, error) {
+		return server.URL, "hub-token", true, nil
+	}
+	waitForCommunityInstanceRetry = func(context.Context) error { return nil }
+	t.Cleanup(func() {
+		loadCommunityInstanceCredentials = previousCredentials
+		waitForCommunityInstanceRetry = previousWait
+	})
+
+	err := createCommunityAgentInstanceRequest(context.Background(), hub.Template{
+		Namespace: "alice",
+		Name:      "ReviewBot",
+	}, auth.Status{UserID: "alice", UserUUID: "uuid-alice"})
+	if !errors.Is(err, errCommunityInstanceTemplatePending) {
+		t.Fatalf("error = %v, want errCommunityInstanceTemplatePending", err)
+	}
+	if errors.Is(err, errCommunityInstanceSensitiveCheck) {
+		t.Fatalf("error = %v, should not classify pending review as sensitive-check failure", err)
+	}
+	if got, want := attempts, communityInstanceDeployRetries+1; got != want {
+		t.Fatalf("attempts = %d, want %d", got, want)
+	}
+}
+
+func TestCreateCommunityAgentInstanceClassifiesUnavailableResource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"RESOURCE-ERR-1","msg":"The resource is temporarily unavailable."}`))
+	}))
+	defer server.Close()
+
+	previousCredentials := loadCommunityInstanceCredentials
+	loadCommunityInstanceCredentials = func() (string, string, bool, error) {
+		return server.URL, "hub-token", true, nil
+	}
+	t.Cleanup(func() { loadCommunityInstanceCredentials = previousCredentials })
+
+	err := createCommunityAgentInstanceRequest(context.Background(), hub.Template{
+		Namespace: "alice",
+		Name:      "ReviewBot",
+	}, auth.Status{UserID: "alice", UserUUID: "uuid-alice"})
+	if !errors.Is(err, errCommunityInstanceResourceUnavailable) {
+		t.Fatalf("error = %v, want errCommunityInstanceResourceUnavailable", err)
 	}
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1775,19 +1775,32 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 		}
 		if err != nil {
 			status := http.StatusBadGateway
+			code := hub.RemoteAPIErrorCode(err)
 			if !publishingTemplate {
 				status = http.StatusBadRequest
 			}
 			if errors.Is(err, hub.ErrTemplateAlreadyExists) {
 				status = http.StatusConflict
+				if code == "" {
+					code = "template_already_exists"
+				}
 			}
 			if errors.Is(err, hub.ErrTemplateSensitiveInfo) {
 				status = http.StatusBadRequest
+				if code == "" {
+					code = "SENSITIVE-ERR-0"
+				}
 			}
 			if strings.Contains(strings.ToLower(err.Error()), "not found") {
 				status = http.StatusNotFound
+				if code == "" {
+					code = "template_not_found"
+				}
 			}
-			http.Error(w, err.Error(), status)
+			if code == "" {
+				code = "template_publish_failed"
+			}
+			writeHubTemplateError(w, status, code, err.Error(), "")
 			return
 		}
 		if req.Deploy {
@@ -1800,16 +1813,14 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 				} else if errors.Is(err, errCommunityInstanceSensitiveCheck) {
 					status = http.StatusConflict
 					code = communityInstanceSensitiveCheckCode
+				} else if errors.Is(err, errCommunityInstanceResourceUnavailable) {
+					status = http.StatusServiceUnavailable
+					code = communityInstanceResourceUnavailableCode
 				}
-				if code != "" {
-					writeJSON(w, status, map[string]any{"error": map[string]any{
-						"code":                  code,
-						"message":               communityInstanceUpstreamMessage(err),
-						"published_template_id": item.ID,
-					}})
-					return
+				if code == "" {
+					code = "template_deploy_failed"
 				}
-				http.Error(w, fmt.Sprintf("template published but deployment failed: %v", err), status)
+				writeHubTemplateError(w, status, code, communityInstanceUpstreamMessage(err), item.ID)
 				return
 			}
 		}
@@ -1817,6 +1828,17 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func writeHubTemplateError(w http.ResponseWriter, status int, code, message, publishedTemplateID string) {
+	payload := map[string]any{
+		"code":    strings.TrimSpace(code),
+		"message": strings.TrimSpace(message),
+	}
+	if publishedTemplateID = strings.TrimSpace(publishedTemplateID); publishedTemplateID != "" {
+		payload["published_template_id"] = publishedTemplateID
+	}
+	writeJSON(w, status, map[string]any{"error": payload})
 }
 
 func validateAgentTemplatePublishTarget(spec hub.PublishSpec, registry string) error {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3614,6 +3614,35 @@ func TestPresentHubTemplateIncludesSensitiveCheckMetadata(t *testing.T) {
 	}
 }
 
+func TestWriteHubTemplateErrorUsesStructuredContract(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeHubTemplateError(
+		recorder,
+		http.StatusServiceUnavailable,
+		communityInstanceResourceUnavailableCode,
+		"The resource is temporarily unavailable.",
+		"alice/reviewer",
+	)
+
+	if got, want := recorder.Code, http.StatusServiceUnavailable; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	var payload struct {
+		Error struct {
+			Code                string `json:"code"`
+			Message             string `json:"message"`
+			PublishedTemplateID string `json:"published_template_id"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error.Code != communityInstanceResourceUnavailableCode ||
+		payload.Error.PublishedTemplateID != "alice/reviewer" {
+		t.Fatalf("error payload = %+v", payload.Error)
+	}
+}
+
 func TestFilterHubTemplatesForConfiguredProvider(t *testing.T) {
 	items := []hub.Template{
 		{ID: "codex-worker", Role: hub.TemplateRoleWorker, RuntimeKind: agent.RuntimeKindCodex, Source: hub.RegistryRef{Kind: hub.RegistryKindRemote}},

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -619,6 +619,16 @@ func ExtractAPIErrorMessage(body []byte) string {
 
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err == nil {
+		if nested, ok := payload["error"].(map[string]any); ok {
+			for _, key := range []string{"message", "code"} {
+				if value, ok := nested[key].(string); ok {
+					value = strings.TrimSpace(value)
+					if value != "" {
+						return value
+					}
+				}
+			}
+		}
 		for _, key := range []string{"error", "message"} {
 			if value, ok := payload[key].(string); ok {
 				value = strings.TrimSpace(value)

--- a/internal/apiclient/client_test.go
+++ b/internal/apiclient/client_test.go
@@ -16,6 +16,20 @@ type recordingHTTPClient struct {
 	requests []string
 }
 
+func TestExtractAPIErrorMessageReadsStructuredError(t *testing.T) {
+	body := []byte(`{"error":{"code":"RESOURCE-ERR-1","message":"The resource is temporarily unavailable."}}`)
+	if got, want := ExtractAPIErrorMessage(body), "The resource is temporarily unavailable."; got != want {
+		t.Fatalf("ExtractAPIErrorMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractAPIErrorMessageFallsBackToStructuredCode(t *testing.T) {
+	body := []byte(`{"error":{"code":"RESOURCE-ERR-1"}}`)
+	if got, want := ExtractAPIErrorMessage(body), "RESOURCE-ERR-1"; got != want {
+		t.Fatalf("ExtractAPIErrorMessage() = %q, want %q", got, want)
+	}
+}
+
 func (c *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.requests = append(c.requests, req.Method+" "+req.URL.RequestURI())
 	status := c.status

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -45,6 +45,42 @@ type RemoteStore struct {
 	maxWorkspace   int64
 }
 
+// RemoteAPIError preserves the stable error contract returned by the Hub API.
+type RemoteAPIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Cause      error
+}
+
+func (e *RemoteAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code != "" && e.Message != "" {
+		return fmt.Sprintf("remote hub request failed with status %d: %s: %s", e.StatusCode, e.Code, e.Message)
+	}
+	if e.Code != "" {
+		return fmt.Sprintf("remote hub request failed with status %d: %s", e.StatusCode, e.Code)
+	}
+	return fmt.Sprintf("remote hub request failed with status %d: %s", e.StatusCode, e.Message)
+}
+
+func (e *RemoteAPIError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func RemoteAPIErrorCode(err error) string {
+	var remoteErr *RemoteAPIError
+	if errors.As(err, &remoteErr) {
+		return strings.TrimSpace(remoteErr.Code)
+	}
+	return ""
+}
+
 type remoteCodeListResponse struct {
 	Data  []remoteCodeRepository `json:"data"`
 	Total int                    `json:"total"`
@@ -883,10 +919,11 @@ func (s *RemoteStore) postJSON(ctx context.Context, endpoint string, input, out 
 		return fmt.Errorf("remote hub response exceeds %d bytes", s.maxJSON)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if isRemoteSensitiveInformationError(data) {
-			return fmt.Errorf("%w", ErrTemplateSensitiveInfo)
+		remoteErr := decodeRemoteAPIError(resp.StatusCode, data)
+		if strings.EqualFold(remoteErr.Code, "SENSITIVE-ERR-0") {
+			remoteErr.Cause = ErrTemplateSensitiveInfo
 		}
-		return fmt.Errorf("remote hub request failed with status %d: %s", resp.StatusCode, truncateRemoteBody(data))
+		return remoteErr
 	}
 	if out == nil {
 		return nil
@@ -897,20 +934,22 @@ func (s *RemoteStore) postJSON(ctx context.Context, endpoint string, input, out 
 	return nil
 }
 
-func isRemoteSensitiveInformationError(data []byte) bool {
+func decodeRemoteAPIError(statusCode int, data []byte) *RemoteAPIError {
 	var payload struct {
 		Code string `json:"code"`
 		Msg  string `json:"msg"`
 	}
 	if err := json.Unmarshal(data, &payload); err == nil {
-		if strings.EqualFold(strings.TrimSpace(payload.Code), "SENSITIVE-ERR-0") {
-			return true
+		remoteErr := &RemoteAPIError{
+			StatusCode: statusCode,
+			Code:       strings.TrimSpace(payload.Code),
+			Message:    strings.TrimSpace(payload.Msg),
 		}
-		if strings.Contains(strings.ToLower(payload.Msg), "sensitive information is not allowed") {
-			return true
+		if remoteErr.Code != "" || remoteErr.Message != "" {
+			return remoteErr
 		}
 	}
-	return strings.Contains(strings.ToUpper(string(data)), "SENSITIVE-ERR-0")
+	return &RemoteAPIError{StatusCode: statusCode, Message: truncateRemoteBody(data)}
 }
 
 func (s *RemoteStore) uploadArchive(ctx context.Context, upload remoteUploadURL, archive []byte) error {

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -72,6 +72,43 @@ func TestRemoteStorePostJSONRecognizesSensitiveInformationError(t *testing.T) {
 	if !errors.Is(err, ErrTemplateSensitiveInfo) {
 		t.Fatalf("postJSON() error = %v, want ErrTemplateSensitiveInfo", err)
 	}
+	if got, want := RemoteAPIErrorCode(err), "SENSITIVE-ERR-0"; got != want {
+		t.Fatalf("RemoteAPIErrorCode() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteStorePostJSONPreservesStructuredErrorCode(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"USER-ERR-18","msg":"User email is empty"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := NewRemoteStore(srv.URL, "token")
+	err := store.postJSON(context.Background(), srv.URL, nil, nil)
+	if got, want := RemoteAPIErrorCode(err), "USER-ERR-18"; got != want {
+		t.Fatalf("RemoteAPIErrorCode() = %q, want %q; error=%v", got, want, err)
+	}
+}
+
+func TestRemoteStorePostJSONPreservesNonstandardJSONErrorBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"temporary failure"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := NewRemoteStore(srv.URL, "token")
+	err := store.postJSON(context.Background(), srv.URL, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), `{"error":"temporary failure"}`) {
+		t.Fatalf("postJSON() error = %v, want preserved JSON diagnostics", err)
+	}
 }
 
 func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {

--- a/web/app/src/hooks/workspace/types.ts
+++ b/web/app/src/hooks/workspace/types.ts
@@ -282,6 +282,7 @@ export type UseAgentControllerArgs = {
   selectModelProvider?: WorkspaceNavigationController["selectModelProvider"];
   setAgentsData: WorkspaceQuerySetter<AgentLike[]>;
   setBootstrapData: WorkspaceQuerySetter<IMData | null>;
+  setHubPublishError?: (message: string) => void;
   setSelectedHubTemplateId: WorkspaceUiState["setSelectedHubTemplateId"];
   t: TranslateFn;
 };

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -1741,16 +1741,18 @@ export function useAgentController({
       const deployReviewPending = errorCode === HubTemplateErrorCodes.reviewPending;
       const publishedTemplateID = String((err as ApiError | null)?.publishedTemplateId ?? "").trim();
       const message = errorMessage(err, t("agentActionFailed"));
-      if (target === "official_deploy" && publishedTemplateID && (deploySensitiveCheckFailed || deployReviewPending)) {
+      if (target === "official_deploy" && publishedTemplateID) {
         await refreshHubTemplates();
-        queryClient.setQueryData<HubTemplate[]>(workspaceQueryKeys.hubTemplates(), (templates) =>
-          upsertHubTemplateReviewState(
-            templates,
-            publishedTemplateID,
-            deployReviewPending ? "Pending" : "Fail",
-            deployReviewPending ? "" : message,
-          ),
-        );
+        if (deploySensitiveCheckFailed || deployReviewPending) {
+          queryClient.setQueryData<HubTemplate[]>(workspaceQueryKeys.hubTemplates(), (templates) =>
+            upsertHubTemplateReviewState(
+              templates,
+              publishedTemplateID,
+              deployReviewPending ? "Pending" : "Fail",
+              deployReviewPending ? "" : message,
+            ),
+          );
+        }
         setSelectedHubTemplateId(publishedTemplateID);
         navigatePane({ type: WorkspacePaneTypes.hub, id: publishedTemplateID, resourceType: "template" }, rooms);
         return true;

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -468,6 +468,7 @@ export function useAgentController({
   selectModelProvider = noopSelectModelProvider,
   setAgentsData,
   setBootstrapData,
+  setHubPublishError = () => undefined,
   setSelectedHubTemplateId,
   t,
 }: UseAgentControllerArgs) {
@@ -1752,6 +1753,8 @@ export function useAgentController({
               deployReviewPending ? "" : message,
             ),
           );
+        } else {
+          setHubPublishError(message);
         }
         setSelectedHubTemplateId(publishedTemplateID);
         navigatePane({ type: WorkspacePaneTypes.hub, id: publishedTemplateID, resourceType: "template" }, rooms);

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -29,14 +29,7 @@ import {
 import type { AgentUpdatePayload, FeishuRegistration, FetchAgentsOptions } from "@/api/agents";
 import { patchCsgclawUserRequest } from "@/api/participants";
 import { publishAgentTemplateRequest, type AgentTemplatePublishTarget } from "@/api/hub";
-import {
-  isHubTemplateAccountEmailMissing,
-  isHubTemplateDeployReviewPendingError,
-  isHubTemplateDeploySensitiveCheckError,
-  isHubTemplateNameConflict,
-  isHubTemplateSensitiveInformationError,
-  upsertHubTemplateReviewState,
-} from "@/models/hubWorkspace";
+import { HubTemplateErrorCodes, hubTemplateErrorCode, upsertHubTemplateReviewState } from "@/models/hubWorkspace";
 import type { HubTemplate } from "@/models/hubWorkspace";
 import { createUserRequest, joinAgentToRoomRequest } from "@/api/im";
 import { fetchSkills } from "@/api/skills";
@@ -1743,9 +1736,11 @@ export function useAgentController({
       }
       return true;
     } catch (err) {
-      const deploySensitiveCheckFailed = isHubTemplateDeploySensitiveCheckError(err);
-      const deployReviewPending = isHubTemplateDeployReviewPendingError(err);
+      const errorCode = hubTemplateErrorCode(err);
+      const deploySensitiveCheckFailed = errorCode === HubTemplateErrorCodes.reviewFailed;
+      const deployReviewPending = errorCode === HubTemplateErrorCodes.reviewPending;
       const publishedTemplateID = String((err as ApiError | null)?.publishedTemplateId ?? "").trim();
+      const message = errorMessage(err, t("agentActionFailed"));
       if (target === "official_deploy" && publishedTemplateID && (deploySensitiveCheckFailed || deployReviewPending)) {
         await refreshHubTemplates();
         queryClient.setQueryData<HubTemplate[]>(workspaceQueryKeys.hubTemplates(), (templates) =>
@@ -1753,26 +1748,13 @@ export function useAgentController({
             templates,
             publishedTemplateID,
             deployReviewPending ? "Pending" : "Fail",
-            deployReviewPending ? "" : t("agentDeploySensitiveCheckFailed"),
+            deployReviewPending ? "" : message,
           ),
         );
         setSelectedHubTemplateId(publishedTemplateID);
         navigatePane({ type: WorkspacePaneTypes.hub, id: publishedTemplateID, resourceType: "template" }, rooms);
         return true;
       }
-      const message = deploySensitiveCheckFailed
-        ? t("agentDeploySensitiveCheckFailed")
-        : deployReviewPending
-          ? t("agentDeploySensitiveCheckPending")
-          : isHubTemplateSensitiveInformationError(err)
-            ? t("agentPublishSensitiveInformation")
-            : target !== "local" && isHubTemplateAccountEmailMissing(err)
-              ? t("resourcesPublishCommunityEmailRequired")
-              : target !== "local" && isHubTemplateNameConflict(err)
-                ? t("resourcesPublishCommunityNameExists")
-                : target === "local" && (err as ApiError | null)?.status === 409
-                  ? t("agentPublishLocalNameExists")
-                  : errorMessage(err, t("agentActionFailed"));
       setAgentPagePublishError(message);
       setAgentPageSaveError(message);
       return false;

--- a/web/app/src/hooks/workspace/useWorkspaceController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceController.ts
@@ -313,6 +313,7 @@ export function useWorkspaceController() {
     selectModelProvider,
     setAgentsData,
     setBootstrapData,
+    setHubPublishError: hub.setPublishError,
     setSelectedHubTemplateId,
     t,
   });

--- a/web/app/src/hooks/workspace/useWorkspaceHubController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubController.ts
@@ -1,21 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { errorMessage, type ApiError } from "@/api/client";
+import { errorMessage as apiErrorMessage, type ApiError } from "@/api/client";
 import { deleteHubTemplateRequest, publishHubTemplateToCommunityRequest } from "@/api/hub";
 import { deleteSkillRequest, installRemoteSkillRequest, uploadSkillArchive } from "@/api/skills";
 import {
+  HubTemplateErrorCodes,
+  hubTemplateErrorCode,
   isDeletableHubTemplate,
-  isHubTemplateAccountEmailMissing,
-  isHubTemplateDeployReviewPendingError,
-  isHubTemplateDeploySensitiveCheckError,
-  isHubTemplateNameConflict,
-  isHubTemplateSensitiveInformationError,
   isVisibleInHubTemplateList,
   upsertHubTemplateReviewState,
 } from "@/models/hubWorkspace";
 import type { HubTemplate } from "@/models/hubWorkspace";
 import { isReadonlySkill } from "@/models/skillhub";
 import type { SkillSummary } from "@/models/skillhub";
+import { localizeAPIError } from "@/shared/i18n";
 import { workspaceQueryKeys } from "./workspaceQueries";
 import { useWorkspaceHubSelection } from "./useWorkspaceHubSelection";
 import type { UseWorkspaceHubControllerArgs } from "./types";
@@ -95,6 +93,10 @@ export function useWorkspaceHubController({
   refreshWorkspaceHubTemplates,
   t,
 }: UseWorkspaceHubControllerArgs): WorkspaceHubController {
+  const errorMessage = useCallback(
+    (error: unknown, fallback = "") => localizeAPIError(error, t, apiErrorMessage(error, fallback) || fallback),
+    [t],
+  );
   const queryClient = useQueryClient();
   const [resourcesManualError, setResourcesManualError] = useState("");
   const [resourcesDeleteBusy, setResourcesDeleteBusy] = useState(false);
@@ -189,7 +191,7 @@ export function useWorkspaceHubController({
         setResourcesDeleteBusy(false);
       }
     },
-    [queryClient, refreshHubTemplates, setSelectedHubTemplateId, t],
+    [errorMessage, queryClient, refreshHubTemplates, setSelectedHubTemplateId, t],
   );
 
   const deleteSkill = useCallback(
@@ -217,7 +219,7 @@ export function useWorkspaceHubController({
         setSkillDeleteBusy(false);
       }
     },
-    [queryClient, setSelectedHubSkillName, setSelectedHubSkillPath, t],
+    [errorMessage, queryClient, setSelectedHubSkillName, setSelectedHubSkillPath, t],
   );
 
   const publishHubTemplate = useCallback(
@@ -235,21 +237,10 @@ export function useWorkspaceHubController({
         }
         return { status: "success" };
       } catch (err) {
-        const deploySensitiveCheckFailed = isHubTemplateDeploySensitiveCheckError(err);
-        const deployReviewPending = isHubTemplateDeployReviewPendingError(err);
-        const message =
-          deploySensitiveCheckFailed || deployReviewPending
-            ? errorMessage(
-                err,
-                deployReviewPending ? t("agentDeploySensitiveCheckPending") : t("agentDeploySensitiveCheckFailed"),
-              )
-            : isHubTemplateSensitiveInformationError(err)
-              ? t("agentPublishSensitiveInformation")
-              : isHubTemplateAccountEmailMissing(err)
-                ? t("resourcesPublishCommunityEmailRequired")
-                : isHubTemplateNameConflict(err)
-                  ? t("resourcesPublishCommunityNameExists")
-                  : errorMessage(err, t("resourcesPublishCommunityFailed"));
+        const errorCode = hubTemplateErrorCode(err);
+        const deploySensitiveCheckFailed = errorCode === HubTemplateErrorCodes.reviewFailed;
+        const deployReviewPending = errorCode === HubTemplateErrorCodes.reviewPending;
+        const message = errorMessage(err, t("resourcesPublishCommunityFailed"));
         if (deploy) {
           await refreshHubTemplates();
           if (deploySensitiveCheckFailed || deployReviewPending) {
@@ -277,7 +268,15 @@ export function useWorkspaceHubController({
         setResourcesPublishBusy(false);
       }
     },
-    [openCSGAuthenticated, queryClient, refreshHubTemplates, setSelectedHubResourceType, setSelectedHubTemplateId, t],
+    [
+      errorMessage,
+      openCSGAuthenticated,
+      queryClient,
+      refreshHubTemplates,
+      setSelectedHubResourceType,
+      setSelectedHubTemplateId,
+      t,
+    ],
   );
 
   const uploadSkill = useCallback(
@@ -301,7 +300,7 @@ export function useWorkspaceHubController({
         setResourcesUploadBusy(false);
       }
     },
-    [queryClient, setSelectedHubResourceType, setSelectedHubSkillName, setSelectedHubSkillPath, t],
+    [errorMessage, queryClient, setSelectedHubResourceType, setSelectedHubSkillName, setSelectedHubSkillPath, t],
   );
 
   const installRemoteSkill = useCallback(
@@ -333,7 +332,7 @@ export function useWorkspaceHubController({
         setResourcesRemoteInstallBusy("");
       }
     },
-    [queryClient, setSelectedHubResourceType, setSelectedHubSkillName, setSelectedHubSkillPath, t],
+    [errorMessage, queryClient, setSelectedHubResourceType, setSelectedHubSkillName, setSelectedHubSkillPath, t],
   );
 
   return {

--- a/web/app/src/hooks/workspace/useWorkspaceHubController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubController.ts
@@ -243,11 +243,11 @@ export function useWorkspaceHubController({
         const message = errorMessage(err, t("resourcesPublishCommunityFailed"));
         if (deploy) {
           await refreshHubTemplates();
-          if (deploySensitiveCheckFailed || deployReviewPending) {
-            const apiError = err as ApiError;
-            const publishedTemplateID = apiError.publishedTemplateId ?? "";
+          const apiError = err as ApiError;
+          const publishedTemplateID = String(apiError.publishedTemplateId ?? "").trim();
+          if (publishedTemplateID) {
             setSelectedHubResourceType("template");
-            if (publishedTemplateID) {
+            if (deploySensitiveCheckFailed || deployReviewPending) {
               queryClient.setQueryData<HubTemplate[]>(workspaceQueryKeys.hubTemplates(), (templates) =>
                 upsertHubTemplateReviewState(
                   templates,
@@ -256,8 +256,8 @@ export function useWorkspaceHubController({
                   deployReviewPending ? "" : message,
                 ),
               );
-              setSelectedHubTemplateId(publishedTemplateID);
             }
+            setSelectedHubTemplateId(publishedTemplateID);
             setResourcesPublishError("");
             return { status: "partial", message };
           }

--- a/web/app/src/hooks/workspace/useWorkspaceHubController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubController.ts
@@ -57,6 +57,7 @@ export type WorkspaceHubController = {
       template: HubTemplate | null | undefined,
       deploy?: boolean,
     ) => Promise<PublishHubTemplateResult>;
+    setPublishError: (message: string) => void;
     deleteSkill: DeleteSkill;
     skillDeleteBusy: boolean;
     remoteInstallBusy: string;
@@ -343,6 +344,7 @@ export function useWorkspaceHubController({
       deleteHubTemplate,
       publishBusy: resourcesPublishBusy,
       publishHubTemplate,
+      setPublishError: setResourcesPublishError,
       deleteSkill,
       installRemoteSkill,
       remoteInstallBusy: resourcesRemoteInstallBusy,

--- a/web/app/src/models/hubWorkspace.test.ts
+++ b/web/app/src/models/hubWorkspace.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  HubTemplateErrorCodes,
+  hubTemplateErrorCode,
   hubTemplateReviewState,
-  isHubTemplateDeploySensitiveCheckError,
-  isHubTemplateDeployReviewPendingError,
-  isHubTemplateSensitiveInformationError,
   mergeHubTemplateDetail,
   upsertHubTemplateReviewState,
   type HubTemplate,
@@ -122,36 +121,15 @@ describe("upsertHubTemplateReviewState", () => {
   });
 });
 
-describe("isHubTemplateSensitiveInformationError", () => {
-  it("recognizes the normalized backend error", () => {
-    expect(
-      isHubTemplateSensitiveInformationError({ status: 400, message: "template contains sensitive information" }),
-    ).toBe(true);
+describe("hubTemplateErrorCode", () => {
+  it("reads stable structured publishing and deployment codes", () => {
+    expect(hubTemplateErrorCode({ code: "AGENT-ERR-22", message: "review pending" })).toBe(
+      HubTemplateErrorCodes.reviewPending,
+    );
+    expect(hubTemplateErrorCode({ code: "RESOURCE-ERR-1" })).toBe(HubTemplateErrorCodes.deployResourceUnavailable);
   });
 
-  it("recognizes the upstream error code for compatibility", () => {
-    expect(isHubTemplateSensitiveInformationError({ status: 400, message: '{"code":"SENSITIVE-ERR-0"}' })).toBe(true);
-  });
-});
-
-describe("isHubTemplateDeploySensitiveCheckError", () => {
-  it("recognizes the normalized deployment error", () => {
-    expect(
-      isHubTemplateDeploySensitiveCheckError({
-        status: 409,
-        message:
-          "template published but deployment failed: community template has not passed the sensitive-content check",
-      }),
-    ).toBe(true);
-  });
-
-  it("recognizes the upstream deployment error code", () => {
-    expect(isHubTemplateDeploySensitiveCheckError({ status: 409, message: '{"code":"AGENT-ERR-23"}' })).toBe(true);
-  });
-});
-
-describe("isHubTemplateDeployReviewPendingError", () => {
-  it("recognizes the structured pending-review response", () => {
-    expect(isHubTemplateDeployReviewPendingError({ code: "AGENT-ERR-22", message: "review pending" })).toBe(true);
+  it("does not infer codes from legacy error messages", () => {
+    expect(hubTemplateErrorCode({ message: '{"code":"AGENT-ERR-23"}' })).toBe("");
   });
 });

--- a/web/app/src/models/hubWorkspace.ts
+++ b/web/app/src/models/hubWorkspace.ts
@@ -51,62 +51,21 @@ export function isVisibleInHubTemplateList(template: HubTemplate | null | undefi
   );
 }
 
-export function isHubTemplateNameConflict(error: unknown): boolean {
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message ?? "")
-      : error instanceof Error
-        ? error.message
-        : String(error ?? "");
-  const normalized = message.toLowerCase();
-  return normalized.includes("space_err_1") || normalized.includes("space name already exists");
-}
+export const HubTemplateErrorCodes = {
+  accountEmailMissing: "USER-ERR-18",
+  communityNameConflict: "SPACE_ERR_1",
+  deployResourceUnavailable: "RESOURCE-ERR-1",
+  reviewFailed: "AGENT-ERR-23",
+  reviewPending: "AGENT-ERR-22",
+  sensitiveInformation: "SENSITIVE-ERR-0",
+  templateAlreadyExists: "template_already_exists",
+} as const;
 
-export function isHubTemplateAccountEmailMissing(error: unknown): boolean {
-  const code =
-    error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message ?? "")
-      : String(error ?? "");
-  const normalized = `${code} ${message}`.toLowerCase();
-  return normalized.includes("user-err-18") || normalized.includes("user email is empty");
-}
-
-export function isHubTemplateSensitiveInformationError(error: unknown): boolean {
-  const code =
-    error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message ?? "")
-      : String(error ?? "");
-  const normalized = `${code} ${message}`.toLowerCase();
-  return normalized.includes("sensitive-err-0") || normalized.includes("template contains sensitive information");
-}
-
-export function isHubTemplateDeploySensitiveCheckError(error: unknown): boolean {
-  const code =
-    error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message ?? "")
-      : String(error ?? "");
-  const normalized = `${code} ${message}`.toLowerCase();
-  return (
-    normalized.includes("agent-err-23") ||
-    normalized.includes("community template has not passed the sensitive-content check")
-  );
-}
-
-export function isHubTemplateDeployReviewPendingError(error: unknown): boolean {
-  const code =
-    error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message ?? "")
-      : String(error ?? "");
-  const normalized = `${code} ${message}`.toLowerCase();
-  return normalized.includes("agent-err-22") || normalized.includes("sensitive-content review is still pending");
+export function hubTemplateErrorCode(error: unknown): string {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return "";
+  }
+  return String((error as { code?: unknown }).code ?? "").trim();
 }
 
 export type HubTemplate = AgentTemplateLike & {

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -1187,14 +1187,8 @@ export const messages = {
     agentPublishTemplateNameHint: "必须以英文字母开头，最多 24 个字符，仅支持英文字母、数字、下划线和短横线。",
     agentPublishTemplateNameInvalid:
       "模板名称必须以英文字母开头，最多 24 个字符，且只能包含英文字母、数字、下划线和短横线。",
-    agentPublishLocalNameExists: "保存失败：本地已存在同名模板，请修改模板名称后重试。",
-    agentPublishSensitiveInformation: "发布失败：模板名称或描述中包含不允许的敏感信息，请修改后重试。",
-    agentDeploySensitiveCheckFailed: "模板已发布，但未通过敏感内容审核，暂时无法部署。请根据审核原因修改后重新发布。",
-    agentDeploySensitiveCheckPending: "模板已发布，但部署时模板尚未准备完成。请在模板列表中查看最新审核状态。",
     agentPublishTemplateDescription: "模板描述",
     resourcesPublishCommunityFailed: "发布到社区失败。",
-    resourcesPublishCommunityEmailRequired: "发布失败：当前 OpenCSG 账号未设置邮箱，请完善账号资料后重试。",
-    resourcesPublishCommunityNameExists: "发布失败：社区中已存在同名模板，请修改模板名称后重试。",
     resourcesPublishCommunitySuccessTitle: "发布成功",
     resourcesPublishCommunityDeployFailedTitle: "模板已发布，但部署失败",
     resourcesPublishCommunitySuccessMessage: "模板已成功发布到社区。",
@@ -1342,7 +1336,18 @@ export const messages = {
       worker: "worker（对话代理）",
     },
     errors: {
-      agent_home_cleanup_failed: "智能体运行文件仍被占用。请启动 Docker 并等待其运行正常后重新删除；若 Docker 已启动，请重启 CSGClaw 后再试。",
+      "AGENT-ERR-22": "模板已发布，当前仍在审核中。请稍后在模板列表中查看最新状态。",
+      "AGENT-ERR-23": "模板已发布，但未通过敏感内容审核。请根据问题文件修改后重新发布。",
+      "RESOURCE-ERR-1": "模板已成功发布，但社区部署资源暂时不可用，请稍后重试部署。",
+      "SENSITIVE-ERR-0": "发布失败：模板名称或描述中包含不允许的敏感信息，请修改后重试。",
+      SPACE_ERR_1: "发布失败：社区中已存在同名模板，请修改模板名称后重试。",
+      "USER-ERR-18": "发布失败：当前 OpenCSG 账号未设置邮箱，请完善账号资料后重试。",
+      template_already_exists: "保存失败：本地已存在同名模板，请修改模板名称后重试。",
+      template_deploy_failed: "模板已成功发布，但部署失败，请稍后重试。",
+      template_not_found: "未找到要发布的模板，请刷新后重试。",
+      template_publish_failed: "模板发布失败，请稍后重试。",
+      agent_home_cleanup_failed:
+        "智能体运行文件仍被占用。请启动 Docker 并等待其运行正常后重新删除；若 Docker 已启动，请重启 CSGClaw 后再试。",
       docker_availability_timeout: "Docker 服务检测超时，请确认 Docker 服务已启动后重试。",
       docker_unavailable: "Docker 未启动或无法连接，请先启动 Docker 服务后重试。",
       upstream_timeout: "连接模型服务超时，请稍后重试。",
@@ -1670,7 +1675,8 @@ export const messages = {
     resourcesTemplatesSection: "Templates",
     resourcesTemplateReviewPending: "Pending review",
     resourcesTemplateReviewFailed: "Review failed",
-    resourcesTemplateReviewFailedFiles: "Sensitive content was detected in the following files. Update them before publishing again:",
+    resourcesTemplateReviewFailedFiles:
+      "Sensitive content was detected in the following files. Update them before publishing again:",
     resourcesSkillsLabel: "Skills",
     resourcesMCPLabel: "MCP",
     resourcesMCPLoading: "Loading MCP servers...",
@@ -2611,20 +2617,8 @@ export const messages = {
       "Start with an English letter; use up to 24 English letters, numbers, underscores, or hyphens.",
     agentPublishTemplateNameInvalid:
       "Template name must start with an English letter, contain at most 24 characters, and use only English letters, numbers, underscores, or hyphens.",
-    agentPublishLocalNameExists:
-      "Saving failed: a local template with the same name already exists. Choose a different name and try again.",
-    agentPublishSensitiveInformation:
-      "Publishing failed: the template name or description contains sensitive information. Edit it and try again.",
-    agentDeploySensitiveCheckFailed:
-      "The template was published but cannot be deployed because it did not pass the sensitive-content check. Review the failure reason, update it, and publish again.",
-    agentDeploySensitiveCheckPending:
-      "The template was published, but it was not ready when deployment was attempted. Check its latest review status in the template list.",
     agentPublishTemplateDescription: "Template description",
     resourcesPublishCommunityFailed: "Failed to publish the template to the community.",
-    resourcesPublishCommunityEmailRequired:
-      "Publishing failed because the current OpenCSG account has no email address. Complete the account profile and try again.",
-    resourcesPublishCommunityNameExists:
-      "Publishing failed: a template with the same name already exists in the community. Choose a different name and try again.",
     resourcesPublishCommunitySuccessTitle: "Published successfully",
     resourcesPublishCommunityDeployFailedTitle: "Template published, but deployment failed",
     resourcesPublishCommunitySuccessMessage: "The template has been published to the community.",
@@ -2784,6 +2778,22 @@ export const messages = {
       worker: "worker",
     },
     errors: {
+      "AGENT-ERR-22": "The template was published and is still under review. Check the template list again later.",
+      "AGENT-ERR-23":
+        "The template was published but did not pass sensitive-content review. Update the affected files and publish again.",
+      "RESOURCE-ERR-1":
+        "The template was published, but community deployment resources are temporarily unavailable. Try deploying again later.",
+      "SENSITIVE-ERR-0":
+        "Publishing failed because the template name or description contains disallowed sensitive information. Update it and try again.",
+      SPACE_ERR_1:
+        "Publishing failed because a community template with the same name already exists. Choose another name and try again.",
+      "USER-ERR-18":
+        "Publishing failed because the current OpenCSG account has no email address. Complete the account profile and try again.",
+      template_already_exists:
+        "Saving failed because a local template with the same name already exists. Choose another name and try again.",
+      template_deploy_failed: "The template was published, but deployment failed. Try deploying again later.",
+      template_not_found: "The template to publish was not found. Refresh and try again.",
+      template_publish_failed: "Template publishing failed. Try again later.",
       agent_home_cleanup_failed:
         "The agent runtime files are still in use. Start Docker and wait until it is ready, then delete the agent again. If Docker is already running, restart CSGClaw and retry.",
       docker_availability_timeout: "Docker availability check timed out. Make sure Docker is running.",

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -216,6 +216,7 @@ function useAgentControllerHarness(
     bootstrapConfig?: RuntimeBootstrapConfig | null;
     refreshedBootstrapConfig?: RuntimeBootstrapConfig | null;
     refreshMCPServers?: () => Promise<unknown>;
+    setHubPublishError?: (message: string) => void;
     t?: TranslateFn;
   } = {},
 ) {
@@ -290,6 +291,7 @@ function useAgentControllerHarness(
     setBootstrapData: (value) => {
       setData((current) => (typeof value === "function" ? value(current) : value));
     },
+    setHubPublishError: options.setHubPublishError,
     setSelectedHubTemplateId: setSelectedHubTemplateIdRef.current,
     t: options.t ?? t,
   });
@@ -1191,6 +1193,7 @@ describe("useAgentController", () => {
     ["RESOURCE-ERR-1", "deployment resource is unavailable"],
     ["template_deploy_failed", "template deployment failed"],
   ])("opens the published template after partial deployment failure %s", async (code, message) => {
+    const setHubPublishError = vi.fn();
     const worker: AgentLike = {
       ...oldAgent,
       id: "u-worker",
@@ -1210,6 +1213,7 @@ describe("useAgentController", () => {
           activePane: { type: WorkspacePaneTypes.agent, id: "u-worker" },
           agents: [worker],
           openCSGAuthenticated: true,
+          setHubPublishError,
         }),
       { wrapper: createWrapper() },
     );
@@ -1227,6 +1231,7 @@ describe("useAgentController", () => {
     expect(published).toBe(true);
     expect(result.current.refreshHubTemplates).toHaveBeenCalledOnce();
     expect(result.current.setSelectedHubTemplateId).toHaveBeenCalledWith("alice/reviewer");
+    expect(setHubPublishError).toHaveBeenCalledWith(message);
     expect(result.current.navigatePane).toHaveBeenCalledWith(
       { type: WorkspacePaneTypes.hub, id: "alice/reviewer", resourceType: "template" },
       [],

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -1187,6 +1187,52 @@ describe("useAgentController", () => {
     );
   });
 
+  it.each([
+    ["RESOURCE-ERR-1", "deployment resource is unavailable"],
+    ["template_deploy_failed", "template deployment failed"],
+  ])("opens the published template after partial deployment failure %s", async (code, message) => {
+    const worker: AgentLike = {
+      ...oldAgent,
+      id: "u-worker",
+      name: "reviewer",
+      role: "worker",
+      runtime_kind: "codex",
+    };
+    vi.mocked(publishAgentTemplateRequest).mockRejectedValueOnce({
+      status: 502,
+      code,
+      message,
+      publishedTemplateId: "alice/reviewer",
+    } satisfies ApiError);
+    const { result } = renderHook(
+      () =>
+        useAgentControllerHarness({
+          activePane: { type: WorkspacePaneTypes.agent, id: "u-worker" },
+          agents: [worker],
+          openCSGAuthenticated: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    let published = false;
+    await act(async () => {
+      published =
+        (await result.current.controller.agentViewProps.onPublish?.(
+          "official_deploy",
+          "reviewer",
+          "Reviews changes",
+        )) ?? false;
+    });
+
+    expect(published).toBe(true);
+    expect(result.current.refreshHubTemplates).toHaveBeenCalledOnce();
+    expect(result.current.setSelectedHubTemplateId).toHaveBeenCalledWith("alice/reviewer");
+    expect(result.current.navigatePane).toHaveBeenCalledWith(
+      { type: WorkspacePaneTypes.hub, id: "alice/reviewer", resourceType: "template" },
+      [],
+    );
+  });
+
   it("does not wait for bootstrap or skill refresh after saving only the selected agent model", async () => {
     const aiGatewayAgent: AgentLike = {
       agent_profile: {

--- a/web/app/tests/models/hubWorkspace.test.ts
+++ b/web/app/tests/models/hubWorkspace.test.ts
@@ -3,9 +3,9 @@ import {
   formatHubDate,
   formatHubDateTime,
   formatHubTemplateCount,
+  HubTemplateErrorCodes,
+  hubTemplateErrorCode,
   isDeletableHubTemplate,
-  isHubTemplateAccountEmailMissing,
-  isHubTemplateNameConflict,
   isVisibleInHubTemplateList,
 } from "@/models/hubWorkspace";
 
@@ -40,28 +40,10 @@ describe("hub workspace helpers", () => {
     ).toBe(false);
   });
 
-  it("recognizes duplicate community template errors", () => {
-    expect(
-      isHubTemplateNameConflict({
-        status: 502,
-        message:
-          'remote hub request failed with status 500: {"code":"SPACE_ERR_1","msg":"SPACE_ERR_1: The space name already exists."}',
-      }),
-    ).toBe(true);
-    expect(isHubTemplateNameConflict(new Error("The space name already exists."))).toBe(true);
-    expect(isHubTemplateNameConflict(new Error("network unavailable"))).toBe(false);
-  });
-
-  it("recognizes a missing OpenCSG account email during community publishing", () => {
-    expect(
-      isHubTemplateAccountEmailMissing({
-        status: 502,
-        message:
-          'remote hub request failed with status 500: {"code":"USER-ERR-18","msg":"USER-ERR-18: User email is empty"}',
-      }),
-    ).toBe(true);
-    expect(isHubTemplateAccountEmailMissing({ code: "USER-ERR-18", message: "publish failed" })).toBe(true);
-    expect(isHubTemplateAccountEmailMissing(new Error("network unavailable"))).toBe(false);
+  it("uses structured codes for community publishing errors", () => {
+    expect(hubTemplateErrorCode({ code: "SPACE_ERR_1" })).toBe(HubTemplateErrorCodes.communityNameConflict);
+    expect(hubTemplateErrorCode({ code: "USER-ERR-18" })).toBe(HubTemplateErrorCodes.accountEmailMissing);
+    expect(hubTemplateErrorCode(new Error("The space name already exists."))).toBe("");
   });
 
   it("shows worker templates and official remote templates in hub lists", () => {

--- a/web/app/tests/shared/i18n.test.ts
+++ b/web/app/tests/shared/i18n.test.ts
@@ -43,6 +43,18 @@ describe("i18n messages", () => {
     expect(
       localizeAPIError({ status: 503, code: "model_unavailable", message: "服务不可用" }, createTranslator("en")),
     ).toContain("temporarily unavailable");
+    expect(
+      localizeAPIError(
+        { status: 503, code: "RESOURCE-ERR-1", message: "The resource is temporarily unavailable." },
+        createTranslator("zh"),
+      ),
+    ).toBe("模板已成功发布，但社区部署资源暂时不可用，请稍后重试部署。");
+    expect(
+      localizeAPIError(
+        { status: 409, code: "SPACE_ERR_1", message: "The space name already exists." },
+        createTranslator("en"),
+      ),
+    ).toContain("same name already exists");
   });
 
   it("localizes unavailable Docker errors without exposing platform diagnostics", () => {
@@ -52,7 +64,9 @@ describe("i18n messages", () => {
       message: "open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified",
     };
 
-    expect(localizeAPIError(error, createTranslator("zh"))).toBe("Docker 未启动或无法连接，请先启动 Docker 服务后重试。");
+    expect(localizeAPIError(error, createTranslator("zh"))).toBe(
+      "Docker 未启动或无法连接，请先启动 Docker 服务后重试。",
+    );
     expect(localizeAPIError(error, createTranslator("en"))).toBe(
       "Docker is not running or cannot be reached. Start Docker and try again.",
     );


### PR DESCRIPTION
- preserve upstream Hub error codes and return a consistent structured API error contract
- distinguish pending sensitive-content reviews from failed reviews after deployment retries
- localize publishing, review, conflict, account, and resource errors through shared error-code messages
- keep published template ids on partial deployment failures and retain server review details
- teach CLI clients to read nested structured errors and preserve nonstandard upstream diagnostics
- add backend and frontend regression coverage for error classification, localization, and compatibility