### PR TITLE
fix(web): prevent agent profile drawer flicker after delete

### DIFF
--- a/web/app/src/hooks/workspace/types.ts
+++ b/web/app/src/hooks/workspace/types.ts
@@ -260,6 +260,7 @@ export type UseAgentControllerArgs = {
   modelProviders?: ModelProviderCatalog | null;
   modelProvidersLoaded?: boolean;
   openCSGAuthenticated?: boolean;
+  onAgentDeleted?: (item: AgentLike) => void;
   profileDetailAgentID?: string;
   refreshMCPServers?: () => Promise<unknown>;
   refreshHubTemplates: () => Promise<void>;

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -470,6 +470,7 @@ export function useAgentController({
   modelProviders = null,
   modelProvidersLoaded = false,
   openCSGAuthenticated = false,
+  onAgentDeleted,
   profileDetailAgentID = "",
   refreshMCPServers = async () => null,
   refreshHubTemplates,
@@ -2011,6 +2012,7 @@ export function useAgentController({
       const deletingNotificationBot = action === "delete" && isNotificationBotAgent(item);
       if (action === "delete") {
         await deleteAgentLikeRequest(item);
+        onAgentDeleted?.(item);
         if (activePane.type === WorkspacePaneTypes.agent && activePane.id === item.id) {
           const fallbackAgent = agentSelectionAfterDelete(agentItems, item.id);
           if (fallbackAgent) {

--- a/web/app/src/hooks/workspace/useWorkspaceController.ts
+++ b/web/app/src/hooks/workspace/useWorkspaceController.ts
@@ -204,6 +204,15 @@ export function useWorkspaceController() {
   const rooms = useMemo(() => displayData?.rooms ?? [], [displayData]);
   const [conversationProfileDetailAgentID, setConversationProfileDetailAgentID] = useState("");
   const conversationProfileDetailTriggerRef = useRef<HTMLElement | null>(null);
+  const handleAgentDeleted = useCallback((item: AgentLike) => {
+    setConversationProfileDetailAgentID((current) => {
+      if (current !== item.id) {
+        return current;
+      }
+      conversationProfileDetailTriggerRef.current = null;
+      return "";
+    });
+  }, []);
   const loadingError = bootstrapQuery.isError ? t("loadingFailed") : "";
   const {
     navigatePane,
@@ -296,6 +305,7 @@ export function useWorkspaceController() {
     modelProviders,
     modelProvidersLoaded,
     openCSGAuthenticated: isAuthenticated(auth.status),
+    onAgentDeleted: handleAgentDeleted,
     profileDetailAgentID: conversationProfileDetailAgentID,
     refreshMCPServers: hub.refetchMCPServers,
     refreshHubTemplates,

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -212,6 +212,7 @@ function useAgentControllerHarness(
     managerProfile?: AgentProfileLike | null;
     modelProviders?: ModelProviderCatalog | null;
     modelProvidersLoaded?: boolean;
+    onAgentDeleted?: (item: AgentLike) => void;
     openCSGAuthenticated?: boolean;
     bootstrapConfig?: RuntimeBootstrapConfig | null;
     refreshedBootstrapConfig?: RuntimeBootstrapConfig | null;
@@ -274,6 +275,7 @@ function useAgentControllerHarness(
     managerProfile: options.managerProfile ?? null,
     modelProviders: options.modelProviders ?? null,
     modelProvidersLoaded: options.modelProvidersLoaded ?? false,
+    onAgentDeleted: options.onAgentDeleted,
     openCSGAuthenticated: options.openCSGAuthenticated ?? false,
     refreshMCPServers: options.refreshMCPServers ?? vi.fn(async () => null),
     refreshHubTemplates: refreshHubTemplatesRef.current,
@@ -1077,7 +1079,10 @@ describe("useAgentController", () => {
   });
 
   it("deletes an agent through the agent-aware delete endpoint", async () => {
-    const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
+    const onAgentDeleted = vi.fn();
+    const { result } = renderHook(() => useAgentControllerHarness({ onAgentDeleted }).controller, {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.agentViewProps.onDelete?.(oldAgent);
@@ -1085,6 +1090,21 @@ describe("useAgentController", () => {
 
     expect(deleteAgentLikeRequest).toHaveBeenCalledWith(oldAgent);
     expect(deleteBotRequest).not.toHaveBeenCalled();
+    expect(onAgentDeleted).toHaveBeenCalledWith(oldAgent);
+  });
+
+  it("keeps the profile detail open when deleting the agent fails", async () => {
+    const onAgentDeleted = vi.fn();
+    vi.mocked(deleteAgentLikeRequest).mockRejectedValueOnce(new Error("Delete failed"));
+    const { result } = renderHook(() => useAgentControllerHarness({ onAgentDeleted }).controller, {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.agentViewProps.onDelete?.(oldAgent);
+    });
+
+    expect(onAgentDeleted).not.toHaveBeenCalled();
   });
 
   it("keeps the agent module selected and switches to the adjacent agent after deletion", async () => {


### PR DESCRIPTION
## Summary

- close the conversation profile drawer as soon as its agent is successfully deleted
- clear the stored drawer trigger so stale agent-list responses cannot reopen the deleted profile
- keep the drawer open when deletion fails so the error remains visible
- add regression coverage for successful and failed deletion callbacks
