### PR TITLE
fix(codex): isolate managed agents from host model providers

### DIFF
--- a/docs/tech/config.md
+++ b/docs/tech/config.md
@@ -136,6 +136,8 @@ Recreation replaces generated configuration and model catalogs, process metadata
 Deleting the Agent still removes its complete Agent home, including memory.
 
 For complete Codex worker profiles, CSGClaw writes `~/.csgclaw/agents/<agent-name>/.codex/home/config.toml` with an OpenAI-compatible proxy provider and always sets `wire_api = "responses"` because the Codex CLI app-server path uses the Responses API.
+When the profile supplies both the model name and base URL, CSGClaw removes inherited `model_providers` from the Agent's generated configuration before adding its managed proxy provider.
+This also cleans existing Agent configuration when it is regenerated, preventing unused host providers from failing read-only mode's strict configuration checks while leaving the host Codex configuration unchanged.
 When Codex memory is enabled, CSGClaw sets `memories.min_rollout_idle_hours = 1`, the minimum supported idle window, so completed room threads become eligible for background extraction sooner.
 Because Codex skips the currently active thread, CSGClaw forks an invisible checkpoint after a successful room turn, at most once per conversation per hour, without changing the thread that continues serving the room.
 After the checkpoint has been idle for one hour, CSGClaw sends an invisible maintenance turn on the Runtime's private maintenance thread so memory extraction can run even when the user never opens another room.

--- a/docs/tech/config.zh.md
+++ b/docs/tech/config.zh.md
@@ -136,6 +136,8 @@ Memory 文件属于自动生成的 runtime state，必须始终生效的 Agent �
 删除 Agent 时仍会删除完整 Agent home，包括 memory。
 
 对于完整的 Codex worker profile，CSGClaw 会写入 `~/.csgclaw/agents/<agent-name>/.codex/home/config.toml`，其中 OpenAI 兼容代理 provider 始终使用 `wire_api = "responses"`，因为 Codex CLI 的 app-server 路径走的是 Responses API。
+当 profile 同时提供模型名称和 base URL 时，CSGClaw 会先清理 Agent 生成配置中继承的 `model_providers`，再写入自身管理的代理 provider。
+已有 Agent 重新生成配置时也会执行清理，避免未使用的宿主 provider 导致只读模式的严格配置检查失败，宿主 Codex 配置保持不变。
 启用 Codex 记忆时，CSGClaw 会设置 `memories.min_rollout_idle_hours = 1`，使用 Codex 支持的最短空闲窗口，让已结束的房间线程更早具备后台提取资格。
 由于 Codex 会跳过当前活跃线程，CSGClaw 会在房间对话轮次成功结束后创建不可见 checkpoint，每个会话每小时最多一次，同时保持原线程继续服务当前房间。
 Checkpoint 空闲满一小时后，CSGClaw 会在 Runtime 私有的 maintenance thread 上发送不可见维护轮次，因此即使用户始终不进入其他房间，也能启动记忆提取。

