### PR TITLE
fix(web): open file picker from Upload zip button

### DIFF
--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SkillUploadDialog.test.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SkillUploadDialog.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SkillUploadDialog } from "./SkillUploadDialog";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("SkillUploadDialog", () => {
+  it.each([false, true])("opens the ZIP picker and uploads the selected file (remote mode: %s)", async (remote) => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(true);
+    const onOpenChange = vi.fn();
+    render(
+      <SkillUploadDialog
+        open
+        busy={false}
+        error=""
+        installedSkills={[]}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        remoteInstallBusy=""
+        remoteInstallError=""
+        remoteSkills={[]}
+        remoteSkillsError=""
+        remoteSkillsHasMore={false}
+        remoteSkillsLoading={false}
+        remoteSkillsLoadingMore={false}
+        remoteSkillsSearch=""
+        t={(key) => key}
+      />,
+    );
+    if (remote) {
+      await user.click(screen.getByRole("tab", { name: "resourcesSkillRemoteInstallTab" }));
+    }
+    const openPicker = vi.spyOn(HTMLInputElement.prototype, "click");
+    await user.click(screen.getByRole("tab", { name: "resourcesSkillUploadZipTab" }));
+    expect(openPicker).toHaveBeenCalledOnce();
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    const file = new File(["skill archive"], "example.zip", { type: "application/zip" });
+    await user.upload(input!, file);
+    expect(screen.getByText("example.zip")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "resourcesSkillUploadSubmit" }));
+    expect(onSubmit).toHaveBeenCalledWith(file);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SkillUploadDialog.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceSidebar/SkillUploadDialog.tsx
@@ -180,7 +180,10 @@ export function SkillUploadDialog({
               role="tab"
               size="sm"
               variant={mode === "zip" ? "primary" : "secondaryGray"}
-              onClick={() => setMode("zip")}
+              onClick={() => {
+                setMode("zip");
+                inputRef.current?.click();
+              }}
             >
               <UploadCloud size={15} strokeWidth={2} aria-hidden="true" />
               {t("resourcesSkillUploadZipTab")}
@@ -197,6 +200,13 @@ export function SkillUploadDialog({
               {t("resourcesSkillRemoteInstallTab")}
             </Button>
           </div>
+          <input
+            ref={inputRef}
+            className={styles.fileInput}
+            type="file"
+            accept=".zip,application/zip"
+            onChange={handleFileChange}
+          />
           {mode === "zip" ? (
             <>
               <button
@@ -229,13 +239,6 @@ export function SkillUploadDialog({
                   <small>{selectedFile ? selectedFile.name : t("resourcesSkillUploadDropHint")}</small>
                 </span>
               </button>
-              <input
-                ref={inputRef}
-                className={styles.fileInput}
-                type="file"
-                accept=".zip,application/zip"
-                onChange={handleFileChange}
-              />
               {localError || error ? <div className="form-error">{localError || error}</div> : null}
             </>
           ) : (


### PR DESCRIPTION
## Summary

- Open the file picker when clicking Upload zip, including when switching from Remote install.
- Keep file selection and upload behavior intact, with regression coverage for both entry paths.