### PR TITLE
fix(web): preserve manager config during rebuild

### DIFF
--- a/web/app/src/api/agents.ts
+++ b/web/app/src/api/agents.ts
@@ -256,6 +256,7 @@ export function createManagerAgentRequest(): Promise<AgentLike> {
   const payload = {
     id: MANAGER_AGENT_ID, // Legacy contract: id: "u-manager",
     replace: true,
+    field_mask: ["id"],
   };
   return post("api/v1/agents", payload);
 }

--- a/web/app/tests/api/agents.test.ts
+++ b/web/app/tests/api/agents.test.ts
@@ -52,7 +52,7 @@ describe("agents API", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "api/v1/agents",
       expect.objectContaining({
-        body: JSON.stringify({ id: "u-manager", replace: true }),
+        body: JSON.stringify({ id: "u-manager", replace: true, field_mask: ["id"] }),
         method: "POST",
       }),
     );


### PR DESCRIPTION
## Summary

- Preserve the manager's existing configuration when rebuilding it from the Web UI.
- Add regression coverage for the manager rebuild request contract.