### PR TITLE
fix(channel): complete built-in IM adapter cutover

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -44,8 +44,6 @@ import (
 	feishubinding "csgclaw/internal/channel/feishu/binding"
 	"csgclaw/internal/channel/feishu/participantprovider"
 	feishutransport "csgclaw/internal/channel/feishu/transport"
-	"csgclaw/internal/channelbridge/codexbridge"
-	"csgclaw/internal/channelbridge/codexmanager"
 	"csgclaw/internal/channelbridge/runtimebridge"
 	"csgclaw/internal/cliproxy"
 	"csgclaw/internal/config"
@@ -109,7 +107,6 @@ var (
 		}
 		return svc.StopRunningSandboxAgents(ctx)
 	}
-	NewCodexBridgeManager   = newCodexBridgeManager
 	NewFeishuBindingManager = newFeishuBindingManager
 	NewCSGClawAdapterSource = newCSGClawAdapterSource
 	OpenBrowser             = openBrowser
@@ -124,6 +121,7 @@ type desktopServeCmd struct{}
 
 type csgclawAdapterSource interface {
 	Start(context.Context) error
+	Reconcile(context.Context) error
 	Close()
 }
 
@@ -635,22 +633,24 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 	// One Engine instance owns admission for both HTTP sessions and direct
 	// channel execution. Channel packages must never construct a second Engine.
 	conversationEngine := agentengine.New(svc)
-	codexBridgeMgr, err := NewCodexBridgeManager(cfg, svc, feishuSvc, workRegistry)
-	if err != nil {
-		return err
-	}
 	feishuBindingMgr, err := NewFeishuBindingManager(feishuSvc, conversationEngine)
 	if err != nil {
 		return err
 	}
+	imAdapterSource, err := NewCSGClawAdapterSource(conversationEngine, svc, imSvc, imBus, participantSvc, workRegistry, participantBridge)
+	if err != nil {
+		return err
+	}
 	if svc != nil {
-		svc.SetLifecycleObserver(codexBridgeMgr)
-		if activator := newChannelBindingActivator(codexBridgeMgr, feishuBindingMgr); activator != nil {
+		if activator := newChannelBindingActivator(imAdapterSource, feishuBindingMgr); activator != nil {
 			svc.SetBindingActivator(activator)
 		}
 	}
-	if codexBridgeMgr != nil {
-		defer codexBridgeMgr.Close()
+	if imAdapterSource != nil {
+		defer imAdapterSource.Close()
+		if err := imAdapterSource.Start(ctx); err != nil {
+			return err
+		}
 	}
 	if feishuBindingMgr != nil {
 		defer feishuBindingMgr.Close()
@@ -660,16 +660,6 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 		if err := feishuBindingMgr.Start(ctx); err != nil {
 			return err
 		}
-	}
-	imAdapterSource, err := NewCSGClawAdapterSource(conversationEngine, svc, imSvc, imBus, participantSvc, workRegistry, participantBridge)
-	if err != nil {
-		return err
-	}
-	if imAdapterSource != nil {
-		if err := imAdapterSource.Start(ctx); err != nil {
-			return err
-		}
-		defer imAdapterSource.Close()
 	}
 	llmSvc, err := NewLLMService(cfg, svc)
 	if err != nil {
@@ -834,11 +824,6 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 				}
 				if err := startConfiguredAgents(ctx, svc); err != nil {
 					slog.Warn("some configured agents failed to start", "error", err)
-				}
-				if codexBridgeMgr != nil {
-					if err := codexBridgeMgr.Start(ctx); err != nil {
-						slog.Warn("some codex bridges failed to start", "error", err)
-					}
 				}
 			}()
 		},
