### PR TITLE
feat(agentengine): batch agent skill summaries

### DIFF
--- a/docs/tech/agent-engine-decoupling.md
+++ b/docs/tech/agent-engine-decoupling.md
@@ -54,6 +54,10 @@ Write-only credentials and model secrets are preserved when omitted, and never r
 Incremental Extension reload never reapplies them.
 Workspace browsing, logs, template publishing and model configuration use dedicated support interfaces.
 Ordinary Agent Get reads the stored resource; `ProbeRuntime` explicitly requests live observation.
+`Agents().Get` with `IncludeSkillSummaries` reads optional `Status.SkillSummaries` containing names, descriptions and per-file error codes.
+Profile uses `GET /api/v1/agents/{id}/skill-summaries` to fetch this projection in one request; full Skill files remain lazy workspace reads.
+The existing Skill/Workspace owners read top-level `SKILL.md` frontmatter with at most eight concurrent readers and a 64 KiB metadata limit.
+Results are name-sorted, cancelable, and tolerate individual unreadable or invalid metadata without exposing Runtime paths or file bodies.
 
 ## Conversations
 

--- a/docs/tech/agent-engine-decoupling.zh.md
+++ b/docs/tech/agent-engine-decoupling.zh.md
@@ -54,6 +54,10 @@ Profile/model、Skills、MCP、instructions 和 memory 的 HTTP 操作都翻译�
 增量 Extension reload 不重新执行它们。
 Workspace 浏览、日志、模板发布和模型配置由专门的支持接口提供。
 普通 Agent Get 读取已保存资源，只有 `ProbeRuntime` 显式要求实时探测。
+`Agents().Get` 的 `IncludeSkillSummaries` 选项按需返回 `Status.SkillSummaries`，包含名称、描述和单文件错误码。
+Profile 通过 `GET /api/v1/agents/{id}/skill-summaries` 一次获取摘要；完整 Skill 文件仍通过 Workspace 按需读取。
+既有 Skill/Workspace 服务只扫描顶层 `SKILL.md` 的 frontmatter，最多并发读取 8 个文件，元数据上限为 64 KiB。
+结果按名称稳定排序、支持取消，单文件不可读或格式错误不会影响其他条目，也不返回 Runtime 路径或文件正文。
 
 ## Conversations
 

