### PR TITLE
fix(server): avoid idle event stream shutdown delays

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -11,13 +11,11 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -311,9 +309,6 @@ func (c internalServeCmd) Run(ctx context.Context, run *command.Context, args []
 	defer instanceLock.Release()
 	restoreAuthDetect := applyNoAuthDetectEnv(*noAuthDetect)
 	defer restoreAuthDetect()
-
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	if *pidPath != "" {
 		if err := writePIDFile(*pidPath, os.Getpid()); err != nil {

--- a/cmd/csgclaw/main.go
+++ b/cmd/csgclaw/main.go
@@ -28,7 +28,20 @@ func run(args []string) error {
 }
 
 func executeWithSignalContext(args []string, execFn func(context.Context, []string) error) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	go func() {
+		select {
+		case <-signals:
+			// Restore default signal handling before starting cleanup so a
+			// second Ctrl+C can terminate a blocked shutdown.
+			signal.Stop(signals)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 	return execFn(ctx, args)
 }

--- a/cmd/csgclaw/main_signal_test.go
+++ b/cmd/csgclaw/main_signal_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSecondInterruptStopsBlockedShutdown(t *testing.T) {
+	if os.Getenv("CSGCLAW_TEST_BLOCKED_SHUTDOWN") == "1" {
+		_ = executeWithSignalContext(nil, func(ctx context.Context, _ []string) error {
+			fmt.Println("ready")
+			<-ctx.Done()
+			fmt.Println("stopping")
+			select {}
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSecondInterruptStopsBlockedShutdown$")
+	cmd.Env = append(os.Environ(), "CSGCLAW_TEST_BLOCKED_SHUTDOWN=1")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	scanner := bufio.NewScanner(stdout)
+	for _, want := range []string{"ready", "stopping"} {
+		if !scanner.Scan() || scanner.Text() != want {
+			t.Fatalf("subprocess output = %q, want %q; error: %v", scanner.Text(), want, scanner.Err())
+		}
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = cmd.Wait()
+	if ctx.Err() != nil {
+		t.Fatal("second Ctrl+C did not terminate blocked shutdown")
+	}
+	if err == nil {
+		t.Fatal("expected the second Ctrl+C to terminate the process by signal")
+	}
+	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGINT {
+		t.Fatalf("process exit = %v, want SIGINT", cmd.ProcessState)
+	}
+}

--- a/cmd/csgclaw/main_test.go
+++ b/cmd/csgclaw/main_test.go
@@ -9,8 +9,10 @@ import (
 
 func TestRunUsesCancelableContext(t *testing.T) {
 	called := false
+	var runCtx context.Context
 	err := executeWithSignalContext([]string{"serve"}, func(ctx context.Context, _ []string) error {
 		called = true
+		runCtx = ctx
 		if ctx == context.Background() {
 			t.Fatal("executeWithSignalContext() passed context.Background(), want signal-aware context")
 		}
@@ -33,6 +35,9 @@ func TestRunUsesCancelableContext(t *testing.T) {
 	})
 	if !called {
 		t.Fatal("execFn was not called")
+	}
+	if runCtx.Err() != context.Canceled {
+		t.Fatal("command context was not canceled after executeWithSignalContext() returned")
 	}
 	if err == nil || err.Error() != "stop" {
 		t.Fatalf("executeWithSignalContext() error = %v, want stop", err)

--- a/internal/api/event_stream_shutdown_test.go
+++ b/internal/api/event_stream_shutdown_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"csgclaw/internal/channel/feishu"
+	"csgclaw/internal/im"
+	agentruntime "csgclaw/internal/runtime"
+	"csgclaw/internal/worklease"
+)
+
+func TestFeishuEventStreamShutdownUnsubscribes(t *testing.T) {
+	service := feishu.NewService()
+	handler := &Handler{feishu: service, serverAccessToken: "shutdown-test"}
+	shutdown := make(chan struct{})
+	handler.SetEventStreamShutdown(shutdown)
+	response, done := openShutdownEventStream(t, func(w http.ResponseWriter, r *http.Request) {
+		handler.streamFeishuEvents(w, r, feishuEventTarget{IDs: []string{"pt-worker"}})
+	})
+
+	close(shutdown)
+	waitForEventStreamShutdown(t, response, done)
+	// The bus has no public subscriber count. Inspect it after the handler has
+	// returned to verify unsubscribe without adding a production API.
+	subscribers := reflect.ValueOf(service.MessageBus()).Elem().FieldByName("subscribers")
+	if got := subscribers.Len(); got != 0 {
+		t.Fatalf("subscriptions after shutdown = %d, want 0", got)
+	}
+}
+
+func TestParticipantEventStreamShutdownUnsubscribes(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	controls := worklease.NewControlBus()
+	handler := &Handler{participantBridge: bridge, workControlBus: controls}
+	shutdown := make(chan struct{})
+	handler.SetEventStreamShutdown(shutdown)
+	response, done := openShutdownEventStream(t, func(w http.ResponseWriter, r *http.Request) {
+		handler.handleParticipantEventsStream(w, r, "pt-worker")
+	})
+	if got := bridge.SubscriberCount("pt-worker"); got != 1 {
+		t.Fatalf("active subscriptions = %d, want 1", got)
+	}
+	if err := controls.StopTurn(context.Background(), agentruntime.TurnRef{ParticipantID: "pt-worker"}); err != nil {
+		t.Fatalf("active control subscription: %v", err)
+	}
+
+	close(shutdown)
+	waitForEventStreamShutdown(t, response, done)
+	if got := bridge.SubscriberCount("pt-worker"); got != 0 {
+		t.Fatalf("subscriptions after shutdown = %d, want 0", got)
+	}
+	if err := controls.StopTurn(context.Background(), agentruntime.TurnRef{ParticipantID: "pt-worker"}); !errors.Is(err, agentruntime.ErrTurnControlUnavailable) {
+		t.Fatalf("control after shutdown = %v, want no subscriber", err)
+	}
+}
+
+func TestParticipantEventStreamShutdownRequeuesBufferedEvents(t *testing.T) {
+	bridge := im.NewParticipantBridge("")
+	handler := &Handler{participantBridge: bridge}
+	shutdown := make(chan struct{})
+	handler.SetEventStreamShutdown(shutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	release := make(chan struct{})
+	writer := &shutdownBufferedEventWriter{
+		failingBotEventWriter: failingBotEventWriter{header: make(http.Header)},
+		ready:                 make(chan struct{}),
+		release:               release,
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(http.MethodGet, "/events", nil).WithContext(ctx)
+		handler.handleParticipantEventsStream(writer, req, "pt-worker")
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("handler did not stop during cleanup")
+		}
+	})
+	select {
+	case <-writer.ready:
+	case <-time.After(time.Second):
+		t.Fatal("participant stream did not subscribe")
+	}
+	room := im.Room{ID: "room-shutdown", IsDirect: true, Members: []string{"user-admin", "pt-worker"}}
+	sender := im.User{ID: "user-admin", Name: "admin"}
+	want := map[string]string{"msg-first": "first", "msg-second": "second", "msg-third": "third"}
+	for id, content := range want {
+		message := im.Message{ID: id, SenderID: sender.ID, Content: content}
+		if !bridge.EnqueueMessageEvent(room, sender, message, "pt-worker") {
+			t.Fatalf("event %s was not buffered in the active subscription", id)
+		}
+	}
+	// Shutdown can race with selecting an already-buffered event. The writer
+	// models the disconnected client so either exit path must preserve all events.
+	close(shutdown)
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("participant stream did not stop on shutdown")
+	}
+	if got := bridge.SubscriberCount("pt-worker"); got != 0 {
+		t.Fatalf("subscriptions after shutdown = %d, want 0", got)
+	}
+	events, unsubscribe := bridge.Subscribe("pt-worker")
+	defer unsubscribe()
+	for range len(want) {
+		select {
+		case event := <-events:
+			content, ok := want[event.MessageID]
+			if !ok || event.Text != content || event.RoomID != room.ID {
+				t.Fatalf("unexpected or duplicate replayed event: %+v", event)
+			}
+			delete(want, event.MessageID)
+			bridge.Ack("pt-worker", event.MessageID)
+		case <-time.After(time.Second):
+			t.Fatalf("buffered events lost on shutdown: %v", want)
+		}
+	}
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected extra replayed event: %+v", event)
+	default:
+	}
+}
+
+type shutdownBufferedEventWriter struct {
+	failingBotEventWriter
+	ready   chan struct{}
+	release <-chan struct{}
+}
+
+func (w *shutdownBufferedEventWriter) Flush() {
+	close(w.ready)
+	<-w.release
+}
+
+func openShutdownEventStream(t *testing.T, handler http.HandlerFunc) (*http.Response, <-chan struct{}) {
+	t.Helper()
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer shutdown-test")
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = response.Body.Close() })
+	if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("unexpected event stream response: %s %q", response.Status, response.Header.Get("Content-Type"))
+	}
+	if line, err := bufio.NewReader(response.Body).ReadString('\n'); err != nil || line != ": connected\n" {
+		t.Fatalf("stream greeting = %q, error = %v", line, err)
+	}
+	return response, done
+}
+
+func waitForEventStreamShutdown(t *testing.T, response *http.Response, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not return after closing the shutdown channel")
+	}
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
+		t.Fatalf("stream did not close cleanly: %v", err)
+	}
+}

--- a/internal/api/feishu.go
+++ b/internal/api/feishu.go
@@ -92,6 +92,8 @@ func (h *Handler) streamFeishuEvents(w http.ResponseWriter, r *http.Request, tar
 		select {
 		case <-r.Context().Done():
 			return
+		case <-h.eventStreamShutdown:
+			return
 		case <-ticker.C:
 			if _, err := io.WriteString(w, ": ping\n\n"); err != nil {
 				return

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -52,6 +52,7 @@ type Handler struct {
 	im                         *im.Service
 	csgclaw                    *csgclawchannel.Service
 	imBus                      *im.Bus
+	eventStreamShutdown        <-chan struct{}
 	workBus                    *worklease.Bus
 	workControlBus             *worklease.ControlBus
 	participantWork            worklease.ParticipantWorkReporter
@@ -812,6 +813,14 @@ func NewHandlerWithAuth(svc AgentServices, engine agentengine.Interface, imSvc *
 		upgradeApply:      upgrade.StartApplyHelper, workspace: svc.Workspace, agentModels: svc.Models, agentRuntime: svc.Runtime,
 	}
 	return h
+}
+
+// SetEventStreamShutdown supplies the shutdown notification for passive event
+// subscriptions. Configure it before serving requests.
+func (h *Handler) SetEventStreamShutdown(done <-chan struct{}) {
+	if h != nil {
+		h.eventStreamShutdown = done
+	}
 }
 
 func (h *Handler) SetNotificationDeliver(d notification.Fanouter) {
@@ -2989,6 +2998,8 @@ func (h *Handler) handleIMEvents(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-r.Context().Done():
+			return
+		case <-h.eventStreamShutdown:
 			return
 		case <-ticker.C:
 			if _, err := io.WriteString(w, ": ping\n\n"); err != nil {

--- a/internal/api/participant_bridge.go
+++ b/internal/api/participant_bridge.go
@@ -449,6 +449,8 @@ func (h *Handler) handleParticipantEventsStream(w http.ResponseWriter, r *http.R
 		select {
 		case <-r.Context().Done():
 			return
+		case <-h.eventStreamShutdown:
+			return
 		case <-heartbeat.C:
 			if err := writeParticipantSSEComment(w, controller, flusher, "heartbeat"); err != nil {
 				return

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -100,6 +100,10 @@ func Run(opts Options) error {
 	if opts.Context == nil {
 		opts.Context = context.Background()
 	}
+	runCtx, cancelRun := context.WithCancel(opts.Context)
+	defer cancelRun()
+	streamCtx, cancelStreams := context.WithCancel(context.Background())
+	defer cancelStreams()
 
 	listener := opts.Listener
 	if listener == nil {
@@ -111,6 +115,7 @@ func Run(opts Options) error {
 	}
 
 	handler := newHandler(opts)
+	handler.SetEventStreamShutdown(streamCtx.Done())
 	router := handler.Routes()
 	router.Handle("/*", uiFallbackHandler())
 
@@ -181,8 +186,6 @@ func Run(opts Options) error {
 		go opts.ScheduledTask.Start(opts.Context)
 	}
 
-	runCtx, cancelRun := context.WithCancel(opts.Context)
-	defer cancelRun()
 	shutdownDone := make(chan struct{})
 	var shutdownErr error
 	go func() {
@@ -192,6 +195,9 @@ func Run(opts Options) error {
 			shutdownErr = opts.BeforeShutdown(hookCtx)
 			cancel()
 		}
+		// Keep event subscriptions available to the shutdown hook, then end
+		// them while ordinary requests retain their HTTP shutdown grace period.
+		cancelStreams()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		for _, endpoint := range endpoints {

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +13,224 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"csgclaw/internal/api"
+	"csgclaw/internal/im"
 	"csgclaw/internal/mcp"
 )
+
+func TestRunStopsActiveEventStreams(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		desktop       bool
+		closeListener bool
+	}{
+		{name: "context cancellation"},
+		{name: "listener failure", closeListener: true},
+		{name: "desktop listeners", desktop: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, err := net.Listen("tcp4", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			const accessToken = "shutdown-test-token"
+			opts := Options{
+				Listener:    listener,
+				Context:     ctx,
+				IMBus:       im.NewBus(),
+				AccessToken: accessToken,
+			}
+			addresses := []string{listener.Addr().String()}
+			hookStarted := make(chan struct{})
+			releaseHook := make(chan struct{})
+			defer close(releaseHook)
+			if tt.desktop {
+				sandboxListener, err := net.Listen("tcp4", "127.0.0.1:0")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer sandboxListener.Close()
+				opts.SandboxListener = sandboxListener
+				opts.Desktop = &DesktopOptions{
+					BaseURL:           "http://" + listener.Addr().String(),
+					SessionToken:      "sssssssssssssssssssssssssssssssssssssssssss",
+					ServerAccessToken: accessToken,
+					ServerAccessHosts: []string{sandboxListener.Addr().String()},
+				}
+				addresses = append(addresses, sandboxListener.Addr().String())
+				opts.BeforeShutdown = func(ctx context.Context) error {
+					close(hookStarted)
+					select {
+					case <-releaseHook:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+			runErr := make(chan error, 1)
+			go func() { runErr <- Run(opts) }()
+			stopped := false
+			t.Cleanup(func() {
+				cancel()
+				if !stopped {
+					select {
+					case <-runErr:
+					case <-time.After(6 * time.Second):
+						t.Error("server did not stop during cleanup")
+					}
+				}
+			})
+
+			client := &http.Client{Timeout: 10 * time.Second}
+			streamsDone := make(chan error, len(addresses))
+			for _, address := range addresses {
+				req, err := http.NewRequest(http.MethodGet, "http://"+address+"/api/v1/events", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", "Bearer "+accessToken)
+				response, err := client.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+				if response.StatusCode != http.StatusOK || response.Header.Get("Content-Type") != "text/event-stream" {
+					t.Fatalf("event stream response = %s, %q", response.Status, response.Header.Get("Content-Type"))
+				}
+				go func() {
+					_, err := io.Copy(io.Discard, response.Body)
+					streamsDone <- err
+				}()
+			}
+
+			if tt.closeListener {
+				if err := listener.Close(); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				cancel()
+			}
+			if tt.desktop {
+				select {
+				case <-hookStarted:
+				case <-time.After(time.Second):
+					t.Fatal("shutdown hook did not start")
+				}
+				select {
+				case <-streamsDone:
+					t.Fatal("event stream closed before shutdown hook completed")
+				case <-time.After(50 * time.Millisecond):
+				}
+				releaseHook <- struct{}{}
+			}
+			select {
+			case err := <-runErr:
+				stopped = true
+				if tt.closeListener && !errors.Is(err, net.ErrClosed) {
+					t.Fatalf("Run() error = %v, want closed listener", err)
+				}
+				if !tt.closeListener && err != nil {
+					t.Fatalf("Run() error = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("server shutdown waited for open event streams")
+			}
+			for range addresses {
+				select {
+				case err := <-streamsDone:
+					if err != nil {
+						t.Fatalf("event stream did not close cleanly: %v", err)
+					}
+				case <-time.After(time.Second):
+					t.Fatal("event stream remained open after server shutdown")
+				}
+			}
+		})
+	}
+}
+
+func TestRunDrainsOrdinaryRequestsDuringShutdown(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ready := make(chan struct{})
+	started := make(chan struct{})
+	shutdownStarted := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- Run(Options{
+			Listener: listener,
+			Context:  ctx,
+			OnReady: func(_ *api.Handler, router chi.Router) {
+				router.Get("/inflight", func(w http.ResponseWriter, r *http.Request) {
+					close(started)
+					select {
+					case <-release:
+						w.WriteHeader(http.StatusNoContent)
+					case <-r.Context().Done():
+						w.WriteHeader(http.StatusServiceUnavailable)
+					}
+				})
+				close(ready)
+			},
+			BeforeShutdown: func(context.Context) error {
+				close(shutdownStarted)
+				return nil
+			},
+		})
+	}()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not become ready")
+	}
+	requestResult := make(chan int, 1)
+	go func() {
+		client := &http.Client{Timeout: 5 * time.Second}
+		response, err := client.Get("http://" + listener.Addr().String() + "/inflight")
+		if err != nil {
+			requestResult <- 0
+			return
+		}
+		defer response.Body.Close()
+		requestResult <- response.StatusCode
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not start")
+	}
+	cancel()
+	<-shutdownStarted
+	select {
+	case status := <-requestResult:
+		t.Fatalf("in-flight request terminated before completing: status %d", status)
+	case <-runErr:
+		t.Fatal("server returned before its in-flight request completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release <- struct{}{}
+	if status := <-requestResult; status != http.StatusNoContent {
+		t.Fatalf("in-flight request status = %d, want 204", status)
+	}
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not finish shutdown after request completed")
+	}
+}
 
 func TestNewHandlerWiresMCPService(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
@@ -67,11 +285,33 @@ func TestRunDesktopServesRendererAndSandboxOnSeparateListeners(t *testing.T) {
 				ServerAccessHosts: []string{sandboxHost},
 			},
 			Context: ctx,
-			OnReady: func(_ *api.Handler, _ chi.Router) {
+			OnReady: func(_ *api.Handler, router chi.Router) {
+				router.Get("/shutdown-probe", func(w http.ResponseWriter, r *http.Request) {
+					if r.Context().Err() != nil {
+						http.Error(w, "request canceled before shutdown hook completed", http.StatusServiceUnavailable)
+						return
+					}
+					w.WriteHeader(http.StatusNoContent)
+				})
 				close(ready)
 			},
-			BeforeShutdown: func(context.Context) error {
+			BeforeShutdown: func(ctx context.Context) error {
 				close(beforeShutdown)
+				for _, address := range []string{rendererHost, sandboxHost} {
+					req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+address+"/shutdown-probe", nil)
+					if err != nil {
+						return err
+					}
+					req.Header.Set("Authorization", "Bearer "+serverToken)
+					response, err := http.DefaultClient.Do(req)
+					if err != nil {
+						return err
+					}
+					_ = response.Body.Close()
+					if response.StatusCode != http.StatusNoContent {
+						return errors.New("HTTP requests unavailable during shutdown hook")
+					}
+				}
 				return nil
 			},
 		})


### PR DESCRIPTION
## Summary

- [#407](https://github.com/OpenCSGs/csgclaw/pull/407) (`ce7ff551`) correctly made shutdown await HTTP cleanup, but persistent event streams kept it waiting for the full five-second timeout whenever the Web UI was open.
- Close passive IM, Feishu, and participant event streams after desktop sandbox cleanup, preserving shutdown of both HTTP listeners, the five-second grace period for ordinary requests, and runtime cleanup.
- Allow a second Ctrl+C to terminate stalled cleanup in both foreground and daemon mode.
- Validated end to end with open event streams, in-flight request completion, desktop shutdown ordering, and child-process cleanup.