### PR TITLE
refactor(template): simplify agent manifest fields

### DIFF
--- a/docs/tech/agent-template-manifest.zh.md
+++ b/docs/tech/agent-template-manifest.zh.md
@@ -1,0 +1,44 @@
+# Agent 模板清单字段
+
+本文档记录 CSGClaw Agent 模板中 `agent.toml` 的字段含义、必填要求，以及后续是否计划保留。
+
+> 注意：表格记录字段精简决策。标记为 ❌ 的字段已经从当前实现中移除；旧清单中残留的这些字段会被忽略。
+>
+> `runtime_options.memory_mode` 是规划字段，当前版本尚未支持。当前 `[runtime_options]` 只允许配置 `execution_mode`。
+
+| 字段名 | 含义 | 是否必须 | 是否计划保留 |
+|---|---|---|---|
+| `schema_version` | `agent.toml` 的格式版本。目前发布模板时会写入 `agentfile/v1`，但读取时尚未校验 | 否 | ✅ |
+| `name` | 模板名称，用于模板展示；创建 Agent 时可作为默认名称 | 是 | ✅ |
+| `description` | 模板说明；创建 Agent 时可作为 Agent 的默认描述 | 否 | ✅ |
+| `role` | 模板角色，旧格式只支持 `manager` 或 `worker` | 否，已移除 | ❌ |
+| `runtime_kind` | Agent 运行时类型，只支持 `codex`、`picoclaw` 或 `openclaw` | 是 | ✅ |
+| `version` | 模板版本，用于模板展示及判断沙箱镜像是否需要升级 | 否 | ✅ |
+| `updated_at` | 模板更新时间，必须是 RFC 3339 时间格式，用于 Hub 展示和排序 | 否 | ✅ |
+| `image.ref` | 沙箱运行时使用的容器镜像地址 | `picoclaw`、`openclaw` 必须；`codex` 不必须 | ✅ |
+| `image.digest` | 容器镜像摘要 | 否，已移除 | ❌ |
+| `image.platforms` | 镜像支持的平台列表 | 否，已移除 | ❌ |
+| `image.env` | 容器镜像所需的环境变量定义列表 | 否 | ✅ |
+| `image.env[].name` | 环境变量名称；同一模板内不允许出现大小写不同但名称相同的重复项 | 存在 `image.env` 条目时必须 | ✅ |
+| `image.env[].required` | 是否要求用户在创建 Agent 时填写该环境变量，默认值为 `false` | 否 | ✅ |
+| `image.env[].secret` | 是否为敏感信息。设置为 `true` 时不允许同时设置 `default` | 否 | ✅ |
+| `image.env[].default` | 环境变量默认值；创建 Agent 时自动填入。敏感变量不能设置默认值 | 否 | ✅ |
+| `image.env[].description` | 环境变量说明 | 否，已移除 | ❌ |
+| `image.env[].choices` | 环境变量可选值列表 | 否，已移除 | ❌ |
+| `image.env[].pattern` | 环境变量值的正则表达式约束 | 否，已移除 | ❌ |
+| `image.env[].example` | 环境变量示例值 | 否，已移除 | ❌ |
+| `image.env[].placeholder` | 环境变量输入提示 | 否，已移除 | ❌ |
+| `runtime_options` | Agent 运行时选项。目前只支持 Codex Worker 模板，并且只允许包含 `execution_mode` | 否 | ✅ |
+| `runtime_options.execution_mode` | Codex Worker 的执行模式；`standard` 表示标准模式，`read_only` 表示只读模式 | 否，未设置时按 `standard` 模式运行 | ✅ |
+| `runtime_options.memory_mode` | Agent 记忆模式；`enabled` 表示启用，`disabled` 表示不启用。该字段为规划字段，当前尚未实现 | 否 | ✅ |
+
+## 当前约束
+
+- 内置模板的角色由内置模板注册表决定；本地模板和社区模板统一作为 Worker。
+- 从 Manager 保存或发布的模板仍允许创建，但保存后会作为普通 Worker 模板使用。
+- `runtime_kind` 当前只接受 `codex`、`picoclaw` 或 `openclaw`。
+- `image.ref` 对沙箱运行时 `picoclaw` 和 `openclaw` 是必填字段。
+- `runtime_options` 当前仅适用于 Codex Worker 模板。
+- `runtime_options.execution_mode` 当前只接受 `standard` 或 `read_only`。
+- `runtime_options.memory_mode` 尚未实现，在当前版本的 `agent.toml` 中配置该字段会导致模板校验失败。
+- `image.env[].secret = true` 时不能同时设置非空的 `default`。

--- a/docs/tech/agent-template-manifest.zh.md
+++ b/docs/tech/agent-template-manifest.zh.md
@@ -4,7 +4,7 @@
 
 > 注意：表格记录字段精简决策。标记为 ❌ 的字段已经从当前实现中移除；旧清单中残留的这些字段会被忽略。
 >
-> `runtime_options.memory_mode` 是规划字段，当前版本尚未支持。当前 `[runtime_options]` 只允许配置 `execution_mode`。
+> `[runtime_options]` 当前仅适用于 Codex Worker 模板，支持 `execution_mode` 和 `memory_mode`。
 
 | 字段名 | 含义 | 是否必须 | 是否计划保留 |
 |---|---|---|---|
@@ -28,9 +28,9 @@
 | `image.env[].pattern` | 环境变量值的正则表达式约束 | 否，已移除 | ❌ |
 | `image.env[].example` | 环境变量示例值 | 否，已移除 | ❌ |
 | `image.env[].placeholder` | 环境变量输入提示 | 否，已移除 | ❌ |
-| `runtime_options` | Agent 运行时选项。目前只支持 Codex Worker 模板，并且只允许包含 `execution_mode` | 否 | ✅ |
+| `runtime_options` | Agent 运行时选项。目前只支持 Codex Worker 模板，并且只允许包含 `execution_mode` 和 `memory_mode` | 否 | ✅ |
 | `runtime_options.execution_mode` | Codex Worker 的执行模式；`standard` 表示标准模式，`read_only` 表示只读模式 | 否，未设置时按 `standard` 模式运行 | ✅ |
