### PR TITLE
fix(web): resolve shared worker event endpoint

### DIFF
--- a/web/app/src/shared/realtime/imEvents.ts
+++ b/web/app/src/shared/realtime/imEvents.ts
@@ -24,7 +24,13 @@ export function safeParseEventData(raw: string): IMServerEvent | null {
   }
 }
 
+export function resolveIMEventsEndpoint(baseURI: string): string {
+  return new URL(ApiEndpoints.imEvents, baseURI).toString();
+}
+
 export function subscribeIMEvents(onEvent: (payload: IMServerEvent) => void): () => void {
+  const endpoint = resolveIMEventsEndpoint(document.baseURI);
+
   if (typeof window.SharedWorker === "function") {
     try {
       const worker = createSharedWorker();
@@ -41,7 +47,7 @@ export function subscribeIMEvents(onEvent: (payload: IMServerEvent) => void): ()
 
       port.addEventListener("message", handleMessage);
       port.start();
-      port.postMessage({ type: "subscribe", endpoint: ApiEndpoints.imEvents });
+      port.postMessage({ type: "subscribe", endpoint });
 
       return () => {
         port.postMessage({ type: "close" });
@@ -53,7 +59,7 @@ export function subscribeIMEvents(onEvent: (payload: IMServerEvent) => void): ()
     }
   }
 
-  const source = new EventSource(ApiEndpoints.imEvents);
+  const source = new EventSource(endpoint);
   source.onmessage = (event) => {
     const payload = safeParseEventData(event.data);
     if (payload) {

--- a/web/app/src/shared/realtime/sseSharedWorker.ts
+++ b/web/app/src/shared/realtime/sseSharedWorker.ts
@@ -2,6 +2,8 @@ type SharedWorkerGlobal = typeof globalThis & {
   onconnect: ((event: MessageEvent) => void) | null;
 };
 
+export {};
+
 type WorkerControlMessage = {
   endpoint?: string;
   type?: "close" | "subscribe" | string;
@@ -9,7 +11,7 @@ type WorkerControlMessage = {
 
 let es: EventSource | null = null;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
-let endpoint = "/api/v1/events";
+let endpoint: string | null = null;
 const ports = new Set<MessagePort>();
 let reconnectDelayMs = 3000;
 
@@ -45,7 +47,7 @@ function scheduleReconnect(): void {
 }
 
 function connect(): void {
-  if (es || ports.size === 0) {
+  if (es || ports.size === 0 || !endpoint) {
     return;
   }
 
@@ -79,7 +81,11 @@ function connect(): void {
   port.onmessage = ({ data }: MessageEvent<WorkerControlMessage>) => {
     if (data?.type === "subscribe") {
       if (typeof data.endpoint === "string" && data.endpoint.length > 0) {
-        endpoint = data.endpoint;
+        if (endpoint !== data.endpoint) {
+          endpoint = data.endpoint;
+          clearReconnectTimer();
+          cleanup();
+        }
       }
       connect();
       return;
@@ -92,6 +98,4 @@ function connect(): void {
       }
     }
   };
-
-  connect();
 };

--- a/web/app/tests/shared/realtime/imEvents.test.ts
+++ b/web/app/tests/shared/realtime/imEvents.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveIMEventsEndpoint } from "@/shared/realtime/imEvents";
+
+type SharedWorkerTestGlobal = typeof self & {
+  onconnect?: (event: MessageEvent) => void;
+};
+
+const workerGlobal = self as SharedWorkerTestGlobal;
+
+describe("resolveIMEventsEndpoint", () => {
+  it("resolves the SSE endpoint from the application root", () => {
+    expect(resolveIMEventsEndpoint("http://127.0.0.1:5173/")).toBe("http://127.0.0.1:5173/api/v1/events");
+  });
+
+  it("preserves a production application subpath", () => {
+    expect(resolveIMEventsEndpoint("https://example.com/v1/sandboxes/demo/")).toBe(
+      "https://example.com/v1/sandboxes/demo/api/v1/events",
+    );
+  });
+});
+
+describe("SSE SharedWorker", () => {
+  afterEach(() => {
+    delete workerGlobal.onconnect;
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("waits for an absolute endpoint and reconnects after the last port closes", async () => {
+    const sources: EventSourceMock[] = [];
+
+    class EventSourceMock {
+      static readonly CLOSED = 2;
+      static readonly CONNECTING = 0;
+
+      readonly close = vi.fn();
+      readonly url: string;
+      onerror: (() => void) | null = null;
+      onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      onopen: (() => void) | null = null;
+      readyState = 1;
+
+      constructor(url: string | URL) {
+        this.url = String(url);
+        sources.push(this);
+      }
+    }
+
+    vi.stubGlobal("EventSource", EventSourceMock);
+    await import("@/shared/realtime/sseSharedWorker");
+
+    const connect = workerGlobal.onconnect;
+    expect(connect).toBeTypeOf("function");
+
+    const firstPort = createPortMock();
+    connect?.({ ports: [firstPort] } as unknown as MessageEvent);
+    expect(sources).toHaveLength(0);
+
+    firstPort.onmessage?.(controlMessage({ type: "subscribe", endpoint: "http://127.0.0.1:5173/api/v1/events" }));
+    expect(sources.map((source) => source.url)).toEqual(["http://127.0.0.1:5173/api/v1/events"]);
+
+    firstPort.onmessage?.(controlMessage({ type: "close" }));
+    expect(sources[0]?.close).toHaveBeenCalledOnce();
+
+    const secondPort = createPortMock();
+    connect?.({ ports: [secondPort] } as unknown as MessageEvent);
+    expect(sources).toHaveLength(1);
+
+    secondPort.onmessage?.(controlMessage({ type: "subscribe", endpoint: "http://127.0.0.1:5173/api/v1/events" }));
+    expect(sources.map((source) => source.url)).toEqual([
+      "http://127.0.0.1:5173/api/v1/events",
+      "http://127.0.0.1:5173/api/v1/events",
+    ]);
+
+    secondPort.onmessage?.(controlMessage({ type: "close" }));
+  });
+});
+
+function createPortMock(): MessagePort {
+  return {
+    close: vi.fn(),
+    onmessage: null,
+    postMessage: vi.fn(),
+    start: vi.fn(),
+  } as unknown as MessagePort;
+}
+
+function controlMessage(data: { endpoint?: string; type: string }): MessageEvent {
+  return { data } as MessageEvent;
+}


### PR DESCRIPTION
- Resolve IM event endpoints from the page base URI before passing them to the SharedWorker, preserving root and subpath deployments.
- Wait for the resolved endpoint before opening the SSE connection so development reconnects continue receiving messages and agent work updates.
