### PR TITLE
fix: preserve text accompanying structured questions

### DIFF
--- a/internal/agentengine/runtime_adapter.go
+++ b/internal/agentengine/runtime_adapter.go
@@ -218,7 +218,7 @@ func (a *codexRuntimeAdapter) handleEvent(ctx context.Context, request TurnReque
 			return &result
 		}
 		if artifact.RequestUserInput != nil {
-			if result := emit(TurnEvent{Kind: TurnEventOutputItem, Output: &OutputItem{Kind: OutputItemRequestUserInput, Payload: *artifact.RequestUserInput}}); result != nil {
+			if result := emit(TurnEvent{Kind: TurnEventOutputItem, Text: event.Text, Output: &OutputItem{Kind: OutputItemRequestUserInput, Payload: *artifact.RequestUserInput}}); result != nil {
 				return result
 			}
 		}

--- a/internal/agentengine/structured_output_test.go
+++ b/internal/agentengine/structured_output_test.go
@@ -1,0 +1,37 @@
+package agentengine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"csgclaw/internal/activity"
+)
+
+func TestStructuredQuestionPreservesReadableOutput(t *testing.T) {
+	adapter := &codexRuntimeAdapter{}
+	var events []TurnEvent
+	var output strings.Builder
+	var files []*OutputFile
+	text := "## 交互式输出演示 - 第 1/3 步\n\n请选择工作流分支。"
+	result := adapter.handleEvent(context.Background(), TurnRequest{}, EventSinkFunc(func(_ context.Context, event TurnEvent) error {
+		events = append(events, event)
+		return nil
+	}), activity.RuntimeEvent{
+		Kind: activity.RuntimeEventStructuredOutput,
+		Text: text,
+		Payload: activity.StructuredOutputArtifact{
+			RequestUserInput: &activity.RequestUserInputArgs{Questions: []activity.RequestUserInputQuestion{{ID: "demo_kind", Header: "演示类型", Question: "请选择工作流分支。"}}},
+			ResourceLinks:    []activity.ResourceLink{{Type: "resource_link", Name: "docs", URI: "https://example.com/docs"}},
+		},
+	}, &output, &files)
+	if result != nil || len(events) != 2 {
+		t.Fatalf("result = %+v, events = %+v", result, events)
+	}
+	if events[0].Output.Kind != OutputItemRequestUserInput || events[0].Text != text {
+		t.Fatalf("question event = %+v, want readable output preserved", events[0])
+	}
+	if events[1].Output.Kind != OutputItemResourceLink || events[1].Text != "" {
+		t.Fatalf("link event = %+v, want link without duplicate text", events[1])
+	}
+}

--- a/internal/channel/csgclaw/delivery/delivery.go
+++ b/internal/channel/csgclaw/delivery/delivery.go
@@ -379,6 +379,7 @@ func (r *TranscriptRenderer) captureOutputItem(state *turnRenderState, event age
 		state.structuredUserInput = cloneRequestUserInputArgs(&args)
 		state.renderer.ApplyStructuredOutput(activity.RuntimeEvent{
 			Kind: activity.RuntimeEventStructuredOutput,
+			Text: event.Text,
 			Payload: activity.StructuredOutputArtifact{
 				RequestUserInput: cloneRequestUserInputArgs(&args),
 			},

--- a/internal/channel/csgclaw/delivery/delivery_test.go
+++ b/internal/channel/csgclaw/delivery/delivery_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"csgclaw/internal/activity"
 	"csgclaw/internal/agentengine"
 	"csgclaw/internal/channel"
 )
@@ -14,6 +15,42 @@ import (
 type recordingStore struct {
 	messages   []deliveredMessage
 	activities int
+}
+
+func TestTranscriptRendererPreservesStructuredQuestionText(t *testing.T) {
+	for _, text := range []string{"## Step 1\n\nChoose the workflow branch.", "## 交互式输出演示 - 第 2/3 步\n\n请配置验证方式。", ""} {
+		t.Run(text, func(t *testing.T) {
+			store := &recordingStore{}
+			renderer := NewTranscriptRenderer(store)
+			turn := channel.TurnContext{RoomID: "room-demo", SourceMessageID: "message-demo"}
+			for _, event := range []agentengine.TurnEvent{
+				{Kind: agentengine.TurnEventTextDelta, Text: "Earlier model commentary."},
+				{Kind: agentengine.TurnEventOutputItem, Text: text, Output: &agentengine.OutputItem{
+					Kind:    agentengine.OutputItemRequestUserInput,
+					Payload: activity.RequestUserInputArgs{Questions: []activity.RequestUserInputQuestion{{ID: "demo_kind", Header: "Demo", Question: "Which workflow?"}}},
+				}},
+				{Kind: agentengine.TurnEventOutputItem, Output: &agentengine.OutputItem{
+					Kind:    agentengine.OutputItemResourceLink,
+					Payload: activity.ResourceLink{Type: "resource_link", Name: "docs", URI: "https://example.com/docs"},
+				}},
+			} {
+				if err := renderer.Emit(context.Background(), turn, event); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := renderer.Complete(context.Background(), turn, agentengine.TurnResult{Status: agentengine.TurnSucceeded}); err != nil {
+				t.Fatal(err)
+			}
+			want := text
+			if want == "" {
+				want = "Earlier model commentary."
+			}
+			want += "\n\nLinks\n- [docs](<https://example.com/docs>)"
+			if len(store.messages) != 1 || store.messages[0].text != want {
+				t.Fatalf("messages = %+v, want %q", store.messages, want)
+			}
+		})
+	}
 }
 
 type deliveredMessage struct {


### PR DESCRIPTION
## Summary

- Preserve readable text accompanying structured questions in chat instead of replacing it with the default prompt.
- Keep resource links and existing text fallback behavior intact, with English and Chinese regression coverage.