### PR TITLE
fix(desktop): prevent Windows proxy from breaking agent network access

### DIFF
--- a/desktop/src/main/sidecar/childEnvironment.test.ts
+++ b/desktop/src/main/sidecar/childEnvironment.test.ts
@@ -77,7 +77,7 @@ test("keeps the inherited environment when login shell discovery fails", async (
   );
 });
 
-test("uses the system proxy without importing shell proxy settings", async () => {
+test("scopes the system proxy to embedded CLIProxy without importing shell proxy settings", async () => {
   const env = await resolveSidecarEnvironment({
     baseEnvironment: { PATH: "/usr/bin:/bin" },
     homeDirectory: "/Users/test",
@@ -93,13 +93,33 @@ test("uses the system proxy without importing shell proxy settings", async () =>
     resolveSystemProxy: async () => "PROXY 127.0.0.1:7890",
   });
 
-  assert.equal(env.HTTP_PROXY, "http://127.0.0.1:7890");
-  assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:7890");
-  assert.equal(env.http_proxy, "http://127.0.0.1:7890");
-  assert.equal(env.https_proxy, "http://127.0.0.1:7890");
-  assert.equal(env.NO_PROXY, "localhost,127.0.0.1,::1");
-  assert.equal(env.no_proxy, "localhost,127.0.0.1,::1");
+  assert.equal(env.CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL, "http://127.0.0.1:7890");
+  assert.equal(env.HTTP_PROXY, undefined);
+  assert.equal(env.HTTPS_PROXY, undefined);
+  assert.equal(env.http_proxy, undefined);
+  assert.equal(env.https_proxy, undefined);
+  assert.equal(env.NO_PROXY, undefined);
+  assert.equal(env.no_proxy, undefined);
   assert.equal(env.UNRELATED_SECRET, undefined);
+});
+
+test("scopes an inherited standard proxy to embedded CLIProxy", async () => {
+  const env = await resolveSidecarEnvironment({
+    baseEnvironment: {
+      PATH: "/usr/bin:/bin",
+      HTTPS_PROXY: "http://127.0.0.1:7891",
+      HTTP_PROXY: "http://127.0.0.1:7892",
+    },
+    homeDirectory: "/home/test",
+    loginShell: "/bin/bash",
+    platform: DesktopPlatform.Linux,
+    runCommand: async () => "PATH=/usr/bin:/bin\0",
+    resolveSystemProxy: async () => "PROXY 127.0.0.1:7890",
+  });
+
+  assert.equal(env.CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL, "http://127.0.0.1:7891");
+  assert.equal(env.HTTPS_PROXY, undefined);
+  assert.equal(env.HTTP_PROXY, undefined);
 });
 
 test("uses an interactive non-login shell for Linux terminal configuration", async () => {

--- a/desktop/src/main/sidecar/childEnvironment.test.ts
+++ b/desktop/src/main/sidecar/childEnvironment.test.ts
@@ -103,12 +103,14 @@ test("scopes the system proxy to embedded CLIProxy without importing shell proxy
   assert.equal(env.UNRELATED_SECRET, undefined);
 });
 
-test("scopes an inherited standard proxy to embedded CLIProxy", async () => {
+test("preserves explicitly inherited proxy settings for the whole sidecar", async () => {
   const env = await resolveSidecarEnvironment({
     baseEnvironment: {
       PATH: "/usr/bin:/bin",
       HTTPS_PROXY: "http://127.0.0.1:7891",
       HTTP_PROXY: "http://127.0.0.1:7892",
+      ALL_PROXY: "socks5://127.0.0.1:7893",
+      NO_PROXY: "localhost,127.0.0.1,.example.com",
     },
     homeDirectory: "/home/test",
     loginShell: "/bin/bash",
@@ -117,9 +119,11 @@ test("scopes an inherited standard proxy to embedded CLIProxy", async () => {
     resolveSystemProxy: async () => "PROXY 127.0.0.1:7890",
   });
 
-  assert.equal(env.CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL, "http://127.0.0.1:7891");
-  assert.equal(env.HTTPS_PROXY, undefined);
-  assert.equal(env.HTTP_PROXY, undefined);
+  assert.equal(env.CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL, "http://127.0.0.1:7890");
+  assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:7891");
+  assert.equal(env.HTTP_PROXY, "http://127.0.0.1:7892");
+  assert.equal(env.ALL_PROXY, "socks5://127.0.0.1:7893");
+  assert.equal(env.NO_PROXY, "localhost,127.0.0.1,.example.com");
 });
 
 test("uses an interactive non-login shell for Linux terminal configuration", async () => {

--- a/desktop/src/main/sidecar/childEnvironment.ts
+++ b/desktop/src/main/sidecar/childEnvironment.ts
@@ -3,7 +3,8 @@ import { userInfo } from "node:os";
 import path from "node:path";
 import { DesktopPlatform } from "../../shared/desktopEnvironment";
 import {
-  resolveSystemProxyEnvironment,
+  CLIPROXY_SYSTEM_PROXY_ENV,
+  resolveSystemCLIProxyEnvironment,
   type SystemProxyResolver,
 } from "./systemProxy";
 
@@ -17,6 +18,14 @@ const SHELL_ENVIRONMENT_KEYS = [
   "DOCKER_CONFIG",
   "DOCKER_CERT_PATH",
   "DOCKER_TLS_VERIFY",
+] as const;
+const STANDARD_PROXY_ENVIRONMENT_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "ALL_PROXY",
+  "all_proxy",
 ] as const;
 const WINDOWS_ENVIRONMENT_SCRIPT = `
 [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
@@ -73,7 +82,22 @@ export async function resolveSidecarEnvironment({
 }: ResolveSidecarEnvironmentOptions): Promise<NodeJS.ProcessEnv> {
   // Restore the environment that a newly opened terminal would normally
   // provide, while keeping packaged helper executables ahead of host tools.
+  const inheritedProxyURL = standardProxyEnvironmentValue(
+    baseEnvironment,
+    platform,
+  );
   const env = sanitizeEnvironment(baseEnvironment, platform);
+  if (
+    inheritedProxyURL &&
+    !environmentValue(env, CLIPROXY_SYSTEM_PROXY_ENV, platform)?.trim()
+  ) {
+    setEnvironmentValue(
+      env,
+      CLIPROXY_SYSTEM_PROXY_ENV,
+      inheritedProxyURL,
+      platform,
+    );
+  }
   const currentPath = environmentValue(env, "PATH", platform);
   let discovered: NodeJS.ProcessEnv = {};
 
@@ -137,7 +161,7 @@ export async function resolveSidecarEnvironment({
   }
 
   if (resolveSystemProxy) {
-    const systemProxy = await resolveSystemProxyEnvironment(resolveSystemProxy);
+    const systemProxy = await resolveSystemCLIProxyEnvironment(resolveSystemProxy);
     for (const [key, value] of Object.entries(systemProxy)) {
       if (value && !environmentValue(env, key, platform)?.trim()) {
         setEnvironmentValue(env, key, value, platform);
@@ -210,7 +234,23 @@ function sanitizeEnvironment(
   deleteEnvironmentValue(env, "NODE_OPTIONS", platform);
   deleteEnvironmentValue(env, "CSGCLAW_CODEX_PATH", platform);
   deleteEnvironmentValue(env, "CSGCLAW_CODEX_ACP_PATH", platform);
+  for (const key of STANDARD_PROXY_ENVIRONMENT_KEYS) {
+    deleteEnvironmentValue(env, key, platform);
+  }
   return env;
+}
+
+function standardProxyEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | undefined {
+  for (const key of STANDARD_PROXY_ENVIRONMENT_KEYS) {
+    const value = environmentValue(env, key, platform)?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function resolveLoginShell(

--- a/desktop/src/main/sidecar/childEnvironment.ts
+++ b/desktop/src/main/sidecar/childEnvironment.ts
@@ -3,7 +3,6 @@ import { userInfo } from "node:os";
 import path from "node:path";
 import { DesktopPlatform } from "../../shared/desktopEnvironment";
 import {
-  CLIPROXY_SYSTEM_PROXY_ENV,
   resolveSystemCLIProxyEnvironment,
   type SystemProxyResolver,
 } from "./systemProxy";
@@ -18,14 +17,6 @@ const SHELL_ENVIRONMENT_KEYS = [
   "DOCKER_CONFIG",
   "DOCKER_CERT_PATH",
   "DOCKER_TLS_VERIFY",
-] as const;
-const STANDARD_PROXY_ENVIRONMENT_KEYS = [
-  "HTTPS_PROXY",
-  "https_proxy",
-  "HTTP_PROXY",
-  "http_proxy",
-  "ALL_PROXY",
-  "all_proxy",
 ] as const;
 const WINDOWS_ENVIRONMENT_SCRIPT = `
 [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
@@ -82,22 +73,7 @@ export async function resolveSidecarEnvironment({
 }: ResolveSidecarEnvironmentOptions): Promise<NodeJS.ProcessEnv> {
   // Restore the environment that a newly opened terminal would normally
   // provide, while keeping packaged helper executables ahead of host tools.
-  const inheritedProxyURL = standardProxyEnvironmentValue(
-    baseEnvironment,
-    platform,
-  );
   const env = sanitizeEnvironment(baseEnvironment, platform);
-  if (
-    inheritedProxyURL &&
-    !environmentValue(env, CLIPROXY_SYSTEM_PROXY_ENV, platform)?.trim()
-  ) {
-    setEnvironmentValue(
-      env,
-      CLIPROXY_SYSTEM_PROXY_ENV,
-      inheritedProxyURL,
-      platform,
-    );
-  }
   const currentPath = environmentValue(env, "PATH", platform);
   let discovered: NodeJS.ProcessEnv = {};
 
@@ -234,23 +210,7 @@ function sanitizeEnvironment(
   deleteEnvironmentValue(env, "NODE_OPTIONS", platform);
   deleteEnvironmentValue(env, "CSGCLAW_CODEX_PATH", platform);
   deleteEnvironmentValue(env, "CSGCLAW_CODEX_ACP_PATH", platform);
-  for (const key of STANDARD_PROXY_ENVIRONMENT_KEYS) {
-    deleteEnvironmentValue(env, key, platform);
-  }
   return env;
-}
-
-function standardProxyEnvironmentValue(
-  env: NodeJS.ProcessEnv,
-  platform: NodeJS.Platform,
-): string | undefined {
-  for (const key of STANDARD_PROXY_ENVIRONMENT_KEYS) {
-    const value = environmentValue(env, key, platform)?.trim();
-    if (value) {
-      return value;
-    }
-  }
-  return undefined;
 }
 
 function resolveLoginShell(

--- a/desktop/src/main/sidecar/systemProxy.test.ts
+++ b/desktop/src/main/sidecar/systemProxy.test.ts
@@ -1,22 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { firstProxyURL, resolveSystemProxyEnvironment } from "./systemProxy";
+import {
+  CLIPROXY_SYSTEM_PROXY_ENV,
+  firstProxyURL,
+  resolveSystemCLIProxyEnvironment,
+} from "./systemProxy";
 
-test("maps Electron system proxy rules to sidecar environment variables", async () => {
-  const env = await resolveSystemProxyEnvironment(async () => "PROXY 127.0.0.1:7890");
+test("scopes the Electron system proxy to embedded CLIProxy", async () => {
+  const env = await resolveSystemCLIProxyEnvironment(async () => "PROXY 127.0.0.1:7890");
 
   assert.deepEqual(env, {
-    HTTP_PROXY: "http://127.0.0.1:7890",
-    HTTPS_PROXY: "http://127.0.0.1:7890",
-    NO_PROXY: "localhost,127.0.0.1,::1",
-    http_proxy: "http://127.0.0.1:7890",
-    https_proxy: "http://127.0.0.1:7890",
-    no_proxy: "localhost,127.0.0.1,::1",
+    [CLIPROXY_SYSTEM_PROXY_ENV]: "http://127.0.0.1:7890",
   });
 });
 
 test("keeps direct system proxy rules unset", async () => {
-  assert.deepEqual(await resolveSystemProxyEnvironment(async () => "DIRECT"), {});
+  assert.deepEqual(await resolveSystemCLIProxyEnvironment(async () => "DIRECT"), {});
 });
 
 test("uses the first supported proxy rule", () => {

--- a/desktop/src/main/sidecar/systemProxy.ts
+++ b/desktop/src/main/sidecar/systemProxy.ts
@@ -1,37 +1,17 @@
-const SYSTEM_PROXY_URLS = {
-  HTTP_PROXY: "http://api.openai.com/",
-  HTTPS_PROXY: "https://api.openai.com/",
-} as const;
-const LOOPBACK_PROXY_BYPASS = ["localhost", "127.0.0.1", "::1"];
+const SYSTEM_PROXY_PROBE_URL = "https://api.openai.com/";
+export const CLIPROXY_SYSTEM_PROXY_ENV = "CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL";
 
 export type SystemProxyResolver = (url: string) => Promise<string>;
 
-export async function resolveSystemProxyEnvironment(
+export async function resolveSystemCLIProxyEnvironment(
   resolveProxy: SystemProxyResolver,
 ): Promise<NodeJS.ProcessEnv> {
   try {
-    const [httpRules, httpsRules] = await Promise.all([
-      resolveProxy(SYSTEM_PROXY_URLS.HTTP_PROXY),
-      resolveProxy(SYSTEM_PROXY_URLS.HTTPS_PROXY),
-    ]);
-    const httpProxy = firstProxyURL(httpRules);
-    const httpsProxy = firstProxyURL(httpsRules);
-    if (!httpProxy && !httpsProxy) {
+    const proxyURL = firstProxyURL(await resolveProxy(SYSTEM_PROXY_PROBE_URL));
+    if (!proxyURL) {
       return {};
     }
-
-    const env: NodeJS.ProcessEnv = {
-      NO_PROXY: LOOPBACK_PROXY_BYPASS.join(","),
-      no_proxy: LOOPBACK_PROXY_BYPASS.join(","),
-    };
-    setProxyPair(env, "HTTP_PROXY", "http_proxy", httpProxy);
-    setProxyPair(env, "HTTPS_PROXY", "https_proxy", httpsProxy);
-
-    const allProxy = commonSocksProxy(httpProxy, httpsProxy);
-    if (allProxy) {
-      setProxyPair(env, "ALL_PROXY", "all_proxy", allProxy);
-    }
-    return env;
+    return { [CLIPROXY_SYSTEM_PROXY_ENV]: proxyURL };
   } catch {
     return {};
   }
@@ -77,27 +57,4 @@ function proxyScheme(type: string): string {
     default:
       return "http";
   }
-}
-
-function setProxyPair(
-  env: NodeJS.ProcessEnv,
-  upperKey: string,
-  lowerKey: string,
-  value: string | undefined,
-): void {
-  if (!value) {
-    return;
-  }
-  env[upperKey] = value;
-  env[lowerKey] = value;
-}
-
-function commonSocksProxy(
-  httpProxy: string | undefined,
-  httpsProxy: string | undefined,
-): string | undefined {
-  if (!httpProxy || httpProxy !== httpsProxy || !httpProxy.startsWith("socks")) {
-    return undefined;
-  }
-  return httpProxy;
 }

--- a/docs/tech/desktop/electron-desktop-migration-plan.zh.md
+++ b/docs/tech/desktop/electron-desktop-migration-plan.zh.md
@@ -47,6 +47,7 @@ csgclaw _desktop-serve
 - Sandbox API 使用独立的动态端口监听宿主机 IPv4 接口，并强制校验 Host、server access token 和空 Origin。
 - Electron 通过 stdin 发送启动信息，Go 通过 stdout 返回就绪信息。
 - Electron 退出或监督重启 sidecar 时通知 Go 先停止运行中的 Agent，再优雅关闭 HTTP 服务。
+- Electron 解析到的系统代理通过 CLIProxy 专用环境变量传给 sidecar，仅供 Codex 和 Claude Code 模型 Provider 使用；OpenCSG、CSGHub Lite 和自定义 Provider 不继承该自动代理。
 - Go 自升级在桌面版中关闭，由 Electron 统一更新完整应用。
 
 ### 2.2 启动流程

--- a/docs/tech/desktop/electron-desktop-migration-plan.zh.md
+++ b/docs/tech/desktop/electron-desktop-migration-plan.zh.md
@@ -47,7 +47,7 @@ csgclaw _desktop-serve
 - Sandbox API 使用独立的动态端口监听宿主机 IPv4 接口，并强制校验 Host、server access token 和空 Origin。
 - Electron 通过 stdin 发送启动信息，Go 通过 stdout 返回就绪信息。
 - Electron 退出或监督重启 sidecar 时通知 Go 先停止运行中的 Agent，再优雅关闭 HTTP 服务。
-- Electron 解析到的系统代理通过 CLIProxy 专用环境变量传给 sidecar，仅供 Codex 和 Claude Code 模型 Provider 使用；OpenCSG、CSGHub Lite 和自定义 Provider 不继承该自动代理。
+- Electron 解析到的系统代理通过 CLIProxy 专用环境变量传给 sidecar，仅供 Codex 和 Claude Code 模型 Provider 使用；OpenCSG、CSGHub Lite 和自定义 Provider 不继承该自动代理，但仍遵循用户显式设置的标准代理环境变量。
 - Go 自升级在桌面版中关闭，由 Electron 统一更新完整应用。
 
 ### 2.2 启动流程

--- a/internal/cliproxy/service.go
+++ b/internal/cliproxy/service.go
@@ -36,6 +36,11 @@ const (
 
 	configDirEnv = "CSGCLAW_CLIPROXY_CONFIG_DIR"
 	authDirEnv   = "CSGCLAW_CLIPROXY_AUTH_DIR"
+	// systemProxyURLEnv carries the Electron-resolved system proxy only to the
+	// embedded CLIProxy used by the Codex and Claude Code model providers. It
+	// intentionally does not use HTTP_PROXY/HTTPS_PROXY, which would route all
+	// Go sidecar traffic, including OpenCSG and custom providers, through it.
+	systemProxyURLEnv = "CSGCLAW_CLIPROXY_SYSTEM_PROXY_URL"
 
 	embeddedCLIProxySkipGinLogKey = "__gin_skip_request_logging__"
 
@@ -428,7 +433,7 @@ func configDir() (string, error) {
 }
 
 func configuredProxyURL() string {
-	for _, name := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"} {
+	for _, name := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", systemProxyURLEnv} {
 		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
 			return value
 		}

--- a/internal/cliproxy/service_test.go
+++ b/internal/cliproxy/service_test.go
@@ -332,6 +332,7 @@ func TestManagedRetryRecoversStreamingTransientBeforeFirstByte(t *testing.T) {
 
 func TestBuildConfigUsesStandardProxyEnvironmentForCLIProxyAPI(t *testing.T) {
 	clearStandardProxyEnv(t)
+	t.Setenv(systemProxyURLEnv, "")
 	t.Setenv(configDirEnv, t.TempDir())
 	t.Setenv(authDirEnv, filepath.Join(t.TempDir(), "auth"))
 	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
@@ -352,6 +353,31 @@ func TestBuildConfigUsesStandardProxyEnvironmentForCLIProxyAPI(t *testing.T) {
 	}
 	if text := string(content); !strings.Contains(text, `proxy-url: "http://127.0.0.1:7890"`) {
 		t.Fatalf("generated config missing proxy-url:\n%s", text)
+	}
+}
+
+func TestBuildConfigUsesScopedDesktopSystemProxyForCLIProxyAPI(t *testing.T) {
+	clearStandardProxyEnv(t)
+	t.Setenv(systemProxyURLEnv, "http://127.0.0.1:7890")
+	t.Setenv(configDirEnv, t.TempDir())
+	t.Setenv(authDirEnv, filepath.Join(t.TempDir(), "auth"))
+
+	cfg, cfgPath, _, err := buildConfig()
+	if err != nil {
+		t.Fatalf("buildConfig returned error: %v", err)
+	}
+	if cfg.ProxyURL != "http://127.0.0.1:7890" {
+		t.Fatalf("ProxyURL = %q, want scoped desktop system proxy", cfg.ProxyURL)
+	}
+	if err := writeConfigFile(cfgPath, cfg); err != nil {
+		t.Fatalf("writeConfigFile returned error: %v", err)
+	}
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if text := string(content); !strings.Contains(text, `proxy-url: "http://127.0.0.1:7890"`) {
+		t.Fatalf("generated config missing scoped proxy-url:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
- Prevent Windows system proxy settings from routing all CSGClaw traffic through a local proxy and breaking direct site access.
- Keep the proxy scoped to Codex and Claude Code providers while other services use their default network path.