@@ -1054,10 +1039,6 @@ func openBrowser(rawURL string) error {
 
 func apiBaseURL(server config.ServerConfig) string {
 	return config.ResolveAdvertiseBaseURL(server)
-}
-
-func codexBridgeBaseURL(server config.ServerConfig) string {
-	return config.ResolveLocalBaseURL(server)
 }
 
 func serveAPIBaseURL(serverConfig config.ServerConfig, opts serveOptions) string {
@@ -1285,37 +1266,39 @@ func newAgentTemplateHubService(cfg config.HubConfig) (*hub.Service, error) {
 	return hub.NewService(cfg.Resolved(), hub.DefaultStoreFactory)
 }
 
-type codexBridgeManager = codexmanager.Manager
-
 type feishuBindingManager interface {
 	Start(context.Context) error
 	Reconcile(context.Context) error
 	Close()
 }
 
-// channelBindingActivator keeps binding configuration changes on their owning
-// channel manager. Agent runtime lifecycle remains owned by codexBridgeManager;
-// Feishu App Bindings are deliberately independent from that lifecycle.
-type channelBindingActivator struct {
-	csgclaw codexBridgeManager
-	feishu  feishuBindingManager
+type channelBindingReconciler interface {
+	Reconcile(context.Context) error
 }
 
-func newChannelBindingActivator(csgclaw codexBridgeManager, feishu feishuBindingManager) agent.BindingActivator {
+// channelBindingActivator keeps binding configuration changes on their owning
+// channel manager. Both built-in IM and Feishu bindings are deliberately
+// independent from Agent runtime lifecycle.
+type channelBindingActivator struct {
+	csgclaw channelBindingReconciler
+	feishu  channelBindingReconciler
+}
+
+func newChannelBindingActivator(csgclaw, feishu channelBindingReconciler) agent.BindingActivator {
 	if csgclaw == nil && feishu == nil {
 		return nil
 	}
 	return &channelBindingActivator{csgclaw: csgclaw, feishu: feishu}
 }
 
-func (a *channelBindingActivator) RefreshAgentChannel(ctx context.Context, target agent.Agent, channel string) error {
+func (a *channelBindingActivator) RefreshAgentChannel(ctx context.Context, _ agent.Agent, channel string) error {
 	channel = strings.ToLower(strings.TrimSpace(channel))
 	switch channel {
 	case csgclawchannel.ChannelID:
 		if a.csgclaw == nil {
 			return fmt.Errorf("channel %q binding activator is not configured", channel)
 		}
-		return a.csgclaw.RefreshAgentChannel(ctx, target, channel)
+		return a.csgclaw.Reconcile(ctx)
 	case feishu.ChannelID:
 		if a.feishu == nil {
 			return fmt.Errorf("channel %q binding activator is not configured", channel)
@@ -1327,7 +1310,17 @@ func (a *channelBindingActivator) RefreshAgentChannel(ctx context.Context, targe
 }
 
 func (a *channelBindingActivator) CanRefreshStoppedAgentBinding(channel string) bool {
-	return a != nil && a.feishu != nil && strings.EqualFold(strings.TrimSpace(channel), feishu.ChannelID)
+	if a == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case csgclawchannel.ChannelID:
+		return a.csgclaw != nil
+	case feishu.ChannelID:
+		return a.feishu != nil
+	default:
+		return false
+	}
 }
 
 func channelActivityDecider(svc *agent.Service) api.ActivityDecider {
@@ -1360,23 +1353,6 @@ func codexRuntimeForService(svc *agent.Service) *runtimecodex.Runtime {
 	}
 	codexRuntime, _ := runtimeImpl.(*runtimecodex.Runtime)
 	return codexRuntime
-}
-
-func newCodexBridgeManager(cfg config.Config, svc *agent.Service, _ *feishu.Service, workReporter worklease.ParticipantWorkReporter) (codexBridgeManager, error) {
-	if svc == nil {
-		return nil, nil
-	}
-	opts := codexmanager.Options{
-		Agents:       svc,
-		Runtimes:     svc,
-		WorkReporter: workReporter,
-		CSGClawClient: &codexbridge.HTTPClient{
-			BaseURL:     codexBridgeBaseURL(cfg.Server),
-			Token:       cfg.Server.AccessToken,
-			MentionOnly: true,
-		},
-	}
-	return codexmanager.New(opts)
 }
 
 func newFeishuBindingManager(feishuSvc *feishu.Service, engine agentengine.Interface) (feishuBindingManager, error) {
@@ -1434,7 +1410,12 @@ func newCSGClawAdapterSource(
 	var interactionCoordinator *csgclawinteraction.Coordinator
 	var rendererOptions []delivery.RendererOption
 	if codexRuntime := codexRuntimeForService(agentSvc); codexRuntime != nil {
-		interactionCoordinator = csgclawinteraction.NewCoordinator(codexRuntime.UserInputBroker(), participantSvc, store)
+		interactionCoordinator = csgclawinteraction.NewCoordinator(
+			codexRuntime.UserInputBroker(),
+			participantSvc,
+			store,
+			csgclawinteraction.WithRuntimeIdentity(engine.Agents(), codexRuntime),
+		)
 		if interactionCoordinator != nil {
 			rendererOptions = append(rendererOptions,
 				delivery.WithUserInputBinder(interactionCoordinator),

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -767,7 +767,6 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 	origNewLLMService := NewLLMService
 	origEnsureBootstrapManager := EnsureBootstrapManager
 	origStartConfiguredAgents := StartConfiguredAgents
-	origNewCodexBridgeManager := NewCodexBridgeManager
 	origEnsureCLIProxy := EnsureCLIProxy
 	origShutdownCLIProxy := ShutdownCLIProxy
 	t.Cleanup(func() {
@@ -778,7 +777,6 @@ func TestServeForegroundPassesContextToServer(t *testing.T) {
 		NewLLMService = origNewLLMService
 		EnsureBootstrapManager = origEnsureBootstrapManager
 		StartConfiguredAgents = origStartConfiguredAgents
-		NewCodexBridgeManager = origNewCodexBridgeManager
 		EnsureCLIProxy = origEnsureCLIProxy
 		ShutdownCLIProxy = origShutdownCLIProxy
 	})
@@ -1114,68 +1112,6 @@ func TestServeForegroundPassesConfigPathToServer(t *testing.T) {
 	}
 }
 
-func TestServeForegroundStartsCodexBridgesAfterConfiguredAgents(t *testing.T) {
-	restore := stubServeDependencies(t)
-	defer restore()
-
-	origNewCodexBridgeManager := NewCodexBridgeManager
-	t.Cleanup(func() {
-		NewCodexBridgeManager = origNewCodexBridgeManager
-	})
-
-	startedAgents := make(chan struct{})
-	releaseAgents := make(chan struct{})
-	bridgeStarted := make(chan struct{})
-	bridgeClosed := make(chan struct{})
-
-	StartConfiguredAgents = func(context.Context, *agent.Service) error {
-		close(startedAgents)
-		<-releaseAgents
-		return nil
-	}
-	NewCodexBridgeManager = func(config.Config, *agent.Service, *feishu.Service, worklease.ParticipantWorkReporter) (codexBridgeManager, error) {
-		return &fakeCodexBridgeManager{
-			start: func(context.Context) error {
-				select {
-				case <-startedAgents:
-				default:
-					t.Fatal("codex bridge started before configured agents")
-				}
-				close(bridgeStarted)
-				return nil
-			},
-			close: func() {
-				close(bridgeClosed)
-			},
-		}, nil
-	}
-	RunServer = func(opts server.Options) error {
-		if opts.OnReady == nil {
-			return fmt.Errorf("OnReady is nil")
-		}
-		opts.OnReady(nil, nil)
-		close(releaseAgents)
-		if opts.Context == nil {
-			return fmt.Errorf("Context is nil")
-		}
-		return nil
-	}
-
-	if err := serveForeground(context.Background(), testContext(), config.Config{Server: config.ServerConfig{ListenAddr: "127.0.0.1:18080"}}, "json"); err != nil {
-		t.Fatalf("serveForeground() error = %v", err)
-	}
-	select {
-	case <-bridgeStarted:
-	case <-time.After(time.Second):
-		t.Fatal("codex bridge manager did not start")
-	}
-	select {
-	case <-bridgeClosed:
-	case <-time.After(time.Second):
-		t.Fatal("codex bridge manager did not close")
-	}
-}
-
 func TestServeForegroundSharesOneAgentEngineWithFeishuBindings(t *testing.T) {
 	restore := stubServeDependencies(t)
 	defer restore()
@@ -1222,12 +1158,15 @@ func TestServeForegroundSharesOneAgentEngineWithFeishuBindings(t *testing.T) {
 	}
 }
 
-func TestServeForegroundStartsBuiltInIMAdapterSource(t *testing.T) {
+func TestServeForegroundUsesSingleBuiltInIMAdapterSource(t *testing.T) {
 	restore := stubServeDependencies(t)
 	defer restore()
 
 	started := make(chan struct{})
 	closed := make(chan struct{})
+	handled := make(chan im.ParticipantEvent, 2)
+	var sourceBridge *im.ParticipantBridge
+	var cancelSubscription func()
 	NewCSGClawAdapterSource = func(
 		engine *agentengine.Engine,
 		_ *agent.Service,
@@ -1240,15 +1179,55 @@ func TestServeForegroundStartsBuiltInIMAdapterSource(t *testing.T) {
 		if engine == nil || workReporter == nil || bridge == nil {
 			t.Fatal("built-in IM adapter dependencies were not assembled")
 		}
+		sourceBridge = bridge
 		return &fakeCSGClawAdapterSource{
 			start: func(context.Context) error {
+				events, cancel := bridge.Subscribe("manager")
+				cancelSubscription = cancel
+				go func() {
+					if event, ok := <-events; ok {
+						handled <- event
+					}
+				}()
 				close(started)
 				return nil
 			},
-			close: func() { close(closed) },
+			close: func() {
+				if cancelSubscription != nil {
+					cancelSubscription()
+				}
+				close(closed)
+			},
 		}, nil
 	}
-	RunServer = func(server.Options) error { return nil }
+	RunServer = func(opts server.Options) error {
+		if opts.ParticipantBridge != sourceBridge {
+			return fmt.Errorf("server and built-in IM adapter use different participant bridges")
+		}
+		if got := opts.ParticipantBridge.SubscriberCount("manager"); got != 1 {
+			return fmt.Errorf("manager participant subscribers = %d, want exactly 1", got)
+		}
+		room := im.Room{ID: "room-1", IsDirect: true, Members: []string{"user-admin", "manager"}}
+		sender := im.User{ID: "user-admin", Name: "admin"}
+		message := im.Message{ID: "message-1", SenderID: sender.ID, Content: "hello"}
+		if ok := opts.ParticipantBridge.EnqueueMessageEvent(room, sender, message, "manager"); !ok {
+			return fmt.Errorf("message was not delivered to built-in IM adapter")
+		}
+		select {
+		case event := <-handled:
+			if event.MessageID != message.ID {
+				return fmt.Errorf("handled message = %q, want %q", event.MessageID, message.ID)
+			}
+		case <-time.After(time.Second):
+			return fmt.Errorf("built-in IM adapter did not handle message")
+		}
+		select {
+		case event := <-handled:
+			return fmt.Errorf("message was handled more than once: %q", event.MessageID)
+		case <-time.After(20 * time.Millisecond):
+		}
+		return nil
+	}
 
 	if err := serveForeground(context.Background(), testContext(), config.Config{
 		Server: config.ServerConfig{ListenAddr: "127.0.0.1:18080"},
@@ -1270,20 +1249,17 @@ func TestServeForegroundStartsBuiltInIMAdapterSource(t *testing.T) {
 func TestChannelBindingActivatorRoutesToChannelOwner(t *testing.T) {
 	t.Parallel()
 
-	target := agent.Agent{ID: "agent-1"}
 	var csgclawCalls, feishuCalls int
-	csgclawManager := &fakeCodexBridgeManager{refresh: func(_ context.Context, got agent.Agent, channel string) error {
+	csgclawSource := &fakeCSGClawAdapterSource{reconcile: func(context.Context) error {
 		csgclawCalls++
-		if got.ID != target.ID || channel != csgclawchannel.ChannelID {
-			t.Fatalf("csgclaw refresh = (%q, %q)", got.ID, channel)
-		}
 		return nil
 	}}
 	feishuManager := &fakeFeishuBindingManager{reconcile: func(context.Context) error {
 		feishuCalls++
 		return nil
 	}}
-	activator := newChannelBindingActivator(csgclawManager, feishuManager)
+	activator := newChannelBindingActivator(csgclawSource, feishuManager)
+	target := agent.Agent{ID: "agent-1"}
 	if err := activator.RefreshAgentChannel(context.Background(), target, " CSGCLAW "); err != nil {
 		t.Fatalf("refresh csgclaw: %v", err)
 	}
@@ -1295,6 +1271,19 @@ func TestChannelBindingActivatorRoutesToChannelOwner(t *testing.T) {
 	}
 	if err := activator.RefreshAgentChannel(context.Background(), target, "unknown"); err == nil {
 		t.Fatal("refresh unknown channel succeeded")
+	}
+	stoppedPolicy, ok := activator.(agent.StoppedAgentBindingActivator)
+	if !ok {
+		t.Fatal("binding activator does not expose stopped-agent refresh policy")
+	}
+	if !stoppedPolicy.CanRefreshStoppedAgentBinding(csgclawchannel.ChannelID) {
+		t.Fatal("csgclaw binding should refresh independently of agent runtime state")
+	}
+	if !stoppedPolicy.CanRefreshStoppedAgentBinding(feishu.ChannelID) {
+		t.Fatal("feishu binding should refresh independently of agent runtime state")
+	}
+	if stoppedPolicy.CanRefreshStoppedAgentBinding("unknown") {
+		t.Fatal("unknown binding should not refresh while the agent is stopped")
 	}
 	feishuOnly := newChannelBindingActivator(nil, feishuManager)
 	if err := feishuOnly.RefreshAgentChannel(context.Background(), target, csgclawchannel.ChannelID); err == nil {
@@ -1789,7 +1778,6 @@ func stubServeDependencies(t *testing.T) func() {
 	origEnsureBootstrapManager := EnsureBootstrapManager
 	origStartConfiguredAgents := StartConfiguredAgents
 	origStopRunningSandboxAgents := StopRunningSandboxAgents
-	origNewCodexBridgeManager := NewCodexBridgeManager
 	origNewFeishuBindingManager := NewFeishuBindingManager
 	origNewCSGClawAdapterSource := NewCSGClawAdapterSource
 	origEnsureCLIProxy := EnsureCLIProxy
@@ -1818,9 +1806,6 @@ func stubServeDependencies(t *testing.T) func() {
 	EnsureBootstrapManager = func(context.Context, *agent.Service) error { return nil }
 	StartConfiguredAgents = func(context.Context, *agent.Service) error { return nil }
 	StopRunningSandboxAgents = func(context.Context, *agent.Service) error { return nil }
-	NewCodexBridgeManager = func(config.Config, *agent.Service, *feishu.Service, worklease.ParticipantWorkReporter) (codexBridgeManager, error) {
-		return nil, nil
-	}
 	NewFeishuBindingManager = func(*feishu.Service, agentengine.Interface) (feishuBindingManager, error) {
 		return nil, nil
 	}
@@ -1855,7 +1840,6 @@ func stubServeDependencies(t *testing.T) func() {
 		EnsureBootstrapManager = origEnsureBootstrapManager
 		StartConfiguredAgents = origStartConfiguredAgents
 		StopRunningSandboxAgents = origStopRunningSandboxAgents
-		NewCodexBridgeManager = origNewCodexBridgeManager
 		NewFeishuBindingManager = origNewFeishuBindingManager
 		NewCSGClawAdapterSource = origNewCSGClawAdapterSource
 		EnsureCLIProxy = origEnsureCLIProxy
@@ -1943,17 +1927,6 @@ func TestAPIBaseURLPrefersAdvertiseBaseURL(t *testing.T) {
 	want := "http://example.test/base"
 	if got != want {
 		t.Fatalf("apiBaseURL() = %q, want %q", got, want)
-	}
-}
-
-func TestCodexBridgeBaseURLUsesLocalListener(t *testing.T) {
-	got := codexBridgeBaseURL(config.ServerConfig{
-		ListenAddr:       "0.0.0.0:19090",
-		AdvertiseBaseURL: "https://public.example.test/csgclaw",
-	})
-	want := "http://127.0.0.1:19090"
-	if got != want {
-		t.Fatalf("codexBridgeBaseURL() = %q, want %q", got, want)
 	}
 }
 
@@ -2095,14 +2068,6 @@ func (b *notifyingBuffer) String() string {
 	return b.buf.String()
 }
 
-type fakeCodexBridgeManager struct {
-	start   func(context.Context) error
-	ensure  func(context.Context, agent.Agent) error
-	stop    func(string)
-	refresh func(context.Context, agent.Agent, string) error
-	close   func()
-}
-
 type fakeFeishuBindingManager struct {
 	start     func(context.Context) error
 	reconcile func(context.Context) error
@@ -2110,13 +2075,21 @@ type fakeFeishuBindingManager struct {
 }
 
 type fakeCSGClawAdapterSource struct {
-	start func(context.Context) error
-	close func()
+	start     func(context.Context) error
+	reconcile func(context.Context) error
+	close     func()
 }
 
 func (s *fakeCSGClawAdapterSource) Start(ctx context.Context) error {
 	if s != nil && s.start != nil {
 		return s.start(ctx)
+	}
+	return nil
+}
+
+func (s *fakeCSGClawAdapterSource) Reconcile(ctx context.Context) error {
+	if s != nil && s.reconcile != nil {
+		return s.reconcile(ctx)
 	}
 	return nil
 }
@@ -2142,39 +2115,6 @@ func (m *fakeFeishuBindingManager) Reconcile(ctx context.Context) error {
 }
 
 func (m *fakeFeishuBindingManager) Close() {
-	if m != nil && m.close != nil {
-		m.close()
-	}
-}
-
-func (m *fakeCodexBridgeManager) Start(ctx context.Context) error {
-	if m != nil && m.start != nil {
-		return m.start(ctx)
-	}
-	return nil
-}
-
-func (m *fakeCodexBridgeManager) EnsureAgent(ctx context.Context, a agent.Agent) error {
-	if m != nil && m.ensure != nil {
-		return m.ensure(ctx, a)
-	}
-	return nil
-}
-
-func (m *fakeCodexBridgeManager) StopAgent(agentID string) {
-	if m != nil && m.stop != nil {
-		m.stop(agentID)
-	}
-}
-
-func (m *fakeCodexBridgeManager) RefreshAgentChannel(ctx context.Context, a agent.Agent, channel string) error {
-	if m != nil && m.refresh != nil {
-		return m.refresh(ctx, a, channel)
-	}
-	return nil
-}
-
-func (m *fakeCodexBridgeManager) Close() {
 	if m != nil && m.close != nil {
 		m.close()
 	}

--- a/internal/channel/csgclaw/interaction/interaction.go
+++ b/internal/channel/csgclaw/interaction/interaction.go
@@ -31,6 +31,25 @@ type eventSubmitter interface {
 	IsCurrent(channel.BindingID, agentengine.ConversationKey, string) bool
 }
 
+type agentProvider interface {
+	Get(context.Context, string) (agentengine.Agent, error)
+}
+
+type sessionResolver interface {
+	ExistingEngineSession(context.Context, string, string) (string, bool, error)
+}
+
+type Option func(*Coordinator)
+
+// WithRuntimeIdentity lets detached requests participate in the same
+// Runtime/session cancellation lifecycle as native Codex interactions.
+func WithRuntimeIdentity(agents agentProvider, sessions sessionResolver) Option {
+	return func(coordinator *Coordinator) {
+		coordinator.agents = agents
+		coordinator.sessions = sessions
+	}
+}
+
 type detachedRequest struct {
 	turn    channel.TurnContext
 	binding channel.Binding
@@ -43,6 +62,8 @@ type Coordinator struct {
 	broker       runtimecodex.UserInputBroker
 	participants participantResolver
 	store        *delivery.IMTranscriptStore
+	agents       agentProvider
+	sessions     sessionResolver
 
 	mu        sync.Mutex
 	submitter eventSubmitter
@@ -53,6 +74,7 @@ func NewCoordinator(
 	broker runtimecodex.UserInputBroker,
 	participants participantResolver,
 	store *delivery.IMTranscriptStore,
+	opts ...Option,
 ) *Coordinator {
 	if broker == nil || participants == nil || store == nil {
 		return nil
@@ -62,6 +84,11 @@ func NewCoordinator(
 		participants: participants,
 		store:        store,
 		requests:     make(map[string]detachedRequest),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(coordinator)
+		}
 	}
 	broker.AddDetachedHandler(coordinator.handleDetachedResolution)
 	return coordinator
@@ -91,12 +118,13 @@ func (c *Coordinator) Activate(
 	if c == nil || c.broker == nil {
 		return activity.UserInputSnapshot{}, fmt.Errorf("structured user input is not configured")
 	}
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			return activity.UserInputSnapshot{}, ctx.Err()
-		default:
-		}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return activity.UserInputSnapshot{}, ctx.Err()
+	default:
 	}
 	questions := make([]activity.UserInputQuestionSnapshot, 0, len(args.Questions))
 	for _, question := range args.Questions {
@@ -120,13 +148,14 @@ func (c *Coordinator) Activate(
 	if args.AutoResolutionMS != nil {
 		autoResolve = time.Duration(*args.AutoResolutionMS) * time.Millisecond
 	}
+	execution, err := c.execution(ctx, turn)
+	if err != nil {
+		return activity.UserInputSnapshot{}, err
+	}
+	execution.ToolCallID = "structured-output-" + strings.TrimSpace(turn.SourceMessageID)
+	execution.ToolKind = "request_user_input"
 	snapshot, err := c.broker.CreateDetached(runtimecodex.PendingUserInputRequest{
-		Execution: activity.ExecutionRef{
-			RuntimeKind: "codex",
-			TurnID:      string(turn.TurnID),
-			ToolCallID:  "structured-output-" + strings.TrimSpace(turn.SourceMessageID),
-			ToolKind:    "request_user_input",
-		},
+		Execution:   execution,
 		Questions:   questions,
 		RequestedAt: time.Now().UTC(),
 		AutoResolve: autoResolve,
@@ -153,6 +182,34 @@ func (c *Coordinator) Activate(
 	}
 	c.mu.Unlock()
 	return snapshot, nil
+}
+
+func (c *Coordinator) execution(ctx context.Context, turn channel.TurnContext) (activity.ExecutionRef, error) {
+	if c.agents == nil || c.sessions == nil {
+		return activity.ExecutionRef{}, fmt.Errorf("structured user input runtime identity is not configured")
+	}
+	selected, err := c.agents.Get(ctx, strings.TrimSpace(turn.AgentID))
+	if err != nil {
+		return activity.ExecutionRef{}, fmt.Errorf("resolve structured user input agent: %w", err)
+	}
+	runtimeID := strings.TrimSpace(selected.Status.RuntimeID)
+	if runtimeID == "" {
+		return activity.ExecutionRef{}, fmt.Errorf("structured user input runtime is unavailable")
+	}
+	sessionID, ok, err := c.sessions.ExistingEngineSession(ctx, runtimeID, strings.TrimSpace(string(turn.ConversationKey)))
+	if err != nil {
+		return activity.ExecutionRef{}, fmt.Errorf("resolve structured user input session: %w", err)
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if !ok || sessionID == "" {
+		return activity.ExecutionRef{}, fmt.Errorf("structured user input session is unavailable")
+	}
+	return activity.ExecutionRef{
+		RuntimeKind: "codex",
+		RuntimeID:   runtimeID,
+		SessionID:   sessionID,
+		TurnID:      string(turn.TurnID),
+	}, nil
 }
 
 func (c *Coordinator) handleDetachedResolution(resolution runtimecodex.DetachedUserInputResolution) {

--- a/internal/channel/csgclaw/interaction/interaction_test.go
+++ b/internal/channel/csgclaw/interaction/interaction_test.go
@@ -1,0 +1,87 @@
+package interaction
+
+import (
+	"context"
+	"testing"
+
+	"csgclaw/internal/activity"
+	"csgclaw/internal/agentengine"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/channel"
+	"csgclaw/internal/channel/csgclaw/delivery"
+	"csgclaw/internal/im"
+	runtimecodex "csgclaw/internal/runtime/codex"
+)
+
+type staticParticipants struct{}
+
+func (staticParticipants) Get(_ string, id string) (apitypes.Participant, bool) {
+	return apitypes.Participant{ID: id, ChannelUserRef: "user-" + id}, true
+}
+
+type staticAgents struct {
+	agent agentengine.Agent
+}
+
+func (a staticAgents) Get(context.Context, string) (agentengine.Agent, error) {
+	return a.agent, nil
+}
+
+type staticSessions struct {
+	runtimeID       string
+	conversationKey string
+	sessionID       string
+}
+
+func (s *staticSessions) ExistingEngineSession(_ context.Context, runtimeID, conversationKey string) (string, bool, error) {
+	s.runtimeID = runtimeID
+	s.conversationKey = conversationKey
+	return s.sessionID, true, nil
+}
+
+func TestCoordinatorDetachedRequestUsesRuntimeSessionCancellationIdentity(t *testing.T) {
+	broker := runtimecodex.NewUserInputBroker(nil)
+	store, err := delivery.NewIMTranscriptStore(im.NewService(), staticParticipants{})
+	if err != nil {
+		t.Fatalf("NewIMTranscriptStore() error = %v", err)
+	}
+	sessions := &staticSessions{sessionID: "session-1"}
+	coordinator := NewCoordinator(
+		broker,
+		staticParticipants{},
+		store,
+		WithRuntimeIdentity(staticAgents{agent: agentengine.Agent{
+			ID:     "agent-1",
+			Status: agentengine.AgentStatus{RuntimeID: "runtime-1"},
+		}}, sessions),
+	)
+
+	snapshot, err := coordinator.Activate(context.Background(), channel.TurnContext{
+		BindingID:       "binding-1",
+		ParticipantID:   "participant-1",
+		AgentID:         "agent-1",
+		RoomID:          "room-1",
+		SourceMessageID: "message-1",
+		ConversationKey: "conversation-1",
+		TurnID:          "turn-1",
+	}, activity.RequestUserInputArgs{Questions: []activity.RequestUserInputQuestion{{
+		ID: "choice", Header: "Choice", Question: "Continue?",
+	}}})
+	if err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	if sessions.runtimeID != "runtime-1" || sessions.conversationKey != "conversation-1" {
+		t.Fatalf("session lookup = (%q, %q), want (runtime-1, conversation-1)", sessions.runtimeID, sessions.conversationKey)
+	}
+
+	broker.CancelSession("binding-1", "conversation-1")
+	if pending, ok := broker.Get(snapshot.ID); !ok || pending.Status != activity.UserInputStatusPending {
+		t.Fatalf("request after channel-identity cancellation = (%q, %v), want pending", pending.Status, ok)
+	}
+
+	broker.CancelSession("runtime-1", "session-1")
+	resolved, ok := broker.Get(snapshot.ID)
+	if !ok || resolved.Status != activity.UserInputStatusInterrupted {
+		t.Fatalf("request after runtime/session cancellation = (%q, %v), want interrupted", resolved.Status, ok)
+	}
+}

--- a/internal/channel/csgclaw/source/source_test.go
+++ b/internal/channel/csgclaw/source/source_test.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -317,5 +318,79 @@ func TestSourceRetriesEventWhileSubscriptionRemainsActive(t *testing.T) {
 	}
 	if ok := bridge.EnqueueMessageEvent(room, sender, message, "pt-worker"); !ok {
 		t.Fatal("acked retried event should be recognized as handled")
+	}
+}
+
+func TestSourceDrainsBridgePendingAfterRetryBackpressure(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	var available atomic.Bool
+	firstAttempt := make(chan struct{})
+	var firstAttemptOnce sync.Once
+	succeeded := make(chan string, 32)
+	workers := &fakeWorkers{
+		ensured: make(chan channel.Binding, 1),
+		submits: make(chan submittedEvent, 128),
+		submit: func(_ channel.Binding, event channelbridge.BotEvent) error {
+			if !available.Load() {
+				firstAttemptOnce.Do(func() { close(firstAttempt) })
+				return errors.New("worker unavailable")
+			}
+			succeeded <- event.MessageID
+			return nil
+		},
+	}
+	source, err := newSource(
+		bridge,
+		nil,
+		fakeParticipants{items: []apitypes.Participant{{
+			ID: "pt-worker", Channel: participant.ChannelCSGClaw, Type: participant.TypeAgent, AgentID: "agent-worker",
+		}}},
+		fakeAgents{items: map[string]agentengine.Agent{
+			"agent-worker": {ID: "agent-worker", Spec: agentengine.AgentSpec{Runtime: agentengine.RuntimeSpec{Adapter: "codex"}}},
+		}},
+		workers,
+	)
+	if err != nil {
+		t.Fatalf("newSource() error = %v", err)
+	}
+	source.retryInitial = time.Millisecond
+	source.retryMax = 2 * time.Millisecond
+	if err := source.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer source.Close()
+
+	room := im.Room{ID: "room-1", IsDirect: true, Members: []string{"user-admin", "pt-worker"}}
+	sender := im.User{ID: "user-admin", Name: "admin"}
+	enqueue := func(index int) {
+		message := im.Message{
+			ID:       fmt.Sprintf("message-%02d", index),
+			SenderID: sender.ID,
+			Content:  fmt.Sprintf("message %d", index),
+		}
+		bridge.EnqueueMessageEvent(room, sender, message, "pt-worker")
+	}
+
+	enqueue(0)
+	select {
+	case <-firstAttempt:
+	case <-time.After(time.Second):
+		t.Fatal("source did not reach worker backpressure")
+	}
+	const messageCount = 24 // exceeds the ParticipantBridge subscription buffer
+	for index := 1; index < messageCount; index++ {
+		enqueue(index)
+	}
+	available.Store(true)
+
+	seen := make(map[string]struct{}, messageCount)
+	deadline := time.After(2 * time.Second)
+	for len(seen) < messageCount {
+		select {
+		case messageID := <-succeeded:
+			seen[messageID] = struct{}{}
+		case <-deadline:
+			t.Fatalf("successfully submitted messages = %d, want %d; pending events remained stranded", len(seen), messageCount)
+		}
 	}
 }

--- a/internal/im/participant_bridge.go
+++ b/internal/im/participant_bridge.go
@@ -249,6 +249,39 @@ func (b *ParticipantBridge) Ack(participantID, messageID string) {
 	}
 	b.removePendingLocked(participantID, messageID)
 	b.markSeenLocked(participantID, messageID)
+	b.drainPendingLocked(participantID)
+}
+
+// drainPendingLocked refills active subscribers after a consumer acknowledges
+// an event. This matters when a consumer was temporarily backpressured: once
+// the subscriber channel filled, enqueue stored later events in pending, and
+// the acknowledgement is the first reliable signal that capacity is available
+// again without forcing the consumer to replace its subscription.
+func (b *ParticipantBridge) drainPendingLocked(participantID string) {
+	pending := append([]ParticipantEvent(nil), b.pending[participantID]...)
+	if len(pending) == 0 {
+		return
+	}
+	delete(b.pending, participantID)
+	subs := b.subscribers[participantID]
+	for _, evt := range pending {
+		if b.hasSeenOrInflightLocked(participantID, evt.MessageID) {
+			continue
+		}
+		sent := false
+		for ch := range subs {
+			select {
+			case ch <- evt:
+				sent = true
+			default:
+			}
+		}
+		if sent {
+			b.markInflightLocked(participantID, evt)
+			continue
+		}
+		b.addPendingLocked(participantID, evt)
+	}
 }
 
 func (b *ParticipantBridge) Requeue(participantID string, evt ParticipantEvent) {


### PR DESCRIPTION
- Follow up on the built-in IM and Agent Engine refactor merged in #507 by making the in-process adapter the sole data-plane subscriber and binding lifecycle owner.
- Drain ParticipantBridge pending events when retry backpressure clears, preventing messages from remaining stranded after worker recovery.
- Attach detached request_user_input prompts to the active Codex runtime and session identity so `/new` interrupts obsolete requests.
