### PR TITLE
fix(feishu): use local callback for lark-cli source

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -792,6 +792,7 @@ func startServerWithConfigPath(ctx context.Context, run *command.Context, cfg co
 		AccessToken:        cfg.Server.AccessToken,
 		NoAuth:             cfg.Server.NoAuth,
 		AdvertiseBaseURL:   apiURL,
+		InternalBaseURL:    serveInternalBaseURL(cfg.Server, serveOpts),
 		Desktop:            serveOpts.Desktop,
 		Context:            ctx,
 		BeforeShutdown:     beforeShutdown,
@@ -1050,6 +1051,18 @@ func serveAPIBaseURL(serverConfig config.ServerConfig, opts serveOptions) string
 		}
 	}
 	return apiBaseURL(serverConfig)
+}
+
+func serveInternalBaseURL(serverConfig config.ServerConfig, opts serveOptions) string {
+	if opts.Desktop != nil {
+		if baseURL := strings.TrimRight(strings.TrimSpace(opts.Desktop.BaseURL), "/"); baseURL != "" {
+			return baseURL
+		}
+	}
+	if opts.Listener != nil {
+		serverConfig.ListenAddr = opts.Listener.Addr().String()
+	}
+	return config.ResolveLocalBaseURL(serverConfig)
 }
 
 func printEffectiveConfig(run *command.Context, cfg config.Config, output string) {

--- a/cli/serve/serve_test.go
+++ b/cli/serve/serve_test.go
@@ -1996,6 +1996,26 @@ func TestServeAPIBaseURLUsesDesktopRendererEndpoint(t *testing.T) {
 	}
 }
 
