### PR TITLE
fix(template): normalize repository path conflicts

### DIFF
--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	defaultRemoteHTTPTimeout    = 60 * time.Second
-	defaultRemoteMaxJSONBytes   = 4 * 1024 * 1024
-	defaultRemoteMaxFileBytes   = 50 * 1024 * 1024
-	officialTemplateNamespace   = "Agentic"
-	remoteManifestFileName      = "agent.toml"
-	remoteFilePreviewMaxBytes   = 256 * 1024
-	remoteAgentTemplatesPerPage = 20
+	defaultRemoteHTTPTimeout         = 60 * time.Second
+	defaultRemoteMaxJSONBytes        = 4 * 1024 * 1024
+	defaultRemoteMaxFileBytes        = 50 * 1024 * 1024
+	officialTemplateNamespace        = "Agentic"
+	remoteRepositoryPathConflictCode = "SYS-ERR-4"
+	remoteManifestFileName           = "agent.toml"
+	remoteFilePreviewMaxBytes        = 256 * 1024
+	remoteAgentTemplatesPerPage      = 20
 )
 
 type RemoteStore struct {
@@ -945,10 +946,23 @@ func decodeRemoteAPIError(statusCode int, data []byte) *RemoteAPIError {
 			Message:    strings.TrimSpace(payload.Msg),
 		}
 		if remoteErr.Code != "" || remoteErr.Message != "" {
-			return remoteErr
+			return normalizeRemoteAPIError(remoteErr)
 		}
 	}
-	return &RemoteAPIError{StatusCode: statusCode, Message: truncateRemoteBody(data)}
+	return normalizeRemoteAPIError(&RemoteAPIError{StatusCode: statusCode, Message: truncateRemoteBody(data)})
+}
+
+func normalizeRemoteAPIError(remoteErr *RemoteAPIError) *RemoteAPIError {
+	if remoteErr == nil || strings.TrimSpace(remoteErr.Code) != "" {
+		return remoteErr
+	}
+	message := strings.ToLower(remoteErr.Message)
+	if strings.Contains(message, "idx_repositories_git_path") &&
+		strings.Contains(message, "sqlstate 23505") {
+		remoteErr.Code = remoteRepositoryPathConflictCode
+		remoteErr.Message = "repository path already exists"
+	}
+	return remoteErr
 }
 
 func (s *RemoteStore) uploadArchive(ctx context.Context, upload remoteUploadURL, archive []byte) error {

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -128,7 +128,7 @@ func TestRemoteStorePostJSONPreservesRepositoryPathConflictCode(t *testing.T) {
 	}
 }
 
-func TestRemoteStorePostJSONDoesNotInferConflictWithoutCode(t *testing.T) {
+func TestRemoteStorePostJSONNormalizesRepositoryPathConstraintViolation(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -139,8 +139,11 @@ func TestRemoteStorePostJSONDoesNotInferConflictWithoutCode(t *testing.T) {
 
 	store := NewRemoteStore(srv.URL, "token")
 	err := store.postJSON(context.Background(), srv.URL, nil, nil)
-	if errors.Is(err, ErrTemplateAlreadyExists) {
-		t.Fatalf("postJSON() error = %v, must not infer a name conflict without an upstream code", err)
+	if got, want := RemoteAPIErrorCode(err), remoteRepositoryPathConflictCode; got != want {
+		t.Fatalf("RemoteAPIErrorCode() = %q, want %q; error=%v", got, want, err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "sqlstate") {
+		t.Fatalf("postJSON() error = %v, must not expose the database error", err)
 	}
 }
 


### PR DESCRIPTION
- Normalize raw repository-path unique-constraint failures from AgenticHub into the existing `SYS-ERR-4` conflict contract so users receive an actionable localized message instead of database diagnostics.
- Keep other unstructured Hub errors unchanged to avoid misclassifying unrelated failures.