--- a/internal/runtime/codex/runtime_config.go
+++ b/internal/runtime/codex/runtime_config.go
@@ -444,6 +444,7 @@ func configureCodexHomeConfigWithWorkspaceForPlatformAndRuntimeOptions(
 ) string {
 	executionMode := options.ExecutionMode
 	memoryEnabled := options.MemoryMode != MemoryModeDisabled
+	providerBlock := buildProviderConfigBlock(profile)
 	content := sanitizeCopiedCodexConfigContent(existing)
 	content = strings.TrimLeft(content, "\n")
 
@@ -458,6 +459,9 @@ func configureCodexHomeConfigWithWorkspaceForPlatformAndRuntimeOptions(
 	content = stripManagedBlock(content, csgclawMemoryFeatureBeginMarker, csgclawMemoryFeatureEndMarker)
 	content = stripManagedBlock(content, csgclawMemoryConfigBeginMarker, csgclawMemoryConfigEndMarker)
 	content = stripManagedBlock(content, csgclawMCPBeginMarker, csgclawMCPEndMarker)
+	if providerBlock != "" {
+		content = stripModelProviders(content)
+	}
 	if mcpServers != nil || executionMode == ExecutionModeReadOnly {
 		content = stripTableBlocks(content, mcpServersTableHeaderRe)
 	}
@@ -517,8 +521,8 @@ func configureCodexHomeConfigWithWorkspaceForPlatformAndRuntimeOptions(
 			content = appendManagedBlock(content, "[windows]\n"+windowsSandboxBlock)
 		}
 	}
-	if block := buildProviderConfigBlock(profile); block != "" {
-		content = insertManagedBlockBeforeFirstTable(content, block)
+	if providerBlock != "" {
+		content = insertManagedBlockBeforeFirstTable(content, providerBlock)
 	}
 	if block, err := buildMCPServersBlockForExecutionMode(mcpServers, workspaceDir, executionMode); err == nil && block != "" {
 		content = appendManagedBlock(content, block)
@@ -528,6 +532,24 @@ func configureCodexHomeConfigWithWorkspaceForPlatformAndRuntimeOptions(
 		return ""
 	}
 	return strings.TrimRight(content, "\n") + "\n"
+}
+
+// stripModelProviders removes host providers when CSGClaw supplies the active
+// provider. Unused providers are still validated by Codex's strict config loader.
+func stripModelProviders(content string) string {
+	var cfg map[string]any
+	if err := toml.Unmarshal([]byte(content), &cfg); err != nil {
+		return content
+	}
+	if _, exists := cfg["model_providers"]; !exists {
+		return content
+	}
+	delete(cfg, "model_providers")
+	stripped, err := toml.Marshal(cfg)
+	if err != nil {
+		return content
+	}
+	return string(stripped)
 }
 
 func stripUserProviderDirectives(content string) string {

--- a/internal/runtime/codex/runtime_config_provider_test.go
+++ b/internal/runtime/codex/runtime_config_provider_test.go
@@ -1,0 +1,187 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+
+	agentruntime "csgclaw/internal/runtime"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func TestConfigureCodexHomeConfigManagedProviderDropsInheritedProviders(t *testing.T) {
+	const settings = `model_reasoning_effort = "high"
+developer_instructions = "Keep the example [model_providers.dongfang] in this text."
+`
+	const tables = `
+[projects."/workspace/support/打包资料"]
+trust_level = "trusted"
+
+[history]
+persistence = "save-all"
+`
+	fixtures := map[string]string{
+		"provider tables and nested settings": `
+[model_providers.dongfang]
+name = "Host provider"
+base_url = "https://host.example/v1"
+api_key = "test-only-invalid-host-key"
+[model_providers.dongfang.http_headers]
+"X-Test" = "host-header"
+[model_providers.dongfang.auth]
+command = "host-auth"
+args = [
+  "--test",
+  "--provider=dongfang",
+]
+[model_providers.another]
+name = "Another host provider"
+env_key = "HOST_API_KEY"
+`,
+		"quoted table keys": `
+[ "model_providers" . 'dongfang.custom' ] # custom host provider
+name = "Host provider"
+api_key = "test-only-invalid-host-key"
+[ 'model_providers' . "dongfang.custom" . 'http_headers' ]
+"X-Test" = "host-header"
+[model_providers."proxy"]
+name = "Stale proxy"
+api_key = "test-only-invalid-proxy-key"
+`,
+		"provider root table with inline entries": `
+[model_providers]
+dongfang = { name = "Host provider", api_key = "test-only-invalid-host-key", http_headers = { "X-Test" = "host-header" } }
+proxy = { name = "Stale proxy", api_key = "test-only-invalid-proxy-key" }
+`,
+		"root inline providers": `model_providers = { dongfang = { name = "Host provider", api_key = "test-only-invalid-host-key" }, proxy = { name = "Stale proxy", api_key = "test-only-invalid-proxy-key" } }
+`,
+		"root dotted provider keys": `model_providers.dongfang.name = "Host provider"
+"model_providers" . "dongfang" . api_key = "test-only-invalid-host-key"
+'model_providers'.dongfang.http_headers."X-Test" = "host-header"
+model_providers."proxy".name = "Stale proxy"
+`,
+	}
+	profile := agentruntime.Profile{
+		ModelID: "managed-model",
+		BaseURL: "https://managed.example/v1",
+		APIKey:  "test-only-managed-key",
+	}
+	for name, providerConfig := range fixtures {
+		for _, mode := range []string{ExecutionModeStandard, ExecutionModeReadOnly} {
+			t.Run(name+"/"+mode, func(t *testing.T) {
+				existing := settings + providerConfig + tables
+				before := parseProviderTestConfig(t, existing)
+				generated := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(existing, profile, nil, "", false, mode)
+				after := assertManagedProviderTestConfig(t, generated, profile)
+				for _, key := range []string{"model_reasoning_effort", "developer_instructions", "projects", "history"} {
+					if !reflect.DeepEqual(after[key], before[key]) {
+						t.Errorf("unrelated setting %q changed: got %#v, want %#v", key, after[key], before[key])
+					}
+				}
+				repeated := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(generated, profile, nil, "", false, mode)
+				if !reflect.DeepEqual(parseProviderTestConfig(t, repeated), after) {
+					t.Error("repeated configuration changed the generated config semantics")
+				}
+			})
+		}
+	}
+}
+
+func TestConfigureCodexHomeConfigManagedProviderCleansExistingAgentConfig(t *testing.T) {
+	profile := agentruntime.Profile{ModelID: "old-model", BaseURL: "https://old.example/v1"}
+	existing := configureCodexHomeConfig(`
+[projects."/workspace/support"]
+trust_level = "trusted"
+`, profile, nil)
+	// An existing Agent can still contain providers copied before isolation.
+	existing += `
+[model_providers.dongfang]
+api_key = "test-only-invalid-host-key"
+[model_providers.dongfang.http_headers]
+"X-Test" = "host-header"
+`
+	profile = agentruntime.Profile{ModelID: "new-model", BaseURL: "https://new.example/v1", APIKey: "test-only-managed-key"}
+	for _, mode := range []string{ExecutionModeReadOnly, ExecutionModeStandard} {
+		existing = configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(existing, profile, nil, "", false, mode)
+		parsed := assertManagedProviderTestConfig(t, existing, profile)
+		projects, ok := parsed["projects"].(map[string]any)
+		if !ok || !reflect.DeepEqual(projects["/workspace/support"], map[string]any{"trust_level": "trusted"}) {
+			t.Fatalf("project settings were changed during %s reconfiguration: %#v", mode, parsed["projects"])
+		}
+	}
+}
+
+func TestConfigureCodexHomeConfigUnmanagedProviderPreservesHostProviders(t *testing.T) {
+	const existing = `
+[model_providers.dongfang]
+name = "Host provider"
+base_url = "https://host.example/v1"
+env_key = "HOST_API_KEY"
+[model_providers.dongfang.http_headers]
+"X-Test" = "host-header"
+[projects."/workspace/support"]
+trust_level = "trusted"
+`
+	before := parseProviderTestConfig(t, existing)
+	for name, profile := range map[string]agentruntime.Profile{
+		"empty profile":    {},
+		"missing model":    {BaseURL: "https://managed.example/v1"},
+		"missing endpoint": {ModelID: "managed-model"},
+		"blank model":      {BaseURL: "https://managed.example/v1", ModelID: " "},
+		"blank endpoint":   {BaseURL: " ", ModelID: "managed-model"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, mode := range []string{ExecutionModeStandard, ExecutionModeReadOnly} {
+				generated := configureCodexHomeConfigWithWorkspaceForPlatformAndExecutionMode(existing, profile, nil, "", false, mode)
+				after := parseProviderTestConfig(t, generated)
+				if !reflect.DeepEqual(after["model_providers"], before["model_providers"]) {
+					t.Errorf("%s mode changed unmanaged providers: got %#v, want %#v", mode, after["model_providers"], before["model_providers"])
+				}
+			}
+		})
+	}
+}
+
+func parseProviderTestConfig(t *testing.T, config string) map[string]any {
+	t.Helper()
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(config), &parsed); err != nil {
+		t.Fatalf("generated configuration is not valid TOML: %v\n%s", err, config)
+	}
+	return parsed
+}
+
+func assertManagedProviderTestConfig(t *testing.T, config string, profile agentruntime.Profile) map[string]any {
+	t.Helper()
+	parsed := parseProviderTestConfig(t, config)
+	providers, ok := parsed["model_providers"].(map[string]any)
+	if !ok || len(providers) != 1 {
+		t.Fatalf("managed configuration should contain exactly one provider, got %#v", parsed["model_providers"])
+	}
+	proxy, ok := providers["proxy"].(map[string]any)
+	if !ok {
+		t.Fatalf("managed proxy missing from providers: %#v", providers)
+	}
+	for key, want := range map[string]any{
+		"name":                "OpenAI using LLM proxy",
+		"base_url":            profile.BaseURL,
+		"wire_api":            "responses",
+		"supports_websockets": false,
+	} {
+		if !reflect.DeepEqual(proxy[key], want) {
+			t.Errorf("proxy %s = %#v, want %#v", key, proxy[key], want)
+		}
+	}
+	for _, key := range []string{"api_key", "http_headers", "auth"} {
+		if value, ok := proxy[key]; ok {
+			t.Errorf("inherited proxy setting %q survived: %#v", key, value)
+		}
+	}
+	if profile.APIKey != "" && proxy["env_key"] != "OPENAI_API_KEY" {
+		t.Errorf("proxy env_key = %#v, want OPENAI_API_KEY", proxy["env_key"])
+	}
+	if parsed["model_provider"] != "proxy" || parsed["model"] != profile.ModelID {
+		t.Errorf("model selection = %#v/%#v, want proxy/%s", parsed["model_provider"], parsed["model"], profile.ModelID)
+	}
+	return parsed
+}

--- a/internal/runtime/codex/runtime_test.go
+++ b/internal/runtime/codex/runtime_test.go
@@ -2661,6 +2661,7 @@ func TestRuntimeCreateCopiesAndSanitizesHostConfig(t *testing.T) {
 	root := t.TempDir()
 	hostHome := t.TempDir()
 	t.Setenv("HOME", hostHome)
+	t.Setenv("CODEX_HOME", "")
 	if err := os.MkdirAll(filepath.Join(hostHome, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -2674,9 +2675,10 @@ func TestRuntimeCreateCopiesAndSanitizesHostConfig(t *testing.T) {
 		`name = "Stale host proxy"`,
 		`base_url = "https://stale.example/v1"`,
 		``,
-		`[model_providers.preserved]`,
-		`name = "Preserved provider"`,
-		`base_url = "https://preserved.example/v1"`,
+		`[model_providers.dongfang]`,
+		`name = "Unused host provider"`,
+		`base_url = "https://unused.example/v1"`,
+		`api_key = "unused-test-key"`,
 		``,
 		`[[skills.config]]`,
 		`name = "superpowers:brainstorming"`,
@@ -2756,8 +2758,6 @@ func TestRuntimeCreateCopiesAndSanitizesHostConfig(t *testing.T) {
 	}
 	for _, want := range []string{
 		`approval_policy = "on-request"`,
-		`[model_providers.preserved]`,
-		`base_url = "https://preserved.example/v1"`,
 		csgclawProviderBeginMarker,
 		csgclawSandboxBeginMarker,
 		csgclawMultiAgentBeginMarker,
@@ -2774,6 +2774,9 @@ func TestRuntimeCreateCopiesAndSanitizesHostConfig(t *testing.T) {
 		}
 	}
 	for _, unwanted := range []string{
+		`dongfang`,
+		`unused-test-key`,
+		`https://unused.example/v1`,
 		`stale-host-model`,
 		`stale-catalog.json`,
 		`Stale host proxy`,
@@ -2796,6 +2799,13 @@ func TestRuntimeCreateCopiesAndSanitizesHostConfig(t *testing.T) {
 	}
 	if got := parsed["approval_policy"]; got != "on-request" {
 		t.Fatalf("root approval_policy = %#v, want on-request\n%s", got, configText)
+	}
+	hostRaw, err := os.ReadFile(filepath.Join(hostHome, ".codex", configFileName))
+	if err != nil {
+		t.Fatalf("read host config: %v", err)
+	}
+	if string(hostRaw) != hostConfig {
+		t.Fatal("runtime creation changed the host Codex config")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove unused host model providers when CSGClaw manages the Agent's model, preventing strict-config startup failures in read-only mode.
- Clean both new and existing Agent configurations without changing the host Codex file, with regression tests and real Codex startup verification.