-| `runtime_options.memory_mode` | Agent 记忆模式；`enabled` 表示启用，`disabled` 表示不启用。该字段为规划字段，当前尚未实现 | 否 | ✅ |
+| `runtime_options.memory_mode` | Codex Worker 的记忆模式；`enabled` 表示启用，`disabled` 表示不启用 | 否，未设置时按 `enabled` 模式运行 | ✅ |
 
 ## 当前约束
 
@@ -40,5 +40,5 @@
 - `image.ref` 对沙箱运行时 `picoclaw` 和 `openclaw` 是必填字段。
 - `runtime_options` 当前仅适用于 Codex Worker 模板。
 - `runtime_options.execution_mode` 当前只接受 `standard` 或 `read_only`。
-- `runtime_options.memory_mode` 尚未实现，在当前版本的 `agent.toml` 中配置该字段会导致模板校验失败。
+- `runtime_options.memory_mode` 当前只接受 `enabled` 或 `disabled`。
 - `image.env[].secret = true` 时不能同时设置非空的 `default`。

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -251,7 +251,6 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 		ID:             got.Name,
 		Name:           got.Name,
 		Description:    got.Description,
-		Role:           got.Role,
 		RuntimeKind:    got.RuntimeConfig().Kind(),
 		Image:          got.Image,
 		RuntimeOptions: runtimeOptions,

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -8429,7 +8429,7 @@ func TestImageNeedsTemplateVersionUpgradeIgnoresCurrentSharedImageTag(t *testing
 	}
 }
 
