### PR TITLE
fix(agent): stabilize restart and LLM Wiki MCP sync

### DIFF
--- a/internal/api/agent_mcp_server_source.go
+++ b/internal/api/agent_mcp_server_source.go
@@ -8,30 +8,23 @@ import (
 
 	"csgclaw/internal/agent"
 	"csgclaw/internal/agentengine"
-	"csgclaw/internal/knowledgebase"
 )
 
 type agentMCPServerSourceSyncResponse struct {
-	Agent       agent.MCPServersView          `json:"agent"`
-	GlobalState map[string]any                `json:"global_state"`
-	Source      mcpServerSourceStatusResponse `json:"source"`
+	Agent  agent.MCPServersView          `json:"agent"`
+	Source mcpServerSourceStatusResponse `json:"source"`
 }
 
 type resolvedAgentMCPServerSource struct {
-	Agent           agentengine.Agent
-	AgentName       string
-	GlobalName      string
-	GlobalRefreshed map[string]any
-	Managed         resolvedManagedMCPServerSource
+	Agent       agentengine.Agent
+	AgentName   string
+	Managed     resolvedManagedMCPServerSource
+	SourceError error
 }
 
 func (h *Handler) handleAgentMCPServerSource(w http.ResponseWriter, r *http.Request) {
 	if h.agentEngine == nil {
 		http.Error(w, "agent service is not configured", http.StatusServiceUnavailable)
-		return
-	}
-	if h.mcp == nil {
-		http.Error(w, "mcp service is not configured", http.StatusServiceUnavailable)
 		return
 	}
 	agentID := strings.TrimSpace(pathValue(r, "id"))
@@ -53,12 +46,11 @@ func (h *Handler) handleAgentMCPServerSource(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-
-	globalState, globalName, err := h.persistManagedMCPGlobalSnapshot(r.Context(), resolved)
-	if err != nil {
-		writeMCPServerError(w, err)
+	if resolved.SourceError != nil {
+		writeMCPServerSourceError(w, resolved.SourceError)
 		return
 	}
+
 	server, err := agentMCPServerConfig(resolved.AgentName, resolved.Managed.Refreshed)
 	if err != nil {
 		writeAgentMCPServersMutationError(w, err)
@@ -81,8 +73,6 @@ func (h *Handler) handleAgentMCPServerSource(w http.ResponseWriter, r *http.Requ
 	status := resolved.Managed.Status
 	status.AgentUpdateAvailable = false
 	status.ConfiguredEndpointURL = status.LatestEndpointURL
-	status.GlobalServerName = globalName
-	status.GlobalUpdateAvailable = false
 	status.UpdateAvailable = false
 	writeJSON(w, http.StatusOK, agentMCPServerSourceSyncResponse{
 		Agent: agent.MCPServersView{
@@ -90,8 +80,7 @@ func (h *Handler) handleAgentMCPServerSource(w http.ResponseWriter, r *http.Requ
 			RuntimeKind: updated.Status.RuntimeKind,
 			Servers:     serviceMCPServers(updated.Spec.MCPServers),
 		},
-		GlobalState: globalState,
-		Source:      status,
+		Source: status,
 	})
 }
 
@@ -107,45 +96,22 @@ func (h *Handler) resolveAgentMCPServerSource(ctx context.Context, agentID, name
 	config := map[string]any(raw)
 	managed, err := h.resolveManagedMCPServerSource(ctx, config)
 	if err != nil {
-		return resolvedAgentMCPServerSource{}, err
-	}
-	servers, err := h.mcp.ListServers(ctx)
-	if err != nil {
-		return resolvedAgentMCPServerSource{}, err
-	}
-	metadata, _ := knowledgebase.ManagedMetadataFromServer(config)
-	globalName := knowledgebase.FindConfiguredServer(servers, metadata.ContentID)
-	globalUpdateAvailable := globalName == ""
-	var globalRefreshed map[string]any
-	if globalName != "" {
-		globalConfig, ok := servers[globalName].(map[string]any)
-		if !ok {
-			return resolvedAgentMCPServerSource{}, fmt.Errorf("mcp server %q config must be an object", globalName)
-		}
-		globalRefreshed, err = knowledgebase.RefreshManagedServerConfig(globalConfig, managed.Item, managed.Connection.CSGHubAccessToken)
-		if err != nil {
+		unavailable, missing := unavailableManagedMCPServerSource(config, err)
+		if !missing {
 			return resolvedAgentMCPServerSource{}, err
 		}
-		globalUpdateAvailable = managedMCPRuntimeSnapshotChanged(globalConfig, globalRefreshed)
+		return resolvedAgentMCPServerSource{
+			Agent:       current,
+			AgentName:   name,
+			Managed:     unavailable,
+			SourceError: err,
+		}, nil
 	}
 	managed.Status.AgentUpdateAvailable = managedMCPRuntimeSnapshotChanged(config, managed.Refreshed)
-	managed.Status.GlobalServerName = globalName
-	managed.Status.GlobalUpdateAvailable = globalUpdateAvailable
-	managed.Status.UpdateAvailable = managed.Status.AgentUpdateAvailable || globalUpdateAvailable
+	managed.Status.UpdateAvailable = managed.Status.AgentUpdateAvailable
 	return resolvedAgentMCPServerSource{
-		Agent:           current,
-		AgentName:       name,
-		GlobalName:      globalName,
-		GlobalRefreshed: globalRefreshed,
-		Managed:         managed,
+		Agent:     current,
+		AgentName: name,
+		Managed:   managed,
 	}, nil
-}
-
-func (h *Handler) persistManagedMCPGlobalSnapshot(ctx context.Context, resolved resolvedAgentMCPServerSource) (map[string]any, string, error) {
-	if resolved.GlobalName != "" {
-		state, err := h.mcp.UpdateServer(ctx, resolved.GlobalName, resolved.GlobalName, resolved.GlobalRefreshed)
-		return state, resolved.GlobalName, err
-	}
-	state, err := h.mcp.CreateServer(ctx, resolved.Managed.CanonicalName, resolved.Managed.CanonicalConfig)
-	return state, resolved.Managed.CanonicalName, err
 }

--- a/internal/api/mcp_server_source.go
+++ b/internal/api/mcp_server_source.go
@@ -21,10 +21,10 @@ type mcpServerSourceStatusResponse struct {
 	ConfiguredEndpointURL string `json:"configured_endpoint_url"`
 	ContentID             string `json:"content_id"`
 	GlobalServerName      string `json:"global_server_name,omitempty"`
-	GlobalUpdateAvailable bool   `json:"global_update_available,omitempty"`
 	Kind                  string `json:"kind"`
 	LatestEndpointURL     string `json:"latest_endpoint_url"`
 	ResourceID            string `json:"resource_id"`
+	SourceAvailable       bool   `json:"source_available"`
 	SourceDescription     string `json:"source_description,omitempty"`
 	SourceName            string `json:"source_name,omitempty"`
 	UpdateAvailable       bool   `json:"update_available"`
@@ -36,12 +36,8 @@ type mcpServerSourceSyncResponse struct {
 }
 
 type resolvedManagedMCPServerSource struct {
-	CanonicalConfig map[string]any
-	CanonicalName   string
-	Connection      knowledgeBaseConnection
-	Item            knowledgebase.KnowledgeBase
-	Refreshed       map[string]any
-	Status          mcpServerSourceStatusResponse
+	Refreshed map[string]any
+	Status    mcpServerSourceStatusResponse
 }
 
 func (h *Handler) handleMCPServerSourceByName(w http.ResponseWriter, r *http.Request) {
@@ -107,16 +103,8 @@ func (h *Handler) resolveManagedMCPServerSource(ctx context.Context, config map[
 	if err != nil {
 		return resolvedManagedMCPServerSource{}, err
 	}
-	canonicalName, canonicalConfig, err := knowledgebase.ServerConfig(item, connection.CSGHubAccessToken)
-	if err != nil {
-		return resolvedManagedMCPServerSource{}, err
-	}
 	return resolvedManagedMCPServerSource{
-		CanonicalConfig: canonicalConfig,
-		CanonicalName:   canonicalName,
-		Connection:      connection,
-		Item:            item,
-		Refreshed:       refreshed,
+		Refreshed: refreshed,
 		Status: mcpServerSourceStatusResponse{
 			AuthType:              knowledgebase.ManagedAuthType,
 			ConfiguredEndpointURL: mcpSourceString(config["url"]),
@@ -124,11 +112,34 @@ func (h *Handler) resolveManagedMCPServerSource(ctx context.Context, config map[
 			Kind:                  metadata.Kind,
 			LatestEndpointURL:     mcpSourceString(refreshed["url"]),
 			ResourceID:            strconv.FormatInt(metadata.KnowledgeBaseID, 10),
+			SourceAvailable:       true,
 			SourceDescription:     strings.TrimSpace(item.Description),
 			SourceName:            strings.TrimSpace(item.Name),
 			UpdateAvailable:       managedMCPRuntimeSnapshotChanged(config, refreshed),
 		},
 	}, nil
+}
+
+func unavailableManagedMCPServerSource(config map[string]any, err error) (resolvedManagedMCPServerSource, bool) {
+	var remoteErr *knowledgebase.HTTPError
+	if !errors.As(err, &remoteErr) || remoteErr.StatusCode != http.StatusNotFound {
+		return resolvedManagedMCPServerSource{}, false
+	}
+	metadata, ok := knowledgebase.ManagedMetadataFromServer(config)
+	if !ok {
+		return resolvedManagedMCPServerSource{}, false
+	}
+	return resolvedManagedMCPServerSource{
+		Status: mcpServerSourceStatusResponse{
+			AuthType:              knowledgebase.ManagedAuthType,
+			ConfiguredEndpointURL: mcpSourceString(config["url"]),
+			ContentID:             metadata.ContentID,
+			Kind:                  metadata.Kind,
+			ResourceID:            strconv.FormatInt(metadata.KnowledgeBaseID, 10),
+			SourceAvailable:       false,
+			UpdateAvailable:       false,
+		},
+	}, true
 }
 
 func mcpSourceString(value any) string {

--- a/internal/api/mcp_servers_test.go
+++ b/internal/api/mcp_servers_test.go
@@ -176,7 +176,7 @@ func TestManagedKnowledgeBaseMCPSourceStatusAndManualSync(t *testing.T) {
 	if err := json.NewDecoder(statusRecorder.Body).Decode(&status); err != nil {
 		t.Fatalf("decode source status: %v", err)
 	}
-	if !status.UpdateAvailable || status.ConfiguredEndpointURL != "https://gateway.example.test/snapshot/mcp" || status.LatestEndpointURL != "https://gateway.example.test/current/mcp" {
+	if !status.SourceAvailable || !status.UpdateAvailable || status.ConfiguredEndpointURL != "https://gateway.example.test/snapshot/mcp" || status.LatestEndpointURL != "https://gateway.example.test/current/mcp" {
 		t.Fatalf("source status = %#v", status)
 	}
 	if got := store.servers["content-42"].(map[string]any)["url"]; got != "https://gateway.example.test/snapshot/mcp" {
@@ -214,7 +214,7 @@ func TestManagedKnowledgeBaseMCPSourceStatusAndManualSync(t *testing.T) {
 	}
 }
 
-func TestAgentManagedKnowledgeBaseMCPSourceSyncUpdatesGlobalAndCurrentAgent(t *testing.T) {
+func TestAgentManagedKnowledgeBaseMCPSourceSyncUsesAgentSnapshotWithoutGlobalMCP(t *testing.T) {
 	originalLoader := loadKnowledgeBaseConnection
 	originalTransport := http.DefaultTransport
 	defer func() {
@@ -246,13 +246,9 @@ func TestAgentManagedKnowledgeBaseMCPSourceSyncUpdatesGlobalAndCurrentAgent(t *t
 	}); err != nil {
 		t.Fatalf("seed Agent MCP snapshot: %v", err)
 	}
-	globalConfig := managedKnowledgeBaseMCPConfigForTest("https://gateway.example.test/global-snapshot/mcp", "global-snapshot-token")
-	globalConfig["startup_timeout_sec"] = float64(30)
-	globalConfig["tool_timeout_sec"] = float64(60)
-	globalConfig["headers"].(map[string]any)["X-Local"] = "global"
-	if _, err := handler.mcp.CreateServer(context.Background(), "content-42", globalConfig); err != nil {
-		t.Fatalf("seed global MCP snapshot: %v", err)
-	}
+	// Once installed, the Agent snapshot refreshes directly from AgenticHub and
+	// must not depend on the global MCP catalog still being configured.
+	handler.mcp = nil
 
 	router := handler.Routes()
 	statusRecorder := httptest.NewRecorder()
@@ -264,7 +260,7 @@ func TestAgentManagedKnowledgeBaseMCPSourceSyncUpdatesGlobalAndCurrentAgent(t *t
 	if err := json.NewDecoder(statusRecorder.Body).Decode(&status); err != nil {
 		t.Fatalf("decode Agent MCP source status: %v", err)
 	}
-	if !status.UpdateAvailable || !status.AgentUpdateAvailable || !status.GlobalUpdateAvailable || status.GlobalServerName != "content-42" {
+	if !status.SourceAvailable || !status.UpdateAvailable || !status.AgentUpdateAvailable || status.GlobalServerName != "" {
 		t.Fatalf("Agent MCP source status = %#v", status)
 	}
 
@@ -277,24 +273,8 @@ func TestAgentManagedKnowledgeBaseMCPSourceSyncUpdatesGlobalAndCurrentAgent(t *t
 	if err := json.NewDecoder(syncRecorder.Body).Decode(&synced); err != nil {
 		t.Fatalf("decode Agent MCP source sync: %v", err)
 	}
-	if synced.Source.UpdateAvailable || synced.Source.GlobalServerName != "content-42" {
+	if synced.Source.UpdateAvailable || synced.Source.AgentUpdateAvailable || synced.Source.GlobalServerName != "" {
 		t.Fatalf("synced source status = %#v", synced.Source)
-	}
-
-	globalServers, err := handler.mcp.ListServers(context.Background())
-	if err != nil {
-		t.Fatalf("list global MCP servers: %v", err)
-	}
-	assertManagedKnowledgeBaseMCPRuntimeSnapshot(t, globalServers["content-42"], "https://gateway.example.test/current/mcp", "current-token")
-	refreshedGlobal := globalServers["content-42"].(map[string]any)
-	if got, want := refreshedGlobal["startup_timeout_sec"], float64(30); got != want {
-		t.Fatalf("global startup_timeout_sec = %#v, want %#v", got, want)
-	}
-	if got, want := refreshedGlobal["tool_timeout_sec"], float64(60); got != want {
-		t.Fatalf("global tool_timeout_sec = %#v, want %#v", got, want)
-	}
-	if got, want := refreshedGlobal["headers"].(map[string]any)["X-Local"], "global"; got != want {
-		t.Fatalf("global X-Local = %#v, want %q", got, want)
 	}
 	saved, ok := service.Agent(created.ID)
 	if !ok {
@@ -310,6 +290,71 @@ func TestAgentManagedKnowledgeBaseMCPSourceSyncUpdatesGlobalAndCurrentAgent(t *t
 	}
 	if got, want := refreshedAgent["headers"].(map[string]any)["X-Local"], "agent"; got != want {
 		t.Fatalf("Agent X-Local = %#v, want %q", got, want)
+	}
+}
+
+func TestAgentManagedKnowledgeBaseMCPMissingSourceCanStillBeRemoved(t *testing.T) {
+	originalLoader := loadKnowledgeBaseConnection
+	originalTransport := http.DefaultTransport
+	defer func() {
+		loadKnowledgeBaseConnection = originalLoader
+		http.DefaultTransport = originalTransport
+	}()
+	loadKnowledgeBaseConnection = func(context.Context) (knowledgeBaseConnection, error) {
+		return knowledgeBaseConnection{CSGHubBaseURL: "https://hub.example.test", CSGHubAccessToken: "current-token"}, nil
+	}
+	http.DefaultTransport = knowledgeBaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"message":"knowledge base not found"}`)),
+		}, nil
+	})
+
+	handler, service, created := newAgentMCPManagementTestServer(t)
+	agentConfig := managedKnowledgeBaseMCPConfigForTest("https://gateway.example.test/deleted/mcp", "snapshot-token")
+	agentSnapshot := map[string]any{"content-42": agentConfig}
+	if _, err := service.Update(context.Background(), created.ID, agent.UpdateRequest{
+		MCPServers:    &agentSnapshot,
+		MCPServersSet: true,
+		FieldMask:     []string{"mcpServers"},
+	}); err != nil {
+		t.Fatalf("seed Agent MCP snapshot: %v", err)
+	}
+	handler.mcp = nil
+
+	router := handler.Routes()
+	statusRecorder := httptest.NewRecorder()
+	router.ServeHTTP(statusRecorder, httptest.NewRequest(http.MethodGet, "/api/v1/agents/"+created.ID+"/mcp-servers/content-42/source", nil))
+	if got, want := statusRecorder.Code, http.StatusOK; got != want {
+		t.Fatalf("GET deleted Agent MCP source status = %d, want %d; body=%s", got, want, statusRecorder.Body.String())
+	}
+	var status mcpServerSourceStatusResponse
+	if err := json.NewDecoder(statusRecorder.Body).Decode(&status); err != nil {
+		t.Fatalf("decode deleted Agent MCP source status: %v", err)
+	}
+	if status.SourceAvailable || status.UpdateAvailable || status.ContentID != "content-42" || status.ResourceID != "42" || status.ConfiguredEndpointURL != "https://gateway.example.test/deleted/mcp" {
+		t.Fatalf("deleted Agent MCP source status = %#v", status)
+	}
+
+	syncRecorder := httptest.NewRecorder()
+	router.ServeHTTP(syncRecorder, httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+created.ID+"/mcp-servers/content-42/source:sync", nil))
+	if got, want := syncRecorder.Code, http.StatusNotFound; got != want {
+		t.Fatalf("POST deleted Agent MCP source sync = %d, want %d; body=%s", got, want, syncRecorder.Body.String())
+	}
+
+	deleteRecorder := httptest.NewRecorder()
+	deleteRequest := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+created.ID+"/mcp-servers:batchDelete", strings.NewReader(`{"names":["content-42"]}`))
+	router.ServeHTTP(deleteRecorder, deleteRequest)
+	if got, want := deleteRecorder.Code, http.StatusOK; got != want {
+		t.Fatalf("POST delete stale Agent MCP = %d, want %d; body=%s", got, want, deleteRecorder.Body.String())
+	}
+	var deleted agent.MCPServersView
+	if err := json.NewDecoder(deleteRecorder.Body).Decode(&deleted); err != nil {
+		t.Fatalf("decode deleted Agent MCP view: %v", err)
+	}
+	if _, exists := deleted.Servers["content-42"]; exists {
+		t.Fatalf("deleted Agent MCP view still contains content-42: %#v", deleted.Servers)
 	}
 }
 

--- a/internal/runtime/codex/runtime.go
+++ b/internal/runtime/codex/runtime.go
@@ -2008,8 +2008,18 @@ func stopProcess(pid int) error {
 	if pid <= 0 {
 		return nil
 	}
+	// Stopping the tracked app-server can race with the process exiting after
+	// its stdin is closed. On Windows, os.FindProcess opens a process handle and
+	// returns ERROR_INVALID_PARAMETER once that PID no longer exists. Treat an
+	// already-exited process as a successful, idempotent stop.
+	if !processAlive(pid) {
+		return nil
+	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {
+		if !processAlive(pid) {
+			return nil
+		}
 		return err
 	}
 	_ = proc.Signal(os.Interrupt)
@@ -2031,6 +2041,9 @@ func stopProcess(pid int) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	if err := proc.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		if !processAlive(pid) {
+			return nil
+		}
 		return err
 	}
 	deadline = time.Now().Add(3 * time.Second)

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -1004,6 +1004,21 @@ func TestRuntimeStopAndDelete(t *testing.T) {
 	}
 }
 
+func TestStopProcessTreatsExitedProcessAsStopped(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start short-lived process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait for short-lived process: %v", err)
+	}
+
+	if err := stopProcess(pid); err != nil {
+		t.Fatalf("stopProcess(%d) after exit error = %v, want nil", pid, err)
+	}
+}
+
 func TestBuildSessionEnvOnlyInjectsOpenAIAPIKey(t *testing.T) {
 	t.Setenv("HOME", "/host-home")
 	t.Setenv("OPENAI_BASE_URL", "https://host.example/v1")

--- a/web/app/src/api/mcp.ts
+++ b/web/app/src/api/mcp.ts
@@ -34,10 +34,10 @@ type MCPServerSourceStatusResponse = {
   configured_endpoint_url?: unknown;
   content_id?: unknown;
   global_server_name?: unknown;
-  global_update_available?: unknown;
   kind?: unknown;
   latest_endpoint_url?: unknown;
   resource_id?: unknown;
+  source_available?: unknown;
   source_description?: unknown;
   source_name?: unknown;
   update_available?: unknown;
@@ -50,7 +50,6 @@ type MCPServerSourceSyncResponse = {
 
 type AgentMCPServerSourceSyncResponse = {
   agent?: unknown;
-  global_state?: unknown;
   source?: unknown;
 };
 
@@ -94,14 +93,13 @@ export async function fetchAgentMCPServerSourceStatus(agentID: string, name: str
 export async function syncAgentMCPServerSource(
   agentID: string,
   name: string,
-): Promise<{ agent: AgentMCPServersView; globalState: JSONRecord; source: MCPServerSourceStatus }> {
+): Promise<{ agent: AgentMCPServersView; source: MCPServerSourceStatus }> {
   const payload = await post<AgentMCPServerSourceSyncResponse>(`${agentMCPServerPath(agentID, name)}/source:sync`);
-  if (!isJSONRecord(payload?.agent) || !isJSONRecord(payload?.global_state)) {
+  if (!isJSONRecord(payload?.agent)) {
     throw new Error("Agent MCP source sync returned an invalid state");
   }
   return {
     agent: payload.agent as AgentMCPServersView,
-    globalState: payload.global_state,
     source: normalizeMCPServerSourceStatus(payload.source),
   };
 }
@@ -197,10 +195,10 @@ export function normalizeMCPServerSourceStatus(record: unknown): MCPServerSource
     configuredEndpointURL: stringFromUnknown(record.configured_endpoint_url),
     contentID,
     globalServerName: stringFromUnknown(record.global_server_name) || undefined,
-    globalUpdateAvailable: record.global_update_available === true,
     kind,
     latestEndpointURL: stringFromUnknown(record.latest_endpoint_url),
     resourceID,
+    sourceAvailable: record.source_available !== false,
     sourceDescription: stringFromUnknown(record.source_description) || undefined,
     sourceName: stringFromUnknown(record.source_name) || undefined,
     updateAvailable: record.update_available === true,

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -113,7 +113,7 @@ import type {
   RuntimeBootstrapConfig,
 } from "@/models/agents";
 import { isDirectConversation, localIdentitiesMatch, upsertUserInData } from "@/models/conversations";
-import { managedMCPServerSnapshotDiffers, mcpManagedKnowledgeBaseSource, mcpServersFromMap } from "@/models/mcp";
+import { mcpManagedKnowledgeBaseSource, mcpServersFromMap } from "@/models/mcp";
 import type { MCPServerSourceStatus } from "@/models/mcp";
 import { displayTeam, teamMemberIDs } from "@/models/tasks";
 import type { WorkspaceTeam } from "@/models/tasks";
@@ -827,25 +827,25 @@ export function useAgentController({
       ),
     [agentMCPSourceQueries, agentManagedMCPServers],
   );
-  const agentMCPSourceErrorNames = useMemo(
+  const agentMCPSourceUnavailableNames = useMemo(
     () =>
       new Set(
-        agentManagedMCPServers.filter((_, index) => agentMCPSourceQueries[index]?.isError).map((server) => server.name),
+        agentManagedMCPServers
+          .filter((server) => agentMCPSourceStatusByName[server.name]?.sourceAvailable === false)
+          .map((server) => server.name),
       ),
-    [agentMCPSourceQueries, agentManagedMCPServers],
+    [agentMCPSourceStatusByName, agentManagedMCPServers],
   );
   const agentMCPUpdateAvailableNames = useMemo(() => {
-    const catalogByName = new Map(catalogMCPServers.map((server) => [server.name, server]));
     return new Set(
       agentMCPServers
-        .filter(
-          (server) =>
-            agentMCPSourceStatusByName[server.name]?.updateAvailable ||
-            managedMCPServerSnapshotDiffers(server.config, catalogByName.get(server.name)?.config),
-        )
+        .filter((server) => {
+          const sourceStatus = agentMCPSourceStatusByName[server.name];
+          return sourceStatus?.sourceAvailable !== false && sourceStatus?.updateAvailable;
+        })
         .map((server) => server.name),
     );
-  }, [agentMCPServers, agentMCPSourceStatusByName, catalogMCPServers]);
+  }, [agentMCPServers, agentMCPSourceStatusByName]);
   const activeConversation = useMemo(
     () => data?.rooms.find((item) => item.id === activeConversationId) ?? null,
     [data, activeConversationId],
@@ -2587,25 +2587,6 @@ export function useAgentController({
     [agentMCPAddBusy, errorMessage, queryClient, agentDetailAgentID, t],
   );
 
-  const checkAgentMCPServerSource = useCallback(
-    async (server: { name?: string | null } | string | null | undefined) => {
-      const name = (typeof server === "string" ? server : String(server?.name || "")).trim();
-      if (!agentDetailAgentID || !name) {
-        return null;
-      }
-      try {
-        return await queryClient.fetchQuery({
-          queryKey: workspaceQueryKeys.agentMCPServerSource(agentDetailAgentID, name),
-          queryFn: () => fetchAgentMCPServerSourceStatus(agentDetailAgentID, name),
-          staleTime: 0,
-        });
-      } catch {
-        return null;
-      }
-    },
-    [agentDetailAgentID, queryClient],
-  );
-
   const syncAgentMCPServerSnapshot = useCallback(
     async (server: { name?: string | null } | string | null | undefined) => {
       const name = (typeof server === "string" ? server : String(server?.name || "")).trim();
@@ -2619,7 +2600,6 @@ export function useAgentController({
         const result = await syncAgentMCPServerSource(agentDetailAgentID, name);
         const mcpServers = cloneMCPServersForDraft(result.agent.servers);
         queryClient.setQueryData(workspaceQueryKeys.agentMCPServers(agentDetailAgentID), result.agent);
-        queryClient.setQueryData(workspaceQueryKeys.mcpServers(), result.globalState);
         queryClient.setQueryData(workspaceQueryKeys.agentMCPServerSource(agentDetailAgentID, name), result.source);
         setAgentPageDraft((current) => (current ? { ...current, mcpServers } : current));
         setAgentPageSavedDraft((current) => (current ? { ...current, mcpServers } : current));
@@ -2805,7 +2785,7 @@ export function useAgentController({
       mcpServers: agentMCPServers,
       mcpUpdateAvailableNames: agentMCPUpdateAvailableNames,
       mcpSourceBusyNames: agentMCPSourceBusyNames,
-      mcpSourceErrorNames: agentMCPSourceErrorNames,
+      mcpSourceUnavailableNames: agentMCPSourceUnavailableNames,
       mcpSourceSyncBusyName: agentMCPSourceSyncBusyName,
       mcpAddBusy: agentMCPAddBusy,
       mcpAddError: agentMCPAddError,
@@ -2843,7 +2823,6 @@ export function useAgentController({
       onAddSkills: batchAddAgentSkills,
       onDeleteSkill: deleteAgentSkill,
       onInstallMCPServers: installAgentMCPServers,
-      onCheckMCPServerSource: checkAgentMCPServerSource,
       onUpdateMCPServer: syncAgentMCPServerSnapshot,
       onDeleteMCPServer: deleteAgentMCPServer,
       onRetryMCPServers: refreshMCPServers,

--- a/web/app/src/models/mcp.ts
+++ b/web/app/src/models/mcp.ts
@@ -30,10 +30,10 @@ export type MCPServerSourceStatus = {
   configuredEndpointURL: string;
   contentID: string;
   globalServerName?: string;
-  globalUpdateAvailable?: boolean;
   kind: string;
   latestEndpointURL: string;
   resourceID: string;
+  sourceAvailable: boolean;
   sourceDescription?: string;
   sourceName?: string;
   updateAvailable: boolean;

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.test.tsx
@@ -358,4 +358,64 @@ describe("AgentDetailPane MCP snapshots", () => {
     await user.click(screen.getByRole("button", { name: "agentMCPUpdateConfig" }));
     expect(onUpdateMCPServer).toHaveBeenCalledWith(mcpServer);
   });
+
+  it("keeps a stale knowledge base MCP removable without offering update or retry", async () => {
+    const user = userEvent.setup();
+    const onDeleteMCPServer = vi.fn().mockResolvedValue(true);
+    const onUpdateMCPServer = vi.fn();
+    const mcpServer = {
+      name: "kb_deleted",
+      description: "Deleted knowledge base snapshot",
+      config: {
+        url: "https://old.example.test/mcp",
+        _meta: {
+          "com.opencsg/mcp": {
+            auth_type: "csghub_access_token",
+            content_id: "kb_deleted",
+            resource_id: "143",
+            type: "llm_wiki",
+          },
+        },
+      },
+    };
+    render(
+      <Harness
+        workspaceSupported
+        mcpServers={[mcpServer]}
+        mcpSourceUnavailableNames={new Set([mcpServer.name])}
+        onUpdateMCPServer={onUpdateMCPServer}
+        onDeleteMCPServer={onDeleteMCPServer}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "agentProfileMCPTab" }));
+    expect(screen.getByText("agentKnowledgeMCPSourceDeleted")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "agentMCPUpdateConfig" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "agentDeleteMCP" })).toBeEnabled();
+  });
+
+  it("keeps source-check failures silent while the saved MCP remains usable", async () => {
+    const user = userEvent.setup();
+    const mcpServer = {
+      name: "kb_unchecked",
+      description: "Saved knowledge base snapshot",
+      config: {
+        url: "https://saved.example.test/mcp",
+        _meta: {
+          "com.opencsg/mcp": {
+            auth_type: "csghub_access_token",
+            content_id: "kb_unchecked",
+            resource_id: "144",
+            type: "llm_wiki",
+          },
+        },
+      },
+    };
+    render(<Harness workspaceSupported mcpServers={[mcpServer]} />);
+
+    await user.click(screen.getByRole("button", { name: "agentProfileMCPTab" }));
+    expect(screen.queryByText("agentKnowledgeMCPSourceDeleted")).not.toBeInTheDocument();
+    expect(screen.queryByText("agentKnowledgeMCPUpdateAvailable")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "agentDeleteMCP" })).toBeEnabled();
+  });
 });

--- a/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
+++ b/web/app/src/pages/AgentPage/components/AgentDetailPane/AgentDetailPane.tsx
@@ -82,7 +82,7 @@ import {
 import type { IMConversation, TranslateFn } from "@/models/conversations";
 import type { LocaleCode } from "@/models/conversations";
 import { mcpManagedKnowledgeBaseSource } from "@/models/mcp";
-import type { MCPServer, MCPServerSourceStatus } from "@/models/mcp";
+import type { MCPServer } from "@/models/mcp";
 import { skillSourceBadgeName } from "@/models/skillhub";
 import type { SkillSummary } from "@/models/skillhub";
 import type { SlashSkillOption } from "@/models/slashCommands";
@@ -207,7 +207,7 @@ export type AgentDetailPaneProps = {
   mcpCandidatesLoading?: boolean;
   mcpServers?: MCPServer[];
   mcpSourceBusyNames?: ReadonlySet<string>;
-  mcpSourceErrorNames?: ReadonlySet<string>;
+  mcpSourceUnavailableNames?: ReadonlySet<string>;
   mcpSourceSyncBusyName?: string;
   mcpUpdateAvailableNames?: ReadonlySet<string>;
   mcpAddBusy?: boolean;
@@ -223,9 +223,6 @@ export type AgentDetailPaneProps = {
   onAddSkills?: (skillNames: string[]) => Promise<boolean> | boolean;
   onDeleteSkill?: (skill: SlashSkillOption | string) => Promise<boolean> | boolean;
   onInstallMCPServers?: (serverNames: string[]) => Promise<boolean> | boolean;
-  onCheckMCPServerSource?: (
-    server: MCPServer | string,
-  ) => Promise<MCPServerSourceStatus | null> | MCPServerSourceStatus | null;
   onUpdateMCPServer?: (server: MCPServer | string) => Promise<boolean> | boolean;
   onDeleteMCPServer?: (server: MCPServer | string) => Promise<boolean> | boolean;
   onRetryMCPServers?: () => void | Promise<unknown>;
@@ -281,7 +278,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
     mcpCandidatesLoading = false,
     mcpServers = [],
     mcpSourceBusyNames = new Set<string>(),
-    mcpSourceErrorNames = new Set<string>(),
+    mcpSourceUnavailableNames = new Set<string>(),
     mcpSourceSyncBusyName = "",
     mcpUpdateAvailableNames = new Set<string>(),
     mcpAddBusy = false,
@@ -311,7 +308,6 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
     onAddSkills,
     onDeleteSkill,
     onInstallMCPServers,
-    onCheckMCPServerSource,
     onUpdateMCPServer,
     onDeleteMCPServer,
     onRetryMCPServers,
@@ -994,7 +990,7 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                 deleteError={mcpDeleteError}
                 servers={mcpServers}
                 sourceBusyNames={mcpSourceBusyNames}
-                sourceErrorNames={mcpSourceErrorNames}
+                sourceUnavailableNames={mcpSourceUnavailableNames}
                 sourceSyncBusyName={mcpSourceSyncBusyName}
                 updateAvailableNames={mcpUpdateAvailableNames}
                 t={t}
@@ -1003,7 +999,6 @@ export const AgentDetailPane = forwardRef<AgentDetailPaneHandle, AgentDetailPane
                   setMCPPendingDelete(server);
                   setDeleteMCPDialogOpen(true);
                 }}
-                onCheckMCPSource={onCheckMCPServerSource}
                 onUpdateMCP={onUpdateMCPServer}
               />
             ) : null}
@@ -1545,11 +1540,10 @@ type AgentMCPPanelProps = {
   deleteError: string;
   onOpenAddMCP: () => void;
   onRequestDeleteMCP: (server: MCPServer) => void;
-  onCheckMCPSource?: (server: MCPServer) => Promise<MCPServerSourceStatus | null> | MCPServerSourceStatus | null;
   onUpdateMCP?: (server: MCPServer) => Promise<boolean> | boolean;
   servers: readonly MCPServer[];
   sourceBusyNames: ReadonlySet<string>;
-  sourceErrorNames: ReadonlySet<string>;
+  sourceUnavailableNames: ReadonlySet<string>;
   sourceSyncBusyName: string;
   updateAvailableNames: ReadonlySet<string>;
   t: TranslateFn;
@@ -1562,11 +1556,10 @@ function AgentMCPPanel({
   deleteError,
   onOpenAddMCP,
   onRequestDeleteMCP,
-  onCheckMCPSource,
   onUpdateMCP,
   servers,
   sourceBusyNames,
-  sourceErrorNames,
+  sourceUnavailableNames,
   sourceSyncBusyName,
   updateAvailableNames,
   t,
@@ -1621,7 +1614,7 @@ function AgentMCPPanel({
           {servers.map((server) => {
             const managedSource = Boolean(mcpManagedKnowledgeBaseSource(server.config));
             const sourceBusy = sourceBusyNames.has(server.name);
-            const sourceError = sourceErrorNames.has(server.name);
+            const sourceUnavailable = sourceUnavailableNames.has(server.name);
             const updateAvailable = updateAvailableNames.has(server.name);
             const syncBusy = sourceSyncBusyName === server.name;
             return (
@@ -1637,18 +1630,18 @@ function AgentMCPPanel({
                     ) : null}
                   </div>
                   <p>{server.description || "-"}</p>
-                  {managedSource && (updateAvailable || sourceError) ? (
+                  {managedSource && (sourceUnavailable || updateAvailable) ? (
                     <p
                       className={`agent-mcp-source-hint ${
-                        updateAvailable ? "update-available" : sourceError ? "source-error" : ""
+                        sourceUnavailable ? "source-error" : updateAvailable ? "update-available" : ""
                       }`.trim()}
                     >
-                      {updateAvailable ? t("agentKnowledgeMCPUpdateAvailable") : t("agentKnowledgeMCPCheckFailed")}
+                      {sourceUnavailable ? t("agentKnowledgeMCPSourceDeleted") : t("agentKnowledgeMCPUpdateAvailable")}
                     </p>
                   ) : null}
                 </div>
                 <div className="agent-mcp-summary-actions">
-                  {updateAvailable && !sourceError && onUpdateMCP ? (
+                  {updateAvailable && !sourceUnavailable && onUpdateMCP ? (
                     <Button
                       variant="secondaryGray"
                       size="sm"
@@ -1661,20 +1654,6 @@ function AgentMCPPanel({
                     >
                       <RefreshCw aria-hidden="true" size={14} strokeWidth={2} />
                       {t("agentMCPUpdateConfig")}
-                    </Button>
-                  ) : managedSource && sourceError && onCheckMCPSource ? (
-                    <Button
-                      variant="secondaryGray"
-                      size="sm"
-                      loading={sourceBusy}
-                      loadingLabel={t("agentMCPSourceRetry")}
-                      disabled={deleteBusy || Boolean(sourceSyncBusyName)}
-                      onClick={() => {
-                        void onCheckMCPSource(server);
-                      }}
-                    >
-                      <RefreshCw aria-hidden="true" size={14} strokeWidth={2} />
-                      {t("agentMCPSourceRetry")}
                     </Button>
                   ) : null}
                   <Tooltip content={t("agentDeleteMCP")}>

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -517,8 +517,7 @@ export const messages = {
     agentMCPEmpty: "当前没有安装 MCP servers。",
     agentKnowledgeMCPBadge: "知识库 MCP",
     agentKnowledgeMCPUpdateAvailable: "这个知识库的 MCP 配置有更新，建议更新当前 Agent。",
-    agentKnowledgeMCPCheckFailed: "暂时无法检查这个知识库的 MCP 配置，当前 Agent 仍会使用已保存的配置。",
-    agentMCPSourceRetry: "重新检查",
+    agentKnowledgeMCPSourceDeleted: "AgenticHub 知识库已删除，此 MCP 配置已失效，请从当前 Agent 中移除。",
     agentMCPUpdateConfig: "更新配置",
     agentMCPSourceSyncFailed: "同步知识库 MCP 配置失败，请稍后重试。",
     agentDeleteMCP: "删除",
@@ -2062,9 +2061,8 @@ export const messages = {
     agentKnowledgeMCPBadge: "Knowledge base MCP",
     agentKnowledgeMCPUpdateAvailable:
       "This knowledge base MCP configuration has changed. We recommend updating the current agent.",
-    agentKnowledgeMCPCheckFailed:
-      "Unable to check this knowledge base MCP configuration. The current agent will keep using its saved configuration.",
-    agentMCPSourceRetry: "Check again",
+    agentKnowledgeMCPSourceDeleted:
+      "The AgenticHub knowledge base has been deleted. This MCP configuration is no longer valid; remove it from the current agent.",
     agentMCPUpdateConfig: "Update configuration",
     agentMCPSourceSyncFailed: "Failed to sync the knowledge base MCP configuration. Please try again.",
     agentDeleteMCP: "Delete",

--- a/web/app/tests/api/mcp.test.ts
+++ b/web/app/tests/api/mcp.test.ts
@@ -146,15 +146,40 @@ describe("MCP API", () => {
       configuredEndpointURL: "https://old.example.test/mcp",
       contentID: "kb-investment",
       globalServerName: undefined,
-      globalUpdateAvailable: false,
       kind: "llm_wiki",
       latestEndpointURL: "https://current.example.test/mcp",
       resourceID: "143",
+      sourceAvailable: true,
       sourceDescription: "Investment knowledge base",
       sourceName: "Investment",
       updateAvailable: true,
     });
     expect(fetchMock).toHaveBeenCalledWith("api/v1/mcp-servers/kb-investment/source", expect.any(Object));
+  });
+
+  it("reports a deleted knowledge base source as unavailable", async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            auth_type: "csghub_access_token",
+            configured_endpoint_url: "https://old.example.test/mcp",
+            content_id: "kb-investment",
+            kind: "agentichub_knowledge_base",
+            latest_endpoint_url: "",
+            resource_id: "143",
+            source_available: false,
+            update_available: false,
+          }),
+          { status: 200 },
+        ),
+    );
+
+    await expect(fetchAgentMCPServerSourceStatus("agent-1", "kb-investment")).resolves.toMatchObject({
+      contentID: "kb-investment",
+      sourceAvailable: false,
+      updateAvailable: false,
+    });
   });
 
   it("manually syncs a managed MCP source and returns the persisted snapshot", async () => {
@@ -211,19 +236,14 @@ describe("MCP API", () => {
                 kb_investment: { url: "https://current.example.test/mcp" },
               },
             },
-            global_state: {
-              mcpServers: {
-                kb_investment: { url: "https://current.example.test/mcp" },
-              },
-            },
             source: {
               auth_type: "csghub_access_token",
               configured_endpoint_url: "https://current.example.test/mcp",
               content_id: "kb_investment",
-              global_server_name: "kb_investment",
               kind: "agentichub_knowledge_base",
               latest_endpoint_url: "https://current.example.test/mcp",
               resource_id: "143",
+              source_available: true,
               update_available: false,
             },
           }),
@@ -236,10 +256,10 @@ describe("MCP API", () => {
           auth_type: "csghub_access_token",
           configured_endpoint_url: "https://old.example.test/mcp",
           content_id: "kb_investment",
-          global_update_available: true,
           kind: "agentichub_knowledge_base",
           latest_endpoint_url: "https://current.example.test/mcp",
           resource_id: "143",
+          source_available: true,
           update_available: true,
         }),
         { status: 200 },
@@ -249,13 +269,12 @@ describe("MCP API", () => {
     await expect(fetchAgentMCPServerSourceStatus("agent-1", "kb_investment")).resolves.toMatchObject({
       agentUpdateAvailable: true,
       contentID: "kb_investment",
-      globalUpdateAvailable: true,
+      sourceAvailable: true,
       updateAvailable: true,
     });
     await expect(syncAgentMCPServerSource("agent-1", "kb_investment")).resolves.toMatchObject({
       agent: { agent_id: "agent-1", servers: { kb_investment: { url: "https://current.example.test/mcp" } } },
-      globalState: { mcpServers: { kb_investment: { url: "https://current.example.test/mcp" } } },
-      source: { globalServerName: "kb_investment", updateAvailable: false },
+      source: { sourceAvailable: true, updateAvailable: false },
     });
     expect(synced).toBe(true);
     expect(fetchMock).toHaveBeenNthCalledWith(

--- a/web/app/tests/components/HubDetailPane.test.tsx
+++ b/web/app/tests/components/HubDetailPane.test.tsx
@@ -464,6 +464,7 @@ function renderMCPDetailPane({
                   ? "https://current.example.test/mcp"
                   : "https://old.example.test/mcp",
                 resourceID: "143",
+                sourceAvailable: true,
                 updateAvailable: sourceUpdateAvailable,
               }
             : null,


### PR DESCRIPTION
- Make Codex agent restarts idempotent when the tracked process has already exited, avoiding Windows OpenProcess failures during rebuilds and configuration changes.
- Refresh an Agent's LLM Wiki MCP snapshot directly from AgenticHub metadata without depending on or mutating the global MCP catalog.
- Keep temporary source-check failures silent and show a removable stale-configuration warning when the AgenticHub knowledge base has been deleted.
