### PR TITLE
feat(codex): preserve memory in agent templates

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -954,10 +954,10 @@ func TestExecuteHubGetEscapesNamespaceTemplateIDAsSinglePathSegment(t *testing.T
 }
 
 func TestExecuteHubPublishUsesHTTPClient(t *testing.T) {
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	app := &App{
 		stdout: &stdout,
-		stderr: &bytes.Buffer{},
+		stderr: &stderr,
 		httpClient: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			if req.Method != http.MethodPost {
 				t.Fatalf("method = %q, want %q", req.Method, http.MethodPost)
@@ -978,18 +978,24 @@ func TestExecuteHubPublishUsesHTTPClient(t *testing.T) {
 			if payload["name"] != "ReviewBot_2" || payload["description"] != "Reviews changes" {
 				t.Fatalf("payload metadata = %#v/%#v, want CLI values", payload["name"], payload["description"])
 			}
+			if payload["include_memory"] != true {
+				t.Fatalf("payload[include_memory] = %#v, want true", payload["include_memory"])
+			}
 			return jsonResponse(http.StatusCreated, `{"id":"local.alice","name":"alice","runtime_kind":"codex","source":{"name":"local","kind":"local"}}`), nil
 		}),
 	}
 
 	if err := app.Execute(context.Background(), []string{
 		"--endpoint", "http://example.test", "--output", "json", "template", "publish",
-		"--agent", "u-alice", "--registry", "local", "--name", "ReviewBot_2", "--description", "Reviews changes",
+		"--agent", "u-alice", "--registry", "local", "--name", "ReviewBot_2", "--description", "Reviews changes", "--include-memory",
 	}); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	if !strings.Contains(stdout.String(), `"id": "local.alice"`) {
 		t.Fatalf("stdout = %q, want template id", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "private information derived from conversation history") {
+		t.Fatalf("stderr = %q, want sensitive-memory warning", stderr.String())
 	}
 }
 
@@ -1004,6 +1010,9 @@ func TestExecuteHubPublishDefaultsToOfficialRegistry(t *testing.T) {
 			}
 			if got, want := payload["registry"], "official"; got != want {
 				t.Fatalf("payload[registry] = %#v, want %q", got, want)
+			}
+			if _, ok := payload["include_memory"]; ok {
+				t.Fatalf("payload[include_memory] = %#v, want omitted by default", payload["include_memory"])
 			}
 			return jsonResponse(http.StatusCreated, `{"id":"official.alice/review-bot","name":"review-bot","source":{"name":"official","kind":"remote"}}`), nil
 		}),

--- a/cli/completion/completion.go
+++ b/cli/completion/completion.go
@@ -287,6 +287,7 @@ func templateSpec() CommandSpec {
 					{Name: "registry", TakesValue: true},
 					{Name: "name", TakesValue: true},
 					{Name: "description", TakesValue: true},
+					{Name: "include-memory"},
 				},
 			},
 		},

