### PR TITLE
fix(feishu): support lark-cli trusted paths on Windows

### DIFF
--- a/internal/api/lark_cli.go
+++ b/internal/api/lark_cli.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -849,7 +850,7 @@ func writeLarkChannelSourceConfig(path string, cfg larkChannelSourceConfig) erro
 					"command":             cfg.HelperPath,
 					"args":                []string{"pt", "app-info", "--channel", "feishu", "--agent-id", cfg.AgentID, "--exec-provider"},
 					"env":                 sourceProviderEnv(cfg.BaseURL, cfg.AccessToken),
-					"trustedDirs":         []string{filepath.Dir(cfg.HelperPath)},
+					"trustedDirs":         larkCLIExecProviderTrustedPaths(cfg.HelperPath, runtime.GOOS),
 					"allowInsecurePath":   true,
 					"allowSymlinkCommand": true,
 					"noOutputTimeoutMs":   larkCLIExecProviderTimeoutMS,
@@ -863,6 +864,15 @@ func writeLarkChannelSourceConfig(path string, cfg larkChannelSourceConfig) erro
 		return err
 	}
 	return writeFile0600Atomic(path, append(data, '\n'))
+}
+
+func larkCLIExecProviderTrustedPaths(helperPath, goos string) []string {
+	if goos == "windows" {
+		// lark-cli's descendant check uses a slash separator, so Windows paths
+		// must use its supported exact-path match.
+		return []string{helperPath}
+	}
+	return []string{filepath.Dir(helperPath)}
 }
 
 func writeLarkCLIBindMarker(path string, marker larkCLIBindMarker) error {

--- a/internal/api/lark_cli_test.go
+++ b/internal/api/lark_cli_test.go
@@ -937,6 +937,25 @@ func TestWriteLarkChannelSourceConfigUsesExecProvider(t *testing.T) {
 	}
 }
 
+func TestLarkCLIExecProviderTrustedPathsUsesExactHelperOnWindows(t *testing.T) {
+	helperPath := `D:\csgclaw-main\bin\csgclaw.exe`
+	got := larkCLIExecProviderTrustedPaths(helperPath, "windows")
+	if len(got) != 1 || got[0] != helperPath {
+		t.Fatalf("trusted paths = %#v, want exact helper path %q", got, helperPath)
+	}
+}
+
+func TestLarkCLIExecProviderTrustedPathsUsesParentDirectoryOnUnix(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux"} {
+		t.Run(goos, func(t *testing.T) {
+			got := larkCLIExecProviderTrustedPaths("/usr/local/bin/csgclaw", goos)
+			if len(got) != 1 || got[0] != "/usr/local/bin" {
+				t.Fatalf("trusted paths = %#v, want parent directory", got)
+			}
+		})
+	}
+}
+
 func TestLarkCLIFakeCommand(t *testing.T) {
 	if os.Getenv("CSGCLAW_FAKE_LARK_CLI_COMMAND") != "1" {
 		return


### PR DESCRIPTION
## Summary

- use the exact CSGClaw helper executable as the lark-cli trusted path on Windows
- preserve the existing parent-directory trust behavior on Linux and macOS
- add explicit Windows, Darwin, and Linux regression coverage

## Root Cause

lark-cli cleans Windows paths with backslash separators but checks trusted-directory descendants using a slash suffix. A command such as `D:\csgclaw-main\bin\csgclaw.exe` therefore fails the audit against `D:\csgclaw-main\bin`, even though it is inside that directory. lark-cli supports exact trusted-path matches, which also narrows the Windows trust scope to the helper executable itself.

## Testing

- `go test ./internal/api -run 'Test(LarkCLIExecProviderTrustedPaths.*|WriteLarkChannelSourceConfigUsesExecProvider)$' -count=1`
- `go test ./internal/api -run 'LarkCLI|FinalizeFeishuRegistration' -count=1`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/api`
- `GOOS=darwin GOARCH=arm64 go test -c ./internal/api`
- `go vet ./internal/api`
- `git diff --check`
