### PR TITLE
fix(codex): prevent Windows read-only startup failure

### DIFF
--- a/internal/runtime/codex/appserver_manager.go
+++ b/internal/runtime/codex/appserver_manager.go
@@ -823,6 +823,7 @@ func appServerOverrides(spec SessionSpec) []string {
 		"--config", `approval_policy="never"`,
 		"--config", `default_permissions="csgclaw-read-only"`,
 		"--config", `web_search="disabled"`,
+		"--config", `project_doc_max_bytes=0`,
 		"--config", `shell_environment_policy.inherit="none"`,
 	}
 	if workspaceDir := strings.TrimSpace(spec.WorkspaceDir); workspaceDir != "" {

--- a/internal/runtime/codex/appserver_manager_test.go
+++ b/internal/runtime/codex/appserver_manager_test.go
@@ -2284,7 +2284,7 @@ func TestAppServerReadOnlyParamsAndOverrides(t *testing.T) {
 	}
 	overrides := appServerOverrides(spec)
 	joined := strings.Join(overrides, " ")
-	for _, want := range []string{"--strict-config", "--disable shell_tool", "--disable unified_exec", `approval_policy="never"`, `default_permissions="csgclaw-read-only"`} {
+	for _, want := range []string{"--strict-config", "--disable shell_tool", "--disable unified_exec", `approval_policy="never"`, `default_permissions="csgclaw-read-only"`, `project_doc_max_bytes=0`} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("overrides missing %q: %q", want, overrides)
 		}

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -2759,6 +2759,46 @@ func TestBuildSandboxConfigBlockUsesUnelevatedWindowsSandbox(t *testing.T) {
 	}
 }
 
+func TestWindowsReadOnlyConfigurationSkipsSandboxedProjectDocLoading(t *testing.T) {
+	standardConfig := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(
+		"",
+		agentruntime.Profile{},
+		nil,
+		`C:\workspace`,
+		true,
+		ExecutionModeStandard,
+	)
+	config := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(
+		standardConfig,
+		agentruntime.Profile{},
+		nil,
+		`C:\workspace`,
+		true,
+		ExecutionModeReadOnly,
+	)
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(config), &parsed); err != nil {
+		t.Fatalf("Windows read-only config is invalid TOML: %v\n%s", err, config)
+	}
+	windowsConfig, ok := parsed["windows"].(map[string]any)
+	if !ok || windowsConfig["sandbox"] != "unelevated" {
+		t.Fatalf("Windows read-only sandbox = %#v, want unelevated\n%s", parsed["windows"], config)
+	}
+	permissions := parsed["permissions"].(map[string]any)
+	profile := permissions[readOnlyPermissionsProfile].(map[string]any)
+	filesystem := profile["filesystem"].(map[string]any)
+	if filesystem[":root"] != "deny" {
+		t.Fatalf("Windows read-only filesystem policy = %#v, want root deny\n%s", filesystem, config)
+	}
+	overrides := strings.Join(appServerOverrides(SessionSpec{
+		ExecutionMode: ExecutionModeReadOnly,
+		WorkspaceDir:  `C:\workspace`,
+	}), " ")
+	if !strings.Contains(overrides, `project_doc_max_bytes=0`) {
+		t.Fatalf("Windows read-only app-server overrides do not disable project docs: %q", overrides)
+	}
+}
+
 func TestConfigureCodexHomeConfigReadOnlyModePinsSafeRootSettings(t *testing.T) {
 	config := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(
 		"approval_policy = \"on-request\"\nfeatures.shell_tool = true\nfeatures.unified_exec = true\n",


### PR DESCRIPTION
## Summary

- prevent Windows read-only agents from scanning local project docs before sandbox startup
- preserve unelevated sandbox and root-deny permissions with regression coverage