### PR TITLE
fix(web): open agent profiles in side drawer

### DIFF
--- a/web/app/src/components/business/ConversationPane/ConversationMessageList.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationMessageList.tsx
@@ -62,6 +62,7 @@ export const ConversationMessageList = memo(function ConversationMessageList({
   theme,
   usersById,
   visibleMessages,
+  onOpenAgentDetail,
   onMessageAction,
   onOpenThread,
   onPreviewUser,
@@ -128,8 +129,12 @@ export const ConversationMessageList = memo(function ConversationMessageList({
               <button
                 type="button"
                 className="avatar avatar-button"
-                aria-label={`${t("profilePreview")} ${user.name}`}
+                aria-label={`${t(messageAgent ? "agentDetailPanel" : "profilePreview")} ${user.name}`}
                 onClick={(event) => {
+                  if (messageAgent && onOpenAgentDetail) {
+                    onOpenAgentDetail(messageAgent, event.currentTarget);
+                    return;
+                  }
                   onPreviewUser(user, event.currentTarget);
                 }}
               >

--- a/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
+++ b/web/app/src/components/business/ConversationPane/ConversationThreadPanel.tsx
@@ -544,6 +544,7 @@ function ThreadMessage({
   locale,
   theme,
   t,
+  onOpenAgentDetail,
   onPreviewUser,
   onQuestionSelect,
   compact = false,
@@ -563,8 +564,12 @@ function ThreadMessage({
         <button
           type="button"
           className="thread-message-avatar"
-          aria-label={`${t("profilePreview")} ${name}`}
+          aria-label={`${t(messageAgent ? "agentDetailPanel" : "profilePreview")} ${name}`}
           onClick={(event) => {
+            if (messageAgent && onOpenAgentDetail) {
+              onOpenAgentDetail(messageAgent, event.currentTarget);
+              return;
+            }
             onPreviewUser(user, event.currentTarget);
           }}
         >

--- a/web/app/src/components/business/ConversationPane/ConversationThreads.css
+++ b/web/app/src/components/business/ConversationPane/ConversationThreads.css
@@ -190,7 +190,15 @@
 .csg-dialog-overlay.agent-detail-drawer-backdrop {
   z-index: var(--z-page-overlay);
   background: color-mix(in srgb, var(--gray-900) 24%, transparent);
-  backdrop-filter: blur(2px);
+  will-change: opacity;
+}
+
+.csg-dialog-overlay.agent-detail-drawer-backdrop[data-state="open"] {
+  animation: agent-detail-backdrop-in 180ms ease-out both;
+}
+
+.csg-dialog-overlay.agent-detail-drawer-backdrop[data-state="closed"] {
+  animation: agent-detail-backdrop-out 140ms ease-in both;
 }
 
 .csg-dialog-content.agent-detail-side-panel {
@@ -212,6 +220,43 @@
     var(--shadow);
   outline: none;
   transform: none;
+  contain: layout paint;
+  backface-visibility: hidden;
+  will-change: transform, opacity;
+}
+
+.csg-dialog-content.agent-detail-side-panel[data-state="open"] {
+  animation: agent-detail-drawer-in 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.csg-dialog-content.agent-detail-side-panel[data-state="closed"] {
+  animation: agent-detail-drawer-out 160ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+@keyframes agent-detail-backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes agent-detail-backdrop-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes agent-detail-drawer-in {
+  from {
+    opacity: 0.72;
+    transform: translate3d(32px, 0, 0);
+  }
+}
+
+@keyframes agent-detail-drawer-out {
+  to {
+    opacity: 0;
+    transform: translate3d(24px, 0, 0);
+  }
 }
 
 .agent-detail-side-panel-bar {

--- a/web/app/src/components/business/ConversationPane/ConversationThreads.css
+++ b/web/app/src/components/business/ConversationPane/ConversationThreads.css
@@ -294,19 +294,10 @@
 
   width: 100%;
   height: 100%;
-  padding: 14px 16px 20px;
+  padding: var(--space-6) var(--space-8) 28px;
   border: 0;
   border-radius: 0;
   box-shadow: none;
-}
-
-.agent-detail-side-panel .agent-detail-pane .entity-header {
-  grid-template-columns: 48px minmax(0, 1fr);
-}
-
-.agent-detail-side-panel .agent-detail-pane .entity-toolbar {
-  grid-column: 1 / -1;
-  justify-content: flex-start;
 }
 
 @container agent-detail-drawer (max-width: 1040px) {

--- a/web/app/tests/components/ConversationMessageListProfilePreview.test.tsx
+++ b/web/app/tests/components/ConversationMessageListProfilePreview.test.tsx
@@ -54,9 +54,9 @@ function renderMessageList({
 }
 
 describe("ConversationMessageList profile preview", () => {
-  it("opens the same profile preview for agent avatars", () => {
+  it("opens the profile drawer for agent avatars", () => {
     const { onOpenAgentDetail, onPreviewUser } = renderMessageList();
-    const avatar = screen.getByRole("button", { name: "profilePreview Builder" });
+    const avatar = screen.getByRole("button", { name: "agentDetailPanel Builder" });
 
     avatar.focus();
     expect(onPreviewUser).not.toHaveBeenCalled();
@@ -65,8 +65,8 @@ describe("ConversationMessageList profile preview", () => {
     expect(onPreviewUser).not.toHaveBeenCalled();
 
     fireEvent.click(avatar);
-    expect(onOpenAgentDetail).not.toHaveBeenCalled();
-    expect(onPreviewUser).toHaveBeenCalledWith(agentUser, avatar);
+    expect(onOpenAgentDetail).toHaveBeenCalledWith(expect.objectContaining({ id: agentUser.id }), avatar);
+    expect(onPreviewUser).not.toHaveBeenCalled();
   });
 
   it("still opens the compact preview when a human avatar is activated", () => {
@@ -94,7 +94,7 @@ describe("ConversationMessageList profile preview", () => {
       ],
     });
 
-    const avatar = screen.getByRole("button", { name: "profilePreview Builder" });
+    const avatar = screen.getByRole("button", { name: "agentDetailPanel Builder" });
     expect(avatar.querySelector(".message-avatar-status")).not.toHaveClass("online");
   });
 });

--- a/web/app/tests/components/ConversationPane.test.tsx
+++ b/web/app/tests/components/ConversationPane.test.tsx
@@ -617,7 +617,7 @@ describe("ConversationPane", () => {
     expect(onOpenAgentDetail).not.toHaveBeenCalled();
   });
 
-  it("opens the profile preview when clicking an agent avatar", async () => {
+  it("opens the profile drawer when clicking an agent avatar", async () => {
     const user = userEvent.setup();
     const onOpenAgentDetail = vi.fn();
     const onPreviewUser = vi.fn();
@@ -628,17 +628,17 @@ describe("ConversationPane", () => {
       onPreviewUser,
     });
 
-    const avatar = screen.getAllByRole("button", { name: "profilePreview manager" })[0] as HTMLElement;
+    const avatar = screen.getAllByRole("button", { name: "agentDetailPanel manager" })[0] as HTMLElement;
     await user.hover(avatar);
     expect(onPreviewUser).not.toHaveBeenCalled();
 
     onPreviewUser.mockClear();
     await user.click(avatar);
-    expect(onPreviewUser).toHaveBeenCalledWith(expect.objectContaining({ id: "u-manager" }), avatar);
-    expect(onOpenAgentDetail).not.toHaveBeenCalled();
+    expect(onOpenAgentDetail).toHaveBeenCalledWith(expect.objectContaining({ id: "u-manager" }), avatar);
+    expect(onPreviewUser).not.toHaveBeenCalled();
   });
 
-  it("opens the profile preview when the message sender id is a channel identity alias", async () => {
+  it("opens the profile drawer when the message sender id is a channel identity alias", async () => {
     const user = userEvent.setup();
     const weatherUser: IMUser = {
       avatar: "O",
@@ -670,11 +670,11 @@ describe("ConversationPane", () => {
       usersByIdOverride: userAliases,
     });
 
-    const avatar = screen.getByRole("button", { name: "profilePreview openclaw-weather" });
+    const avatar = screen.getByRole("button", { name: "agentDetailPanel openclaw-weather" });
     await user.click(avatar);
 
-    expect(onPreviewUser).toHaveBeenCalledWith(weatherUser, avatar);
-    expect(onOpenAgentDetail).not.toHaveBeenCalled();
+    expect(onOpenAgentDetail).toHaveBeenCalledWith(expect.objectContaining({ id: "openclaw-weather" }), avatar);
+    expect(onPreviewUser).not.toHaveBeenCalled();
   });
 
   it("renders agent details as a modal drawer with keyboard dismissal", async () => {


### PR DESCRIPTION
## Summary
- open agent profiles from message and thread avatars in the right-side Profile drawer
- replace the intermediate profile card for agents while preserving human profile preview behavior
- smooth drawer and backdrop motion while avoiding page layout shifts
- keep the drawer header layout aligned with the full Profile page