### PR TITLE
fix(web): bound Windows notification tags

### DIFF
--- a/web/app/src/hooks/workspace/useAgentTurnNotifications.ts
+++ b/web/app/src/hooks/workspace/useAgentTurnNotifications.ts
@@ -10,6 +10,7 @@ import {
 } from "@/models/conversations";
 import type { IMConversation, IMMessage, IMServerEvent, TranslateFn, UsersById } from "@/models/conversations";
 import {
+  buildTurnNotificationTag,
   formatTurnNotificationBody,
   isCompletedAgentTurnEvent,
   shouldShowTurnNotification,
@@ -168,9 +169,13 @@ export function useAgentTurnNotifications(args: UseAgentTurnNotificationsArgs): 
       const notification = new window.Notification(current.t("turnNotificationTitle", { agent: agentName }), {
         body,
         icon: "favicon.ico",
-        tag: `csgclaw-${input.eventKey}`,
+        tag: buildTurnNotificationTag(input.eventKey),
       });
       notifiedEventKeysRef.current.add(input.eventKey);
+      notification.onerror = () => {
+        notifiedEventKeysRef.current.delete(input.eventKey);
+        setPermission(readSystemNotificationPermission());
+      };
       notification.onclick = async () => {
         notification.close();
         const desktopBridge = getDesktopBridge();

--- a/web/app/src/models/turnNotifications.ts
+++ b/web/app/src/models/turnNotifications.ts
@@ -11,6 +11,10 @@ export type TurnNotificationMode = (typeof TurnNotificationModes)[keyof typeof T
 
 export const DEFAULT_TURN_NOTIFICATION_MODE: TurnNotificationMode = TurnNotificationModes.whenUnfocused;
 
+const TURN_NOTIFICATION_TAG_PREFIX = "csgclaw-";
+const FNV1A_64_OFFSET_BASIS = 0xcbf29ce484222325n;
+const FNV1A_64_PRIME = 0x100000001b3n;
+
 export function normalizeTurnNotificationMode(value: unknown): TurnNotificationMode {
   return Object.values(TurnNotificationModes).includes(value as TurnNotificationMode)
     ? (value as TurnNotificationMode)
@@ -37,6 +41,17 @@ export function isCompletedAgentTurnEvent(event: IMServerEvent | null | undefine
     event.work.state === "idle" &&
     event.work.reason === "released",
   );
+}
+
+export function buildTurnNotificationTag(eventKey: string): string {
+  // Chromium adds origin data to this value before passing it to the Windows
+  // toast API, whose notification tag is limited to 64 characters.
+  let hash = FNV1A_64_OFFSET_BASIS;
+  for (let index = 0; index < eventKey.length; index += 1) {
+    hash ^= BigInt(eventKey.charCodeAt(index));
+    hash = BigInt.asUintN(64, hash * FNV1A_64_PRIME);
+  }
+  return `${TURN_NOTIFICATION_TAG_PREFIX}${hash.toString(16).padStart(16, "0")}`;
 }
 
 export function resolveTurnNotificationRoomLabel(

--- a/web/app/tests/hooks/useAgentTurnNotifications.test.tsx
+++ b/web/app/tests/hooks/useAgentTurnNotifications.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { buildUsersById, type IMServerEvent, type TranslateFn } from "@/models/conversations";
-import { TurnNotificationModes, type TurnNotificationMode } from "@/models/turnNotifications";
+import { buildTurnNotificationTag, TurnNotificationModes, type TurnNotificationMode } from "@/models/turnNotifications";
 import { useAgentTurnNotifications } from "@/hooks/workspace/useAgentTurnNotifications";
 import type { DesktopBridge } from "@/shared/platform/desktopBridge";
 
@@ -19,6 +19,7 @@ class FakeNotification {
   static requestPermission = vi.fn(async () => FakeNotification.permission);
 
   onclick: ((this: Notification, ev: Event) => unknown) | null = null;
+  onerror: ((this: Notification, ev: Event) => unknown) | null = null;
   private readonly closeMock = vi.fn();
 
   constructor(title: string, options: NotificationOptions = {}) {
@@ -155,7 +156,7 @@ describe("useAgentTurnNotifications", () => {
     expect(notificationRecords).toHaveLength(1);
     expect(notificationRecords[0]).toMatchObject({
       body: "Research room: The report is ready.",
-      tag: "csgclaw-turn:message-1",
+      tag: buildTurnNotificationTag("turn:message-1"),
       title: "Research Agent finished replying",
     });
 
@@ -266,8 +267,35 @@ describe("useAgentTurnNotifications", () => {
     expect(notificationRecords).toHaveLength(1);
     expect(notificationRecords[0]).toMatchObject({
       body: "Research room: Fallback after reconnect",
-      tag: "csgclaw-turn:message-1",
+      tag: buildTurnNotificationTag("turn:message-1"),
     });
+  });
+
+  it("uses a bounded tag for a scheduled task and retries after a native notification error", () => {
+    const { result } = renderNotifications(TurnNotificationModes.always);
+    const scheduledRequestID = "agent-task-task-scheduled-run-1-created";
+    const released = workEvent({
+      reason: "released",
+      request_id: scheduledRequestID,
+      revision: 2,
+      state: "idle",
+    });
+
+    act(() => result.current.handleRealtimeEvent(released));
+
+    expect(notificationRecords).toHaveLength(1);
+    expect(notificationRecords[0]?.tag).toBe(buildTurnNotificationTag(`turn:${scheduledRequestID}`));
+    expect(notificationRecords[0]?.tag).toHaveLength(24);
+
+    act(() => {
+      notificationRecords[0]?.notification.onerror?.call(
+        notificationRecords[0].notification as unknown as Notification,
+        new Event("error"),
+      );
+    });
+    act(() => result.current.handleRealtimeEvent(released));
+
+    expect(notificationRecords).toHaveLength(2);
   });
 
   it("suppresses unfocused-mode notifications while the app has focus", () => {

--- a/web/app/tests/models/turnNotifications.test.ts
+++ b/web/app/tests/models/turnNotifications.test.ts
@@ -1,5 +1,6 @@
 import type { TranslateFn } from "@/models/conversations";
 import {
+  buildTurnNotificationTag,
   DEFAULT_TURN_NOTIFICATION_MODE,
   formatTurnNotificationBody,
   isCompletedAgentTurnEvent,
@@ -66,6 +67,16 @@ describe("turn notifications", () => {
     expect(isCompletedAgentTurnEvent(completed)).toBe(true);
     expect(isCompletedAgentTurnEvent({ ...completed, work: { ...completed.work, state: "working" } })).toBe(false);
     expect(isCompletedAgentTurnEvent({ ...completed, work: { ...completed.work, reason: "expired" } })).toBe(false);
+  });
+
+  it("keeps scheduled-task notification tags within the Windows limit", () => {
+    const eventKey = "turn:agent-task-task-scheduled-run-1-created";
+    const tag = buildTurnNotificationTag(eventKey);
+
+    expect(tag).toMatch(/^csgclaw-[0-9a-f]{16}$/);
+    expect(buildTurnNotificationTag(eventKey)).toBe(tag);
+    expect(buildTurnNotificationTag(`${eventKey}-other`)).not.toBe(tag);
+    expect(`n#http://127.0.0.1:18080#${tag}`.length).toBeLessThanOrEqual(64);
   });
 
   it("omits a room label that repeats the agent name or belongs to a direct chat", () => {


### PR DESCRIPTION
- Fix missing Windows notifications for completed scheduled tasks by replacing long business IDs with short, stable notification tags.