+func TestServeInternalBaseURLIgnoresAdvertiseBaseURL(t *testing.T) {
+	got := serveInternalBaseURL(config.ServerConfig{
+		ListenAddr:       "0.0.0.0:19090",
+		AdvertiseBaseURL: "https://gateway.example.test/sandbox",
+	}, serveOptions{})
+	if want := "http://127.0.0.1:19090"; got != want {
+		t.Fatalf("serveInternalBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestServeInternalBaseURLUsesDesktopRendererEndpoint(t *testing.T) {
+	got := serveInternalBaseURL(
+		config.ServerConfig{ListenAddr: "0.0.0.0:59843"},
+		serveOptions{Desktop: &server.DesktopOptions{BaseURL: "http://127.0.0.1:59842/"}},
+	)
+	if want := "http://127.0.0.1:59842"; got != want {
+		t.Fatalf("serveInternalBaseURL() = %q, want %q", got, want)
+	}
+}
+
 func TestParseServeLogLevel(t *testing.T) {
 	cases := map[string]slog.Level{
 		"":        slog.LevelInfo,

--- a/internal/api/feishu_registration_test.go
+++ b/internal/api/feishu_registration_test.go
@@ -185,7 +185,7 @@ func TestFinalizeFeishuRegistrationConfiguresAvailableLarkCLIForCodexWorker(t *t
 		svc:                        agentSvc,
 		participant:                participantSvc,
 		serverAccessToken:          "server-secret",
-		advertiseBaseURL:           "http://csgclaw.test",
+		internalBaseURL:            "http://csgclaw.test",
 		feishuRegistrationStateDir: filepath.Join(t.TempDir(), "registrations"),
 	}
 	registrationID := startFeishuRegistrationForTest(t, srv, "u-dev")

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -71,6 +71,7 @@ type Handler struct {
 	teamPlanJobs               map[string]struct{}
 	configPath                 string
 	advertiseBaseURL           string
+	internalBaseURL            string
 	runtimeDistribution        string
 	serverAccessToken          string
 	desktopSessionToken        string
@@ -946,6 +947,12 @@ func (h *Handler) SetConfigPath(path string) {
 func (h *Handler) SetAdvertiseBaseURL(baseURL string) {
 	if h != nil {
 		h.advertiseBaseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	}
+}
+
+func (h *Handler) SetInternalBaseURL(baseURL string) {
+	if h != nil {
+		h.internalBaseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	}
 }
 

--- a/internal/api/lark_cli.go
+++ b/internal/api/lark_cli.go
@@ -1016,8 +1016,8 @@ func signLarkCLISourceToken(encodedPayload, secret string) string {
 }
 
 func (h *Handler) internalSourceBaseURL() string {
-	if h != nil && strings.TrimSpace(h.advertiseBaseURL) != "" {
-		return strings.TrimRight(strings.TrimSpace(h.advertiseBaseURL), "/")
+	if h != nil && strings.TrimSpace(h.internalBaseURL) != "" {
+		return strings.TrimRight(strings.TrimSpace(h.internalBaseURL), "/")
 	}
 	return strings.TrimRight(config.DefaultAPIBaseURL(), "/")
 }

--- a/internal/api/lark_cli_test.go
+++ b/internal/api/lark_cli_test.go
@@ -176,9 +176,14 @@ func TestInitAgentLarkCLIReturnsConflictWhenFeishuBotMissing(t *testing.T) {
 }
 
 func TestInternalSourceBaseURLUsesOnlyConfiguredOrDefaultAddress(t *testing.T) {
-	configured := (&Handler{advertiseBaseURL: "http://csgclaw.test/"}).internalSourceBaseURL()
-	if configured != "http://csgclaw.test" {
-		t.Fatalf("configured source base URL = %q, want %q", configured, "http://csgclaw.test")
+	configured := (&Handler{internalBaseURL: "http://127.0.0.1:19090/"}).internalSourceBaseURL()
+	if configured != "http://127.0.0.1:19090" {
+		t.Fatalf("configured source base URL = %q, want %q", configured, "http://127.0.0.1:19090")
+	}
+
+	configured = (&Handler{advertiseBaseURL: "https://gateway.example.test/sandbox"}).internalSourceBaseURL()
+	if want := strings.TrimRight(config.DefaultAPIBaseURL(), "/"); configured != want {
+		t.Fatalf("source base URL with only advertise URL = %q, want local default %q", configured, want)
 	}
 
 	if got, want := (&Handler{}).internalSourceBaseURL(), strings.TrimRight(config.DefaultAPIBaseURL(), "/"); got != want {
@@ -372,7 +377,7 @@ func TestInitAgentLarkCLIConfiguresWorkerScopedSource(t *testing.T) {
 		svc:               svc,
 		participant:       participantSvc,
 		serverAccessToken: "server-secret",
-		advertiseBaseURL:  "http://csgclaw.test",
+		internalBaseURL:   "http://csgclaw.test",
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/u-dev/lark-cli:init", strings.NewReader(`{}`))
@@ -750,7 +755,7 @@ func TestInitAgentLarkCLIPreservesLiveStateWhenBindFails(t *testing.T) {
 		svc:               svc,
 		participant:       participantSvc,
 		serverAccessToken: "server-secret",
-		advertiseBaseURL:  "http://csgclaw.test",
+		internalBaseURL:   "http://csgclaw.test",
 	}
 	layout, err := svc.AgentLayout("agent-dev")
 	if err != nil {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -59,6 +59,7 @@ type Options struct {
 	AccessToken        string
 	NoAuth             bool
 	AdvertiseBaseURL   string
+	InternalBaseURL    string
 	Desktop            *DesktopOptions
 	Context            context.Context
 	OnReady            func(h *api.Handler, router chi.Router)
@@ -85,6 +86,7 @@ func newHandler(opts Options) *api.Handler {
 	handler.SetUpgradeConfigPath(opts.ConfigPath)
 	handler.SetConfigPath(opts.ConfigPath)
 	handler.SetAdvertiseBaseURL(opts.AdvertiseBaseURL)
+	handler.SetInternalBaseURL(opts.InternalBaseURL)
 	if opts.Desktop != nil {
 		handler.SetRuntimeDistribution("electron")
 		handler.SetDesktopSessionToken(opts.Desktop.SessionToken)


### PR DESCRIPTION
## Summary
- separate the user-facing advertise URL from the in-process lark-cli credential callback URL
- use the trusted loopback listener for regular servers and the renderer loopback URL for Desktop
- prevent sandbox lark-cli bind from calling an AI Gateway advertise URL without browser JWT

## Incident
On stg `spaces/sandbox-4f2ba289d11d7542b82d360b0eafcf46`, both automatic bind and manual init failed because the exec provider called the configured AI Gateway advertise URL and received HTTP 401 before reaching CSGClaw.

## Testing
- `go test ./internal/api -run 'LarkCLI|FinalizeFeishuRegistration' -count=1`\n- `go test ./cli/serve ./internal/server -run 'Test(ServeInternalBaseURL.*|ServeAPIBaseURLUsesDesktopRendererEndpoint|NewHandlerWiresMCPService|RunDesktopServesRendererAndSandboxOnSeparateListeners)$' -count=1`