--- a/internal/agentengine/agents/resource_controller.go
+++ b/internal/agentengine/agents/resource_controller.go
@@ -125,6 +125,18 @@ func (f *Controller) Create(ctx context.Context, request contract.AgentCreateReq
 }
 
 func (f *Controller) Get(ctx context.Context, agentID string, options contract.AgentGetOptions) (contract.Agent, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return contract.Agent{}, ctx.Err()
+	}
+	item, err := f.get(ctx, agentID, options)
+	if err != nil || !options.IncludeSkillSummaries {
+		return item, err
+	}
+	item.Status.SkillSummaries, err = f.Workspace().SkillSummaries(ctx, item.ID)
+	return item, err
+}
+
+func (f *Controller) get(ctx context.Context, agentID string, options contract.AgentGetOptions) (contract.Agent, error) {
 	if f == nil {
 		return contract.Agent{}, &contract.TurnError{Code: contract.ErrorAgentUnavailable, Message: "agent service is unavailable"}
 	}

--- a/internal/agentengine/agents/workspace_service.go
+++ b/internal/agentengine/agents/workspace_service.go
@@ -1,6 +1,31 @@
 package agents
 
-import "csgclaw/internal/agentengine/registry"
+import (
+	"context"
+	"csgclaw/internal/agentengine/contract"
+	"csgclaw/internal/agentengine/registry"
+	skilllocal "csgclaw/internal/skill/local"
+	"errors"
+)
+
+func (s *WorkspaceService) SkillSummaries(ctx context.Context, agentID string) ([]contract.SkillSummary, error) {
+	layout, err := s.AgentLayout(agentID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := skilllocal.ListSummaries(ctx, layout.SkillsRoot)
+	if err != nil {
+		if ctx != nil && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, errors.New("Agent skill metadata is unavailable")
+	}
+	out := make([]contract.SkillSummary, 0, len(items))
+	for _, item := range items {
+		out = append(out, contract.SkillSummary{Name: item.Name, Description: item.Description, Error: item.Error})
+	}
+	return out, nil
+}
 
 // WorkspaceService owns layout lookup, read-only browsing/export and logs.
 // It does not expose Agent lifecycle or conversation execution operations.

--- a/internal/agentengine/contract/agent.go
+++ b/internal/agentengine/contract/agent.go
@@ -33,6 +33,8 @@ type AgentGetOptions struct {
 	Reload           bool `json:"reload,omitempty"`
 	ProbeRuntime     bool `json:"probe_runtime,omitempty"`
 	IncludeDocuments bool `json:"include_documents,omitempty"`
+	// IncludeSkillSummaries reads bounded, Runtime-local metadata on demand.
+	IncludeSkillSummaries bool `json:"include_skill_summaries,omitempty"`
 	// AdoptMCPServers reads unmanaged Runtime MCP state for an explicit MCP
 	// administration operation. Runtime read failures are returned to the caller.
 	AdoptMCPServers bool `json:"adopt_mcp_servers,omitempty"`
@@ -164,6 +166,7 @@ type MCPServerConfig map[string]any
 
 // AgentStatus is observed lifecycle state and is never desired configuration.
 type AgentStatus struct {
+	SkillSummaries []SkillSummary       `json:"skill_summaries,omitempty"`
 	State          AgentState           `json:"state"`
 	RuntimeID      string               `json:"runtime_id,omitempty"`
 	RuntimeKind    string               `json:"runtime_kind,omitempty"`
@@ -176,6 +179,14 @@ type AgentStatus struct {
 	Capabilities   AgentCapabilities    `json:"capabilities,omitempty"`
 	Instructions   *InstructionsStatus  `json:"instructions,omitempty"`
 	Memory         *MemoryStatus        `json:"memory,omitempty"`
+}
+
+// SkillSummary is a read-only projection, independent of desired Skill names.
+// Error is a stable per-file code and never contains paths or file contents.
+type SkillSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 type AgentCapabilities struct {

--- a/internal/agentengine/enginetest/contract.go
+++ b/internal/agentengine/enginetest/contract.go
@@ -21,6 +21,22 @@ type InterfaceFactory func(testing.TB, []agentengine.Agent, TurnBehavior) agente
 func RunInterfaceContract(t *testing.T, factory InterfaceFactory) {
 	t.Helper()
 	runDetachedInteractionContract(t, factory)
+	t.Run("skill summaries are opt-in and cancelable", func(t *testing.T) {
+		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, nil)
+		plain, err := client.Agents().Get(context.Background(), "agent-a", agentengine.AgentGetOptions{})
+		if err != nil || plain.Status.SkillSummaries != nil {
+			t.Fatalf("unexpected eager metadata: %+v %v", plain.Status.SkillSummaries, err)
+		}
+		with, err := client.Agents().Get(context.Background(), "agent-a", agentengine.AgentGetOptions{IncludeSkillSummaries: true})
+		if err != nil || with.Status.SkillSummaries == nil || len(with.Status.SkillSummaries) != 0 {
+			t.Fatalf("empty metadata read: %+v %v", with.Status.SkillSummaries, err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := client.Agents().Get(ctx, "agent-a", agentengine.AgentGetOptions{IncludeSkillSummaries: true}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled metadata read: %v", err)
+		}
+	})
 	t.Run("required unsupported extension blocks readiness", func(t *testing.T) {
 		client := factory(t, []agentengine.Agent{contractAgent("agent-a", agentengine.AgentStateRunning, "codex")}, nil)
 		extensions := client.RuntimeExtensions("agent-a")

--- a/internal/agentengine/enginetest/memory_client.go
+++ b/internal/agentengine/enginetest/memory_client.go
@@ -330,7 +330,10 @@ func (a *memoryAgents) Create(_ context.Context, request agentengine.AgentCreate
 	return cloneAgent(item), nil
 }
 
-func (a *memoryAgents) Get(_ context.Context, agentID string, _ agentengine.AgentGetOptions) (agentengine.Agent, error) {
+func (a *memoryAgents) Get(ctx context.Context, agentID string, options agentengine.AgentGetOptions) (agentengine.Agent, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return agentengine.Agent{}, ctx.Err()
+	}
 	a.client.mu.Lock()
 	defer a.client.mu.Unlock()
 	item, ok := a.client.agents[strings.TrimSpace(agentID)]
@@ -345,7 +348,23 @@ func (a *memoryAgents) Get(_ context.Context, agentID string, _ agentengine.Agen
 	if !ok {
 		return agentengine.Agent{}, &agentengine.TurnError{Code: agentengine.ErrorAgentNotFound, Message: fmt.Sprintf("agent %q not found", agentID)}
 	}
-	return a.client.withExtensionReadinessLocked(item), nil
+	item = a.client.withExtensionReadinessLocked(item)
+	if !options.IncludeSkillSummaries {
+		item.Status.SkillSummaries = nil
+	} else {
+		metadata := make(map[string]agentengine.SkillSummary, len(item.Status.SkillSummaries))
+		for _, summary := range item.Status.SkillSummaries {
+			metadata[summary.Name] = summary
+		}
+		item.Status.SkillSummaries = make([]agentengine.SkillSummary, 0, len(item.Spec.Skills))
+		for _, name := range item.Spec.Skills {
+			summary := metadata[name]
+			summary.Name = name
+			item.Status.SkillSummaries = append(item.Status.SkillSummaries, summary)
+		}
+	}
+	sort.Slice(item.Status.SkillSummaries, func(i, j int) bool { return item.Status.SkillSummaries[i].Name < item.Status.SkillSummaries[j].Name })
+	return item, nil
 }
 
 func (a *memoryAgents) List(context.Context, agentengine.AgentListOptions) ([]agentengine.Agent, error) {
@@ -353,6 +372,7 @@ func (a *memoryAgents) List(context.Context, agentengine.AgentListOptions) ([]ag
 	defer a.client.mu.Unlock()
 	out := make([]agentengine.Agent, 0, len(a.client.agents))
 	for _, item := range a.client.agents {
+		item.Status.SkillSummaries = nil
 		out = append(out, a.client.withExtensionReadinessLocked(item))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -1135,6 +1155,7 @@ func failed(code agentengine.ErrorCode, message string) agentengine.TurnResult {
 }
 
 func cloneAgent(input agentengine.Agent) agentengine.Agent {
+	input.Status.SkillSummaries = append([]agentengine.SkillSummary(nil), input.Status.SkillSummaries...)
 	input.Spec = cloneSpec(input.Spec)
 	if input.Status.Instructions != nil {
 		status := *input.Status.Instructions

--- a/internal/agentengine/interface.go
+++ b/internal/agentengine/interface.go
@@ -24,6 +24,7 @@ type ModelView = contract.ModelView
 type ProfileDetectionResult = contract.ProfileDetectionResult
 type MCPServerConfig = contract.MCPServerConfig
 type AgentStatus = contract.AgentStatus
+type SkillSummary = contract.SkillSummary
 type AgentCapabilities = contract.AgentCapabilities
 type InstructionsStatus = contract.InstructionsStatus
 type MemoryStatus = contract.MemoryStatus

--- a/internal/api/agent_skill_summaries_test.go
+++ b/internal/api/agent_skill_summaries_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -133,5 +134,56 @@ func TestAgentSkillSummariesMemoryClientHTTP(t *testing.T) {
 	h.Routes().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/agents/missing/skill-summaries", nil))
 	if w.Code != 404 {
 		t.Fatalf("missing Agent HTTP=%d", w.Code)
+	}
+}
+
+func TestAgentSkillSummariesReadErrorsHTTP(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		invalidRoot bool
+		agentID     string
+		wantStatus  int
+		wantBody    string
+	}{
+		{name: "storage failure", invalidRoot: true, agentID: "agent-skills", wantStatus: http.StatusInternalServerError, wantBody: "Agent skill metadata is unavailable\n"},
+		{name: "missing skills directory", agentID: "agent-skills", wantStatus: http.StatusOK, wantBody: "[]\n"},
+		{name: "missing agent", agentID: "missing", wantStatus: http.StatusNotFound, wantBody: "agent not found\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := completeWorkerAgent("agent-skills", "skills")
+			item.RuntimeKind = agent.RuntimeKindCodex
+			controller := mustNewSeededServiceWithOptions(t, []agent.Agent{item}, agent.WithRuntime(fakeCompatRuntime{kind: item.RuntimeKind}))
+			layout, err := controller.AgentLayout(item.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.invalidRoot {
+				if err := os.MkdirAll(filepath.Dir(layout.SkillsRoot), 0700); err != nil {
+					t.Fatal(err)
+				}
+				// A regular file reliably makes OpenRoot fail, even when tests run as root.
+				if err := os.WriteFile(layout.SkillsRoot, []byte("not a directory"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			h := NewHandler(AgentServices{}, agentengine.New(controller), nil, nil, nil, nil, nil)
+			server := httptest.NewServer(h.Routes())
+			defer server.Close()
+			resp, err := server.Client().Get(server.URL + "/api/v1/agents/" + tc.agentID + "/skill-summaries")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != tc.wantStatus || string(body) != tc.wantBody {
+				t.Fatalf("HTTP %d %q, want %d %q", resp.StatusCode, body, tc.wantStatus, tc.wantBody)
+			}
+			if strings.Contains(string(body), layout.SkillsRoot) {
+				t.Fatal("response leaked Runtime path")
+			}
+		})
 	}
 }

--- a/internal/api/agent_skill_summaries_test.go
+++ b/internal/api/agent_skill_summaries_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"csgclaw/internal/agentengine"
+	agent "csgclaw/internal/agentengine/agents"
+	"csgclaw/internal/agentengine/enginetest"
+	"csgclaw/internal/apitypes"
+	"csgclaw/internal/auth"
+	"csgclaw/internal/im"
+	"csgclaw/internal/participant"
+	"csgclaw/internal/runtimecatalog"
+	webui "csgclaw/web"
+)
+
+// Opt-in full Profile-page verification using real HTTP/Engine metadata reads.
+func TestSkillSummariesBrowserFixture(t *testing.T) {
+	ready := os.Getenv("CSGCLAW_SKILLS_E2E_READY_FILE")
+	if ready == "" {
+		t.Skip("set CSGCLAW_SKILLS_E2E_READY_FILE for headless Profile verification")
+	}
+	t.Cleanup(stubAuthStatus(func(*http.Request) (auth.Status, error) { return auth.Status{}, nil }))
+	item := completeWorkerAgent("agent-skills", "Skills Verification")
+	item.RuntimeKind = agent.RuntimeKindCodex
+	controller := mustNewSeededServiceWithOptions(t, []agent.Agent{item}, agent.WithRuntime(fakeCompatRuntime{kind: agent.RuntimeKindCodex}))
+	layout, err := controller.AgentLayout(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 300; i++ {
+		dir := filepath.Join(layout.SkillsRoot, fmt.Sprintf("skill-%03d", i))
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(fmt.Sprintf("---\ndescription: Batch description %03d\n---\n# Body loaded only on demand\n", i)), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	engine := agentengine.New(controller)
+	h := NewHandlerWithAuth(AgentServices{Records: controller, Workspace: controller.Workspace(), Models: controller.Models(), Runtime: controller}, engine, im.NewServiceFromBootstrap(im.Bootstrap{CurrentUserID: "user-admin", Users: []im.User{{ID: "user-admin", Name: "admin", Role: "admin"}}}), nil, nil, nil, nil, "", true)
+	h.SetParticipantService(participant.NewService(participant.NewMemoryStore([]apitypes.Participant{{ID: "pt-skills", Channel: "csgclaw", Type: participant.TypeAgent, AgentID: item.ID, Name: "Skills Verification", ChannelUserRef: "user-skills", ChannelUserKind: participant.ChannelUserKindLocalUserID}}), participant.WithAgentEngine(engine)))
+	h.SetAgentRuntimeService(runtimecatalog.NewService())
+	router := h.Routes()
+	finished := make(chan struct{})
+	router.Post("/__e2e/finish", func(w http.ResponseWriter, _ *http.Request) { close(finished); w.WriteHeader(204) })
+	router.Handle("/*", webui.Handler())
+	server := httptest.NewServer(router)
+	defer server.Close()
+	data, _ := json.Marshal(map[string]string{"url": server.URL})
+	if err := os.WriteFile(ready, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-finished:
+	case <-time.After(150 * time.Second):
+		t.Fatal("browser verification timed out")
+	}
+}
+
+func TestAgentSkillSummariesThroughEngineHTTP(t *testing.T) {
+	for _, kind := range []string{agent.RuntimeKindCodex, agent.RuntimeKindOpenClawSandbox, agent.RuntimeKindPicoClawSandbox} {
+		t.Run(kind, func(t *testing.T) {
+			item := completeWorkerAgent("agent-skills", "skills")
+			item.RuntimeKind = kind
+			controller := mustNewSeededServiceWithOptions(t, []agent.Agent{item}, agent.WithRuntime(fakeCompatRuntime{kind: kind}))
+			layout, err := controller.AgentLayout(item.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < 1000; i++ {
+				dir := filepath.Join(layout.SkillsRoot, fmt.Sprintf("skill-%04d", i))
+				if err := os.MkdirAll(dir, 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(fmt.Sprintf("---\ndescription: Skill %d\n---\nprivate-body-marker", i)), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			engine := agentengine.New(controller)
+			// This endpoint needs only the Engine, not API-owned Runtime paths.
+			h := NewHandler(AgentServices{}, engine, nil, nil, nil, nil, nil)
+			w := httptest.NewRecorder()
+			h.Routes().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/agents/agent-skills/skill-summaries", nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("HTTP %d %s", w.Code, w.Body)
+			}
+			var items []agentengine.SkillSummary
+			if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+				t.Fatal(err)
+			}
+			if len(items) != 1000 || items[0].Name != "skill-0000" || items[999].Description != "Skill 999" {
+				t.Fatalf("unexpected summaries: count=%d", len(items))
+			}
+			if strings.Contains(w.Body.String(), "private-body-marker") || strings.Contains(w.Body.String(), layout.SkillsRoot) {
+				t.Fatal("summary leaked body or Runtime path")
+			}
+			plain, err := engine.Agents().Get(context.Background(), item.ID, agentengine.AgentGetOptions{})
+			if err != nil || plain.Status.SkillSummaries != nil {
+				t.Fatalf("summaries were not opt-in: %v", err)
+			}
+		})
+	}
+}
+
+func TestAgentSkillSummariesMemoryClientHTTP(t *testing.T) {
+	engine := enginetest.NewMemoryClient(agentengine.Agent{ID: "agent-skills", Spec: agentengine.AgentSpec{Name: "skills", Skills: []string{"beta", "alpha"}}, Status: agentengine.AgentStatus{SkillSummaries: []agentengine.SkillSummary{{Name: "beta", Description: "B"}, {Name: "alpha", Description: "A"}}}})
+	h := NewHandler(AgentServices{}, engine, nil, nil, nil, nil, nil)
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/agents/agent-skills/skill-summaries", nil))
+	if w.Code != 200 || !strings.Contains(w.Body.String(), `"description":"A"`) {
+		t.Fatalf("HTTP %d %s", w.Code, w.Body)
+	}
+	item, err := engine.Agents().Get(context.Background(), "agent-skills", agentengine.AgentGetOptions{IncludeSkillSummaries: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item.Status.SkillSummaries[0].Description = "mutated"
+	item, _ = engine.Agents().Get(context.Background(), "agent-skills", agentengine.AgentGetOptions{IncludeSkillSummaries: true})
+	if item.Status.SkillSummaries[0].Description != "A" {
+		t.Fatal("summary leaked mutable state")
+	}
+	w = httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/agents/missing/skill-summaries", nil))
+	if w.Code != 404 {
+		t.Fatalf("missing Agent HTTP=%d", w.Code)
+	}
+}

--- a/internal/api/agent_skills.go
+++ b/internal/api/agent_skills.go
@@ -23,7 +23,7 @@ func (h *Handler) handleAgentSkillSummaries(w http.ResponseWriter, r *http.Reque
 	}
 	item, err := h.agentEngine.Agents().Get(r.Context(), pathValue(r, "id"), agentengine.AgentGetOptions{IncludeSkillSummaries: true})
 	if err != nil {
-		writeAgentSkillsMutationError(w, err)
+		writeAgentGetError(w, err)
 		return
 	}
 	items := item.Status.SkillSummaries

--- a/internal/api/agent_skills.go
+++ b/internal/api/agent_skills.go
@@ -16,6 +16,23 @@ type batchAddAgentSkillsRequest struct {
 	Names []string `json:"names"`
 }
 
+func (h *Handler) handleAgentSkillSummaries(w http.ResponseWriter, r *http.Request) {
+	if h.agentEngine == nil {
+		http.Error(w, "agent engine is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	item, err := h.agentEngine.Agents().Get(r.Context(), pathValue(r, "id"), agentengine.AgentGetOptions{IncludeSkillSummaries: true})
+	if err != nil {
+		writeAgentSkillsMutationError(w, err)
+		return
+	}
+	items := item.Status.SkillSummaries
+	if items == nil {
+		items = []agentengine.SkillSummary{}
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
 func (h *Handler) handleAgentSkillsBatchAdd(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -45,6 +45,7 @@ func (h *Handler) registerCoreRoutes(router chi.Router) {
 				r.Get("/workspace", h.handleAgentWorkspace)
 				r.Get("/workspace/file", h.handleAgentWorkspaceFile)
 				r.Get("/skills", h.handleAgentSkills)
+				r.Get("/skill-summaries", h.handleAgentSkillSummaries)
 				r.Post("/skills:batchAdd", h.handleAgentSkillsBatchAdd)
 				r.Get("/skills/file", h.handleAgentSkillsFile)
 				r.Delete("/skills/{name}", h.handleAgentSkillDelete)

--- a/internal/skill/local/skill.go
+++ b/internal/skill/local/skill.go
@@ -22,6 +22,7 @@ var ErrSkillInvalid = errors.New("skill directory must contain SKILL.md")
 type SkillSummary struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 func SkillsRoot() (string, error) {
@@ -140,11 +141,19 @@ func skillDescription(path string) (string, error) {
 	if !ok {
 		return "", nil
 	}
+	description, err := parseSkillDescription(frontmatter)
+	if err != nil {
+		return "", fmt.Errorf("parse skill frontmatter %q: %w", path, err)
+	}
+	return description, nil
+}
+
+func parseSkillDescription(frontmatter []byte) (string, error) {
 	var meta struct {
 		Description string `yaml:"description"`
 	}
 	if err := yaml.Unmarshal(frontmatter, &meta); err != nil {
-		return "", fmt.Errorf("parse skill frontmatter %q: %w", path, err)
+		return "", err
 	}
 	return strings.TrimSpace(meta.Description), nil
 }

--- a/internal/skill/local/summaries.go
+++ b/internal/skill/local/summaries.go
@@ -1,0 +1,142 @@
+package local
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+)
+
+const summaryReadConcurrency = 8
+const maxSkillMetadataBytes = 64 * 1024
+
+// ListSummaries reads only top-level Skill metadata. Invalid individual files
+// remain visible with a path-free error; cancellation and root errors fail the read.
+func ListSummaries(ctx context.Context, root string) ([]SkillSummary, error) {
+	return listSummaries(ctx, root, readSkillSummary)
+}
+
+func listSummaries(ctx context.Context, root string, read func(context.Context, *os.Root, string) (SkillSummary, bool)) ([]SkillSummary, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	directory, err := os.OpenRoot(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return []SkillSummary{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer directory.Close()
+	file, err := directory.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	entries, err := file.ReadDir(-1)
+	_ = file.Close()
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	slices.Sort(names)
+	items := make([]SkillSummary, len(names))
+	present := make([]bool, len(names))
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	for range min(summaryReadConcurrency, len(names)) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				items[index], present[index] = read(ctx, directory, names[index])
+			}
+		}()
+	}
+enqueue:
+	for index := range names {
+		select {
+		case jobs <- index:
+		case <-ctx.Done():
+			break enqueue
+		}
+	}
+	close(jobs)
+	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]SkillSummary, 0, len(items))
+	for index, item := range items {
+		if present[index] {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
+func readSkillSummary(ctx context.Context, root *os.Root, name string) (SkillSummary, bool) {
+	item := SkillSummary{Name: name}
+	path := filepath.Join(name, skillFileName)
+	info, err := root.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return item, false
+	}
+	if err != nil || !info.Mode().IsRegular() {
+		item.Error = "metadata_unavailable"
+		return item, true
+	}
+	file, err := root.Open(path)
+	if err != nil {
+		item.Error = "metadata_unavailable"
+		return item, true
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		item.Error = "metadata_unavailable"
+		return item, true
+	}
+	reader := bufio.NewReader(io.LimitReader(file, maxSkillMetadataBytes+1))
+	line, err := reader.ReadString('\n')
+	if strings.TrimSpace(strings.TrimPrefix(line, "\ufeff")) != "---" {
+		return item, true
+	}
+	var metadata strings.Builder
+	bytesRead := len(line)
+	for err == nil && bytesRead <= maxSkillMetadataBytes {
+		if ctx.Err() != nil {
+			return item, true
+		}
+		line, err = reader.ReadString('\n')
+		bytesRead += len(line)
+		if bytesRead > maxSkillMetadataBytes {
+			break
+		}
+		if strings.TrimSpace(line) == "---" {
+			item.Description, err = parseSkillDescription([]byte(metadata.String()))
+			if err != nil {
+				item.Error = "invalid_metadata"
+			}
+			return item, true
+		}
+		metadata.WriteString(line)
+	}
+	item.Error = "invalid_metadata"
+	return item, true
+}

--- a/internal/skill/local/summaries_test.go
+++ b/internal/skill/local/summaries_test.go
@@ -1,0 +1,112 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestListSummariesMetadataIsolation(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a", "SKILL.md"), "\ufeff---\r\ndescription: >\r\n  first line\r\n  second line\r\n---\r\n"+strings.Repeat("body", 1<<19))
+	mustWriteFile(t, filepath.Join(root, "b", "SKILL.md"), "---\ndescription: [broken\n---\n")
+	mustWriteFile(t, filepath.Join(root, "c", "SKILL.md"), "# No frontmatter\n")
+	mustWriteFile(t, filepath.Join(root, "d", "SKILL.md"), "---\ndescription: "+strings.Repeat("x", maxSkillMetadataBytes)+"\n---\n")
+	mustWriteFile(t, filepath.Join(root, "a", "assets", "nested", "SKILL.md"), "---\ndescription: not a top-level skill\n---\n")
+	outside := t.TempDir()
+	mustWriteFile(t, filepath.Join(outside, "SKILL.md"), "---\ndescription: outside-secret\n---\n")
+	if err := os.Symlink(outside, filepath.Join(root, "outside")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "e"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "SKILL.md"), filepath.Join(root, "e", "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+	items, err := ListSummaries(context.Background(), root)
+	if err != nil || len(items) != 5 {
+		t.Fatalf("items=%+v err=%v", items, err)
+	}
+	if items[0].Name != "a" || items[0].Description != "first line second line" {
+		t.Fatalf("description=%+v", items[0])
+	}
+	if items[1].Error != "invalid_metadata" || items[2].Error != "" || items[2].Description != "" || items[3].Error != "invalid_metadata" || items[4].Error != "metadata_unavailable" {
+		t.Fatalf("partial failure handling=%+v", items)
+	}
+	if strings.Contains(fmt.Sprint(items), "outside-secret") {
+		t.Fatal("outside metadata leaked")
+	}
+}
+
+func TestSummaryReadsBoundedAndCanceled(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 300; i++ {
+		if err := os.Mkdir(filepath.Join(root, fmt.Sprintf("skill-%03d", i)), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	entered := make(chan struct{}, summaryReadConcurrency)
+	var calls atomic.Int32
+	done := make(chan error, 1)
+	go func() {
+		_, err := listSummaries(ctx, root, func(ctx context.Context, _ *os.Root, name string) (SkillSummary, bool) {
+			calls.Add(1)
+			entered <- struct{}{}
+			<-ctx.Done()
+			return SkillSummary{Name: name}, true
+		})
+		done <- err
+	}()
+	for range summaryReadConcurrency {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("workers did not start")
+		}
+	}
+	if calls.Load() != summaryReadConcurrency {
+		t.Fatalf("unbounded reads=%d", calls.Load())
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not stop reader")
+	}
+}
+
+func BenchmarkListSummaries(b *testing.B) {
+	for _, count := range []int{300, 1000} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			root := b.TempDir()
+			for i := 0; i < count; i++ {
+				dir := filepath.Join(root, fmt.Sprintf("skill-%04d", i))
+				if err := os.Mkdir(dir, 0700); err != nil {
+					b.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\ndescription: Example skill\n---\n# Body\n"), 0600); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ResetTimer()
+			for range b.N {
+				items, err := ListSummaries(context.Background(), root)
+				if err != nil || len(items) != count {
+					b.Fatalf("count=%d err=%v", len(items), err)
+				}
+			}
+		})
+	}
+}

--- a/web/app/src/api/agents.ts
+++ b/web/app/src/api/agents.ts
@@ -221,6 +221,12 @@ export function fetchAgentSkills(agentID: string, skillsPath = ""): Promise<Work
   return get(`api/v1/agents/${encodeURIComponent(agentID)}/skills${query ? `?${query}` : ""}`);
 }
 
+export type AgentSkillSummary = { name: string; description?: string; error?: string };
+
+export function fetchAgentSkillSummaries(agentID: string, signal?: AbortSignal): Promise<AgentSkillSummary[]> {
+  return get(`api/v1/agents/${encodeURIComponent(agentID)}/skill-summaries`, { signal });
+}
+
 export function fetchAgentSkillsFile(agentID: string, skillsPath: string): Promise<WorkspaceFile> {
   const params = new URLSearchParams({ path: skillsPath });
   return get(`api/v1/agents/${encodeURIComponent(agentID)}/skills/file?${params.toString()}`);

--- a/web/app/src/hooks/workspace/useAgentController.ts
+++ b/web/app/src/hooks/workspace/useAgentController.ts
@@ -18,8 +18,7 @@ import {
   fetchAgentProfile,
   fetchAgentProfileDefaults,
   fetchAgentMCPServers,
-  fetchAgentSkills,
-  fetchAgentSkillsFile,
+  fetchAgentSkillSummaries,
   finalizeFeishuRegistrationRequest,
   initAgentLarkCLIRequest,
   cleanupAgentLarkCLIRequest,
@@ -124,7 +123,6 @@ import {
 } from "@/models/modelProviders";
 import type { ModelProviderOption } from "@/models/modelProviders";
 import { WorkspacePaneTypes } from "@/models/routing";
-import { skillDescriptionFromMarkdown, skillOptionsFromWorkspace } from "@/models/slashCommands";
 import { useCLIProxyAuthStatuses } from "./useCLIProxyAuthStatuses";
 import { workspaceQueryKeys } from "./workspaceQueries";
 import type { MessageAction, MessageActionFeedback, MessageLike } from "@/components/business/MessageContent/types";
@@ -778,23 +776,7 @@ export function useAgentController({
   });
   const agentSkillsQuery = useQuery({
     queryKey: workspaceQueryKeys.agentSkills(agentDetailAgentID),
-    queryFn: async () => {
-      const skillsListing = await fetchAgentSkills(agentDetailAgentID);
-      const skills = skillOptionsFromWorkspace(skillsListing.entries || []);
-      return Promise.all(
-        skills.map(async (skill) => {
-          try {
-            const file = await fetchAgentSkillsFile(agentDetailAgentID, `${skill.name}/SKILL.md`);
-            return {
-              ...skill,
-              description: skillDescriptionFromMarkdown(file.content || "") || skill.description,
-            };
-          } catch {
-            return skill;
-          }
-        }),
-      );
-    },
+    queryFn: ({ signal }) => fetchAgentSkillSummaries(agentDetailAgentID, signal),
     enabled: Boolean(agentDetailAgentID),
   });
   const agentMCPServersQuery = useQuery({
@@ -804,7 +786,9 @@ export function useAgentController({
   });
   const agentSkillsError = agentSkillsQuery.error
     ? errorMessage(agentSkillsQuery.error, t("agentSkillsLoadFailed"))
-    : "";
+    : agentSkillsQuery.data?.some((skill) => skill.error)
+      ? t("agentSkillMetadataUnavailable")
+      : "";
   const agentSkillCandidates = useMemo(() => {
     const currentSkillNames = new Set((agentSkillsQuery.data ?? []).map((skill) => String(skill?.name || "").trim()));
     return (globalSkillsQuery.data ?? []).filter((skill) => {

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -532,6 +532,7 @@ export const messages = {
     agentSkillsLoading: "正在加载 skills...",
     agentSkillsEmpty: "当前没有可用 skills。",
     agentSkillsLoadFailed: "Skills 加载失败，请稍后重试。",
+    agentSkillMetadataUnavailable: "部分 Skill 描述读取失败。",
     agentWorkspaceTitle: "Workspace",
     agentWorkspaceLoading: "正在加载 workspace...",
     agentWorkspaceEmpty: "Workspace 暂无文件。",
@@ -2092,6 +2093,7 @@ export const messages = {
     agentSkillsLoading: "Loading skills...",
     agentSkillsEmpty: "No skills available yet.",
     agentSkillsLoadFailed: "Failed to load skills. Please try again later.",
+    agentSkillMetadataUnavailable: "Some skill descriptions could not be read.",
     agentWorkspaceTitle: "Workspace",
     agentWorkspaceLoading: "Loading workspace...",
     agentWorkspaceEmpty: "No workspace files yet.",
@@ -3085,7 +3087,8 @@ export const messages = {
       "AGENT-ERR-22": "The template was published and is still under review. Check the template list again later.",
       "AGENT-ERR-23":
         "The template was published but did not pass sensitive-content review. Update the affected files and publish again.",
-      "AGENT-ERR-25": "This agent template is still undergoing sensitive-content review, so the agent cannot be created.",
+      "AGENT-ERR-25":
+        "This agent template is still undergoing sensitive-content review, so the agent cannot be created.",
       "RESOURCE-ERR-1":
         "The template was published, but community deployment resources are temporarily unavailable. Try deploying again later.",
       "SENSITIVE-ERR-0":

--- a/web/app/tests/hooks/useAgentController.test.tsx
+++ b/web/app/tests/hooks/useAgentController.test.tsx
@@ -17,7 +17,7 @@ import {
   fetchAgentProfile,
   fetchAgentProfileDefaults,
   fetchAgentProfileModels,
-  fetchAgentSkills,
+  fetchAgentSkillSummaries,
   fetchAgentSkillsFile,
   patchNotificationBotRequest,
   fetchAgentWorkspace,
@@ -91,7 +91,7 @@ vi.mock("@/api/agents", async () => {
     fetchAgentProfile: vi.fn(),
     fetchAgentProfileDefaults: vi.fn(),
     fetchAgentProfileModels: vi.fn(),
-    fetchAgentSkills: vi.fn(),
+    fetchAgentSkillSummaries: vi.fn(),
     fetchAgentSkillsFile: vi.fn(),
     patchNotificationBotRequest: vi.fn(),
     fetchAgentWorkspace: vi.fn(),
@@ -340,7 +340,7 @@ describe("useAgentController", () => {
     vi.mocked(fetchAgentMCPServerSourceStatus).mockReset();
     vi.mocked(fetchAgentWorkspace).mockReset();
     vi.mocked(createUserRequest).mockReset();
-    vi.mocked(fetchAgentSkills).mockReset();
+    vi.mocked(fetchAgentSkillSummaries).mockReset();
     vi.mocked(fetchAgentSkillsFile).mockReset();
     vi.mocked(patchNotificationBotRequest).mockReset();
     vi.mocked(fetchSkills).mockReset();
@@ -403,7 +403,7 @@ describe("useAgentController", () => {
     });
     vi.mocked(fetchAgentWorkspace).mockResolvedValue({ entries: [] });
     vi.mocked(createUserRequest).mockResolvedValue({ id: "u-worker", name: "worker" });
-    vi.mocked(fetchAgentSkills).mockResolvedValue({ entries: [] });
+    vi.mocked(fetchAgentSkillSummaries).mockResolvedValue([]);
     vi.mocked(fetchAgentSkillsFile).mockResolvedValue({ content: "", path: "SKILL.md", size: 0 });
     vi.mocked(patchNotificationBotRequest).mockImplementation(async (_agentID, payload) => ({
       bot_type: "notification",
@@ -668,14 +668,14 @@ describe("useAgentController", () => {
     const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.agentViewProps.draft?.image).toBe(oldImage));
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       await result.current.agentViewProps.onUpgrade?.(oldAgent);
     });
 
     await waitFor(() => expect(result.current.agentViewProps.item?.image).toBe(latestImage));
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(2));
     expect(result.current.agentViewProps.draft?.image).toBe(latestImage);
     expect(result.current.agentViewProps.savedDraft?.image).toBe(latestImage);
     expect(runAgentActionRequest).toHaveBeenCalledWith("u-manager", "upgrade");
@@ -1142,7 +1142,7 @@ describe("useAgentController", () => {
     const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.agentViewProps.draft?.image).toBe(oldImage));
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1));
     act(() => {
       const draft = result.current.agentViewProps.draft;
       result.current.agentViewProps.onDraftChange?.({
@@ -1156,7 +1156,7 @@ describe("useAgentController", () => {
       await result.current.agentViewProps.onSave?.();
     });
 
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(2));
     expect(updateAgentRequest).toHaveBeenCalledWith(
       "u-manager",
       expect.objectContaining({ instructions: "reply briefly" }),
@@ -1337,7 +1337,7 @@ describe("useAgentController", () => {
     );
 
     await waitFor(() => expect(result.current.controller.agentViewProps.draft?.model_id).toBe("MiniMax-M2.4"));
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1));
 
     act(() => {
       const draft = result.current.controller.agentViewProps.draft;
@@ -1361,7 +1361,7 @@ describe("useAgentController", () => {
       }),
     );
     expect(result.current.refreshWorkspaceBootstrap).not.toHaveBeenCalled();
-    expect(fetchAgentSkills).toHaveBeenCalledTimes(1);
+    expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1);
   });
 
   it("saves an edited UTF-8 agent display name from the profile modal", async () => {
@@ -1585,13 +1585,20 @@ describe("useAgentController", () => {
     await waitFor(() => expect(result.current.agentViewProps.savedDraft?.model_id).toBe("MiniMax-M2.5"));
   });
 
+  it("loads hundreds of descriptions with one summary request and no file requests", async () => {
+    const skills = Array.from({ length: 300 }, (_, index) => ({
+      name: `skill-${index}`,
+      description: `Description ${index}`,
+    }));
+    vi.mocked(fetchAgentSkillSummaries).mockResolvedValue(skills);
+    const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.agentViewProps.skills).toEqual(skills));
+    expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1);
+    expect(fetchAgentSkillsFile).not.toHaveBeenCalled();
+  });
+
   it("loads global skill candidates and filters already-installed agent skills", async () => {
-    vi.mocked(fetchAgentSkills).mockResolvedValue({
-      entries: [
-        { name: "alpha", path: "alpha", type: "dir" },
-        { name: "SKILL.md", path: "alpha/SKILL.md", type: "file" },
-      ],
-    });
+    vi.mocked(fetchAgentSkillSummaries).mockResolvedValue([{ name: "alpha", description: "Alpha skill" }]);
     vi.mocked(fetchAgentSkillsFile).mockResolvedValue({
       content: "---\ndescription: Alpha skill\n---\n# Alpha\n",
       path: "alpha/SKILL.md",
@@ -1601,21 +1608,24 @@ describe("useAgentController", () => {
     const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
 
     await waitFor(() => expect(fetchSkills).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(result.current.agentViewProps.skills).toHaveLength(1));
 
     expect(result.current.agentViewProps.skillCandidates).toEqual([{ name: "beta", description: "Beta skill" }]);
   });
 
+  it("keeps skills visible when individual descriptions cannot be read", async () => {
+    vi.mocked(fetchAgentSkillSummaries).mockResolvedValue([{ name: "alpha", error: "invalid_metadata" }]);
+    const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.agentViewProps.skills).toHaveLength(1));
+    expect(result.current.agentViewProps.skillsError).toBeTruthy();
+    expect(fetchAgentSkillsFile).not.toHaveBeenCalled();
+  });
+
   it("adds selected global skills into the current agent runtime and refreshes skills", async () => {
-    vi.mocked(fetchAgentSkills)
-      .mockResolvedValueOnce({ entries: [] })
-      .mockResolvedValueOnce({
-        entries: [
-          { name: "alpha", path: "alpha", type: "dir" },
-          { name: "SKILL.md", path: "alpha/SKILL.md", type: "file" },
-        ],
-      });
+    vi.mocked(fetchAgentSkillSummaries)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ name: "alpha", description: "Alpha skill" }]);
     vi.mocked(fetchAgentSkillsFile).mockResolvedValue({
       content: "---\ndescription: Alpha skill\n---\n# Alpha\n",
       path: "alpha/SKILL.md",
@@ -1624,27 +1634,22 @@ describe("useAgentController", () => {
 
     const { result } = renderHook(() => useAgentControllerHarness().controller, { wrapper: createWrapper() });
 
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       await result.current.agentViewProps.onAddSkills?.(["alpha"]);
     });
 
     expect(batchAddAgentSkillsRequest).toHaveBeenCalledWith("u-manager", ["alpha"]);
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(2));
     expect(result.current.agentViewProps.skillAddError).toBe("");
     expect(result.current.agentViewProps.skills.map((item) => item.name)).toEqual(["alpha"]);
   });
 
   it("deletes an agent-scoped skill and refreshes the agent skill list", async () => {
-    vi.mocked(fetchAgentSkills)
-      .mockResolvedValueOnce({
-        entries: [
-          { name: "alpha", path: "alpha", type: "dir" },
-          { name: "SKILL.md", path: "alpha/SKILL.md", type: "file" },
-        ],
-      })
-      .mockResolvedValueOnce({ entries: [] });
+    vi.mocked(fetchAgentSkillSummaries)
+      .mockResolvedValueOnce([{ name: "alpha", description: "Alpha skill" }])
+      .mockResolvedValueOnce([]);
     vi.mocked(fetchAgentSkillsFile).mockResolvedValue({
       content: "---\ndescription: Alpha skill\n---\n# Alpha\n",
       path: "alpha/SKILL.md",
@@ -1660,7 +1665,7 @@ describe("useAgentController", () => {
     });
 
     expect(deleteAgentSkillRequest).toHaveBeenCalledWith("u-manager", "alpha");
-    await waitFor(() => expect(fetchAgentSkills).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchAgentSkillSummaries).toHaveBeenCalledTimes(2));
     expect(result.current.agentViewProps.skillDeleteError).toBe("");
     expect(result.current.agentViewProps.skills).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- Load Agent Profile skill names and descriptions in one Engine-backed request, keeping full file reads on demand.
- Bound metadata reads and isolate invalid files, with cancellation, stable ordering, and large-list regression coverage.