-func TestAgentMarksOutdatedManagerImageUpgradeRequiredFromDefaultTemplateVersion(t *testing.T) {
+func TestAgentIgnoresLocalTemplatePublishedFromManagerForManagerUpgrade(t *testing.T) {
 	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
 
 	const (
@@ -8488,8 +8488,8 @@ func TestAgentMarksOutdatedManagerImageUpgradeRequiredFromDefaultTemplateVersion
 	if got.AgentProfile.EnvRestartRequired {
 		t.Fatalf("Agent().AgentProfile.EnvRestartRequired = true, want false for image-only upgrade")
 	}
-	if !got.AgentProfile.ImageUpgradeRequired {
-		t.Fatalf("Agent().AgentProfile.ImageUpgradeRequired = false, want true for outdated manager image")
+	if got.AgentProfile.ImageUpgradeRequired {
+		t.Fatalf("Agent().AgentProfile.ImageUpgradeRequired = true, want false for local worker template")
 	}
 }
 
@@ -8969,7 +8969,7 @@ func TestCreateWorkerRejectsMissingDefaultTemplate(t *testing.T) {
 	}
 }
 
-func TestCreateWorkerRejectsDefaultTemplateRoleMismatch(t *testing.T) {
+func TestCreateWorkerTreatsLocalManagerPublishAsWorkerTemplate(t *testing.T) {
 	t.Cleanup(TestOnlySetSandboxProvider(sandboxtest.NewProvider()))
 
 	hubSvc := mustNewLocalTemplateHubService(t, "review-manager", hub.Template{
@@ -8993,12 +8993,12 @@ func TestCreateWorkerRejectsDefaultTemplateRoleMismatch(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	_, err = svc.CreateWorker(context.Background(), CreateAgentSpec{Name: "alice"})
-	if err == nil {
-		t.Fatal("CreateWorker() error = nil, want role mismatch")
+	got, err := svc.CreateWorker(context.Background(), CreateAgentSpec{Name: "alice"})
+	if err != nil {
+		t.Fatalf("CreateWorker() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), `default worker template "local.review-manager" points to a manager template`) {
-		t.Fatalf("CreateWorker() error = %v, want worker/manager mismatch", err)
+	if got.Role != RoleWorker || got.Description != "manager template" {
+		t.Fatalf("CreateWorker() = role %q description %q, want worker using published template", got.Role, got.Description)
 	}
 }
 
@@ -9167,9 +9167,6 @@ func TestHubPublishSpecUsesAgentWorkspaceSnapshot(t *testing.T) {
 	}
 	if spec.Description != "review worker" {
 		t.Fatalf("Description = %q, want %q", spec.Description, "review worker")
-	}
-	if spec.Role != hub.TemplateRoleWorker {
-		t.Fatalf("Role = %q, want %q", spec.Role, hub.TemplateRoleWorker)
 	}
 	if spec.RuntimeKind != RuntimeNamePicoClaw {
 		t.Fatalf("RuntimeKind = %q, want %q", spec.RuntimeKind, RuntimeNamePicoClaw)
@@ -11485,7 +11482,6 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 		ID:             id,
 		Name:           item.Name,
 		Description:    item.Description,
-		Role:           item.Role,
 		RuntimeKind:    item.RuntimeKind,
 		Version:        item.Version,
 		Image:          item.Image,
@@ -11527,9 +11523,6 @@ func appendTemplateImageEnvContracts(t *testing.T, manifestPath string, items []
 		fmt.Fprintf(&b, "\n[[image.env]]\nname = %q\nrequired = %t\nsecret = %t\n", item.Name, item.Required, item.Secret)
 		if item.Default != "" {
 			fmt.Fprintf(&b, "default = %q\n", item.Default)
-		}
-		if item.Description != "" {
-			fmt.Fprintf(&b, "description = %q\n", item.Description)
 		}
 	}
 	if err := os.WriteFile(manifestPath, []byte(b.String()), 0o644); err != nil {
@@ -11596,7 +11589,6 @@ func mustNewLocalTemplateHubServiceWithoutWorkspace(t *testing.T, id string, ite
 		ID:          id,
 		Name:        item.Name,
 		Description: item.Description,
-		Role:        item.Role,
 		RuntimeKind: item.RuntimeKind,
 		Version:     item.Version,
 		Image:       item.Image,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1628,7 +1628,7 @@ func TestHandleAgentsListReportsImageUpgradeRequiredByTemplateVersion(t *testing
 	}
 }
 
-func TestHandleManagerGetReportsImageUpgradeRequiredByTemplateVersion(t *testing.T) {
+func TestHandleManagerGetIgnoresLocalTemplatePublishedFromManager(t *testing.T) {
 	tests := []struct {
 		name         string
 		currentImage string
@@ -1637,18 +1637,18 @@ func TestHandleManagerGetReportsImageUpgradeRequiredByTemplateVersion(t *testing
 		wantRequired bool
 	}{
 		{
-			name:         "older manager version requires upgrade",
+			name:         "older local template version is ignored",
 			currentImage: "registry.example/opencsghq/picoclaw-manager:0.1.0",
 			latestImage:  "registry.example/opencsghq/picoclaw-manager:0.2.0",
 			version:      "0.2.0",
-			wantRequired: true,
+			wantRequired: false,
 		},
 		{
-			name:         "legacy manager base image requires upgrade to template wrapper",
+			name:         "legacy manager base image is ignored",
 			currentImage: "registry.example/opencsghq/picoclaw:2026.5.27",
 			latestImage:  "registry.example/opencsghq/picoclaw-manager:0.2.0",
 			version:      "0.2.0",
-			wantRequired: true,
+			wantRequired: false,
 		},
 		{
 			name:         "newer manager version does not require upgrade",
@@ -5428,7 +5428,6 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 		ID:             id,
 		Name:           item.Name,
 		Description:    item.Description,
-		Role:           item.Role,
 		RuntimeKind:    item.RuntimeKind,
 		Version:        item.Version,
 		Image:          item.Image,
@@ -5460,7 +5459,6 @@ func mustNewLocalTemplateHubServiceWithoutWorkspace(t *testing.T, id string, ite
 		ID:             id,
 		Name:           item.Name,
 		Description:    item.Description,
-		Role:           item.Role,
 		RuntimeKind:    item.RuntimeKind,
 		Version:        item.Version,
 		Image:          item.Image,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5256,6 +5256,67 @@ func TestHandleHubTemplatesPublishesAgentSnapshot(t *testing.T) {
 	}
 }
 
+func TestHandleHubTemplatesPublishesCodexRuntimeOptions(t *testing.T) {
+	created := agent.Agent{
+		ID:          "u-codex-worker",
+		Name:        "codex-worker",
+		Role:        agent.RoleWorker,
+		RuntimeKind: agent.RuntimeKindCodex,
+		RuntimeOptions: map[string]any{
+			"execution_mode": "read_only",
+			"memory_mode":    "disabled",
+		},
+	}
+	svc := mustNewSeededService(t, []agent.Agent{created})
+	publishSpec, err := svc.HubPublishSpec(created.ID)
+	if err != nil {
+		t.Fatalf("HubPublishSpec() error = %v", err)
+	}
+	if err := os.MkdirAll(publishSpec.WorkspaceRef.Path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+
+	registryRoot := t.TempDir()
+	hubSvc, err := hub.NewService(config.HubConfig{
+		DefaultRegistry:        "local",
+		DefaultPublishRegistry: "local",
+		Registries: []config.HubRegistryConfig{
+			{Name: "local", Kind: hub.RegistryKindLocal, Path: registryRoot, Enabled: true},
+		},
+	}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
+	}
+
+	srv := &Handler{svc: svc}
+	srv.SetHubService(hubSvc)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hub/templates", strings.NewReader(
+		fmt.Sprintf(`{"agent_id":%q,"registry":"local"}`, created.ID),
+	))
+	rec := httptest.NewRecorder()
+
+	srv.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var got apitypes.HubTemplate
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.RuntimeOptions["execution_mode"] != "read_only" || got.RuntimeOptions["memory_mode"] != "disabled" {
+		t.Fatalf("runtime options = %#v, want execution_mode=read_only and memory_mode=disabled", got.RuntimeOptions)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(registryRoot, "templates", created.Name, "agent.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(agent.toml) error = %v", err)
+	}
+	manifest := string(manifestData)
+	if !strings.Contains(manifest, "execution_mode = 'read_only'") || !strings.Contains(manifest, "memory_mode = 'disabled'") {
+		t.Fatalf("agent.toml missing Codex runtime options:\n%s", manifest)
+	}
+}
+
 func TestHandleHubTemplatesRequiresOpenCSGLoginForOfficialPublish(t *testing.T) {
 	restore := stubAuthStatus(func(*http.Request) (auth.Status, error) {
 		return auth.Status{Authenticated: false}, nil

--- a/internal/apitypes/hub.go
+++ b/internal/apitypes/hub.go
@@ -12,15 +12,10 @@ type CreateHubTemplateRequest struct {
 }
 
 type ImageEnvContract struct {
-	Name        string   `json:"name"`
-	Required    bool     `json:"required,omitempty"`
-	Secret      bool     `json:"secret,omitempty"`
-	Default     string   `json:"default,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Choices     []string `json:"choices,omitempty"`
-	Pattern     string   `json:"pattern,omitempty"`
-	Example     string   `json:"example,omitempty"`
-	Placeholder string   `json:"placeholder,omitempty"`
+	Name     string `json:"name"`
+	Required bool   `json:"required,omitempty"`
+	Secret   bool   `json:"secret,omitempty"`
+	Default  string `json:"default,omitempty"`
 }
 
 type HubTemplate struct {

--- a/internal/template/builtin_store.go
+++ b/internal/template/builtin_store.go
@@ -54,7 +54,14 @@ func (s *BuiltinStore) Get(_ context.Context, id string) (Template, error) {
 	if err != nil {
 		return Template{}, fmt.Errorf("validate builtin hub manifest %q: %w", id, err)
 	}
-	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	builtin, ok := hubtemplates.LookupBuiltin(id)
+	if !ok {
+		return Template{}, fmt.Errorf("%w: %s", ErrTemplateNotFound, id)
+	}
+	if normalizeTemplateRole(builtin.Role) != TemplateRoleWorker && len(manifest.RuntimeOptions) > 0 {
+		return Template{}, fmt.Errorf("validate builtin hub manifest %q runtime options: runtime_options are supported only for Codex worker templates", id)
+	}
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.RuntimeOptions)
 	if err != nil {
 		return Template{}, fmt.Errorf("validate builtin hub manifest %q runtime options: %w", id, err)
 	}
@@ -62,7 +69,7 @@ func (s *BuiltinStore) Get(_ context.Context, id string) (Template, error) {
 		ID:             id,
 		Name:           manifest.Name,
 		Description:    manifest.Description,
-		Role:           normalizeTemplateRole(manifest.Role),
+		Role:           normalizeTemplateRole(builtin.Role),
 		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
 		Version:        strings.TrimSpace(manifest.Version),
 		Image:          manifestImageRef(manifest.Image),

--- a/internal/template/builtin_store_test.go
+++ b/internal/template/builtin_store_test.go
@@ -52,8 +52,19 @@ func TestBuiltinStoreListGetAndFetchWorkspace(t *testing.T) {
 	if got, want := codexItem.RuntimeKind, runtime.KindCodex; got != want {
 		t.Fatalf("Get(codex-worker).RuntimeKind = %q, want %q", got, want)
 	}
+	if got, want := codexItem.Role, TemplateRoleWorker; got != want {
+		t.Fatalf("Get(codex-worker).Role = %q, want %q", got, want)
+	}
 	if got := codexItem.Image; got != "" {
 		t.Fatalf("Get(codex-worker).Image = %q, want empty", got)
+	}
+
+	managerItem, err := store.Get(context.Background(), "manager-codex")
+	if err != nil {
+		t.Fatalf("Get(manager-codex) error = %v", err)
+	}
+	if got, want := managerItem.Role, TemplateRoleManager; got != want {
+		t.Fatalf("Get(manager-codex).Role = %q, want %q", got, want)
 	}
 
 	workspace, err := store.FetchWorkspace(context.Background(), "openclaw-worker")
@@ -108,7 +119,6 @@ func TestServiceListAggregatesBuiltinAndLocalWithDefaultStoreFactory(t *testing.
 	localStore := NewLocalStore(registryRoot)
 	if _, err := localStore.Publish(context.Background(), PublishSpec{
 		Name:         "team-helper",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	}); err != nil {

--- a/internal/template/embed/manager/codex/agent.toml
+++ b/internal/template/embed/manager/codex/agent.toml
@@ -1,6 +1,5 @@
 name = "manager-codex"
 description = "Built-in Codex manager template"
-role = "manager"
 runtime_kind = "codex"
 version = "0.1.0"
 updated_at = "2026-07-08T00:00:00Z"

--- a/internal/template/embed/worker/codex/agent.toml
+++ b/internal/template/embed/worker/codex/agent.toml
@@ -1,6 +1,5 @@
 name = "generic-assistant-codex"
 description = "通用型助手（Codex版）"
-role = "worker"
 runtime_kind = "codex"
 updated_at = "2026-07-09T00:00:00Z"
 version = "0.1.0"

--- a/internal/template/embed/worker/openclaw/agent.toml
+++ b/internal/template/embed/worker/openclaw/agent.toml
@@ -1,6 +1,5 @@
 name = "generic-assistant-openclaw"
 description = "通用型助手（OpenClaw版）"
-role = "worker"
 runtime_kind = "openclaw"
 updated_at = "2026-07-22T08:23:15Z"
 version = "0.1.7"

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -92,7 +92,7 @@ func (s *LocalStore) Get(_ context.Context, id string) (Template, error) {
 	if err != nil {
 		return Template{}, fmt.Errorf("validate local hub manifest %q: %w", id, err)
 	}
-	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.RuntimeOptions)
 	if err != nil {
 		return Template{}, fmt.Errorf("validate local hub manifest %q runtime options: %w", id, err)
 	}
@@ -100,7 +100,7 @@ func (s *LocalStore) Get(_ context.Context, id string) (Template, error) {
 		ID:             id,
 		Name:           manifest.Name,
 		Description:    manifest.Description,
-		Role:           normalizeTemplateRole(manifest.Role),
+		Role:           TemplateRoleWorker,
 		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
 		Version:        strings.TrimSpace(manifest.Version),
 		Image:          manifestImageRef(manifest.Image),
@@ -263,7 +263,6 @@ func (s *LocalStore) writeManifest(path string, spec PublishSpec) error {
 	manifest := templateManifest{
 		Name:        spec.Name,
 		Description: spec.Description,
-		Role:        spec.Role,
 		RuntimeKind: normalizeTemplateRuntimeKind(spec.RuntimeKind),
 		Version:     spec.Version,
 		Image: templateImageSection{
@@ -296,15 +295,11 @@ func normalizePublishSpec(spec PublishSpec) (PublishSpec, error) {
 	if spec.Name == "" {
 		return PublishSpec{}, ErrTemplateNameRequired
 	}
-	spec.Role = normalizeTemplateRole(spec.Role)
-	if spec.Role == "" {
-		return PublishSpec{}, fmt.Errorf("role must be one of %q or %q", TemplateRoleManager, TemplateRoleWorker)
-	}
 	spec.RuntimeKind = normalizeTemplateRuntimeKind(spec.RuntimeKind)
 	spec.Version = strings.TrimSpace(spec.Version)
 	spec.Image = strings.TrimSpace(spec.Image)
 	spec.Description = strings.TrimSpace(spec.Description)
-	runtimeOptions, err := normalizeTemplateRuntimeOptions(spec.RuntimeKind, spec.Role, spec.RuntimeOptions)
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(spec.RuntimeKind, spec.RuntimeOptions)
 	if err != nil {
 		return PublishSpec{}, err
 	}

--- a/internal/template/local_store_test.go
+++ b/internal/template/local_store_test.go
@@ -30,7 +30,6 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	published, err := store.Publish(context.Background(), PublishSpec{
 		Name:           "frontend-alice",
 		Description:    "Frontend worker with UI and styling skills",
-		Role:           TemplateRoleWorker,
 		RuntimeKind:    runtime.KindCodex,
 		Image:          "worker:latest",
 		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
@@ -124,7 +123,6 @@ func TestLocalStorePublishRejectsDuplicateName(t *testing.T) {
 	first, err := store.Publish(context.Background(), PublishSpec{
 		Name:        "review-bot",
 		Description: "original",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: runtime.KindCodex,
 	})
 	if err != nil {
@@ -133,7 +131,6 @@ func TestLocalStorePublishRejectsDuplicateName(t *testing.T) {
 	_, err = store.Publish(context.Background(), PublishSpec{
 		Name:        "review-bot",
 		Description: "replacement",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: runtime.KindCodex,
 	})
 	if !errors.Is(err, ErrTemplateAlreadyExists) {
@@ -153,7 +150,6 @@ func TestLocalStoreListSkipsInvalidTemplates(t *testing.T) {
 	store := NewLocalStore(registryRoot)
 	if _, err := store.Publish(context.Background(), PublishSpec{
 		Name:        "valid_codex_worker",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: runtime.KindCodex,
 	}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
@@ -205,7 +201,6 @@ func TestLocalStorePublishUsesRuntimeAwareInstructionAndSkillPaths(t *testing.T)
 	store := NewLocalStore(registryRoot)
 	if _, err := store.Publish(context.Background(), PublishSpec{
 		Name:        "codex-worker",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{
 			Kind:             WorkspaceKindDir,
@@ -277,7 +272,6 @@ func TestLocalStoreWriteWorkspaceFileUpdatesCanonicalInstructions(t *testing.T) 
 	workspaceRoot := writeWorkspaceFile(t, "workspace", "AGENTS.md", "old instructions")
 	if _, err := store.Publish(context.Background(), PublishSpec{
 		Name:         "editable-worker",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	}); err != nil {
@@ -304,7 +298,6 @@ func TestLocalStoreDeleteRemovesTemplate(t *testing.T) {
 	if _, err := store.Publish(context.Background(), PublishSpec{
 		ID:          "frontend-alice",
 		Name:        "frontend-alice",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: "picoclaw",
 		Image:       "worker:latest",
 	}); err != nil {
@@ -326,7 +319,6 @@ func TestLocalStorePublishRejectsUnsafeTemplateID(t *testing.T) {
 	_, err := store.Publish(context.Background(), PublishSpec{
 		ID:           "../escape",
 		Name:         "frontend-alice",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	})
@@ -344,7 +336,6 @@ func TestLocalStorePublishAllowsEmptyWorkspace(t *testing.T) {
 
 	published, err := store.Publish(context.Background(), PublishSpec{
 		Name:         "frontend-alice",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	})
@@ -368,7 +359,6 @@ func TestLocalStorePublishAllowsMissingWorkspace(t *testing.T) {
 
 	published, err := store.Publish(context.Background(), PublishSpec{
 		Name:        "frontend-alice",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: runtime.KindCodex,
 	})
 	if err != nil {
@@ -401,7 +391,6 @@ func TestLocalStorePublishRequiresImageForGatewayRuntime(t *testing.T) {
 
 	_, err := store.Publish(context.Background(), PublishSpec{
 		Name:         "gateway-worker",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.NamePicoClaw,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	})
@@ -445,7 +434,6 @@ func TestLocalStorePublishRejectsSymlinks(t *testing.T) {
 
 	_, err := store.Publish(context.Background(), PublishSpec{
 		Name:         "frontend-alice",
-		Role:         TemplateRoleWorker,
 		RuntimeKind:  runtime.KindCodex,
 		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
 	})
@@ -463,15 +451,25 @@ func TestLocalStoreGetMissingTemplate(t *testing.T) {
 	}
 }
 
-func TestLocalStorePublishRejectsMissingRole(t *testing.T) {
+func TestLocalStorePublishTreatsTemplateAsWorker(t *testing.T) {
 	store := NewLocalStore(t.TempDir())
 
-	_, err := store.Publish(context.Background(), PublishSpec{
+	got, err := store.Publish(context.Background(), PublishSpec{
 		Name:        "frontend-alice",
 		RuntimeKind: runtime.KindCodex,
 	})
-	if err == nil || err.Error() != `role must be one of "manager" or "worker"` {
-		t.Fatalf("Publish() error = %v, want missing role validation error", err)
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	if got.Role != TemplateRoleWorker {
+		t.Fatalf("Publish().Role = %q, want %q", got.Role, TemplateRoleWorker)
+	}
+	manifest, err := os.ReadFile(filepath.Join(store.templatesRoot(), "frontend-alice", localManifestFileName))
+	if err != nil {
+		t.Fatalf("ReadFile(agent.toml) error = %v", err)
+	}
+	if strings.Contains(string(manifest), "role =") {
+		t.Fatalf("agent.toml contains removed role field:\n%s", manifest)
 	}
 }
 

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -337,7 +337,7 @@ func (s *RemoteStore) getTemplate(ctx context.Context, id string, repository rem
 		name = strings.TrimSpace(repository.Name)
 	}
 	namespace := strings.SplitN(id, "/", 2)[0]
-	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions)
+	runtimeOptions, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.RuntimeOptions)
 	if err != nil {
 		return Template{}, fmt.Errorf("validate remote hub manifest %q runtime options: %w", id, err)
 	}
@@ -346,7 +346,7 @@ func (s *RemoteStore) getTemplate(ctx context.Context, id string, repository rem
 		Namespace:      namespace,
 		Name:           name,
 		Description:    description,
-		Role:           normalizeTemplateRole(manifest.Role),
+		Role:           TemplateRoleWorker,
 		RuntimeKind:    normalizeTemplateRuntimeKind(manifest.RuntimeKind),
 		Version:        strings.TrimSpace(manifest.Version),
 		Image:          manifestImageRef(manifest.Image),
@@ -801,7 +801,7 @@ func (s *RemoteStore) Publish(ctx context.Context, spec PublishSpec) (Template, 
 		Namespace:      s.username,
 		Name:           normalized.Name,
 		Description:    normalized.Description,
-		Role:           normalized.Role,
+		Role:           TemplateRoleWorker,
 		RuntimeKind:    normalized.RuntimeKind,
 		Version:        normalized.Version,
 		Image:          normalized.Image,

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const remoteTestManifest = `name = "gitlab-assistant"
-role = "worker"
+role = "manager"
 description = "GitLab assistant"
 runtime_kind = "openclaw"
 version = "2026.6.16.0"
@@ -178,7 +178,6 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 		ID:             "legacy-internal-id",
 		Name:           "ReviewBot_2",
 		Description:    "Reviews changes",
-		Role:           TemplateRoleWorker,
 		RuntimeKind:    "codex",
 		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
 		WorkspaceRef: WorkspaceRef{

--- a/internal/template/service.go
+++ b/internal/template/service.go
@@ -255,7 +255,6 @@ func (s *Service) PublishTemplate(ctx context.Context, id, registry string) (Tem
 		ID:             item.Name,
 		Name:           item.Name,
 		Description:    item.Description,
-		Role:           item.Role,
 		RuntimeKind:    item.RuntimeKind,
 		Version:        item.Version,
 		Image:          item.Image,

--- a/internal/template/service_test.go
+++ b/internal/template/service_test.go
@@ -203,7 +203,7 @@ func TestPublishUsesDefaultPublishRegistry(t *testing.T) {
 		"local":   localStore,
 	})
 
-	item, err := svc.Publish(context.Background(), PublishSpec{Name: "frontend-alice", Role: TemplateRoleWorker})
+	item, err := svc.Publish(context.Background(), PublishSpec{Name: "frontend-alice"})
 	if err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -248,7 +248,6 @@ func TestDeleteRemovesLocalTemplate(t *testing.T) {
 	if _, err := store.Publish(context.Background(), PublishSpec{
 		ID:          "review-bot",
 		Name:        "review-bot",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: "picoclaw",
 		Image:       "agent-image:test",
 	}); err != nil {
@@ -300,7 +299,7 @@ func TestPublishRejectsBuiltinRegistry(t *testing.T) {
 		"builtin": stubStore{},
 	})
 
-	_, err := svc.Publish(context.Background(), PublishSpec{Name: "frontend-alice", Role: TemplateRoleWorker})
+	_, err := svc.Publish(context.Background(), PublishSpec{Name: "frontend-alice"})
 	if !errors.Is(err, ErrRegistryNotWritable) {
 		t.Fatalf("Publish() error = %v, want ErrRegistryNotWritable", err)
 	}

--- a/internal/template/template_layout_test.go
+++ b/internal/template/template_layout_test.go
@@ -24,7 +24,6 @@ func TestLocalStoreCodexTemplateDoesNotRoundTripWorkspaceMemory(t *testing.T) {
 	created, err := store.Publish(context.Background(), PublishSpec{
 		ID:          "codex-with-workspace-memory",
 		Name:        "codex-with-workspace-memory",
-		Role:        TemplateRoleWorker,
 		RuntimeKind: agentruntime.KindCodex,
 		WorkspaceRef: WorkspaceRef{
 			Kind: WorkspaceKindDir,

--- a/internal/template/template_manifest.go
+++ b/internal/template/template_manifest.go
@@ -29,7 +29,6 @@ type templateManifest struct {
 	SchemaVersion  string               `toml:"schema_version,omitempty"`
 	Name           string               `toml:"name"`
 	Description    string               `toml:"description,omitempty"`
-	Role           string               `toml:"role"`
 	RuntimeKind    string               `toml:"runtime_kind"`
 	Version        string               `toml:"version,omitempty"`
 	Image          templateImageSection `toml:"image"`
@@ -38,22 +37,15 @@ type templateManifest struct {
 }
 
 type templateImageSection struct {
-	Ref       string                 `toml:"ref"`
-	Digest    string                 `toml:"digest,omitempty"`
-	Platforms []string               `toml:"platforms,omitempty"`
-	Env       []templateImageEnvItem `toml:"env"`
+	Ref string                 `toml:"ref"`
+	Env []templateImageEnvItem `toml:"env"`
 }
 
 type templateImageEnvItem struct {
-	Name        string   `toml:"name"`
-	Required    bool     `toml:"required"`
-	Secret      bool     `toml:"secret"`
-	Default     string   `toml:"default,omitempty"`
-	Description string   `toml:"description,omitempty"`
-	Choices     []string `toml:"choices,omitempty"`
-	Pattern     string   `toml:"pattern,omitempty"`
-	Example     string   `toml:"example,omitempty"`
-	Placeholder string   `toml:"placeholder,omitempty"`
+	Name     string `toml:"name"`
+	Required bool   `toml:"required"`
+	Secret   bool   `toml:"secret"`
+	Default  string `toml:"default,omitempty"`
 }
 
 func manifestImageRef(image templateImageSection) string {
@@ -79,17 +71,10 @@ func normalizeImageEnvContracts(raw []templateImageEnvItem) []apitypes.ImageEnvC
 			continue
 		}
 		contract := apitypes.ImageEnvContract{
-			Name:        name,
-			Required:    item.Required,
-			Secret:      item.Secret,
-			Default:     strings.TrimSpace(item.Default),
-			Description: strings.TrimSpace(item.Description),
-			Pattern:     strings.TrimSpace(item.Pattern),
-			Example:     strings.TrimSpace(item.Example),
-			Placeholder: strings.TrimSpace(item.Placeholder),
-		}
-		if len(item.Choices) > 0 {
-			contract.Choices = append([]string(nil), item.Choices...)
+			Name:     name,
+			Required: item.Required,
+			Secret:   item.Secret,
+			Default:  strings.TrimSpace(item.Default),
 		}
 		out = append(out, contract)
 	}
@@ -115,29 +100,6 @@ func validateImageEnvContracts(items []templateImageEnvItem) error {
 		if item.Secret && strings.TrimSpace(item.Default) != "" {
 			return fmt.Errorf("image.env[%d] secret entries cannot set default", index)
 		}
-		if len(item.Choices) == 0 {
-			continue
-		}
-		if strings.TrimSpace(item.Default) != "" {
-			defaultValue := strings.TrimSpace(item.Default)
-			found := false
-			for _, choice := range item.Choices {
-				if choice == defaultValue {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("image.env[%d].default must appear in choices", index)
-			}
-		}
-		pattern := strings.TrimSpace(item.Pattern)
-		if pattern == "" {
-			continue
-		}
-		if _, err := regexp.Compile(pattern); err != nil {
-			return fmt.Errorf("image.env[%d].pattern is invalid: %w", index, err)
-		}
 	}
 	return nil
 }
@@ -146,11 +108,6 @@ func validateManifest(manifest templateManifest) error {
 	manifest.Name = strings.TrimSpace(manifest.Name)
 	if manifest.Name == "" {
 		return ErrTemplateNameRequired
-	}
-	switch normalizeTemplateRole(manifest.Role) {
-	case TemplateRoleManager, TemplateRoleWorker:
-	default:
-		return fmt.Errorf("role must be one of %q or %q", TemplateRoleManager, TemplateRoleWorker)
 	}
 	manifest.RuntimeKind = normalizeTemplateRuntimeKind(manifest.RuntimeKind)
 	switch manifest.RuntimeKind {
@@ -165,7 +122,7 @@ func validateManifest(manifest templateManifest) error {
 	if err := validateImageEnvContracts(manifest.Image.Env); err != nil {
 		return err
 	}
-	if _, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.Role, manifest.RuntimeOptions); err != nil {
+	if _, err := normalizeTemplateRuntimeOptions(manifest.RuntimeKind, manifest.RuntimeOptions); err != nil {
 		return err
 	}
 	if _, err := parseManifestUpdatedAt(manifest.UpdatedAt); err != nil {
@@ -174,13 +131,12 @@ func validateManifest(manifest templateManifest) error {
 	return nil
 }
 
-func normalizeTemplateRuntimeOptions(runtimeKind, role string, raw map[string]any) (map[string]any, error) {
+func normalizeTemplateRuntimeOptions(runtimeKind string, raw map[string]any) (map[string]any, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
 	runtimeKind = normalizeTemplateRuntimeKind(runtimeKind)
-	role = normalizeTemplateRole(role)
-	if runtimeKind != runtime.KindCodex || role != TemplateRoleWorker {
+	if runtimeKind != runtime.KindCodex {
 		return nil, fmt.Errorf("runtime_options are supported only for Codex worker templates")
 	}
 	if len(raw) != 1 {

--- a/internal/template/template_manifest.go
+++ b/internal/template/template_manifest.go
@@ -139,24 +139,39 @@ func normalizeTemplateRuntimeOptions(runtimeKind string, raw map[string]any) (ma
 	if runtimeKind != runtime.KindCodex {
 		return nil, fmt.Errorf("runtime_options are supported only for Codex worker templates")
 	}
-	if len(raw) != 1 {
-		return nil, fmt.Errorf("runtime_options supports only execution_mode")
+	for key := range raw {
+		if key != "execution_mode" && key != "memory_mode" {
+			return nil, fmt.Errorf("runtime_options supports only execution_mode and memory_mode")
+		}
 	}
-	value, ok := raw["execution_mode"]
-	if !ok {
-		return nil, fmt.Errorf("runtime_options supports only execution_mode")
+	out := make(map[string]any, len(raw))
+	if value, ok := raw["execution_mode"]; ok {
+		mode, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("runtime_options.execution_mode must be a string")
+		}
+		mode = strings.ToLower(strings.TrimSpace(mode))
+		switch mode {
+		case "standard", "read_only":
+			out["execution_mode"] = mode
+		default:
+			return nil, fmt.Errorf("runtime_options.execution_mode must be %q or %q", "standard", "read_only")
+		}
 	}
-	mode, ok := value.(string)
-	if !ok {
-		return nil, fmt.Errorf("runtime_options.execution_mode must be a string")
+	if value, ok := raw["memory_mode"]; ok {
+		mode, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("runtime_options.memory_mode must be a string")
+		}
+		mode = strings.ToLower(strings.TrimSpace(mode))
+		switch mode {
+		case "enabled", "disabled":
+			out["memory_mode"] = mode
+		default:
+			return nil, fmt.Errorf("runtime_options.memory_mode must be %q or %q", "enabled", "disabled")
+		}
 	}
-	mode = strings.ToLower(strings.TrimSpace(mode))
-	switch mode {
-	case "standard", "read_only":
-		return map[string]any{"execution_mode": mode}, nil
-	default:
-		return nil, fmt.Errorf("runtime_options.execution_mode must be %q or %q", "standard", "read_only")
-	}
+	return out, nil
 }
 
 func cloneTemplateRuntimeOptions(raw map[string]any) map[string]any {

--- a/internal/template/template_manifest_test.go
+++ b/internal/template/template_manifest_test.go
@@ -17,11 +17,13 @@ func TestLoadManifestImageEnv(t *testing.T) {
 	manifest := `
 name = "gitlab-assistant"
 description = "GitLab assistant"
-role = "worker"
+role = "manager"
 runtime_kind = "picoclaw"
 
 [image]
 ref = "picoclaw:test"
+digest = "sha256:legacy"
+platforms = ["linux/amd64"]
 
 [[image.env]]
 name = "GITLAB_TOKEN"
@@ -31,6 +33,11 @@ secret = true
 [[image.env]]
 name = "GITLAB_URL"
 default = "https://gitlab.example.com"
+description = "legacy description"
+choices = ["https://gitlab.example.com"]
+pattern = "^https://"
+example = "https://gitlab.example.com"
+placeholder = "https://gitlab.example.com"
 `
 	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
@@ -43,6 +50,9 @@ default = "https://gitlab.example.com"
 	}
 	if got.RuntimeKind != runtime.NamePicoClaw {
 		t.Fatalf("RuntimeKind = %q, want %q", got.RuntimeKind, runtime.NamePicoClaw)
+	}
+	if got.Role != TemplateRoleWorker {
+		t.Fatalf("Role = %q, want legacy manifest role ignored and worker derived", got.Role)
 	}
 	if got.Image != "picoclaw:test" {
 		t.Fatalf("Image = %q, want picoclaw:test", got.Image)
@@ -81,7 +91,7 @@ func TestValidatePublishTemplateName(t *testing.T) {
 }
 
 func TestNormalizeTemplateRuntimeOptions(t *testing.T) {
-	got, err := normalizeTemplateRuntimeOptions(runtime.KindCodex, TemplateRoleWorker, map[string]any{
+	got, err := normalizeTemplateRuntimeOptions(runtime.KindCodex, map[string]any{
 		"execution_mode": " READ_ONLY ",
 	})
 	if err != nil {
@@ -93,16 +103,14 @@ func TestNormalizeTemplateRuntimeOptions(t *testing.T) {
 
 	for name, test := range map[string]struct {
 		runtimeKind string
-		role        string
 		options     map[string]any
 	}{
-		"manager":        {runtimeKind: runtime.KindCodex, role: TemplateRoleManager, options: map[string]any{"execution_mode": "read_only"}},
-		"non codex":      {runtimeKind: runtime.NameOpenClaw, role: TemplateRoleWorker, options: map[string]any{"execution_mode": "read_only"}},
-		"unknown option": {runtimeKind: runtime.KindCodex, role: TemplateRoleWorker, options: map[string]any{"local_workspace_dir": "/tmp/project"}},
-		"invalid mode":   {runtimeKind: runtime.KindCodex, role: TemplateRoleWorker, options: map[string]any{"execution_mode": "unsafe"}},
+		"non codex":      {runtimeKind: runtime.NameOpenClaw, options: map[string]any{"execution_mode": "read_only"}},
+		"unknown option": {runtimeKind: runtime.KindCodex, options: map[string]any{"local_workspace_dir": "/tmp/project"}},
+		"invalid mode":   {runtimeKind: runtime.KindCodex, options: map[string]any{"execution_mode": "unsafe"}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if _, err := normalizeTemplateRuntimeOptions(test.runtimeKind, test.role, test.options); err == nil {
+			if _, err := normalizeTemplateRuntimeOptions(test.runtimeKind, test.options); err == nil {
 				t.Fatal("normalizeTemplateRuntimeOptions() error = nil, want rejection")
 			}
 		})

--- a/internal/template/template_manifest_test.go
+++ b/internal/template/template_manifest_test.go
@@ -93,12 +93,16 @@ func TestValidatePublishTemplateName(t *testing.T) {
 func TestNormalizeTemplateRuntimeOptions(t *testing.T) {
 	got, err := normalizeTemplateRuntimeOptions(runtime.KindCodex, map[string]any{
 		"execution_mode": " READ_ONLY ",
+		"memory_mode":    " DISABLED ",
 	})
 	if err != nil {
 		t.Fatalf("normalizeTemplateRuntimeOptions() error = %v", err)
 	}
 	if got["execution_mode"] != "read_only" {
 		t.Fatalf("execution_mode = %v, want read_only", got["execution_mode"])
+	}
+	if got["memory_mode"] != "disabled" {
+		t.Fatalf("memory_mode = %v, want disabled", got["memory_mode"])
 	}
 
 	for name, test := range map[string]struct {
@@ -108,6 +112,8 @@ func TestNormalizeTemplateRuntimeOptions(t *testing.T) {
 		"non codex":      {runtimeKind: runtime.NameOpenClaw, options: map[string]any{"execution_mode": "read_only"}},
 		"unknown option": {runtimeKind: runtime.KindCodex, options: map[string]any{"local_workspace_dir": "/tmp/project"}},
 		"invalid mode":   {runtimeKind: runtime.KindCodex, options: map[string]any{"execution_mode": "unsafe"}},
+		"invalid memory": {runtimeKind: runtime.KindCodex, options: map[string]any{"memory_mode": "sometimes"}},
+		"memory type":    {runtimeKind: runtime.KindCodex, options: map[string]any{"memory_mode": true}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := normalizeTemplateRuntimeOptions(test.runtimeKind, test.options); err == nil {

--- a/internal/template/types.go
+++ b/internal/template/types.go
@@ -66,7 +66,6 @@ type PublishSpec struct {
 	ID             string
 	Name           string
 	Description    string
-	Role           string
 	RuntimeKind    string
 	Version        string
 	Image          string

--- a/web/app/src/models/agents.ts
+++ b/web/app/src/models/agents.ts
@@ -64,11 +64,6 @@ export type ImageEnvContract = {
   required?: boolean;
   secret?: boolean;
   default?: string | null;
-  description?: string | null;
-  choices?: string[] | null;
-  pattern?: string | null;
-  example?: string | null;
-  placeholder?: string | null;
 };
 
 export type AgentProfileLike = {


### PR DESCRIPTION
- remove deprecated role, image metadata, and unused environment contract fields from agent.toml
- derive built-in template roles from the registry and treat local or remote templates as workers
- preserve manager/worker behavior in internal models, API responses, filtering, and image upgrade logic
- update manifest documentation and regression coverage for legacy fields and role derivation