--- a/cli/completion/completion_test.go
+++ b/cli/completion/completion_test.go
@@ -38,7 +38,7 @@ func TestCompleteSubcommandsAndFlags(t *testing.T) {
 	assertContainsAll(t, got, "list", "get", "publish", "--help")
 
 	got = Complete(FullSpec(), "csgclaw", []string{"csgclaw", "template", "publish", "--"})
-	assertContainsAll(t, got, "--agent", "--registry", "--name", "--description")
+	assertContainsAll(t, got, "--agent", "--registry", "--name", "--description", "--include-memory")
 
 	got = Complete(FullSpec(), "csgclaw", []string{"csgclaw", "team", "task", ""})
 	assertContainsAll(t, got, "list", "create-batch", "plan", "start", "assign", "claim", "claim-next", "update", "--help")

--- a/cli/template/hub.go
+++ b/cli/template/hub.go
@@ -98,6 +98,7 @@ func (c cmd) runPublish(ctx context.Context, run *command.Context, args []string
 	registry := fs.String("registry", "official", "template registry to publish into")
 	name := fs.String("name", "", "template name (starts with a letter; up to 24 letters, numbers, underscores, or hyphens)")
 	description := fs.String("description", "", "template description")
+	includeMemory := fs.Bool("include-memory", false, "include agent memory (may contain private conversation-derived information)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -109,9 +110,13 @@ func (c cmd) runPublish(ctx context.Context, run *command.Context, args []string
 	}
 
 	request := apitypes.CreateHubTemplateRequest{
-		AgentID:  *agentID,
-		Registry: *registry,
-		Name:     *name,
+		AgentID:       *agentID,
+		Registry:      *registry,
+		Name:          *name,
+		IncludeMemory: *includeMemory,
+	}
+	if *includeMemory {
+		fmt.Fprintln(run.Stderr, "Warning: agent memory may contain private information derived from conversation history.")
 	}
 	fs.Visit(func(flag *flag.Flag) {
 		if flag.Name == "description" {

--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -706,8 +706,8 @@ Templates use the following layout:
 
 `AGENTS.md` and `mcp.json` are always emitted when publishing.
 Other instruction files are optional.
-Codex templates snapshot `CODEX_HOME/memories/memory_summary.md` and restore it to the same location for a newly created agent when `memory_mode` is enabled. Templates with `memory_mode = "disabled"` neither package nor restore a memory summary. They do not copy Codex's SQLite memory pipeline state or treat memory as a workspace overlay.
-For non-Codex runtimes, optional template memories are overlaid according to that Runtime's workspace convention.
+Memory is included only when each publish request explicitly sets `include_memory: true`; runtime memory enablement alone never opts a publish into exporting memory. With that publish opt-in, Codex templates snapshot `CODEX_HOME/memories/memory_summary.md` and restore it to the same location for a newly created agent when `memory_mode` is enabled. Templates with `memory_mode = "disabled"` neither package nor restore a memory summary. They do not copy Codex's SQLite memory pipeline state or treat memory as a workspace overlay.
+With the same explicit publish opt-in, supported non-Codex runtimes preserve and overlay optional template memories according to that Runtime's workspace convention.
 During agent creation, skills are installed under `skills/`, and MCP servers from `mcp.json` are applied unless the create request explicitly supplies `mcpServers`.
 
 Codex worker templates may persist their execution mode in `agent.toml`:

--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -758,7 +758,7 @@ Notes:
 
 - `agent_id` is required
 - `registry` uses the default publish registry when omitted
-- `include_memory` must be explicitly set to `true` to publish the Codex memory summary; it defaults to `false` because memories may contain private conversation-derived information
+- `include_memory` must be explicitly set to `true` to publish the Codex memory summary, including when republishing an existing local template via `template_id`; it defaults to `false` because memories may contain private conversation-derived information
 - Successful publish returns `201 Created`
 
 ### `GET /api/v1/hub/templates/{id}`

--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -469,13 +469,13 @@ Returns the Runtime's read-only primary memory document and its enabled state.
 {
   "enabled": true,
   "ready": true,
-  "name": "MEMORY.md",
-  "location": "$CODEX_HOME/memories/MEMORY.md",
+  "name": "memory_summary.md",
+  "location": "$CODEX_HOME/memories/memory_summary.md",
   "content": "# Durable memory\n"
 }
 ```
 
-`location` is a Runtime-provided logical file location for display and diagnostics; Codex currently reports `$CODEX_HOME/memories/MEMORY.md`.
+`location` is a Runtime-provided logical file location for display and diagnostics; Codex currently reports `$CODEX_HOME/memories/memory_summary.md`.
 
 #### `PUT /api/v1/agents/{id}/memory`
 
@@ -699,12 +699,13 @@ Templates use the following layout:
   instructions/AGENTS.md
   skills/<skill>/...
   mcps/mcp.json
+  memories/memory_summary.md # optional Codex memory snapshot
   memories/MEMORY.md         # optional for non-Codex runtimes
 ```
 
 `AGENTS.md` and `mcp.json` are always emitted when publishing.
 Other instruction files are optional.
-Codex templates neither publish nor restore workspace memory files; stable template context belongs in `instructions/`, while Codex-managed memory remains under its isolated `CODEX_HOME/memories/`.
+Codex templates snapshot `CODEX_HOME/memories/memory_summary.md` and restore it to the same location for a newly created agent when `memory_mode` is enabled. Templates with `memory_mode = "disabled"` neither package nor restore a memory summary. They do not copy Codex's SQLite memory pipeline state or treat memory as a workspace overlay.
 For non-Codex runtimes, optional template memories are overlaid according to that Runtime's workspace convention.
 During agent creation, skills are installed under `skills/`, and MCP servers from `mcp.json` are applied unless the create request explicitly supplies `mcpServers`.
 

--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -700,7 +700,8 @@ Templates use the following layout:
   skills/<skill>/...
   mcps/mcp.json
   memories/memory_summary.md # optional Codex memory snapshot
-  memories/MEMORY.md         # optional for non-Codex runtimes
+  memories/MEMORY.md         # optional root memory for non-Codex runtimes
+  memories/memory/*.md       # optional dated memory files for non-Codex runtimes
 ```
 
 `AGENTS.md` and `mcp.json` are always emitted when publishing.

--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -749,7 +749,8 @@ Request body:
 ```json
 {
   "agent_id": "u-alice",
-  "registry": "local"
+  "registry": "local",
+  "include_memory": false
 }
 ```
 
@@ -757,6 +758,7 @@ Notes:
 
 - `agent_id` is required
 - `registry` uses the default publish registry when omitted
+- `include_memory` must be explicitly set to `true` to publish the Codex memory summary; it defaults to `false` because memories may contain private conversation-derived information
 - Successful publish returns `201 Created`
 
 ### `GET /api/v1/hub/templates/{id}`

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -730,7 +730,8 @@ Codex Worker 目前保存 `execution_mode` 和 `memory_mode`，不会保存 `loc
 ```json
 {
   "agent_id": "u-alice",
-  "registry": "local"
+  "registry": "local",
+  "include_memory": false
 }
 ```
 
@@ -738,6 +739,7 @@ Codex Worker 目前保存 `execution_mode` 和 `memory_mode`，不会保存 `loc
 
 - `agent_id` 必填
 - `registry` 省略时使用默认 publish registry
+- 只有显式设置 `include_memory: true` 才会发布 Codex 记忆摘要；由于记忆可能包含从对话中提取的隐私信息，该字段默认是 `false`
 - 发布成功返回 `201 Created`
 
 ### `GET /api/v1/hub/templates/{id}`

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -681,7 +681,8 @@ catalog key。新远端条目默认写入 `enabled: true`、`startup_timeout_sec
   skills/<skill>/...
   mcps/mcp.json
   memories/memory_summary.md # 可选的 Codex 记忆快照
-  memories/MEMORY.md         # 非 Codex Runtime 可选
+  memories/MEMORY.md         # 非 Codex Runtime 可选的根记忆文件
+  memories/memory/*.md       # 非 Codex Runtime 可选的日期记忆文件
 ```
 
 发布时始终生成 `AGENTS.md` 和 `mcp.json`。

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -687,8 +687,8 @@ catalog key。新远端条目默认写入 `enabled: true`、`startup_timeout_sec
 
 发布时始终生成 `AGENTS.md` 和 `mcp.json`。
 其他 instruction 文件可选。
-当 `memory_mode` 启用时，Codex 模板会快照 `CODEX_HOME/memories/memory_summary.md`，并在创建新 Agent 时恢复到相同位置。`memory_mode = "disabled"` 的模板不会打包或恢复记忆摘要；模板也不会复制 Codex 的 SQLite memory 流水线状态，或把 memory 当作 workspace overlay。
-非 Codex Runtime 的可选模板 memories 仍按对应 Runtime 的 workspace 约定叠加。
+只有每次发布请求显式设置 `include_memory: true` 时才会包含记忆；仅启用 Runtime memory 并不代表同意在发布时导出记忆。在显式发布 opt-in 且 `memory_mode` 启用时，Codex 模板会快照 `CODEX_HOME/memories/memory_summary.md`，并在创建新 Agent 时恢复到相同位置。`memory_mode = "disabled"` 的模板不会打包或恢复记忆摘要；模板也不会复制 Codex 的 SQLite memory 流水线状态，或把 memory 当作 workspace overlay。
+在同样显式发布 opt-in 的前提下，受支持的非 Codex Runtime 会按对应 Runtime 的 workspace 约定保留并叠加可选模板 memories。
 根据模板创建 Agent 时，skills 会安装到 `skills/`，`mcp.json` 中的 MCP server 会自动应用；如果创建请求显式传入 `mcpServers`，则以请求内容为准。
 
 Codex Worker 模板可在 `agent.toml` 中保存运行模式：

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -459,13 +459,13 @@ Runtime 尚未生成文档时，`ready` 为 `false`。
 {
   "enabled": true,
   "ready": true,
-  "name": "MEMORY.md",
-  "location": "$CODEX_HOME/memories/MEMORY.md",
+  "name": "memory_summary.md",
+  "location": "$CODEX_HOME/memories/memory_summary.md",
   "content": "# Durable memory\n"
 }
 ```
 
-`location` 是 Runtime 提供、用于展示和诊断的逻辑文件位置；Codex 当前返回 `$CODEX_HOME/memories/MEMORY.md`。
+`location` 是 Runtime 提供、用于展示和诊断的逻辑文件位置；Codex 当前返回 `$CODEX_HOME/memories/memory_summary.md`。
 
 #### `PUT /api/v1/agents/{id}/memory`
 
@@ -680,12 +680,13 @@ catalog key。新远端条目默认写入 `enabled: true`、`startup_timeout_sec
   instructions/AGENTS.md
   skills/<skill>/...
   mcps/mcp.json
+  memories/memory_summary.md # 可选的 Codex 记忆快照
   memories/MEMORY.md         # 非 Codex Runtime 可选
 ```
 
 发布时始终生成 `AGENTS.md` 和 `mcp.json`。
 其他 instruction 文件可选。
-Codex 模板不发布也不恢复 workspace memory 文件；模板必须携带的稳定上下文应放在 `instructions/`，Codex 自动管理的 memory 只保存在隔离的 `CODEX_HOME/memories/`。
+当 `memory_mode` 启用时，Codex 模板会快照 `CODEX_HOME/memories/memory_summary.md`，并在创建新 Agent 时恢复到相同位置。`memory_mode = "disabled"` 的模板不会打包或恢复记忆摘要；模板也不会复制 Codex 的 SQLite memory 流水线状态，或把 memory 当作 workspace overlay。
 非 Codex Runtime 的可选模板 memories 仍按对应 Runtime 的 workspace 约定叠加。
 根据模板创建 Agent 时，skills 会安装到 `skills/`，`mcp.json` 中的 MCP server 会自动应用；如果创建请求显式传入 `mcpServers`，则以请求内容为准。
 

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -739,7 +739,7 @@ Codex Worker 目前保存 `execution_mode` 和 `memory_mode`，不会保存 `loc
 
 - `agent_id` 必填
 - `registry` 省略时使用默认 publish registry
-- 只有显式设置 `include_memory: true` 才会发布 Codex 记忆摘要；由于记忆可能包含从对话中提取的隐私信息，该字段默认是 `false`
+- 只有显式设置 `include_memory: true` 才会发布 Codex 记忆摘要，包括通过 `template_id` 再发布已有本地模板时；由于记忆可能包含从对话中提取的隐私信息，该字段默认是 `false`
 - 发布成功返回 `201 Created`
 
 ### `GET /api/v1/hub/templates/{id}`

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -231,6 +231,8 @@ type CreateAgentSpec struct {
 	SandboxEnabled       bool              `json:"sandbox_enabled,omitempty"`
 	FromTemplate         string            `json:"from_template,omitempty"`
 	TemplateInstructions string            `json:"-"`
+	TemplateMemory       string            `json:"-"`
+	TemplateMemorySet    bool              `json:"-"`
 	Role                 string            `json:"role,omitempty"`
 	Status               string            `json:"status,omitempty"`
 	CreatedAt            time.Time         `json:"created_at,omitempty"`

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -260,6 +260,7 @@ func (s *Service) HubPublishSpec(agentID string, includeMemory bool) (hub.Publis
 	}
 	return hub.PublishSpec{
 		ID:             got.Name,
+		IncludeMemory:  includeMemory,
 		Name:           got.Name,
 		Description:    got.Description,
 		RuntimeKind:    got.RuntimeConfig().Kind(),

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -231,7 +231,7 @@ type templateService interface {
 	FetchWorkspace(context.Context, string) (hub.WorkspaceRef, error)
 }
 
-func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
+func (s *Service) HubPublishSpec(agentID string, includeMemory bool) (hub.PublishSpec, error) {
 	if s == nil {
 		return hub.PublishSpec{}, fmt.Errorf("agent service is required")
 	}
@@ -248,7 +248,7 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 		return hub.PublishSpec{}, err
 	}
 	memoryPath := ""
-	if runtimeOptions[templateMemoryModeKey] != templateMemoryModeDisabled {
+	if includeMemory && runtimeOptions[templateMemoryModeKey] != templateMemoryModeDisabled {
 		memoryPath = codexMemoryPath(layout, got.RuntimeKind)
 	}
 	if memoryPath != "" {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -247,6 +247,17 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 	if err != nil {
 		return hub.PublishSpec{}, err
 	}
+	memoryPath := ""
+	if runtimeOptions[templateMemoryModeKey] != templateMemoryModeDisabled {
+		memoryPath = codexMemoryPath(layout, got.RuntimeKind)
+	}
+	if memoryPath != "" {
+		if _, statErr := os.Stat(memoryPath); errors.Is(statErr, os.ErrNotExist) {
+			memoryPath = ""
+		} else if statErr != nil {
+			return hub.PublishSpec{}, fmt.Errorf("stat codex memory summary: %w", statErr)
+		}
+	}
 	return hub.PublishSpec{
 		ID:             got.Name,
 		Name:           got.Name,
@@ -259,9 +270,17 @@ func (s *Service) HubPublishSpec(agentID string) (hub.PublishSpec, error) {
 			Path:             layout.WorkspaceRoot,
 			InstructionsPath: layout.InstructionsPath,
 			SkillsPath:       layout.SkillsRoot,
+			MemoryPath:       memoryPath,
 		},
 		MCPServers: templateSafeMCPServers(got.MCPServers),
 	}, nil
+}
+
+func codexMemoryPath(layout agentruntime.Layout, runtimeKind string) string {
+	if agentruntime.RuntimeConfigForKind(runtimeKind).LegacyKind() != RuntimeKindCodex || strings.TrimSpace(layout.SkillsRoot) == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(layout.SkillsRoot), "memories", "memory_summary.md")
 }
 
 func WithSandboxProvider(provider sandbox.Provider) ServiceOption {
@@ -1178,6 +1197,25 @@ func (s *Service) resolveTemplateCreateSpecWithService(
 			} else if !errors.Is(readErr, os.ErrNotExist) {
 				return CreateAgentSpec{}, cleanup, fmt.Errorf("read codex template instructions: %w", readErr)
 			}
+			if memoryPath := strings.TrimSpace(workspace.MemoryPath); memoryPath != "" {
+				memoryPath, pathErr := validatedCodexTemplateMemoryPath(workspace.Path, memoryPath)
+				if pathErr != nil {
+					return CreateAgentSpec{}, cleanup, pathErr
+				}
+				if spec.RuntimeOptions[templateMemoryModeKey] != templateMemoryModeDisabled {
+					data, readErr := os.ReadFile(memoryPath)
+					if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+						return CreateAgentSpec{}, cleanup, fmt.Errorf("read codex template memory: %w", readErr)
+					}
+					if readErr == nil {
+						spec.TemplateMemory = string(data)
+						spec.TemplateMemorySet = true
+					}
+				}
+				if removeErr := os.RemoveAll(filepath.Dir(memoryPath)); removeErr != nil {
+					return CreateAgentSpec{}, cleanup, fmt.Errorf("remove staged codex template memory: %w", removeErr)
+				}
+			}
 		}
 		spec.FromTemplate = strings.TrimSpace(workspace.Path)
 		if !createSpecSetsMCPServers(spec) && strings.TrimSpace(workspace.MCPServersJSON) != "" {
@@ -1190,6 +1228,23 @@ func (s *Service) resolveTemplateCreateSpecWithService(
 		}
 	}
 	return spec, cleanup, nil
+}
+
+func validatedCodexTemplateMemoryPath(workspaceRoot, memoryPath string) (string, error) {
+	workspaceRoot, err := filepath.Abs(strings.TrimSpace(workspaceRoot))
+	if err != nil {
+		return "", fmt.Errorf("resolve template workspace path: %w", err)
+	}
+	memoryPath, err = filepath.Abs(strings.TrimSpace(memoryPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve codex template memory path: %w", err)
+	}
+	rel, err := filepath.Rel(workspaceRoot, memoryPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) ||
+		filepath.Base(filepath.Dir(memoryPath)) != ".csgclaw-template-memory" || filepath.Base(memoryPath) != "memory_summary.md" {
+		return "", fmt.Errorf("invalid staged codex template memory path %q", memoryPath)
+	}
+	return memoryPath, nil
 }
 
 func shouldResolveTemplateCreateSpec(spec CreateAgentSpec) bool {
@@ -2446,6 +2501,8 @@ func (s *Service) CreateWorker(ctx context.Context, spec CreateAgentSpec) (Agent
 		AgentName:            name,
 		Instructions:         instructions,
 		TemplateInstructions: spec.TemplateInstructions,
+		TemplateMemory:       spec.TemplateMemory,
+		TemplateMemorySet:    spec.TemplateMemorySet,
 		Profile:              runtimeProfile,
 		RuntimeOptions:       utils.CloneAnyMap(spec.RuntimeOptions),
 		MCPServers:           cloneMCPServers(spec.MCPServers),

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -9164,7 +9164,7 @@ func TestHubPublishSpecUsesAgentWorkspaceSnapshot(t *testing.T) {
 		t.Fatalf("WriteFile(PLAYBOOK.md) error = %v", err)
 	}
 
-	spec, err := svc.HubPublishSpec(created.ID)
+	spec, err := svc.HubPublishSpec(created.ID, false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}
@@ -9220,7 +9220,7 @@ func TestHubPublishSpecUsesOpenClawWorkspaceSnapshot(t *testing.T) {
 		t.Fatalf("WriteFile(PLAYBOOK.md) error = %v", err)
 	}
 
-	spec, err := svc.HubPublishSpec(created.ID)
+	spec, err := svc.HubPublishSpec(created.ID, false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}
@@ -9270,7 +9270,7 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 		t.Fatalf("WriteFile(memory_summary.md) error = %v", err)
 	}
 
-	spec, err := svc.HubPublishSpec("u-alice")
+	spec, err := svc.HubPublishSpec("u-alice", true)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}
@@ -9317,9 +9317,16 @@ func TestHubPublishSpecIncludesCodexMemoryWhenEnabled(t *testing.T) {
 	if err := os.WriteFile(memoryPath, []byte("remember this\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	spec, err := svc.HubPublishSpec("u-alice")
+	spec, err := svc.HubPublishSpec("u-alice", false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
+	}
+	if got := spec.WorkspaceRef.MemoryPath; got != "" {
+		t.Fatalf("MemoryPath = %q, want empty without explicit opt-in", got)
+	}
+	spec, err = svc.HubPublishSpec("u-alice", true)
+	if err != nil {
+		t.Fatalf("HubPublishSpec(include memory) error = %v", err)
 	}
 	if got := spec.WorkspaceRef.MemoryPath; got != memoryPath {
 		t.Fatalf("MemoryPath = %q, want %q", got, memoryPath)

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -8037,6 +8037,12 @@ func TestResolveCodexTemplateCreateSpecSeparatesBaseFromProfileInstructions(t *t
 	if _, err := os.Stat(filepath.Join(resolved.FromTemplate, "AGENTS.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("workspace AGENTS.md stat error = %v, want template instructions separated from overlay", err)
 	}
+	if !resolved.TemplateMemorySet || resolved.TemplateMemory != "# Template memory\n" {
+		t.Fatalf("TemplateMemory = %q (set=%v), want restored template memory", resolved.TemplateMemory, resolved.TemplateMemorySet)
+	}
+	if _, err := os.Stat(filepath.Join(resolved.FromTemplate, ".csgclaw-template-memory")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staged template memory leaked into workspace overlay, stat error = %v", err)
+	}
 }
 
 func TestApplyTemplateDefaultsMergesExplicitRuntimeOptions(t *testing.T) {
@@ -9256,6 +9262,13 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(layout.SkillsRoot, "custom", "SKILL.md"), []byte("custom skill\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(SKILL.md) error = %v", err)
 	}
+	memoryPath := filepath.Join(filepath.Dir(layout.SkillsRoot), "memories", "memory_summary.md")
+	if err := os.MkdirAll(filepath.Dir(memoryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(memories) error = %v", err)
+	}
+	if err := os.WriteFile(memoryPath, []byte("remember this\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(memory_summary.md) error = %v", err)
+	}
 
 	spec, err := svc.HubPublishSpec("u-alice")
 	if err != nil {
@@ -9266,6 +9279,9 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 	}
 	if got, want := spec.WorkspaceRef.SkillsPath, layout.SkillsRoot; got != want {
 		t.Fatalf("SkillsPath = %q, want %q", got, want)
+	}
+	if got := spec.WorkspaceRef.MemoryPath; got != "" {
+		t.Fatalf("MemoryPath = %q, want empty when memory is disabled", got)
 	}
 	if got, want := spec.RuntimeOptions["execution_mode"], "read_only"; got != want {
 		t.Fatalf("RuntimeOptions[execution_mode] = %v, want %q", got, want)
@@ -9279,6 +9295,51 @@ func TestHubPublishSpecUsesCodexHomeAssets(t *testing.T) {
 	remote := spec.MCPServers["remote"].(map[string]any)
 	if _, ok := remote["headers"]; ok {
 		t.Fatalf("published MCP config leaked runtime headers: %#v", remote)
+	}
+}
+
+func TestHubPublishSpecIncludesCodexMemoryWhenEnabled(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	svc, err := NewService(testModelConfig(), config.ServerConfig{}, "manager-image:1", "")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.agents["u-alice"] = Agent{ID: "u-alice", Name: "alice", Role: RoleWorker, RuntimeKind: RuntimeKindCodex}
+	layout, err := svc.agentLayout("u-alice", RuntimeKindCodex)
+	if err != nil {
+		t.Fatalf("agentLayout() error = %v", err)
+	}
+	memoryPath := filepath.Join(filepath.Dir(layout.SkillsRoot), "memories", "memory_summary.md")
+	if err := os.MkdirAll(filepath.Dir(memoryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(memoryPath, []byte("remember this\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := svc.HubPublishSpec("u-alice")
+	if err != nil {
+		t.Fatalf("HubPublishSpec() error = %v", err)
+	}
+	if got := spec.WorkspaceRef.MemoryPath; got != memoryPath {
+		t.Fatalf("MemoryPath = %q, want %q", got, memoryPath)
+	}
+}
+
+func TestValidatedCodexTemplateMemoryPathRejectsPathsOutsideStagingDirectory(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	valid := filepath.Join(workspaceRoot, ".csgclaw-template-memory", "memory_summary.md")
+	if got, err := validatedCodexTemplateMemoryPath(workspaceRoot, valid); err != nil || got != valid {
+		t.Fatalf("valid path = %q, error = %v", got, err)
+	}
+	for _, path := range []string{
+		filepath.Join(t.TempDir(), ".csgclaw-template-memory", "memory_summary.md"),
+		filepath.Join(workspaceRoot, "other", "memory_summary.md"),
+		filepath.Join(workspaceRoot, ".csgclaw-template-memory", "other.md"),
+	} {
+		if _, err := validatedCodexTemplateMemoryPath(workspaceRoot, path); err == nil {
+			t.Fatalf("validatedCodexTemplateMemoryPath(%q) error = nil, want rejection", path)
+		}
 	}
 }
 
@@ -10716,16 +10777,16 @@ func TestEnsureBootstrapStateRecreatesManagerWithLegacyPicoClawBridgeConfig(t *t
 			t.Fatalf("createGatewayBox() got image=%q name=%q botID=%q", image, name, botID)
 		}
 		return &fakeInfoInstance{info: sandbox.Info{
-			ID:        "box-new",
-			Name:      ManagerName,
-			State:     sandbox.StateRunning,
-			CreatedAt: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC),
-		}}, sandbox.Info{
-			ID:        "box-new",
-			Name:      ManagerName,
-			State:     sandbox.StateRunning,
-			CreatedAt: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC),
-		}, nil
+				ID:        "box-new",
+				Name:      ManagerName,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC),
+			}}, sandbox.Info{
+				ID:        "box-new",
+				Name:      ManagerName,
+				State:     sandbox.StateRunning,
+				CreatedAt: time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC),
+			}, nil
 	}
 
 	managerHome, err := seedSvc.agentHomeDir(ManagerUserID)
@@ -11478,6 +11539,14 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 	}
 
 	store := hub.NewLocalStore(registryRoot)
+	workspaceRef := hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot}
+	if agentruntime.RuntimeConfigForKind(item.RuntimeKind).LegacyKind() == RuntimeKindCodex {
+		memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
+		if err := os.WriteFile(memoryPath, []byte("# Template memory\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(memory_summary.md) error = %v", err)
+		}
+		workspaceRef.MemoryPath = memoryPath
+	}
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
 		ID:             id,
 		Name:           item.Name,
@@ -11486,7 +11555,7 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 		Version:        item.Version,
 		Image:          item.Image,
 		RuntimeOptions: item.RuntimeOptions,
-		WorkspaceRef:   hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot},
+		WorkspaceRef:   workspaceRef,
 		MCPServers: map[string]any{
 			"template-docs": map[string]any{"command": "npx", "args": []any{"-y", "template-docs"}},
 		},

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -8227,6 +8227,15 @@ func TestCreateOpenClawWorkerFromTemplateOverlaysOpenClawWorkspace(t *testing.T)
 	if _, err := os.Stat(filepath.Join(openclawWorkspace, "skills", "custom", "SKILL.md")); err != nil {
 		t.Fatalf("template skill missing from OpenClaw workspace after overlay: %v", err)
 	}
+	for path, want := range map[string]string{
+		"MEMORY.md":            "# OpenClaw template memory\n",
+		"memory/2026-08-28.md": "OpenClaw dated memory\n",
+	} {
+		data, readErr := os.ReadFile(filepath.Join(openclawWorkspace, filepath.FromSlash(path)))
+		if readErr != nil || string(data) != want {
+			t.Fatalf("restored OpenClaw memory %s = %q, error = %v, want %q", path, data, readErr, want)
+		}
+	}
 	if _, err := os.Stat(filepath.Join(agentHome, hostWorkspaceDir, "skills", "custom", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("template skill should not be written to legacy workspace path for OpenClaw, stat error = %v", err)
 	}
@@ -11547,16 +11556,29 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 
 	store := hub.NewLocalStore(registryRoot)
 	workspaceRef := hub.WorkspaceRef{Kind: hub.WorkspaceKindDir, Path: workspaceRoot}
+	includeMemory := false
 	if agentruntime.RuntimeConfigForKind(item.RuntimeKind).LegacyKind() == RuntimeKindCodex {
 		memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
 		if err := os.WriteFile(memoryPath, []byte("# Template memory\n"), 0o644); err != nil {
 			t.Fatalf("WriteFile(memory_summary.md) error = %v", err)
 		}
 		workspaceRef.MemoryPath = memoryPath
+		includeMemory = true
+	} else if agentruntime.RuntimeConfigForKind(item.RuntimeKind).LegacyKind() == RuntimeKindOpenClawSandbox {
+		if err := os.WriteFile(filepath.Join(workspaceRoot, "MEMORY.md"), []byte("# OpenClaw template memory\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(MEMORY.md) error = %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(workspaceRoot, "memory"), 0o755); err != nil {
+			t.Fatalf("MkdirAll(memory) error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workspaceRoot, "memory", "2026-08-28.md"), []byte("OpenClaw dated memory\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(dated memory) error = %v", err)
+		}
+		includeMemory = true
 	}
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
 		ID:             id,
-		IncludeMemory:  workspaceRef.MemoryPath != "",
+		IncludeMemory:  includeMemory,
 		Name:           item.Name,
 		Description:    item.Description,
 		RuntimeKind:    item.RuntimeKind,

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -11556,6 +11556,7 @@ func mustNewLocalTemplateHubService(t *testing.T, id string, item hub.Template) 
 	}
 	if _, err := store.Publish(context.Background(), hub.PublishSpec{
 		ID:             id,
+		IncludeMemory:  workspaceRef.MemoryPath != "",
 		Name:           item.Name,
 		Description:    item.Description,
 		RuntimeKind:    item.RuntimeKind,

--- a/internal/api/community_instance.go
+++ b/internal/api/community_instance.go
@@ -20,7 +20,10 @@ const communityAgentInstancePath = "/api/v1/agent/instances"
 const communityInstanceTemplatePendingCode = "AGENT-ERR-22"
 const communityInstanceSensitiveCheckCode = "AGENT-ERR-23"
 const communityInstanceResourceUnavailableCode = "RESOURCE-ERR-1"
-const communityInstanceDeployRetries = 3
+
+// Retry pending reviews for roughly 30 seconds before reporting that the
+// template was published but has not been deployed yet.
+const communityInstanceDeployRetries = 10
 const communityInstanceDeployRetryDelay = 3 * time.Second
 
 var errCommunityInstanceSensitiveCheck = errors.New("community template has not passed the sensitive-content check")

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1781,6 +1781,9 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 			if !publishingTemplate {
 				status = http.StatusBadRequest
 			}
+			if code == "SYS-ERR-4" {
+				status = http.StatusBadRequest
+			}
 			if errors.Is(err, hub.ErrTemplateAlreadyExists) {
 				status = http.StatusConflict
 				if code == "" {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1756,7 +1756,7 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 			item, err = hubSvc.PublishTemplate(r.Context(), req.TemplateID, req.Registry)
 		} else {
 			var spec hub.PublishSpec
-			spec, err = h.svc.HubPublishSpec(req.AgentID)
+			spec, err = h.svc.HubPublishSpec(req.AgentID, req.IncludeMemory)
 			if err == nil {
 				spec.Registry = req.Registry
 				if strings.TrimSpace(req.Name) != "" {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1753,7 +1753,7 @@ func (h *Handler) handleHubTemplates(w http.ResponseWriter, r *http.Request) {
 		var item hub.Template
 		publishingTemplate := strings.TrimSpace(req.TemplateID) != ""
 		if publishingTemplate {
-			item, err = hubSvc.PublishTemplate(r.Context(), req.TemplateID, req.Registry)
+			item, err = hubSvc.PublishTemplate(r.Context(), req.TemplateID, req.Registry, req.IncludeMemory)
 		} else {
 			var spec hub.PublishSpec
 			spec, err = h.svc.HubPublishSpec(req.AgentID, req.IncludeMemory)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5191,7 +5191,7 @@ func TestHandleHubTemplatesPublishesAgentSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	spec, err := svc.HubPublishSpec(created.ID)
+	spec, err := svc.HubPublishSpec(created.ID, false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}
@@ -5268,7 +5268,7 @@ func TestHandleHubTemplatesPublishesCodexRuntimeOptions(t *testing.T) {
 		},
 	}
 	svc := mustNewSeededService(t, []agent.Agent{created})
-	publishSpec, err := svc.HubPublishSpec(created.ID)
+	publishSpec, err := svc.HubPublishSpec(created.ID, false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}
@@ -5314,6 +5314,66 @@ func TestHandleHubTemplatesPublishesCodexRuntimeOptions(t *testing.T) {
 	manifest := string(manifestData)
 	if !strings.Contains(manifest, "execution_mode = 'read_only'") || !strings.Contains(manifest, "memory_mode = 'disabled'") {
 		t.Fatalf("agent.toml missing Codex runtime options:\n%s", manifest)
+	}
+}
+
+func TestHandleHubTemplatesRequiresExplicitMemoryOptIn(t *testing.T) {
+	created := agent.Agent{
+		ID: "u-codex-memory", Name: "codex-memory", Role: agent.RoleWorker, RuntimeKind: agent.RuntimeKindCodex,
+	}
+	svc := mustNewSeededService(t, []agent.Agent{created})
+	publishSpec, err := svc.HubPublishSpec(created.ID, true)
+	if err != nil {
+		t.Fatalf("HubPublishSpec() error = %v", err)
+	}
+	if err := os.MkdirAll(publishSpec.WorkspaceRef.Path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(publishSpec.WorkspaceRef.Path, "AGENTS.md"), []byte("instructions\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md) error = %v", err)
+	}
+	memoryPath := filepath.Join(filepath.Dir(publishSpec.WorkspaceRef.SkillsPath), "memories", "memory_summary.md")
+	if err := os.MkdirAll(filepath.Dir(memoryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(memory) error = %v", err)
+	}
+	if err := os.WriteFile(memoryPath, []byte("private memory\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(memory_summary.md) error = %v", err)
+	}
+
+	registryRoot := t.TempDir()
+	hubSvc, err := hub.NewService(config.HubConfig{
+		DefaultRegistry: "local", DefaultPublishRegistry: "local",
+		Registries: []config.HubRegistryConfig{{Name: "local", Kind: hub.RegistryKindLocal, Path: registryRoot, Enabled: true}},
+	}, hub.DefaultStoreFactory)
+	if err != nil {
+		t.Fatalf("hub.NewService() error = %v", err)
+	}
+	srv := &Handler{svc: svc}
+	srv.SetHubService(hubSvc)
+
+	for _, test := range []struct {
+		name          string
+		includeMemory bool
+		wantMemory    bool
+	}{
+		{name: "WithoutMemory", includeMemory: false, wantMemory: false},
+		{name: "WithMemory", includeMemory: true, wantMemory: true},
+	} {
+		body := fmt.Sprintf(`{"agent_id":%q,"registry":"local","name":%q,"include_memory":%t}`,
+			created.ID, test.name, test.includeMemory)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hub/templates", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("%s status = %d, want %d; body=%s", test.name, rec.Code, http.StatusCreated, rec.Body.String())
+		}
+		_, statErr := os.Stat(filepath.Join(registryRoot, "templates", test.name, "memories", "memory_summary.md"))
+		if test.wantMemory && statErr != nil {
+			t.Fatalf("%s memory missing: %v", test.name, statErr)
+		}
+		if !test.wantMemory && !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("%s memory was published without opt-in: %v", test.name, statErr)
+		}
 	}
 }
 
@@ -5424,7 +5484,7 @@ func TestHandleHubTemplatesPublishesAgentSnapshotToDefaultRegistryWhenOmitted(t 
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	spec, err := svc.HubPublishSpec(created.ID)
+	spec, err := svc.HubPublishSpec(created.ID, false)
 	if err != nil {
 		t.Fatalf("HubPublishSpec() error = %v", err)
 	}

--- a/internal/apitypes/hub.go
+++ b/internal/apitypes/hub.go
@@ -3,12 +3,13 @@ package apitypes
 import "time"
 
 type CreateHubTemplateRequest struct {
-	AgentID     string  `json:"agent_id,omitempty"`
-	TemplateID  string  `json:"template_id,omitempty"`
-	Registry    string  `json:"registry,omitempty"`
-	Name        string  `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Deploy      bool    `json:"deploy,omitempty"`
+	AgentID       string  `json:"agent_id,omitempty"`
+	TemplateID    string  `json:"template_id,omitempty"`
+	Registry      string  `json:"registry,omitempty"`
+	Name          string  `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	IncludeMemory bool    `json:"include_memory,omitempty"`
+	Deploy        bool    `json:"deploy,omitempty"`
 }
 
 type ImageEnvContract struct {

--- a/internal/runtime/codex/memory.go
+++ b/internal/runtime/codex/memory.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	readableMemoryFileName = "MEMORY.md"
-	readableMemoryLocation = "$CODEX_HOME/memories/MEMORY.md"
+	readableMemoryFileName = "memory_summary.md"
+	readableMemoryLocation = "$CODEX_HOME/memories/memory_summary.md"
 )
 
 func (r *Runtime) ReadMemoryDocument(_ context.Context, agentHome string, rawOptions map[string]any) (agentruntime.MemoryDocument, error) {

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -407,6 +407,15 @@ func (r *Runtime) Provision(ctx context.Context, req agentruntime.ProvisionReque
 	if err != nil {
 		return fmt.Errorf("resolve codex home for agent %q: %w", req.AgentName, err)
 	}
+	if req.TemplateMemorySet {
+		memoryPath := filepath.Join(codexHomeDir, "memories", readableMemoryFileName)
+		if err := r.mkdirAll(filepath.Dir(memoryPath), 0o755); err != nil {
+			return fmt.Errorf("create codex memory directory: %w", err)
+		}
+		if err := r.writeFile(memoryPath, []byte(req.TemplateMemory), 0o644); err != nil {
+			return fmt.Errorf("seed codex template memory: %w", err)
+		}
+	}
 	if err := r.syncManagerTemplateSkills(agentID, codexHomeDir); err != nil {
 		return fmt.Errorf("sync manager codex skills for agent %q: %w", req.AgentName, err)
 	}

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -2420,6 +2420,23 @@ func TestRuntimeProvisionSyncsCodexOverlaySkills(t *testing.T) {
 	assertRuntimeSkillFile(t, filepath.Join(root, "agent-alice", ".codex", "home", "skills", "custom", "SKILL.md"), "# Custom\n", 0o644)
 }
 
+func TestRuntimeProvisionRestoresTemplateMemory(t *testing.T) {
+	root := t.TempDir()
+	rt := newTestCodexRuntime(root, func(h agentruntime.Handle) (AgentRef, error) {
+		return AgentRef{ID: "agent-alice", Name: "alice", RuntimeID: h.RuntimeID}, nil
+	})
+
+	if err := rt.Provision(context.Background(), agentruntime.ProvisionRequest{
+		AgentID: "agent-alice", AgentName: "alice", TemplateMemory: "# Memory\n", TemplateMemorySet: true,
+	}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "agent-alice", ".codex", "home", "memories", "memory_summary.md"))
+	if err != nil || string(data) != "# Memory\n" {
+		t.Fatalf("restored memory_summary.md = %q, error = %v", data, err)
+	}
+}
+
 func TestRuntimeCreateOverlaysManagerTemplateAfterHostSkills(t *testing.T) {
 	root := t.TempDir()
 	hostCodexHome := filepath.Join(t.TempDir(), "shared-codex-home")

--- a/internal/runtime/provision.go
+++ b/internal/runtime/provision.go
@@ -30,6 +30,8 @@ type ProvisionRequest struct {
 	AgentName            string
 	Instructions         string
 	TemplateInstructions string
+	TemplateMemory       string
+	TemplateMemorySet    bool
 	Profile              Profile
 	RuntimeOptions       map[string]any
 	MCPServers           map[string]any

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -13,6 +13,7 @@ import (
 
 	"csgclaw/internal/agentworkspace"
 	"csgclaw/internal/apitypes"
+	"csgclaw/internal/runtime"
 	toml "github.com/pelletier/go-toml/v2"
 )
 
@@ -304,6 +305,9 @@ func normalizePublishSpec(spec PublishSpec) (PublishSpec, error) {
 		return PublishSpec{}, err
 	}
 	spec.RuntimeOptions = runtimeOptions
+	if spec.RuntimeKind == runtime.KindCodex && spec.RuntimeOptions["memory_mode"] == "disabled" {
+		spec.WorkspaceRef.MemoryPath = ""
+	}
 	if spec.RuntimeKind == "" {
 		return PublishSpec{}, ErrRuntimeKindRequired
 	}

--- a/internal/template/local_store.go
+++ b/internal/template/local_store.go
@@ -183,7 +183,7 @@ func (s *LocalStore) Publish(_ context.Context, spec PublishSpec) (Template, err
 		return Template{}, err
 	}
 	if normalized.WorkspaceRef.Kind == WorkspaceKindDir {
-		if err := writeTemplateLayout(normalized.WorkspaceRef, tmpDir, normalized.RuntimeKind, normalized.MCPServers); err != nil {
+		if err := writeTemplateLayout(normalized.WorkspaceRef, tmpDir, normalized.RuntimeKind, normalized.MCPServers, normalized.IncludeMemory); err != nil {
 			return Template{}, err
 		}
 	}
@@ -305,7 +305,7 @@ func normalizePublishSpec(spec PublishSpec) (PublishSpec, error) {
 		return PublishSpec{}, err
 	}
 	spec.RuntimeOptions = runtimeOptions
-	if spec.RuntimeKind == runtime.KindCodex && spec.RuntimeOptions["memory_mode"] == "disabled" {
+	if !spec.IncludeMemory || (spec.RuntimeKind == runtime.KindCodex && spec.RuntimeOptions["memory_mode"] == "disabled") {
 		spec.WorkspaceRef.MemoryPath = ""
 	}
 	if spec.RuntimeKind == "" {

--- a/internal/template/local_store_test.go
+++ b/internal/template/local_store_test.go
@@ -33,6 +33,7 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	publishedAt := time.Date(2026, 5, 12, 8, 30, 0, 0, time.UTC)
 	published, err := store.Publish(context.Background(), PublishSpec{
 		Name:           "frontend-alice",
+		IncludeMemory:  true,
 		Description:    "Frontend worker with UI and styling skills",
 		RuntimeKind:    runtime.KindCodex,
 		Image:          "worker:latest",

--- a/internal/template/local_store_test.go
+++ b/internal/template/local_store_test.go
@@ -24,6 +24,10 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "skills", "frontend.txt"), []byte("skill"), 0o755); err != nil {
 		t.Fatalf("WriteFile(skill) error = %v", err)
 	}
+	memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
+	if err := os.WriteFile(memoryPath, []byte("# Learned context\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(memory) error = %v", err)
+	}
 
 	store := NewLocalStore(registryRoot)
 	publishedAt := time.Date(2026, 5, 12, 8, 30, 0, 0, time.UTC)
@@ -32,8 +36,8 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 		Description:    "Frontend worker with UI and styling skills",
 		RuntimeKind:    runtime.KindCodex,
 		Image:          "worker:latest",
-		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
-		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
+		RuntimeOptions: map[string]any{"execution_mode": "read_only", "memory_mode": "enabled"},
+		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot, MemoryPath: memoryPath},
 		UpdatedAt:      publishedAt,
 	})
 	if err != nil {
@@ -51,8 +55,15 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	if got, want := published.RuntimeOptions["execution_mode"], "read_only"; got != want {
 		t.Fatalf("Publish().RuntimeOptions[execution_mode] = %v, want %q", got, want)
 	}
+	if got, want := published.RuntimeOptions["memory_mode"], "enabled"; got != want {
+		t.Fatalf("Publish().RuntimeOptions[memory_mode] = %v, want %q", got, want)
+	}
 	if got, want := published.UpdatedAt, publishedAt; !got.Equal(want) {
 		t.Fatalf("Publish().UpdatedAt = %v, want %v", got, want)
+	}
+	storedMemory, err := os.ReadFile(filepath.Join(registryRoot, localTemplatesDirName, "frontend-alice", localMemoriesDirName, "memory_summary.md"))
+	if err != nil || string(storedMemory) != "# Learned context\n" {
+		t.Fatalf("stored memory_summary.md = %q, error = %v", storedMemory, err)
 	}
 
 	listed, err := store.List(context.Background())
@@ -82,12 +93,17 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	if gotMode, want := got.RuntimeOptions["execution_mode"], "read_only"; gotMode != want {
 		t.Fatalf("Get().RuntimeOptions[execution_mode] = %v, want %q", gotMode, want)
 	}
+	if gotMode, want := got.RuntimeOptions["memory_mode"], "enabled"; gotMode != want {
+		t.Fatalf("Get().RuntimeOptions[memory_mode] = %v, want %q", gotMode, want)
+	}
 	manifestData, err := os.ReadFile(filepath.Join(registryRoot, localTemplatesDirName, "frontend-alice", localManifestFileName))
 	if err != nil {
 		t.Fatalf("ReadFile(agent.toml) error = %v", err)
 	}
-	if !strings.Contains(string(manifestData), "[runtime_options]") || !strings.Contains(string(manifestData), "execution_mode = 'read_only'") {
-		t.Fatalf("agent.toml missing read-only runtime options:\n%s", manifestData)
+	if !strings.Contains(string(manifestData), "[runtime_options]") ||
+		!strings.Contains(string(manifestData), "execution_mode = 'read_only'") ||
+		!strings.Contains(string(manifestData), "memory_mode = 'enabled'") {
+		t.Fatalf("agent.toml missing runtime options:\n%s", manifestData)
 	}
 
 	workspace, err := store.FetchWorkspace(context.Background(), "frontend-alice")
@@ -101,6 +117,12 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 		t.Fatal("FetchWorkspace().Temporary = false, want materialized local workspace to be caller-owned")
 	}
 	defer os.RemoveAll(workspace.Path)
+	if data, err := os.ReadFile(workspace.MemoryPath); err != nil || string(data) != "# Learned context\n" {
+		t.Fatalf("materialized memory = %q, error = %v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace.Path, "MEMORY.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Codex memory leaked into workspace, stat error = %v", err)
+	}
 
 	agentsData, err := os.ReadFile(filepath.Join(workspace.Path, "AGENTS.md"))
 	if err != nil {
@@ -115,6 +137,40 @@ func TestLocalStorePublishRoundTrip(t *testing.T) {
 	}
 	if skillInfo.Mode().Perm()&0o111 == 0 {
 		t.Fatalf("skill mode = %o, want executable bit preserved", skillInfo.Mode().Perm())
+	}
+}
+
+func TestLocalStorePublishOmitsCodexMemoryWhenDisabled(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "AGENTS.md"), []byte("# Instructions\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
+	if err := os.WriteFile(memoryPath, []byte("# Must not publish\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registryRoot := t.TempDir()
+	store := NewLocalStore(registryRoot)
+	created, err := store.Publish(context.Background(), PublishSpec{
+		Name:           "disabled-memory",
+		RuntimeKind:    runtime.KindCodex,
+		RuntimeOptions: map[string]any{"memory_mode": "disabled"},
+		WorkspaceRef:   WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot, MemoryPath: memoryPath},
+	})
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	storedPath := filepath.Join(registryRoot, localTemplatesDirName, created.ID, localMemoriesDirName, "memory_summary.md")
+	if _, err := os.Stat(storedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("disabled memory snapshot stat error = %v, want not exist", err)
+	}
+	workspace, err := store.FetchWorkspace(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("FetchWorkspace() error = %v", err)
+	}
+	defer os.RemoveAll(workspace.Path)
+	if workspace.MemoryPath != "" {
+		t.Fatalf("FetchWorkspace().MemoryPath = %q, want empty", workspace.MemoryPath)
 	}
 }
 
@@ -185,6 +241,9 @@ func TestLocalStorePublishUsesRuntimeAwareInstructionAndSkillPaths(t *testing.T)
 	if err := os.MkdirAll(filepath.Join(skillsRoot, "custom"), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(skillsRoot, ".system", "openai-docs", "references"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(system skill) error = %v", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(instructionsPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(home) error = %v", err)
 	}
@@ -196,6 +255,9 @@ func TestLocalStorePublishUsesRuntimeAwareInstructionAndSkillPaths(t *testing.T)
 	}
 	if err := os.WriteFile(filepath.Join(skillsRoot, "custom", "SKILL.md"), []byte("custom skill\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(SKILL.md) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsRoot, ".system", "openai-docs", "references", "internal.md"), []byte("system skill\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(system skill) error = %v", err)
 	}
 
 	store := NewLocalStore(registryRoot)
@@ -221,6 +283,9 @@ func TestLocalStorePublishUsesRuntimeAwareInstructionAndSkillPaths(t *testing.T)
 		t.Fatalf("ReadFile(template SKILL.md) error = %v", err)
 	} else if got, want := string(data), "custom skill\n"; got != want {
 		t.Fatalf("template SKILL.md = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(templateRoot, localSkillsDirName, ".system")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("template system skills stat error = %v, want not exist", err)
 	}
 }
 

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -1002,7 +1002,7 @@ func buildRemoteTemplateArchive(spec PublishSpec) ([]byte, error) {
 		return nil, err
 	}
 	if spec.WorkspaceRef.Kind == WorkspaceKindDir {
-		if err := writeTemplateLayout(spec.WorkspaceRef, tmpDir, spec.RuntimeKind, spec.MCPServers); err != nil {
+		if err := writeTemplateLayout(spec.WorkspaceRef, tmpDir, spec.RuntimeKind, spec.MCPServers, spec.IncludeMemory); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -155,6 +155,13 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	if err := os.WriteFile(memoryPath, []byte("must not upload\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	stagedMemoryDir := filepath.Join(workspace, codexTemplateMemoryStagingDir)
+	if err := os.MkdirAll(stagedMemoryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedMemoryDir, "memory_summary.md"), []byte("staged memory must not upload\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(workspace, "skills", "custom"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -277,16 +284,20 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	names := make(map[string]bool, len(archive.File))
 	for _, file := range archive.File {
 		names[file.Name] = true
+		reader, openErr := file.Open()
+		if openErr != nil {
+			t.Fatalf("Open(%s) error = %v", file.Name, openErr)
+		}
+		content, readErr := io.ReadAll(reader)
+		_ = reader.Close()
+		if readErr != nil {
+			t.Fatalf("ReadAll(%s) error = %v", file.Name, readErr)
+		}
+		if bytes.Contains(content, []byte("staged memory must not upload")) {
+			t.Errorf("uploaded archive leaked staged memory through %q", file.Name)
+		}
 		if file.Name == "agent.toml" {
-			reader, err := file.Open()
-			if err != nil {
-				t.Fatalf("Open(agent.toml) error = %v", err)
-			}
-			manifest, err := io.ReadAll(reader)
-			_ = reader.Close()
-			if err != nil {
-				t.Fatalf("ReadAll(agent.toml) error = %v", err)
-			}
+			manifest := content
 			if !strings.Contains(string(manifest), `schema_version = "agentfile/v1"`) {
 				t.Errorf("agent.toml missing schema_version: %s", manifest)
 			}
@@ -317,6 +328,9 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 		}
 		if name == "memories/memory_summary.md" {
 			t.Errorf("uploaded archive contains disabled Codex memory summary")
+		}
+		if strings.Contains(name, codexTemplateMemoryStagingDir) {
+			t.Errorf("uploaded archive contains reserved memory staging path %q", name)
 		}
 	}
 }

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -111,11 +111,60 @@ func TestRemoteStorePostJSONPreservesNonstandardJSONErrorBody(t *testing.T) {
 	}
 }
 
+func TestRemoteStorePostJSONPreservesRepositoryPathConflictCode(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"SYS-ERR-4","msg":"repository path already exists"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := NewRemoteStore(srv.URL, "token")
+	err := store.postJSON(context.Background(), srv.URL, nil, nil)
+	if got, want := RemoteAPIErrorCode(err), "SYS-ERR-4"; got != want {
+		t.Fatalf("RemoteAPIErrorCode() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteStorePostJSONDoesNotInferConflictWithoutCode(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`ERROR: duplicate key value violates unique constraint "idx_repositories_git_path" (SQLSTATE 23505)`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := NewRemoteStore(srv.URL, "token")
+	err := store.postJSON(context.Background(), srv.URL, nil, nil)
+	if errors.Is(err, ErrTemplateAlreadyExists) {
+		t.Fatalf("postJSON() error = %v, must not infer a name conflict without an upstream code", err)
+	}
+}
+
 func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	t.Parallel()
 
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "AGENTS.md"), []byte("publish me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
+	if err := os.WriteFile(memoryPath, []byte("must not upload\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "skills", "custom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "skills", ".system", "openai-docs", "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "skills", "custom", "SKILL.md"), []byte("custom skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "skills", ".system", "openai-docs", "references", "internal.md"), []byte("system skill\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -179,10 +228,11 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 		Name:           "ReviewBot_2",
 		Description:    "Reviews changes",
 		RuntimeKind:    "codex",
-		RuntimeOptions: map[string]any{"execution_mode": "read_only"},
+		RuntimeOptions: map[string]any{"execution_mode": "read_only", "memory_mode": "disabled"},
 		WorkspaceRef: WorkspaceRef{
 			Kind:             WorkspaceKindDir,
 			Path:             workspace,
+			MemoryPath:       memoryPath,
 			InstructionsPath: filepath.Join(workspace, "AGENTS.md"),
 		},
 	})
@@ -194,6 +244,9 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 	}
 	if got, want := item.RuntimeOptions["execution_mode"], "read_only"; got != want {
 		t.Fatalf("Publish().RuntimeOptions[execution_mode] = %v, want %q", got, want)
+	}
+	if got, want := item.RuntimeOptions["memory_mode"], "disabled"; got != want {
+		t.Fatalf("Publish().RuntimeOptions[memory_mode] = %v, want %q", got, want)
 	}
 	if got, want := created.CodeFile, "package-uuid"; got != want {
 		t.Fatalf("create code_file = %q, want %q", got, want)
@@ -243,14 +296,27 @@ func TestRemoteStorePublishUploadsArchiveAndCreatesTemplateCode(t *testing.T) {
 			if !strings.Contains(string(manifest), `description = 'Reviews changes'`) {
 				t.Errorf("agent.toml missing template description: %s", manifest)
 			}
-			if !strings.Contains(string(manifest), "[runtime_options]") || !strings.Contains(string(manifest), "execution_mode = 'read_only'") {
-				t.Errorf("agent.toml missing read-only runtime options: %s", manifest)
+			if !strings.Contains(string(manifest), "[runtime_options]") ||
+				!strings.Contains(string(manifest), "execution_mode = 'read_only'") ||
+				!strings.Contains(string(manifest), "memory_mode = 'disabled'") {
+				t.Errorf("agent.toml missing runtime options: %s", manifest)
 			}
 		}
 	}
 	for _, want := range []string{"agent.toml", "instructions/AGENTS.md"} {
 		if !names[want] {
 			t.Errorf("uploaded archive missing %q; names = %#v", want, names)
+		}
+	}
+	if !names["skills/custom/SKILL.md"] {
+		t.Errorf("uploaded archive missing custom skill; names = %#v", names)
+	}
+	for name := range names {
+		if strings.HasPrefix(name, "skills/.system/") {
+			t.Errorf("uploaded archive contains Codex system skill %q", name)
+		}
+		if name == "memories/memory_summary.md" {
+			t.Errorf("uploaded archive contains disabled Codex memory summary")
 		}
 	}
 }
@@ -625,6 +691,41 @@ func TestRemoteStoreFetchWorkspaceSupportsLegacyLayoutAndEmptyMissingTree(t *tes
 		if got := string(data); got != want {
 			t.Fatalf("%s = %q, want %q", name, got, want)
 		}
+	}
+}
+
+func TestRemoteStoreFetchWorkspaceRestoresCodexMemorySummary(t *testing.T) {
+	t.Parallel()
+	const manifest = "name = 'codex-memory'\nruntime_kind = 'codex'\n[runtime_options]\nmemory_mode = 'enabled'\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/codes/Agentic/codex-memory":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"default_branch": "main"}})
+		case "/api/v1/codes/Agentic/codex-memory/download_archive/refs/main":
+			writeRemoteArchive(t, w, "codex-memory-main/", map[string]string{
+				"agent.toml":                 manifest,
+				"instructions/AGENTS.md":     "# Instructions\n",
+				"memories/memory_summary.md": "# Remote memory\n",
+				"skills/custom/SKILL.md":     "# Custom\n",
+				"mcps/mcp.json":              "{}\n",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	workspace, err := NewRemoteStore(srv.URL, "").FetchWorkspace(context.Background(), "Agentic/codex-memory")
+	if err != nil {
+		t.Fatalf("FetchWorkspace() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(workspace.Path) })
+	data, err := os.ReadFile(workspace.MemoryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(MemoryPath) error = %v", err)
+	}
+	if got, want := string(data), "# Remote memory\n"; got != want {
+		t.Fatalf("memory summary = %q, want %q", got, want)
 	}
 }
 

--- a/internal/template/service.go
+++ b/internal/template/service.go
@@ -232,7 +232,7 @@ func (s *Service) Publish(ctx context.Context, spec PublishSpec) (Template, erro
 	return decorateTemplate(cfgStore, item), nil
 }
 
-func (s *Service) PublishTemplate(ctx context.Context, id, registry string) (Template, error) {
+func (s *Service) PublishTemplate(ctx context.Context, id, registry string, includeMemory bool) (Template, error) {
 	item, err := s.Get(ctx, id)
 	if err != nil {
 		return Template{}, err
@@ -244,6 +244,9 @@ func (s *Service) PublishTemplate(ctx context.Context, id, registry string) (Tem
 	if workspace.Temporary && strings.TrimSpace(workspace.Path) != "" {
 		defer func() { _ = os.RemoveAll(workspace.Path) }()
 	}
+	if !includeMemory {
+		workspace.MemoryPath = ""
+	}
 	var mcpServers map[string]any
 	if raw := strings.TrimSpace(workspace.MCPServersJSON); raw != "" {
 		if err := json.Unmarshal([]byte(raw), &mcpServers); err != nil {
@@ -252,6 +255,7 @@ func (s *Service) PublishTemplate(ctx context.Context, id, registry string) (Tem
 	}
 	return s.Publish(ctx, PublishSpec{
 		Registry:       registry,
+		IncludeMemory:  includeMemory,
 		ID:             item.Name,
 		Name:           item.Name,
 		Description:    item.Description,

--- a/internal/template/service_test.go
+++ b/internal/template/service_test.go
@@ -3,6 +3,8 @@ package template
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"csgclaw/internal/config"
@@ -212,6 +214,63 @@ func TestPublishUsesDefaultPublishRegistry(t *testing.T) {
 	}
 	if got, want := item.ID, "local.frontend-alice"; got != want {
 		t.Fatalf("Publish().ID = %q, want %q", got, want)
+	}
+}
+
+func TestPublishTemplateRequiresExplicitMemoryOptIn(t *testing.T) {
+	sourceRoot := t.TempDir()
+	targetRoot := t.TempDir()
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, requiredInstructionsFile), []byte("# Instructions\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	memoryPath := filepath.Join(t.TempDir(), "memory_summary.md")
+	if err := os.WriteFile(memoryPath, []byte("private memory marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sourceStore := NewLocalStore(sourceRoot)
+	if _, err := sourceStore.Publish(context.Background(), PublishSpec{
+		ID: "codex-memory", Name: "codex-memory", RuntimeKind: "codex", IncludeMemory: true,
+		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot, MemoryPath: memoryPath},
+	}); err != nil {
+		t.Fatalf("seed source template: %v", err)
+	}
+	svc, err := NewService(config.HubConfig{
+		DefaultRegistry:        "source",
+		DefaultPublishRegistry: "target",
+		Registries: []config.HubRegistryConfig{
+			{Name: "source", Kind: RegistryKindLocal, Path: sourceRoot, Enabled: true},
+			{Name: "target", Kind: RegistryKindLocal, Path: targetRoot, Enabled: true},
+		},
+	}, DefaultStoreFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := svc.PublishTemplate(context.Background(), "source.codex-memory", "target", false); err != nil {
+		t.Fatalf("PublishTemplate(default) error = %v", err)
+	}
+	targetTemplateRoot := filepath.Join(targetRoot, localTemplatesDirName, "codex-memory")
+	for _, leakedPath := range []string{
+		filepath.Join(targetTemplateRoot, localMemoriesDirName, "memory_summary.md"),
+		filepath.Join(targetTemplateRoot, localInstructionsDirName, codexTemplateMemoryStagingDir, "memory_summary.md"),
+	} {
+		if _, statErr := os.Stat(leakedPath); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("default publish leaked memory at %q: %v", leakedPath, statErr)
+		}
+	}
+	if err := NewLocalStore(targetRoot).Delete(context.Background(), "codex-memory"); err != nil {
+		t.Fatalf("delete default publish: %v", err)
+	}
+	if _, err := svc.PublishTemplate(context.Background(), "source.codex-memory", "target", true); err != nil {
+		t.Fatalf("PublishTemplate(opt-in) error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(targetTemplateRoot, localMemoriesDirName, "memory_summary.md"))
+	if err != nil || string(data) != "private memory marker\n" {
+		t.Fatalf("opt-in memory = %q, error = %v", data, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(targetTemplateRoot, localInstructionsDirName, codexTemplateMemoryStagingDir)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("opt-in publish copied staging directory into instructions: %v", statErr)
 	}
 }
 

--- a/internal/template/template_layout.go
+++ b/internal/template/template_layout.go
@@ -13,15 +13,20 @@ import (
 )
 
 const requiredInstructionsFile = "AGENTS.md"
+const codexSystemSkillsDirName = ".system"
+const codexTemplateMemoryStagingDir = ".csgclaw-template-memory"
 
 func materializeTemplateDir(templateRoot, runtimeKind string) (WorkspaceRef, error) {
 	if !templateLayoutExists(templateRoot) && legacyTemplateWorkspaceExists(templateRoot) {
 		return materializeLegacyTemplateWorkspace(templateRoot)
 	}
 	if strings.TrimSpace(runtimeKind) == "" {
-		if _, manifest, err := loadManifestFS(os.DirFS(templateRoot), localManifestFileName, "template"); err == nil {
-			runtimeKind = manifest.RuntimeKind
+		manifestPath := filepath.Join(filepath.Base(templateRoot), localManifestFileName)
+		_, manifest, err := loadManifestFS(os.DirFS(filepath.Dir(templateRoot)), manifestPath, "template")
+		if err != nil {
+			return WorkspaceRef{}, err
 		}
+		runtimeKind = manifest.RuntimeKind
 	}
 	return materializeTemplateFS(os.DirFS(templateRoot), ".", runtimeKind)
 }
@@ -75,6 +80,18 @@ func materializeTemplateFS(srcFS fs.FS, templateRoot, runtimeKind string) (Works
 			}
 		}
 	}
+	var memoryPath string
+	if normalizeTemplateRuntimeKind(runtimeKind) == agentruntime.KindCodex {
+		source := filepath.ToSlash(filepath.Join(templateRoot, localMemoriesDirName, "memory_summary.md"))
+		if _, statErr := fs.Stat(srcFS, source); statErr == nil {
+			memoryPath = filepath.Join(dstRoot, codexTemplateMemoryStagingDir, "memory_summary.md")
+			if err := copySingleTemplateFileFS(srcFS, source, memoryPath); err != nil {
+				return cleanup(err)
+			}
+		} else if !errors.Is(statErr, fs.ErrNotExist) {
+			return cleanup(statErr)
+		}
+	}
 	servers, err := readTemplateMCPServers(srcFS, filepath.ToSlash(filepath.Join(templateRoot, localMCPsDirName, localMCPFileName)))
 	if err != nil {
 		return cleanup(err)
@@ -83,7 +100,7 @@ func materializeTemplateFS(srcFS fs.FS, templateRoot, runtimeKind string) (Works
 	if err != nil {
 		return cleanup(fmt.Errorf("encode materialized template mcp servers: %w", err))
 	}
-	return WorkspaceRef{Kind: WorkspaceKindDir, Path: dstRoot, MCPServersJSON: string(encodedServers), Temporary: true}, nil
+	return WorkspaceRef{Kind: WorkspaceKindDir, Path: dstRoot, MemoryPath: memoryPath, MCPServersJSON: string(encodedServers), Temporary: true}, nil
 }
 
 func readTemplateMCPServers(srcFS fs.FS, filePath string) (map[string]any, error) {
@@ -133,7 +150,7 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 			if strings.TrimSpace(workspace.SkillsPath) != "" {
 				continue
 			}
-			if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localSkillsDirName)); err != nil {
+			if err := copyTemplateSkills(source, filepath.Join(templateRoot, localSkillsDirName), runtimeKind); err != nil {
 				return err
 			}
 		case "memory":
@@ -167,10 +184,15 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 	}
 	if source := strings.TrimSpace(workspace.SkillsPath); source != "" {
 		if info, err := os.Stat(source); err == nil && info.IsDir() {
-			if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localSkillsDirName)); err != nil {
+			if err := copyTemplateSkills(source, filepath.Join(templateRoot, localSkillsDirName), runtimeKind); err != nil {
 				return err
 			}
 		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if source := strings.TrimSpace(workspace.MemoryPath); source != "" && normalizeTemplateRuntimeKind(runtimeKind) == agentruntime.KindCodex {
+		if err := copySingleTemplateFile(source, filepath.Join(templateRoot, localMemoriesDirName, "memory_summary.md")); err != nil {
 			return err
 		}
 	}
@@ -196,6 +218,15 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 	}
 	data = append(data, '\n')
 	return os.WriteFile(filepath.Join(templateRoot, localMCPsDirName, localMCPFileName), data, 0o644)
+}
+
+func copyTemplateSkills(source, target, runtimeKind string) error {
+	if normalizeTemplateRuntimeKind(runtimeKind) != agentruntime.KindCodex {
+		return copyWorkspaceTree(source, target)
+	}
+	return copyWorkspaceTreeWithFilter(source, target, func(path string, _ fs.DirEntry) bool {
+		return filepath.ToSlash(filepath.Clean(path)) == codexSystemSkillsDirName
+	})
 }
 
 func templateUsesWorkspaceMemory(runtimeKind string) bool {
@@ -225,4 +256,15 @@ func copySingleTemplateFile(source, target string) error {
 		return err
 	}
 	return nil
+}
+
+func copySingleTemplateFileFS(sourceFS fs.FS, source, target string) error {
+	data, err := fs.ReadFile(sourceFS, source)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(target, data, 0o644)
 }

--- a/internal/template/template_layout.go
+++ b/internal/template/template_layout.go
@@ -130,7 +130,7 @@ func readTemplateMCPServers(srcFS fs.FS, filePath string) (map[string]any, error
 	return raw, nil
 }
 
-func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind string, mcpServers map[string]any) error {
+func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind string, mcpServers map[string]any, includeMemory bool) error {
 	workspaceRoot := workspace.Path
 	instructionsRoot := filepath.Join(templateRoot, localInstructionsDirName)
 	if err := os.MkdirAll(instructionsRoot, 0o755); err != nil {
@@ -143,6 +143,30 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 	for _, entry := range entries {
 		name := entry.Name()
 		source := filepath.Join(workspaceRoot, name)
+		reservedName := strings.ToLower(name)
+		if reservedName == strings.ToLower(codexTemplateMemoryStagingDir) {
+			// Materialized Codex templates stage memory inside WorkspaceRef.Path so
+			// agent creation can restore it separately. Never treat that reserved
+			// directory as instructions: memory may only leave through the explicit
+			// WorkspaceRef.MemoryPath channel below.
+			continue
+		}
+		if reservedName == "memory" {
+			if includeMemory && templateUsesWorkspaceMemory(runtimeKind) {
+				if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localMemoriesDirName)); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if reservedName == "memory.md" {
+			if includeMemory && templateUsesWorkspaceMemory(runtimeKind) {
+				if err := copySingleTemplateFile(source, filepath.Join(templateRoot, localMemoriesDirName, "MEMORY.md")); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		switch name {
 		case requiredInstructionsFile:
 			if strings.TrimSpace(workspace.InstructionsPath) != "" {
@@ -156,20 +180,6 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 				continue
 			}
 			if err := copyTemplateSkills(source, filepath.Join(templateRoot, localSkillsDirName), runtimeKind); err != nil {
-				return err
-			}
-		case "memory":
-			if !templateUsesWorkspaceMemory(runtimeKind) {
-				continue
-			}
-			if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localMemoriesDirName)); err != nil {
-				return err
-			}
-		case "MEMORY.md":
-			if !templateUsesWorkspaceMemory(runtimeKind) {
-				continue
-			}
-			if err := copySingleTemplateFile(source, filepath.Join(templateRoot, localMemoriesDirName, name)); err != nil {
 				return err
 			}
 		default:

--- a/internal/template/template_layout.go
+++ b/internal/template/template_layout.go
@@ -69,11 +69,7 @@ func materializeTemplateFS(srcFS fs.FS, templateRoot, runtimeKind string) (Works
 	}
 	for _, part := range []struct{ source, target string }{
 		{localSkillsDirName, localSkillsDirName},
-		{localMemoriesDirName, ""},
 	} {
-		if part.source == localMemoriesDirName && !templateUsesWorkspaceMemory(runtimeKind) {
-			continue
-		}
 		source := filepath.ToSlash(filepath.Join(templateRoot, part.source))
 		if info, statErr := fs.Stat(srcFS, source); statErr == nil && info.IsDir() {
 			target := dstRoot
@@ -83,6 +79,11 @@ func materializeTemplateFS(srcFS fs.FS, templateRoot, runtimeKind string) (Works
 			if err := copyWorkspaceTreeFS(srcFS, source, target, "template "+part.source); err != nil {
 				return cleanup(err)
 			}
+		}
+	}
+	if templateUsesWorkspaceMemory(runtimeKind) {
+		if err := materializeWorkspaceMemoryFS(srcFS, templateRoot, dstRoot); err != nil {
+			return cleanup(err)
 		}
 	}
 	var memoryPath string
@@ -153,7 +154,7 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 		}
 		if reservedName == "memory" {
 			if includeMemory && templateUsesWorkspaceMemory(runtimeKind) {
-				if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localMemoriesDirName)); err != nil {
+				if err := copyWorkspaceTree(source, filepath.Join(templateRoot, localMemoriesDirName, "memory")); err != nil {
 					return err
 				}
 			}
@@ -233,6 +234,46 @@ func writeTemplateLayout(workspace WorkspaceRef, templateRoot, runtimeKind strin
 	}
 	data = append(data, '\n')
 	return os.WriteFile(filepath.Join(templateRoot, localMCPsDirName, localMCPFileName), data, 0o644)
+}
+
+func materializeWorkspaceMemoryFS(srcFS fs.FS, templateRoot, workspaceRoot string) error {
+	memoriesRoot := filepath.ToSlash(filepath.Join(templateRoot, localMemoriesDirName))
+	entries, err := fs.ReadDir(srcFS, memoriesRoot)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		source := filepath.ToSlash(filepath.Join(memoriesRoot, name))
+		if strings.EqualFold(name, "MEMORY.md") && !entry.IsDir() {
+			if err := copySingleTemplateFileFS(srcFS, source, filepath.Join(workspaceRoot, "MEMORY.md")); err != nil {
+				return err
+			}
+			continue
+		}
+		target := filepath.Join(workspaceRoot, "memory")
+		if strings.EqualFold(name, "memory") && entry.IsDir() {
+			if err := copyWorkspaceTreeFS(srcFS, source, target, "template memories/memory"); err != nil {
+				return err
+			}
+			continue
+		}
+		// Older CSGClaw versions flattened memory/* directly under memories/.
+		// Restore those entries under memory/ so existing templates retain the
+		// OpenClaw workspace layout expected by the runtime.
+		target = filepath.Join(target, name)
+		if entry.IsDir() {
+			if err := copyWorkspaceTreeFS(srcFS, source, target, "legacy template memory"); err != nil {
+				return err
+			}
+		} else if err := copySingleTemplateFileFS(srcFS, source, target); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func copyTemplateSkills(source, target, runtimeKind string) error {

--- a/internal/template/template_layout.go
+++ b/internal/template/template_layout.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -21,7 +22,7 @@ func materializeTemplateDir(templateRoot, runtimeKind string) (WorkspaceRef, err
 		return materializeLegacyTemplateWorkspace(templateRoot)
 	}
 	if strings.TrimSpace(runtimeKind) == "" {
-		manifestPath := filepath.Join(filepath.Base(templateRoot), localManifestFileName)
+		manifestPath := templateManifestFSPath(templateRoot)
 		_, manifest, err := loadManifestFS(os.DirFS(filepath.Dir(templateRoot)), manifestPath, "template")
 		if err != nil {
 			return WorkspaceRef{}, err
@@ -29,6 +30,10 @@ func materializeTemplateDir(templateRoot, runtimeKind string) (WorkspaceRef, err
 		runtimeKind = manifest.RuntimeKind
 	}
 	return materializeTemplateFS(os.DirFS(templateRoot), ".", runtimeKind)
+}
+
+func templateManifestFSPath(templateRoot string) string {
+	return path.Join(filepath.ToSlash(filepath.Base(templateRoot)), localManifestFileName)
 }
 
 func materializeLegacyTemplateWorkspace(templateRoot string) (WorkspaceRef, error) {

--- a/internal/template/template_layout_test.go
+++ b/internal/template/template_layout_test.go
@@ -52,27 +52,36 @@ func TestWriteTemplateLayoutKeepsWorkspaceMemoryOutOfCodexTemplates(t *testing.T
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "AGENTS.md"), []byte("# Instructions\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceRoot, "MEMORY.md"), []byte("# Pinned memory\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "memory.md"), []byte("# Pinned memory\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceRoot, "memory"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "Memory"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceRoot, "memory", "2026-08-25.md"), []byte("dated memory\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Memory", "2026-08-25.md"), []byte("dated memory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stagingDir := filepath.Join(workspaceRoot, ".CSGClaw-Template-Memory")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "memory_summary.md"), []byte("staged memory\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	for _, tt := range []struct {
-		name        string
-		runtimeKind string
-		wantMemory  bool
+		name          string
+		runtimeKind   string
+		includeMemory bool
+		wantMemory    bool
 	}{
-		{name: "codex", runtimeKind: agentruntime.KindCodex, wantMemory: false},
-		{name: "openclaw", runtimeKind: agentruntime.NameOpenClaw, wantMemory: true},
+		{name: "codex", runtimeKind: agentruntime.KindCodex, includeMemory: true, wantMemory: false},
+		{name: "openclaw default off", runtimeKind: agentruntime.NameOpenClaw, wantMemory: false},
+		{name: "openclaw explicit opt in", runtimeKind: agentruntime.NameOpenClaw, includeMemory: true, wantMemory: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			templateRoot := t.TempDir()
-			if err := writeTemplateLayout(WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot}, templateRoot, tt.runtimeKind, nil); err != nil {
+			if err := writeTemplateLayout(WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot}, templateRoot, tt.runtimeKind, nil, tt.includeMemory); err != nil {
 				t.Fatalf("writeTemplateLayout() error = %v", err)
 			}
 			for _, path := range []string{
@@ -86,6 +95,9 @@ func TestWriteTemplateLayoutKeepsWorkspaceMemoryOutOfCodexTemplates(t *testing.T
 				if !tt.wantMemory && !errors.Is(err, os.ErrNotExist) {
 					t.Fatalf("Codex template unexpectedly contains workspace memory %q: %v", path, err)
 				}
+			}
+			if _, err := os.Stat(filepath.Join(templateRoot, localInstructionsDirName, ".CSGClaw-Template-Memory")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("reserved memory staging directory leaked into instructions: %v", err)
 			}
 		})
 	}

--- a/internal/template/template_layout_test.go
+++ b/internal/template/template_layout_test.go
@@ -130,3 +130,41 @@ func TestMaterializeTemplateFSSkipsMemoryForCodex(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyTemplateSkillsSkipsOnlyTopLevelCodexSystemSkills(t *testing.T) {
+	source := t.TempDir()
+	for path, content := range map[string]string{
+		".system/builtin/SKILL.md":       "builtin\n",
+		"custom/SKILL.md":                "custom\n",
+		"custom/references/.system/data": "nested\n",
+	} {
+		path = filepath.Join(source, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	codexTarget := t.TempDir()
+	if err := copyTemplateSkills(source, codexTarget, agentruntime.KindCodex); err != nil {
+		t.Fatalf("copyTemplateSkills(codex) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(codexTarget, ".system")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("top-level Codex .system stat error = %v, want not exist", err)
+	}
+	for _, path := range []string{"custom/SKILL.md", "custom/references/.system/data"} {
+		if _, err := os.Stat(filepath.Join(codexTarget, filepath.FromSlash(path))); err != nil {
+			t.Fatalf("Codex custom skill path %q missing: %v", path, err)
+		}
+	}
+
+	openClawTarget := t.TempDir()
+	if err := copyTemplateSkills(source, openClawTarget, agentruntime.NameOpenClaw); err != nil {
+		t.Fatalf("copyTemplateSkills(openclaw) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(openClawTarget, ".system", "builtin", "SKILL.md")); err != nil {
+		t.Fatalf("OpenClaw top-level .system missing: %v", err)
+	}
+}

--- a/internal/template/template_layout_test.go
+++ b/internal/template/template_layout_test.go
@@ -86,7 +86,7 @@ func TestWriteTemplateLayoutKeepsWorkspaceMemoryOutOfCodexTemplates(t *testing.T
 			}
 			for _, path := range []string{
 				filepath.Join(templateRoot, localMemoriesDirName, "MEMORY.md"),
-				filepath.Join(templateRoot, localMemoriesDirName, "2026-08-25.md"),
+				filepath.Join(templateRoot, localMemoriesDirName, "memory", "2026-08-25.md"),
 			} {
 				_, err := os.Stat(path)
 				if tt.wantMemory && err != nil {
@@ -100,6 +100,73 @@ func TestWriteTemplateLayoutKeepsWorkspaceMemoryOutOfCodexTemplates(t *testing.T
 				t.Fatalf("reserved memory staging directory leaked into instructions: %v", err)
 			}
 		})
+	}
+}
+
+func TestOpenClawTemplateMemoryRoundTripPreservesWorkspaceLayout(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	for path, content := range map[string]string{
+		"AGENTS.md":            "# Instructions\n",
+		"MEMORY.md":            "# Durable memory\n",
+		"memory/2026-08-28.md": "dated memory\n",
+	} {
+		path = filepath.Join(workspaceRoot, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	store := NewLocalStore(t.TempDir())
+	created, err := store.Publish(context.Background(), PublishSpec{
+		ID: "openclaw-memory", Name: "openclaw-memory", RuntimeKind: agentruntime.NameOpenClaw,
+		Image: "openclaw:test", IncludeMemory: true,
+		WorkspaceRef: WorkspaceRef{Kind: WorkspaceKindDir, Path: workspaceRoot},
+	})
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	workspace, err := store.FetchWorkspace(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("FetchWorkspace() error = %v", err)
+	}
+	defer os.RemoveAll(workspace.Path)
+	for path, want := range map[string]string{
+		"MEMORY.md":            "# Durable memory\n",
+		"memory/2026-08-28.md": "dated memory\n",
+	} {
+		data, readErr := os.ReadFile(filepath.Join(workspace.Path, filepath.FromSlash(path)))
+		if readErr != nil || string(data) != want {
+			t.Fatalf("restored %s = %q, error = %v, want %q", path, data, readErr, want)
+		}
+	}
+}
+
+func TestMaterializeWorkspaceMemorySupportsLegacyFlattenedEntries(t *testing.T) {
+	templateRoot := t.TempDir()
+	for path, content := range map[string]string{
+		"instructions/AGENTS.md": "# Instructions\n",
+		"memories/MEMORY.md":     "# Durable memory\n",
+		"memories/2026-08-27.md": "legacy dated memory\n",
+		"mcps/mcp.json":          "{}\n",
+	} {
+		path = filepath.Join(templateRoot, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	workspace, err := materializeTemplateFS(os.DirFS(templateRoot), ".", agentruntime.NameOpenClaw)
+	if err != nil {
+		t.Fatalf("materializeTemplateFS() error = %v", err)
+	}
+	defer os.RemoveAll(workspace.Path)
+	if data, readErr := os.ReadFile(filepath.Join(workspace.Path, "memory", "2026-08-27.md")); readErr != nil || string(data) != "legacy dated memory\n" {
+		t.Fatalf("legacy dated memory = %q, error = %v", data, readErr)
 	}
 }
 

--- a/internal/template/template_layout_windows_test.go
+++ b/internal/template/template_layout_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package template
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestTemplateManifestFSPathUsesForwardSlashesOnWindows(t *testing.T) {
+	got := templateManifestFSPath(`C:\hub\templates\codex-memory`)
+	if want := "codex-memory/agent.toml"; got != want {
+		t.Fatalf("templateManifestFSPath() = %q, want %q", got, want)
+	}
+	if !fs.ValidPath(got) {
+		t.Fatalf("templateManifestFSPath() = %q, want a valid fs.FS path", got)
+	}
+}

--- a/internal/template/types.go
+++ b/internal/template/types.go
@@ -64,6 +64,7 @@ type WorkspaceRef struct {
 
 type PublishSpec struct {
 	Registry       string
+	IncludeMemory  bool
 	ID             string
 	Name           string
 	Description    string

--- a/internal/template/types.go
+++ b/internal/template/types.go
@@ -57,6 +57,7 @@ type WorkspaceRef struct {
 	Path             string
 	InstructionsPath string
 	SkillsPath       string
+	MemoryPath       string
 	MCPServersJSON   string
 	Temporary        bool
 }

--- a/internal/template/workspace_copy.go
+++ b/internal/template/workspace_copy.go
@@ -44,6 +44,10 @@ func tempRootMissing(path string) bool {
 }
 
 func copyWorkspaceTree(srcRoot, dstRoot string) error {
+	return copyWorkspaceTreeWithFilter(srcRoot, dstRoot, nil)
+}
+
+func copyWorkspaceTreeWithFilter(srcRoot, dstRoot string, skip func(string, fs.DirEntry) bool) error {
 	srcRoot = strings.TrimSpace(srcRoot)
 	if srcRoot == "" {
 		return ErrWorkspaceDirRequired
@@ -61,10 +65,14 @@ func copyWorkspaceTree(srcRoot, dstRoot string) error {
 	if !info.IsDir() {
 		return ErrWorkspaceDirRequired
 	}
-	return copyWorkspaceTreeFS(os.DirFS(srcRoot), ".", dstRoot, "hub workspace")
+	return copyWorkspaceTreeFSWithFilter(os.DirFS(srcRoot), ".", dstRoot, "hub workspace", skip)
 }
 
 func copyWorkspaceTreeFS(srcFS fs.FS, root, dstRoot, label string) error {
+	return copyWorkspaceTreeFSWithFilter(srcFS, root, dstRoot, label, nil)
+}
+
+func copyWorkspaceTreeFSWithFilter(srcFS fs.FS, root, dstRoot, label string, skip func(string, fs.DirEntry) bool) error {
 	dstRoot = strings.TrimSpace(dstRoot)
 	if dstRoot == "" {
 		return ErrWorkspaceDirRequired
@@ -77,6 +85,12 @@ func copyWorkspaceTreeFS(srcFS fs.FS, root, dstRoot, label string) error {
 		if path == root {
 			if d.Type()&os.ModeSymlink != 0 {
 				return ErrWorkspaceSymlinkDenied
+			}
+			return nil
+		}
+		if skip != nil && skip(path, d) {
+			if d.IsDir() {
+				return fs.SkipDir
 			}
 			return nil
 		}

--- a/web/app/src/api/hub.ts
+++ b/web/app/src/api/hub.ts
@@ -61,10 +61,15 @@ export function publishAgentTemplateRequest(
   return post<HubTemplate>(HUB_TEMPLATES_PATH, payload);
 }
 
-export function publishHubTemplateToCommunityRequest(templateID: string, deploy = false): Promise<HubTemplate> {
+export function publishHubTemplateToCommunityRequest(
+  templateID: string,
+  deploy = false,
+  includeMemory = false,
+): Promise<HubTemplate> {
   return post<HubTemplate>(HUB_TEMPLATES_PATH, {
     template_id: templateID,
     registry: "official",
+    ...(includeMemory ? { include_memory: true } : {}),
     ...(deploy ? { deploy: true } : {}),
   });
 }

--- a/web/app/src/api/hub.ts
+++ b/web/app/src/api/hub.ts
@@ -12,6 +12,7 @@ type PublishAgentTemplatePayload = {
   registry: AgentTemplatePublishTarget;
   name: string;
   description: string;
+  include_memory?: boolean;
   deploy?: boolean;
 };
 
@@ -47,12 +48,14 @@ export function publishAgentTemplateRequest(
   registry: AgentTemplatePublishTarget,
   name: string,
   description: string,
+  includeMemory = false,
 ): Promise<HubTemplate> {
   const payload: PublishAgentTemplatePayload = {
     agent_id: agentID,
     registry: registry === "official_deploy" ? "official" : registry,
     name,
     description,
+    ...(includeMemory ? { include_memory: true } : {}),
     ...(registry === "official_deploy" ? { deploy: true } : {}),
   };
   return post<HubTemplate>(HUB_TEMPLATES_PATH, payload);

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -1753,9 +1753,11 @@ export function useAgentController({
               deployReviewPending ? "" : message,
             ),
           );
-        } else {
-          setHubPublishError(message);
         }
+        // Publishing succeeded, but deployment did not. Keep the upstream
+        // result visible after navigating to the newly published template,
+        // including the common case where review is still pending.
+        setHubPublishError(message);
         setSelectedHubTemplateId(publishedTemplateID);
         navigatePane({ type: WorkspacePaneTypes.hub, id: publishedTemplateID, resourceType: "template" }, rooms);
         return true;

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -1712,6 +1712,7 @@ export function useAgentController({
     target: AgentTemplatePublishTarget,
     name: string,
     description: string,
+    includeMemory: boolean,
   ): Promise<boolean> {
     if (!selectedAgentForPage?.id || agentPagePublishBusy) {
       return false;
@@ -1727,7 +1728,13 @@ export function useAgentController({
     setAgentPagePublishError("");
     setAgentPageSaveError("");
     try {
-      const published = await publishAgentTemplateRequest(selectedAgentForPage.id, target, name, description);
+      const published = await publishAgentTemplateRequest(
+        selectedAgentForPage.id,
+        target,
+        name,
+        description,
+        includeMemory,
+      );
       await refreshHubTemplates();
       if (published?.id) {
         setSelectedHubTemplateId(published.id);

--- a/web/app/src/hooks/workspace/useWorkspaceHubController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceHubController.ts
@@ -56,6 +56,7 @@ export type WorkspaceHubController = {
     publishHubTemplate: (
       template: HubTemplate | null | undefined,
       deploy?: boolean,
+      includeMemory?: boolean,
     ) => Promise<PublishHubTemplateResult>;
     setPublishError: (message: string) => void;
     deleteSkill: DeleteSkill;
@@ -75,6 +76,7 @@ export type WorkspaceHubController = {
       onPublishTemplate: (
         template: HubTemplate | null | undefined,
         deploy?: boolean,
+        includeMemory?: boolean,
       ) => Promise<PublishHubTemplateResult>;
       publishBusy: boolean;
       publishDisabled: boolean;
@@ -224,14 +226,18 @@ export function useWorkspaceHubController({
   );
 
   const publishHubTemplate = useCallback(
-    async (template: HubTemplate | null | undefined, deploy = false): Promise<PublishHubTemplateResult> => {
+    async (
+      template: HubTemplate | null | undefined,
+      deploy = false,
+      includeMemory = false,
+    ): Promise<PublishHubTemplateResult> => {
       if (!template?.id || !isDeletableHubTemplate(template) || !openCSGAuthenticated) {
         return null;
       }
       setResourcesPublishBusy(true);
       setResourcesPublishError("");
       try {
-        const published = await publishHubTemplateToCommunityRequest(template.id, deploy);
+        const published = await publishHubTemplateToCommunityRequest(template.id, deploy, includeMemory);
         await refreshHubTemplates();
         if (published.id) {
           setSelectedHubTemplateId(published.id);

--- a/web/app/src/models/hubWorkspace.ts
+++ b/web/app/src/models/hubWorkspace.ts
@@ -33,6 +33,18 @@ export function canPublishHubTemplateToCommunity(template: HubTemplate | null | 
   return runtimeKind === "codex";
 }
 
+export function isHubTemplateMemoryEnabled(template: HubTemplate | null | undefined): boolean {
+  const runtimeKind = String(template?.runtime_kind ?? "")
+    .trim()
+    .toLowerCase();
+  if (runtimeKind !== "codex") return false;
+  return (
+    String(template?.runtime_options?.memory_mode ?? "enabled")
+      .trim()
+      .toLowerCase() !== "disabled"
+  );
+}
+
 export function isVisibleInHubTemplateList(template: HubTemplate | null | undefined): boolean {
   const sourceKind = String(template?.source?.kind ?? "")
     .trim()
@@ -53,7 +65,7 @@ export function isVisibleInHubTemplateList(template: HubTemplate | null | undefi
 
 export const HubTemplateErrorCodes = {
   accountEmailMissing: "USER-ERR-18",
-  communityNameConflict: "SPACE_ERR_1",
+  communityNameConflict: "SYS-ERR-4",
   deployResourceUnavailable: "RESOURCE-ERR-1",
   reviewFailed: "AGENT-ERR-23",
   reviewPending: "AGENT-ERR-22",

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.css
@@ -2650,6 +2650,33 @@
   font-weight: 500;
 }
 
+.agent-publish-memory-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.agent-publish-memory-option .csg-checkbox {
+  margin-top: 3px;
+}
+
+.agent-publish-memory-option span {
+  display: grid;
+  gap: 4px;
+}
+
+.agent-publish-memory-option small {
+  color: var(--text-muted);
+  font-weight: 400;
+  line-height: 1.45;
+}
+
 .agent-detail-pane .agent-billing-action {
   display: inline-flex;
   align-items: center;

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
@@ -229,8 +229,8 @@ describe("AgentDetailPane memory", () => {
         JSON.stringify({
           enabled,
           ready: true,
-          name: "MEMORY.md",
-          location: "$CODEX_HOME/memories/MEMORY.md",
+          name: "memory_summary.md",
+          location: "$CODEX_HOME/memories/memory_summary.md",
           content: "# Durable memory\n\nRemember this.\n",
         }),
         { headers: { "content-type": "application/json" }, status: 200 },
@@ -247,7 +247,7 @@ describe("AgentDetailPane memory", () => {
     const refresh = screen.getByRole("button", { name: "agentMemoryRefresh" });
     expect(refresh).toHaveClass("agent-skill-add-button");
     expect(refresh.closest(".agent-memory-section-heading")).toBeInTheDocument();
-    expect(screen.getByText("$CODEX_HOME/memories/MEMORY.md").tagName).toBe("CODE");
+    expect(screen.getByText("$CODEX_HOME/memories/memory_summary.md").tagName).toBe("CODE");
 
     const toggle = screen.getByRole("checkbox", { name: "agentMemoryEnabled" });
     expect(toggle).toBeChecked();
@@ -269,7 +269,7 @@ describe("AgentDetailPane memory", () => {
     expect(screen.queryByRole("button", { name: "agentMemoryTab" })).not.toBeInTheDocument();
   });
 
-  it("uses the compact tab empty state before MEMORY.md is generated", async () => {
+  it("uses the compact tab empty state before memory_summary.md is generated", async () => {
     const user = userEvent.setup();
     vi.stubGlobal(
       "fetch",
@@ -279,8 +279,8 @@ describe("AgentDetailPane memory", () => {
             JSON.stringify({
               enabled: true,
               ready: false,
-              name: "MEMORY.md",
-              location: "$CODEX_HOME/memories/MEMORY.md",
+              name: "memory_summary.md",
+              location: "$CODEX_HOME/memories/memory_summary.md",
               content: "",
             }),
             {

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -317,6 +317,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
   const runtimeKind = agentRuntimeKind(item);
   const canPublishLocal = !isManager && (runtimeKind === "codex" || runtimeKind === "openclaw_sandbox");
   const canPublishCommunity = !isManager && runtimeKind === "codex";
+  const supportsTemplateMemory = runtimeKind === "codex" || runtimeKind === "openclaw_sandbox";
   const hasUnsavedChanges =
     hasUnsavedChangesProp ?? Boolean(draft && savedDraft && JSON.stringify(draft) !== JSON.stringify(savedDraft));
   const saveDisabled = agentProfilePageSaveDisabled(draft, item, { saving, savedDraft });
@@ -1237,7 +1238,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 onChange={(event) => setPublishTemplateDescription(event.target.value)}
               />
             </label>
-            {runtimeKind === "codex" ? (
+            {supportsTemplateMemory ? (
               <label className="agent-publish-memory-option">
                 <Checkbox
                   aria-label={t("agentPublishIncludeMemory")}

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -87,6 +87,7 @@ import { localizeTemplateSourceTag } from "@/shared/i18n";
 import type { AgentTemplatePublishTarget } from "@/api/hub";
 import {
   Button,
+  Checkbox,
   DialogBody,
   DialogCloseButton,
   DialogContent,
@@ -149,7 +150,12 @@ export type AgentDetailPaneProps = {
   onOpenDM: AgentActionHandler;
   onRetryModels?: () => void | Promise<unknown>;
   onProviderLogin?: (provider: string) => VoidOrPromise;
-  onPublish?: (target: AgentTemplatePublishTarget, name: string, description: string) => boolean | Promise<boolean>;
+  onPublish?: (
+    target: AgentTemplatePublishTarget,
+    name: string,
+    description: string,
+    includeMemory: boolean,
+  ) => boolean | Promise<boolean>;
   onRecreate: AgentActionHandler;
   onSave?: () => VoidOrPromise;
   onMetadataSave?: (patch: AgentMetadataSavePatch) => VoidOrPromise;
@@ -286,6 +292,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
   const [publishTarget, setPublishTarget] = useState<AgentTemplatePublishTarget | null>(null);
   const [publishTemplateName, setPublishTemplateName] = useState("");
   const [publishTemplateDescription, setPublishTemplateDescription] = useState("");
+  const [publishTemplateIncludeMemory, setPublishTemplateIncludeMemory] = useState(false);
   const [publishTemplateNameError, setPublishTemplateNameError] = useState("");
   const [publishAttempted, setPublishAttempted] = useState(false);
   const [isProfileScrolling, setIsProfileScrolling] = useState(false);
@@ -322,6 +329,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
       setPublishTarget(target);
       setPublishTemplateName(String(item.name || "").trim());
       setPublishTemplateDescription(String(item.description || "").trim());
+      setPublishTemplateIncludeMemory(false);
       setPublishTemplateNameError("");
       setPublishAttempted(false);
     },
@@ -339,12 +347,12 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
       }
       setPublishTemplateNameError("");
       setPublishAttempted(true);
-      const published = await onPublish(target, name, publishTemplateDescription.trim());
+      const published = await onPublish(target, name, publishTemplateDescription.trim(), publishTemplateIncludeMemory);
       if (published) {
         setPublishTarget(null);
       }
     },
-    [onPublish, publishTarget, publishTemplateDescription, publishTemplateName, t],
+    [onPublish, publishTarget, publishTemplateDescription, publishTemplateIncludeMemory, publishTemplateName, t],
   );
   const saveMetadataField = useCallback(
     <K extends keyof AgentMetadataSavePatch>(field: K, value: AgentMetadataSavePatch[K]): boolean => {
@@ -1229,6 +1237,19 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 onChange={(event) => setPublishTemplateDescription(event.target.value)}
               />
             </label>
+            {runtimeKind === "codex" ? (
+              <label className="agent-publish-memory-option">
+                <Checkbox
+                  aria-label={t("agentPublishIncludeMemory")}
+                  checked={publishTemplateIncludeMemory}
+                  onCheckedChange={(checked) => setPublishTemplateIncludeMemory(checked === true)}
+                />
+                <span>
+                  <strong>{t("agentPublishIncludeMemory")}</strong>
+                  <small>{t("agentPublishIncludeMemoryWarning")}</small>
+                </span>
+              </label>
+            ) : null}
             {publishAttempted && publishError ? <div className="form-error">{publishError}</div> : null}
           </DialogBody>
           <DialogFooter>

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
@@ -11,6 +11,33 @@
   background: var(--bg);
 }
 
+.hub-template-publish-memory-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.hub-template-publish-memory-option .csg-checkbox {
+  margin-top: 3px;
+}
+
+.hub-template-publish-memory-option span {
+  display: grid;
+  gap: 4px;
+}
+
+.hub-template-publish-memory-option small {
+  color: var(--text-muted);
+  font-weight: 400;
+  line-height: 1.45;
+}
+
 :root[data-theme="dark"] .hub-detail-pane {
   background: var(--bg);
 }

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.css
@@ -945,6 +945,83 @@
   min-height: 0;
 }
 
+.hub-detail-pane .hub-template-memory-panel {
+  display: grid;
+  gap: 20px;
+  align-content: start;
+  min-height: 0;
+  padding: 4px 0 24px;
+}
+
+.hub-template-memory-heading {
+  width: min(100%, 820px);
+}
+
+.hub-template-memory-location {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 6px;
+  padding: 2px 7px;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background: var(--gray-100);
+  color: var(--gray-600);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-template-memory-document-shell {
+  min-height: 360px;
+}
+
+.hub-template-memory-document {
+  width: 100%;
+  height: min(52vh, 520px);
+  min-height: 360px;
+  padding: 16px;
+  resize: vertical;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  font-family: var(--font-mono);
+  line-height: 1.55;
+  white-space: pre;
+}
+
+.hub-template-memory-document:focus {
+  outline: none;
+}
+
+.hub-template-memory-empty {
+  display: grid;
+  gap: 6px;
+  min-height: 120px;
+  place-content: center;
+  padding: 24px;
+  border: 1px dashed var(--gray-300);
+  border-radius: var(--radius-lg);
+  color: var(--gray-500);
+  text-align: center;
+}
+
+.hub-template-memory-empty strong {
+  color: var(--gray-700);
+}
+
+.hub-template-memory-empty p {
+  margin: 0;
+}
+
+:root[data-theme="dark"] .hub-template-memory-location {
+  background: var(--gray-800);
+  color: var(--gray-300);
+}
+
 .hub-detail-pane .hub-template-skills-panel,
 .hub-detail-pane .hub-template-mcp-panel {
   align-content: start;

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -31,6 +31,7 @@ import { localizeTemplateSourceTag } from "@/shared/i18n";
 import { ModelsIcon } from "@/components/ui/Icons";
 import {
   Button,
+  Checkbox,
   DialogBody,
   DialogCloseButton,
   DialogContent,
@@ -214,6 +215,7 @@ type HubDetailPaneHub = {
     onPublishTemplate?: (
       item: HubTemplate | null | undefined,
       deploy?: boolean,
+      includeMemory?: boolean,
     ) =>
       | Promise<{ status: "success" } | { status: "partial"; message: string } | null>
       | { status: "success" }
@@ -681,6 +683,7 @@ export function HubDetailPane({
   const [publishSuccessDialogOpen, setPublishSuccessDialogOpen] = useState(false);
   const [publishPartialMessage, setPublishPartialMessage] = useState("");
   const [publishChoiceDialogOpen, setPublishChoiceDialogOpen] = useState(false);
+  const [publishTemplateIncludeMemory, setPublishTemplateIncludeMemory] = useState(false);
   const [mcpDeleteDialogOpen, setMCPDeleteDialogOpen] = useState(false);
   const [mcpDraftDocument, setMCPDraftDocument] = useState(DEFAULT_MCP_SERVER_DOCUMENT);
   const [mcpDetailDocument, setMCPDetailDocument] = useState("");
@@ -836,7 +839,7 @@ export function HubDetailPane({
   }
 
   async function handlePublishTemplate(deploy = false) {
-    const result = await onPublishTemplate?.(selectedTemplate, deploy);
+    const result = await onPublishTemplate?.(selectedTemplate, deploy, publishTemplateIncludeMemory);
     if (result?.status === "success") {
       setPublishPartialMessage("");
       setPublishChoiceDialogOpen(false);
@@ -948,7 +951,10 @@ export function HubDetailPane({
                         loading={publishBusy}
                         disabled={publishBusy || publishDisabled}
                         title={publishDisabled ? t("agentPublishLoginRequired") : undefined}
-                        onClick={() => setPublishChoiceDialogOpen(true)}
+                        onClick={() => {
+                          setPublishTemplateIncludeMemory(false);
+                          setPublishChoiceDialogOpen(true);
+                        }}
                       >
                         {t("agentPublishCommunity")}
                       </Button>
@@ -1497,7 +1503,15 @@ export function HubDetailPane({
           </DialogFooter>
         </DialogContent>
       </DialogRoot>
-      <DialogRoot open={publishChoiceDialogOpen} onOpenChange={setPublishChoiceDialogOpen}>
+      <DialogRoot
+        open={publishChoiceDialogOpen}
+        onOpenChange={(open) => {
+          setPublishChoiceDialogOpen(open);
+          if (!open) {
+            setPublishTemplateIncludeMemory(false);
+          }
+        }}
+      >
         <DialogContent className="agent-publish-dialog">
           <DialogHeader>
             <div>
@@ -1506,6 +1520,21 @@ export function HubDetailPane({
             </div>
             <DialogCloseButton label={t("close")} size="sm" variant="tertiaryGray" />
           </DialogHeader>
+          {templateMemoryEnabled ? (
+            <DialogBody>
+              <label className="hub-template-publish-memory-option">
+                <Checkbox
+                  aria-label={t("agentPublishIncludeMemory")}
+                  checked={publishTemplateIncludeMemory}
+                  onCheckedChange={(checked) => setPublishTemplateIncludeMemory(checked === true)}
+                />
+                <span>
+                  <strong>{t("agentPublishIncludeMemory")}</strong>
+                  <small>{t("agentPublishIncludeMemoryWarning")}</small>
+                </span>
+              </label>
+            </DialogBody>
+          ) : null}
           {publishError ? <div className="form-error">{publishError}</div> : null}
           <DialogFooter>
             <Button

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -17,6 +17,7 @@ import {
   hubTemplateFullName,
   hubTemplateReviewState,
   isDeletableHubTemplate,
+  isHubTemplateMemoryEnabled,
 } from "@/models/hubWorkspace";
 import {
   formatMCPServerDocument,
@@ -48,7 +49,7 @@ import type { WorkspaceEntry, WorkspaceFile } from "@/models/workspace";
 import { RemoteMCPList } from "./RemoteMCPList";
 
 const EMPTY_WORKSPACE_ENTRIES: readonly WorkspaceEntry[] = [];
-type TemplateDetailTabID = "profile" | "instructions" | "skills" | "mcp";
+type TemplateDetailTabID = "profile" | "instructions" | "memory" | "skills" | "mcp";
 type MCPCreateMode = "manual" | "remote";
 
 type TemplateSkillSummary = {
@@ -58,7 +59,7 @@ type TemplateSkillSummary = {
 
 function templateSectionEntries(
   entries: readonly WorkspaceEntry[],
-  section: "instructions" | "skills" | "mcps",
+  section: "instructions" | "memories" | "skills" | "mcps",
 ): WorkspaceEntry[] {
   const prefix = `${section}/`;
   return entries
@@ -70,14 +71,14 @@ function templateSectionEntries(
     }));
 }
 
-function templateSectionPath(path: string, section: "instructions" | "skills" | "mcps"): string {
+function templateSectionPath(path: string, section: "instructions" | "memories" | "skills" | "mcps"): string {
   const prefix = `${section}/`;
   return path.startsWith(prefix) ? path.slice(prefix.length) : "";
 }
 
 function firstTemplateSectionFile(
   entries: readonly WorkspaceEntry[],
-  section: "instructions" | "skills" | "mcps",
+  section: "instructions" | "memories" | "skills" | "mcps",
   preferredName?: string,
 ): string {
   const prefix = `${section}/`;
@@ -690,11 +691,15 @@ export function HubDetailPane({
   const [templateInstructionsMode, setTemplateInstructionsMode] = useState<"default" | "advanced">("default");
   const [templateInstructionsDraft, setTemplateInstructionsDraft] = useState("");
   const [templateInstructionsSaving, setTemplateInstructionsSaving] = useState(false);
-  const templateSection = activeTemplateTab === "mcp" ? "mcps" : activeTemplateTab;
+  const templateSection =
+    activeTemplateTab === "mcp" ? "mcps" : activeTemplateTab === "memory" ? "memories" : activeTemplateTab;
   const templateImageEnv = selectedTemplate?.image_env || [];
   const templateSectionWorkspaceEntries = useMemo(
     () =>
-      templateSection === "instructions" || templateSection === "skills" || templateSection === "mcps"
+      templateSection === "instructions" ||
+      templateSection === "memories" ||
+      templateSection === "skills" ||
+      templateSection === "mcps"
         ? templateSectionEntries(workspaceEntries, templateSection)
         : [],
     [templateSection, workspaceEntries],
@@ -719,6 +724,9 @@ export function HubDetailPane({
   const templateInstructionsFile =
     workspaceFiles["instructions/AGENTS.md"] ||
     (workspaceFile?.path === "instructions/AGENTS.md" ? workspaceFile : null);
+  const templateMemoryFile =
+    workspaceFiles["memories/memory_summary.md"] ||
+    (workspaceFile?.path === "memories/memory_summary.md" ? workspaceFile : null);
   const templateInstructions = templateInstructionsFile?.content || "";
   useEffect(() => {
     setTemplateInstructionsDraft(templateInstructions);
@@ -727,10 +735,12 @@ export function HubDetailPane({
   const templateInstructionsValue =
     templateInstructionsMode === "advanced" ? templateInstructionsDraft : templateCustomInstructions;
   const templateInstructionsReadonly = selectedTemplate?.source?.kind !== "local";
+  const templateMemoryEnabled = isHubTemplateMemoryEnabled(selectedTemplate);
   const templateTabs = useMemo(
     () => [
       { id: "profile" as const, label: t("agentProfileTab") },
       { id: "instructions" as const, label: t("agentInstructions") },
+      ...(templateMemoryEnabled ? [{ id: "memory" as const, label: t("agentMemoryTab") }] : []),
       {
         id: "skills" as const,
         label: t("agentProfileSkillsTab"),
@@ -738,7 +748,7 @@ export function HubDetailPane({
       },
       { id: "mcp" as const, label: t("agentProfileMCPTab") },
     ],
-    [t, templateSkillCount],
+    [t, templateMemoryEnabled, templateSkillCount],
   );
   useEffect(() => {
     setActiveTemplateTab("profile");
@@ -746,7 +756,9 @@ export function HubDetailPane({
   useEffect(() => {
     const directories = new Set<string>(["skills"]);
     if (activeTemplateTab !== "profile") {
-      directories.add(activeTemplateTab === "mcp" ? "mcps" : activeTemplateTab);
+      directories.add(
+        activeTemplateTab === "mcp" ? "mcps" : activeTemplateTab === "memory" ? "memories" : activeTemplateTab,
+      );
     }
     if (activeTemplateTab === "skills") {
       templateSkills.forEach((skill) => directories.add(`skills/${skill.name}`));
@@ -853,7 +865,9 @@ export function HubDetailPane({
           ? firstTemplateSectionFile(workspaceEntries, "skills", "SKILL.md")
           : tab === "mcp"
             ? firstTemplateSectionFile(workspaceEntries, "mcps", "mcp.json")
-            : firstTemplateSectionFile(workspaceEntries, "instructions", "AGENTS.md");
+            : tab === "memory"
+              ? firstTemplateSectionFile(workspaceEntries, "memories", "memory_summary.md")
+              : firstTemplateSectionFile(workspaceEntries, "instructions", "AGENTS.md");
       onSelectWorkspaceFile(selectedFile);
     }
   }
@@ -1144,6 +1158,36 @@ export function HubDetailPane({
                     </div>
                   ) : null}
                 </section>
+              ) : activeTemplateTab === "memory" ? (
+                <section className="profile-section hub-template-memory-panel">
+                  <div className="hub-template-memory-heading">
+                    <div className="profile-section-heading">
+                      <div className="profile-section-title">memory_summary.md</div>
+                      <p className="profile-section-description">{t("resourcesTemplateMemoryDescription")}</p>
+                      <code className="hub-template-memory-location">memories/memory_summary.md</code>
+                    </div>
+                  </div>
+                  {workspaceFileError ? <div className="form-error">{workspaceFileError}</div> : null}
+                  {workspaceFileLoading ? (
+                    <div className="hub-template-memory-empty" role="status">
+                      <strong>{t("resourcesWorkspaceFileLoading")}</strong>
+                    </div>
+                  ) : templateMemoryFile && !templateMemoryFile.binary ? (
+                    <div className="agent-section-form hub-template-memory-document-shell">
+                      <textarea
+                        className="compact-textarea hub-template-memory-document"
+                        value={templateMemoryFile.content || ""}
+                        readOnly
+                        aria-label={t("agentMemoryDocumentLabel")}
+                      />
+                    </div>
+                  ) : (
+                    <div className="hub-template-memory-empty">
+                      <strong>{t("resourcesTemplateMemoryEmptyTitle")}</strong>
+                      <p>{t("resourcesTemplateMemoryEmptyDescription")}</p>
+                    </div>
+                  )}
+                </section>
               ) : activeTemplateTab === "skills" ? (
                 <section className="profile-section hub-template-summary-panel hub-template-skills-panel">
                   <div className="hub-template-summary-heading">
@@ -1239,7 +1283,7 @@ export function HubDetailPane({
                       emptyText={t("resourcesWorkspacePreviewHint")}
                       selectedPath={templateSectionPath(
                         selectedWorkspacePath,
-                        templateSection as "instructions" | "skills" | "mcps",
+                        templateSection as "instructions" | "memories" | "skills" | "mcps",
                       )}
                       onSelectFile={(path) => onSelectWorkspaceFile(`${templateSection}/${path}`)}
                     />

--- a/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
+++ b/web/app/src/pages/HubPage/components/HubDetailPane/HubDetailPane.tsx
@@ -770,6 +770,15 @@ export function HubDetailPane({
     }
   }, [activeTemplateTab, onToggleWorkspaceDir, templateSkills, workspaceEntries]);
   useEffect(() => {
+    if (activeTemplateTab !== "memory" || selectedWorkspacePath === "memories/memory_summary.md") {
+      return;
+    }
+    const memoryFile = firstTemplateSectionFile(workspaceEntries, "memories", "memory_summary.md");
+    if (memoryFile) {
+      onSelectWorkspaceFile(memoryFile);
+    }
+  }, [activeTemplateTab, onSelectWorkspaceFile, selectedWorkspacePath, workspaceEntries]);
+  useEffect(() => {
     if (mcpCreateDialogOpen) {
       setMCPDraftDocument(DEFAULT_MCP_SERVER_DOCUMENT);
       setMCPFormError("");

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceModals/WorkspaceModals.css
@@ -1728,7 +1728,9 @@
 
 .selection-item:hover {
   border-color: color-mix(in oklab, var(--brand-600) 42%, var(--line));
-  box-shadow: var(--shadow-xs), 0 0 0 3px color-mix(in oklab, var(--brand-600) 12%, transparent);
+  box-shadow:
+    var(--shadow-xs),
+    0 0 0 3px color-mix(in oklab, var(--brand-600) 12%, transparent);
 }
 
 .profile-editor-shell {

--- a/web/app/src/shared/i18n/index.ts
+++ b/web/app/src/shared/i18n/index.ts
@@ -83,6 +83,15 @@ export function localizeAPIError(error: unknown, t: TranslateFn, fallback = ""):
   if (error && typeof error === "object" && "code" in error) {
     const code = String((error as { code?: unknown }).code || "").trim();
     if (code) {
+      // This is a local fallback code used when the Hub did not provide a
+      // stable business code. Preserve its diagnostic message instead of
+      // replacing the only actionable reason with a generic translation.
+      if (code === "template_publish_failed" && "message" in error) {
+        const message = localizeError((error as { message?: unknown }).message, t);
+        if (message) {
+          return message;
+        }
+      }
       const key = `errors.${code}`;
       const localized = t(key);
       if (localized !== key) {

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -350,6 +350,9 @@ export const messages = {
     resourcesTemplateEnvRequiredBadge: "必填",
     resourcesTemplateEnvCount: "{count} 个变量",
     resourcesTemplateSkillsDescription: "此模板创建 Agent 时会附带的 skills。",
+    resourcesTemplateMemoryDescription: "查看创建此模板时保存的只读记忆摘要。",
+    resourcesTemplateMemoryEmptyTitle: "模板未包含记忆摘要",
+    resourcesTemplateMemoryEmptyDescription: "请使用已生成记忆摘要的 Codex Agent 重新发布此模板。",
     resourcesTemplateSkillsCount: "{count} 项",
     resourcesTemplateSkillsEmptyHint: "此模板创建 Agent 时不会附带额外 skill。",
     resourcesTemplateMCPServersTitle: "MCP Servers",
@@ -1158,8 +1161,8 @@ export const messages = {
     agentMemoryEnabled: "启用记忆",
     agentMemoryToggleHint: "控制是否生成新记忆，并在后续会话中使用已有记忆。",
     agentMemoryRefresh: "刷新",
-    agentMemoryDocumentTitle: "MEMORY.md",
-    agentMemoryDocumentDescription: "查看 Runtime 在后台维护的只读主记忆文档；会话结束后可能不会立即更新。",
+    agentMemoryDocumentTitle: "memory_summary.md",
+    agentMemoryDocumentDescription: "查看 Runtime 在后台维护的只读记忆摘要；会话结束后可能不会立即更新。",
     agentMemoryLoading: "正在加载记忆...",
     agentMemoryLoadFailed: "加载记忆失败",
     agentMemoryUpdateFailed: "更新记忆设置失败",
@@ -1354,7 +1357,7 @@ export const messages = {
       "AGENT-ERR-23": "模板已发布，但未通过敏感内容审核。请根据问题文件修改后重新发布。",
       "RESOURCE-ERR-1": "模板已成功发布，但社区部署资源暂时不可用，请稍后重试部署。",
       "SENSITIVE-ERR-0": "发布失败：模板名称或描述中包含不允许的敏感信息，请修改后重试。",
-      SPACE_ERR_1: "发布失败：社区中已存在同名模板，请修改模板名称后重试。",
+      "SYS-ERR-4": "发布失败：社区仓库已存在，请修改模板名称后重试。",
       "USER-ERR-18": "发布失败：当前 OpenCSG 账号未设置邮箱，请完善账号资料后重试。",
       template_already_exists: "保存失败：本地已存在同名模板，请修改模板名称后重试。",
       template_deploy_failed: "模板已成功发布，但部署失败，请稍后重试。",
@@ -1771,6 +1774,10 @@ export const messages = {
     resourcesTemplateEnvRequiredBadge: "Required",
     resourcesTemplateEnvCount: "{count} variables",
     resourcesTemplateSkillsDescription: "Skills included when creating an agent from this template.",
+    resourcesTemplateMemoryDescription: "View the read-only memory summary captured when this template was created.",
+    resourcesTemplateMemoryEmptyTitle: "No memory summary in this template",
+    resourcesTemplateMemoryEmptyDescription:
+      "Republish this template from a Codex agent with a generated memory summary.",
     resourcesTemplateSkillsCount: "{count} skills",
     resourcesTemplateSkillsEmptyHint: "No additional skills are included when creating an agent from this template.",
     resourcesTemplateMCPServersTitle: "MCP Servers",
@@ -2602,9 +2609,9 @@ export const messages = {
     agentMemoryToggleHint:
       "Control whether new memories are generated and existing memories are used in later sessions.",
     agentMemoryRefresh: "Refresh",
-    agentMemoryDocumentTitle: "MEMORY.md",
+    agentMemoryDocumentTitle: "memory_summary.md",
     agentMemoryDocumentDescription:
-      "View the read-only primary memory document maintained by the runtime. It may not update immediately after a session ends.",
+      "View the read-only memory summary maintained by the runtime. It may not update immediately after a session ends.",
     agentMemoryLoading: "Loading memory...",
     agentMemoryLoadFailed: "Failed to load memory",
     agentMemoryUpdateFailed: "Failed to update memory settings",
@@ -2816,8 +2823,8 @@ export const messages = {
         "The template was published, but community deployment resources are temporarily unavailable. Try deploying again later.",
       "SENSITIVE-ERR-0":
         "Publishing failed because the template name or description contains disallowed sensitive information. Update it and try again.",
-      SPACE_ERR_1:
-        "Publishing failed because a community template with the same name already exists. Choose another name and try again.",
+      "SYS-ERR-4":
+        "Publishing failed because the community repository already exists. Choose another template name and try again.",
       "USER-ERR-18":
         "Publishing failed because the current OpenCSG account has no email address. Complete the account profile and try again.",
       template_already_exists:

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -1205,6 +1205,8 @@ export const messages = {
     agentPublishTemplateNameInvalid:
       "模板名称必须以英文字母开头，最多 24 个字符，且只能包含英文字母、数字、下划线和短横线。",
     agentPublishTemplateDescription: "模板描述",
+    agentPublishIncludeMemory: "包含智能体记忆",
+    agentPublishIncludeMemoryWarning: "可能包含从历史对话中提取的私人信息。仅在确认内容适合共享时启用。",
     resourcesPublishCommunityFailed: "发布到社区失败。",
     resourcesPublishCommunitySuccessTitle: "发布成功",
     resourcesPublishCommunityDeployFailedTitle: "模板已发布，但部署失败",
@@ -2656,6 +2658,9 @@ export const messages = {
     agentPublishTemplateNameInvalid:
       "Template name must start with an English letter, contain at most 24 characters, and use only English letters, numbers, underscores, or hyphens.",
     agentPublishTemplateDescription: "Template description",
+    agentPublishIncludeMemory: "Include agent memory",
+    agentPublishIncludeMemoryWarning:
+      "This may contain private information learned from past conversations. Enable it only after confirming the content is safe to share.",
     resourcesPublishCommunityFailed: "Failed to publish the template to the community.",
     resourcesPublishCommunitySuccessTitle: "Published successfully",
     resourcesPublishCommunityDeployFailedTitle: "Template published, but deployment failed",

--- a/web/app/tests/api/agents.test.ts
+++ b/web/app/tests/api/agents.test.ts
@@ -98,8 +98,8 @@ describe("agents API", () => {
           JSON.stringify({
             enabled: true,
             ready: true,
-            name: "MEMORY.md",
-            location: "$CODEX_HOME/memories/MEMORY.md",
+            name: "memory_summary.md",
+            location: "$CODEX_HOME/memories/memory_summary.md",
             content: "# Memory\n",
           }),
           {

--- a/web/app/tests/api/hub.test.ts
+++ b/web/app/tests/api/hub.test.ts
@@ -139,6 +139,24 @@ describe("hub API", () => {
     );
   });
 
+  it("includes local template memory only after explicit opt-in", async () => {
+    const fetchMock = mockFetch();
+
+    await publishHubTemplateToCommunityRequest("local.review-bot", false, true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "api/v1/hub/templates",
+      expect.objectContaining({
+        body: JSON.stringify({
+          template_id: "local.review-bot",
+          registry: "official",
+          include_memory: true,
+        }),
+        method: "POST",
+      }),
+    );
+  });
+
   it("uses single-id paths for template delete requests", async () => {
     const fetchMock = mockFetch();
 

--- a/web/app/tests/api/hub.test.ts
+++ b/web/app/tests/api/hub.test.ts
@@ -97,6 +97,20 @@ describe("hub API", () => {
     );
   });
 
+  it("includes agent memory only after explicit opt-in", async () => {
+    const fetchMock = mockFetch();
+
+    await publishAgentTemplateRequest("agent-alice", "official", "ReviewBot_2", "Reviews changes", true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "api/v1/hub/templates",
+      expect.objectContaining({
+        body: expect.stringContaining('"include_memory":true'),
+        method: "POST",
+      }),
+    );
+  });
+
   it("publishes a local template to the official registry", async () => {
     const fetchMock = mockFetch();
 

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -144,9 +144,16 @@ describe("agent action visibility", () => {
     expect(screen.getByRole("dialog", { name: "Publish agent template" })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Template name" })).toHaveValue("Worker");
     expect(screen.getByRole("textbox", { name: "Template description" })).toHaveValue("Agent description");
+    expect(screen.getByRole("checkbox", { name: "Include agent memory" })).not.toBeChecked();
     await user.click(screen.getByRole("button", { name: "Save as local template" }));
     expect(onPublish).toHaveBeenCalledWith("local", "Worker", "Agent description", false);
     expect(screen.queryByRole("dialog", { name: "Publish agent template" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+    await user.click(screen.getByRole("menuitem", { name: "Save as local template" }));
+    await user.click(screen.getByRole("checkbox", { name: "Include agent memory" }));
+    await user.click(screen.getByRole("button", { name: "Save as local template" }));
+    expect(onPublish).toHaveBeenLastCalledWith("local", "Worker", "Agent description", true);
 
     await user.click(screen.getByRole("button", { name: "More" }));
     expect(screen.queryByRole("menuitem", { name: "Publish to community" })).not.toBeInTheDocument();

--- a/web/app/tests/components/AgentActions.test.tsx
+++ b/web/app/tests/components/AgentActions.test.tsx
@@ -34,6 +34,8 @@ const labels: Record<string, string> = {
   agentPublishTemplateNameInvalid: "Invalid template name",
   agentPublishLocalNameExists: "A local template with this name already exists.",
   agentPublishTemplateDescription: "Template description",
+  agentPublishIncludeMemory: "Include agent memory",
+  agentPublishIncludeMemoryWarning: "Memory may contain private information.",
   agentProfileSectionNavLabel: "Profile sections",
   agentProfileTab: "Profile",
   agentProfileSkillsTab: "Skills",
@@ -143,7 +145,7 @@ describe("agent action visibility", () => {
     expect(screen.getByRole("textbox", { name: "Template name" })).toHaveValue("Worker");
     expect(screen.getByRole("textbox", { name: "Template description" })).toHaveValue("Agent description");
     await user.click(screen.getByRole("button", { name: "Save as local template" }));
-    expect(onPublish).toHaveBeenCalledWith("local", "Worker", "Agent description");
+    expect(onPublish).toHaveBeenCalledWith("local", "Worker", "Agent description", false);
     expect(screen.queryByRole("dialog", { name: "Publish agent template" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "More" }));
@@ -180,12 +182,13 @@ describe("agent action visibility", () => {
     expect(screen.getByRole("button", { name: "Publish and deploy" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Publish template only" }));
 
-    expect(onPublish).toHaveBeenCalledWith("official", "Worker", "Agent description");
+    expect(onPublish).toHaveBeenCalledWith("official", "Worker", "Agent description", false);
 
     await user.click(screen.getByRole("button", { name: "More" }));
     await user.click(screen.getByRole("menuitem", { name: "Publish to community" }));
+    await user.click(screen.getByRole("checkbox", { name: "Include agent memory" }));
     await user.click(screen.getByRole("button", { name: "Publish and deploy" }));
-    expect(onPublish).toHaveBeenCalledWith("official_deploy", "Worker", "Agent description");
+    expect(onPublish).toHaveBeenCalledWith("official_deploy", "Worker", "Agent description", true);
   });
 
   it("does not show template publishing actions for the manager", async () => {
@@ -279,7 +282,7 @@ describe("agent action visibility", () => {
     await user.clear(nameInput);
     await user.type(nameInput, "review-bot_2");
     await user.click(screen.getByRole("button", { name: "Save as local template" }));
-    expect(onPublish).toHaveBeenCalledWith("local", "review-bot_2", "Agent description");
+    expect(onPublish).toHaveBeenCalledWith("local", "review-bot_2", "Agent description", false);
   });
 
   it("keeps the publish dialog open and shows duplicate local template errors", async () => {

--- a/web/app/tests/components/HubDetailPane.test.tsx
+++ b/web/app/tests/components/HubDetailPane.test.tsx
@@ -142,6 +142,7 @@ function renderHubDetailPane(
     ) => Promise<{ status: "success" } | { status: "partial"; message: string } | null>;
     publishDisabled?: boolean;
     publishError?: string;
+    lazyMemory?: boolean;
   } = {},
 ) {
   const selectedTemplate = options.selectedTemplate ?? template;
@@ -181,6 +182,19 @@ function renderHubDetailPane(
   };
   function Harness() {
     const [selectedWorkspacePath, setSelectedWorkspacePath] = useState("instructions/AGENTS.md");
+    const [workspaceEntries, setWorkspaceEntries] = useState([
+      { name: "instructions", path: "instructions", type: "dir" as const, depth: 0 },
+      { name: "AGENTS.md", path: "instructions/AGENTS.md", type: "file" as const, depth: 1 },
+      { name: "memories", path: "memories", type: "dir" as const, depth: 0 },
+      ...(!options.lazyMemory
+        ? [{ name: "memory_summary.md", path: "memories/memory_summary.md", type: "file" as const, depth: 1 }]
+        : []),
+      { name: "skills", path: "skills", type: "dir" as const, depth: 0 },
+      { name: "demo", path: "skills/demo", type: "dir" as const, depth: 1 },
+      { name: "SKILL.md", path: "skills/demo/SKILL.md", type: "file" as const, depth: 2 },
+      { name: "mcps", path: "mcps", type: "dir" as const, depth: 0 },
+      { name: "mcp.json", path: "mcps/mcp.json", type: "file" as const, depth: 1 },
+    ]);
     const workspaceFile = workspaceFiles[selectedWorkspacePath as keyof typeof workspaceFiles] || null;
     return (
       <HubDetailPane
@@ -197,7 +211,23 @@ function renderHubDetailPane(
             onSelectSkillFile: vi.fn(),
             onSelectTemplate: vi.fn(),
             onSelectWorkspaceFile: setSelectedWorkspacePath,
-            onToggleWorkspaceDir: vi.fn(),
+            onToggleWorkspaceDir: (path) => {
+              if (options.lazyMemory && path === "memories") {
+                setWorkspaceEntries((entries) =>
+                  entries.some((entry) => entry.path === "memories/memory_summary.md")
+                    ? entries
+                    : [
+                        ...entries,
+                        {
+                          name: "memory_summary.md",
+                          path: "memories/memory_summary.md",
+                          type: "file" as const,
+                          depth: 1,
+                        },
+                      ],
+                );
+              }
+            },
             mcpServers: [],
             selectedMCPServer: null,
             selectedMCPServerName: "",
@@ -219,17 +249,7 @@ function renderHubDetailPane(
             workspaceFiles,
             workspaceFileError: "",
             workspaceFileLoading: false,
-            workspaceEntries: [
-              { name: "instructions", path: "instructions", type: "dir", depth: 0 },
-              { name: "AGENTS.md", path: "instructions/AGENTS.md", type: "file", depth: 1 },
-              { name: "memories", path: "memories", type: "dir", depth: 0 },
-              { name: "memory_summary.md", path: "memories/memory_summary.md", type: "file", depth: 1 },
-              { name: "skills", path: "skills", type: "dir", depth: 0 },
-              { name: "demo", path: "skills/demo", type: "dir", depth: 1 },
-              { name: "SKILL.md", path: "skills/demo/SKILL.md", type: "file", depth: 2 },
-              { name: "mcps", path: "mcps", type: "dir", depth: 0 },
-              { name: "mcp.json", path: "mcps/mcp.json", type: "file", depth: 1 },
-            ],
+            workspaceEntries,
             deleteBusy: false,
             onDeleteTemplate: vi.fn(),
             onPublishTemplate: options.onPublishTemplate,
@@ -598,6 +618,20 @@ describe("HubDetailPane", () => {
     await user.click(screen.getByRole("button", { name: "MCP" }));
     expect(screen.getByText("context7")).toBeInTheDocument();
     expect(screen.getByText("Context lookup")).toBeInTheDocument();
+  });
+
+  it("selects the memory summary after the memories directory is lazily loaded", async () => {
+    const user = userEvent.setup();
+    renderHubDetailPane("template", {
+      selectedTemplate: { ...template, runtime_kind: "codex" },
+      lazyMemory: true,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Memory" }));
+
+    expect(await screen.findByRole("textbox", { name: "Read-only memory summary" })).toHaveValue(
+      "# Memory Summary\n\nThe user prefers concise Chinese replies.",
+    );
   });
 
   it("keeps the MCP empty state visible when templates are available", () => {

--- a/web/app/tests/components/HubDetailPane.test.tsx
+++ b/web/app/tests/components/HubDetailPane.test.tsx
@@ -28,6 +28,9 @@ function t(key: string, params: Record<string, string | number> = {}) {
     resourcesTemplateEnvRequired: "Required",
     resourcesTemplateEnvRequiredBadge: "Required",
     resourcesTemplateSkillsDescription: "Template skills.",
+    resourcesTemplateMemoryDescription: "Template memory summary.",
+    resourcesTemplateMemoryEmptyTitle: "No memory summary",
+    resourcesTemplateMemoryEmptyDescription: "Republish from an agent with memory.",
     resourcesTemplateMCPServersTitle: "MCP Servers",
     resourcesTemplateMCPServersDescription: "Template MCP configs.",
     resourcesLoading: "Loading resources",
@@ -75,6 +78,8 @@ function t(key: string, params: Record<string, string | number> = {}) {
       "This template only contains generated defaults. Switch to Advanced to view the full content.",
     resourcesTemplateInstructionsViewAdvancedAction: "View complete AGENTS.md",
     agentProfileSkillsTab: "Skills",
+    agentMemoryTab: "Memory",
+    agentMemoryDocumentLabel: "Read-only memory summary",
     agentProfileMCPTab: "MCP",
     agentProfileSectionNavLabel: "Template sections",
     agentSkillsTitle: "Skills",
@@ -167,6 +172,12 @@ function renderHubDetailPane(
       path: "mcps/mcp.json",
       size: 120,
     },
+    "memories/memory_summary.md": {
+      binary: false,
+      content: "# Memory Summary\n\nThe user prefers concise Chinese replies.",
+      path: "memories/memory_summary.md",
+      size: 58,
+    },
   };
   function Harness() {
     const [selectedWorkspacePath, setSelectedWorkspacePath] = useState("instructions/AGENTS.md");
@@ -211,6 +222,8 @@ function renderHubDetailPane(
             workspaceEntries: [
               { name: "instructions", path: "instructions", type: "dir", depth: 0 },
               { name: "AGENTS.md", path: "instructions/AGENTS.md", type: "file", depth: 1 },
+              { name: "memories", path: "memories", type: "dir", depth: 0 },
+              { name: "memory_summary.md", path: "memories/memory_summary.md", type: "file", depth: 1 },
               { name: "skills", path: "skills", type: "dir", depth: 0 },
               { name: "demo", path: "skills/demo", type: "dir", depth: 1 },
               { name: "SKILL.md", path: "skills/demo/SKILL.md", type: "file", depth: 2 },
@@ -552,9 +565,11 @@ describe("HubDetailPane", () => {
     expect(screen.queryByRole("button", { name: "Publish to community" })).not.toBeInTheDocument();
   });
 
-  it("groups template details into runtime, instructions, skills, and MCP tabs", async () => {
+  it("groups template details into runtime, instructions, memory, skills, and MCP tabs", async () => {
     const user = userEvent.setup();
-    renderHubDetailPane();
+    const { container } = renderHubDetailPane("template", {
+      selectedTemplate: { ...template, runtime_kind: "codex" },
+    });
 
     expect(screen.getByRole("button", { name: "Profile" })).toHaveAttribute("aria-current", "location");
     expect(screen.getByDisplayValue("demo:latest")).toBeInTheDocument();
@@ -573,6 +588,12 @@ describe("HubDetailPane", () => {
     await user.click(screen.getByRole("button", { name: /^Skills/ }));
     expect(screen.getByText("demo")).toBeInTheDocument();
     expect(screen.getByText("Demo template skill")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Memory" }));
+    expect(screen.getByRole("textbox", { name: "Read-only memory summary" })).toHaveValue(
+      "# Memory Summary\n\nThe user prefers concise Chinese replies.",
+    );
+    expect(container.querySelector(".workspace-file-tree")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "MCP" }));
     expect(screen.getByText("context7")).toBeInTheDocument();

--- a/web/app/tests/components/HubDetailPane.test.tsx
+++ b/web/app/tests/components/HubDetailPane.test.tsx
@@ -15,6 +15,8 @@ function t(key: string, params: Record<string, string | number> = {}) {
     agentPublishLoginRequired: "Sign in first",
     agentPublishTemplateCommunitySubtitle: "Publish remotely",
     agentPublishTemplateTitle: "Publish agent template",
+    agentPublishIncludeMemory: "Include agent memory",
+    agentPublishIncludeMemoryWarning: "Memory may contain private information.",
     agentPublishing: "Publishing",
     resourcesDeleteSkill: "Delete skill",
     resourcesDeleteSkillConfirmAction: "Delete",
@@ -139,6 +141,7 @@ function renderHubDetailPane(
     onPublishTemplate?: (
       item: HubTemplate | null | undefined,
       deploy?: boolean,
+      includeMemory?: boolean,
     ) => Promise<{ status: "success" } | { status: "partial"; message: string } | null>;
     publishDisabled?: boolean;
     publishError?: string;
@@ -469,7 +472,7 @@ describe("HubDetailPane", () => {
     expect(screen.getByRole("button", { name: "Publish and deploy" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Publish template only" }));
 
-    expect(onPublishTemplate).toHaveBeenCalledWith(localTemplate, false);
+    expect(onPublishTemplate).toHaveBeenCalledWith(localTemplate, false, false);
     expect(await screen.findByRole("dialog", { name: "Published successfully" })).toBeInTheDocument();
     expect(screen.getByText("The template has been published to the community.")).toBeInTheDocument();
 
@@ -510,9 +513,10 @@ describe("HubDetailPane", () => {
     renderHubDetailPane("template", { selectedTemplate: localTemplate, onPublishTemplate });
 
     await user.click(screen.getByRole("button", { name: "Publish to community" }));
+    await user.click(screen.getByRole("checkbox", { name: "Include agent memory" }));
     await user.click(screen.getByRole("button", { name: "Publish and deploy" }));
 
-    expect(onPublishTemplate).toHaveBeenCalledWith(localTemplate, true);
+    expect(onPublishTemplate).toHaveBeenCalledWith(localTemplate, true, true);
   });
 
   it("closes the publish form and shows deployment details after partial success", async () => {

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -1139,7 +1139,7 @@ describe("useAgentController", () => {
     expect(result.current.agentViewProps.saveBillingURL).toBe("https://opencsg-stg.com/settings/billing");
 
     await act(async () => {
-      await result.current.agentViewProps.onPublish?.("official", "manager", "manager template");
+      await result.current.agentViewProps.onPublish?.("official", "manager", "manager template", false);
     });
 
     expect(result.current.agentViewProps.saveError).toBe("agentPublishLoginRequired");
@@ -1179,6 +1179,7 @@ describe("useAgentController", () => {
           "official_deploy",
           "reviewer",
           "Reviews changes",
+          false,
         )) ?? false;
     });
 
@@ -1228,6 +1229,7 @@ describe("useAgentController", () => {
           "official_deploy",
           "reviewer",
           "Reviews changes",
+          false,
         )) ?? false;
     });
 

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -1147,6 +1147,7 @@ describe("useAgentController", () => {
   });
 
   it("opens the published template when community deployment is waiting for review", async () => {
+    const setHubPublishError = vi.fn();
     const worker: AgentLike = {
       ...oldAgent,
       id: "u-worker",
@@ -1166,6 +1167,7 @@ describe("useAgentController", () => {
           activePane: { type: WorkspacePaneTypes.agent, id: "u-worker" },
           agents: [worker],
           openCSGAuthenticated: true,
+          setHubPublishError,
         }),
       { wrapper: createWrapper() },
     );
@@ -1183,6 +1185,7 @@ describe("useAgentController", () => {
     expect(published).toBe(true);
     expect(result.current.refreshHubTemplates).toHaveBeenCalledOnce();
     expect(result.current.setSelectedHubTemplateId).toHaveBeenCalledWith("alice/reviewer");
+    expect(setHubPublishError).toHaveBeenCalledWith("sensitive-content review is still pending");
     expect(result.current.navigatePane).toHaveBeenCalledWith(
       { type: WorkspacePaneTypes.hub, id: "alice/reviewer", resourceType: "template" },
       [],

--- a/web/app/tests/legacy-contract.test.ts
+++ b/web/app/tests/legacy-contract.test.ts
@@ -87,7 +87,7 @@ describe("legacy UI contract", () => {
     expect(source).toContain("function publishAgentTemplateRequest");
     expect(source).toContain('const HUB_TEMPLATES_PATH = "/api/v1/hub/templates";');
     expect(source).toContain("post<HubTemplate>(HUB_TEMPLATES_PATH, payload)");
-    expect(source).toContain("publishAgentTemplateRequest(selectedAgentForPage.id, target, name, description)");
+    expect(source).toContain("includeMemory,");
     expect(source).toContain('get("api/v1/agents/image-candidates")');
     expect(source).toContain("agent_id: agentID");
     expect(source).toContain("setSelectedHubTemplateId(published.id);");

--- a/web/app/tests/models/hubWorkspace.test.ts
+++ b/web/app/tests/models/hubWorkspace.test.ts
@@ -7,6 +7,7 @@ import {
   hubTemplateErrorCode,
   isDeletableHubTemplate,
   isVisibleInHubTemplateList,
+  isHubTemplateMemoryEnabled,
 } from "@/models/hubWorkspace";
 
 describe("hub workspace helpers", () => {
@@ -40,8 +41,19 @@ describe("hub workspace helpers", () => {
     ).toBe(false);
   });
 
+  it("shows memory only for Codex templates whose memory mode is enabled", () => {
+    expect(isHubTemplateMemoryEnabled({ runtime_kind: "codex" })).toBe(true);
+    expect(isHubTemplateMemoryEnabled({ runtime_kind: "codex", runtime_options: { memory_mode: "enabled" } })).toBe(
+      true,
+    );
+    expect(isHubTemplateMemoryEnabled({ runtime_kind: "codex", runtime_options: { memory_mode: "disabled" } })).toBe(
+      false,
+    );
+    expect(isHubTemplateMemoryEnabled({ runtime_kind: "openclaw_sandbox" })).toBe(false);
+  });
+
   it("uses structured codes for community publishing errors", () => {
-    expect(hubTemplateErrorCode({ code: "SPACE_ERR_1" })).toBe(HubTemplateErrorCodes.communityNameConflict);
+    expect(hubTemplateErrorCode({ code: "SYS-ERR-4" })).toBe(HubTemplateErrorCodes.communityNameConflict);
     expect(hubTemplateErrorCode({ code: "USER-ERR-18" })).toBe(HubTemplateErrorCodes.accountEmailMissing);
     expect(hubTemplateErrorCode(new Error("The space name already exists."))).toBe("");
   });

--- a/web/app/tests/shared/i18n.test.ts
+++ b/web/app/tests/shared/i18n.test.ts
@@ -51,10 +51,21 @@ describe("i18n messages", () => {
     ).toBe("模板已成功发布，但社区部署资源暂时不可用，请稍后重试部署。");
     expect(
       localizeAPIError(
-        { status: 409, code: "SPACE_ERR_1", message: "The space name already exists." },
+        { status: 400, code: "SYS-ERR-4", message: "The repository already exists." },
         createTranslator("en"),
       ),
-    ).toContain("same name already exists");
+    ).toContain("community repository already exists");
+  });
+
+  it("preserves the upstream reason for generic template publishing failures", () => {
+    const message =
+      'publish hub template to "official": remote hub request failed with status 500: failed to update repository path';
+    expect(
+      localizeAPIError(
+        { status: 400, code: "template_publish_failed", message },
+        createTranslator("zh"),
+      ),
+    ).toBe(message);
   });
 
   it("localizes unavailable Docker errors without exposing platform diagnostics", () => {

--- a/web/app/tests/shared/i18n.test.ts
+++ b/web/app/tests/shared/i18n.test.ts
@@ -60,12 +60,9 @@ describe("i18n messages", () => {
   it("preserves the upstream reason for generic template publishing failures", () => {
     const message =
       'publish hub template to "official": remote hub request failed with status 500: failed to update repository path';
-    expect(
-      localizeAPIError(
-        { status: 400, code: "template_publish_failed", message },
-        createTranslator("zh"),
-      ),
-    ).toBe(message);
+    expect(localizeAPIError({ status: 400, code: "template_publish_failed", message }, createTranslator("zh"))).toBe(
+      message,
+    );
   });
 
   it("localizes unavailable Docker errors without exposing platform diagnostics", () => {


### PR DESCRIPTION
- snapshot and restore memory_summary.md for enabled Codex templates
- expose template memory summaries in the Hub UI and align the agent memory API
- omit disabled memory and system skills while validating staging paths
- improve community publish error feedback and deployment retry handling
- update API documentation and add backend and frontend regression coverage
<img width="1329" height="362" alt="image" src="https://github.com/user-attachments/assets/0470c12d-a477-4b3a-914f-c14ba31507b3" />
<img width="1277" height="780" alt="image" src="https://github.com/user-attachments/assets/01c247f3-a2ee-4530-b833-630996c12e4c" />
