### PR TITLE
feat(web): add sandboxed HTML attachment previews

### DIFF
--- a/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewContent.tsx
+++ b/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewContent.tsx
@@ -6,6 +6,7 @@ import { documentPreviewKind, formatPreviewText } from "./previewTypes";
 import { syntaxLanguageForFile } from "./syntaxLanguages";
 
 const DocxPreview = lazy(() => import("./DocxPreview"));
+const HtmlPreview = lazy(() => import("./HtmlPreview"));
 const PdfPreview = lazy(() => import("./PdfPreview"));
 const PowerPointPreview = lazy(() => import("./PowerPointPreview"));
 const SpreadsheetPreview = lazy(() => import("./SpreadsheetPreview"));
@@ -28,7 +29,7 @@ export function DocumentPreviewContent({
 }) {
   const kind = documentPreviewKind(item, data);
   const text = useMemo(
-    () => (kind === "markdown" || kind === "text" ? formatPreviewText(data, item.mediaType) : ""),
+    () => (kind === "html" || kind === "markdown" || kind === "text" ? formatPreviewText(data, item.mediaType) : ""),
     [data, item.mediaType, kind],
   );
   const syntaxLanguage = useMemo(
@@ -51,6 +52,13 @@ export function DocumentPreviewContent({
   }
   if (kind === "markdown") {
     return <MarkdownPreview scale={scale} text={text} t={t} />;
+  }
+  if (kind === "html") {
+    return (
+      <Suspense fallback={loading}>
+        <HtmlPreview scale={scale} text={text} t={t} />
+      </Suspense>
+    );
   }
   if (kind === "text") {
     if (syntaxLanguage) {

--- a/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewPanel.css
+++ b/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewPanel.css
@@ -252,6 +252,32 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
+.document-preview-html-shell {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: var(--surface);
+}
+
+.document-preview-html-frame-wrap {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background: var(--surface);
+}
+
+.document-preview-html-frame {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  display: block;
+  border: 0;
+  background: var(--surface);
+}
+
 .document-preview-markdown-main {
   min-width: 0;
   min-height: 0;

--- a/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewPanel.tsx
+++ b/web/app/src/components/business/DocumentPreviewPanel/DocumentPreviewPanel.tsx
@@ -112,7 +112,11 @@ export function DocumentPreviewPanel({
     void load
       .then(async (blob) => {
         const initialKind = documentPreviewKind(item);
-        const limitTextBytes = initialKind === "markdown" || initialKind === "text" || initialKind === "unsupported";
+        const limitTextBytes =
+          initialKind === "html" ||
+          initialKind === "markdown" ||
+          initialKind === "text" ||
+          initialKind === "unsupported";
         const truncated = limitTextBytes && blob.size > MAX_TEXT_PREVIEW_BYTES;
         const previewBlob = limitTextBytes ? blob.slice(0, MAX_TEXT_PREVIEW_BYTES) : blob;
         const buffer = initialKind === "image" ? new ArrayBuffer(0) : await previewBlob.arrayBuffer();

--- a/web/app/src/components/business/DocumentPreviewPanel/HtmlPreview.tsx
+++ b/web/app/src/components/business/DocumentPreviewPanel/HtmlPreview.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from "react";
+import DOMPurify from "dompurify";
+import { SyntaxHighlightedText } from "./SyntaxHighlightedText";
+
+const htmlPreviewCSP = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "img-src data: blob:",
+  "media-src data: blob:",
+  "font-src data:",
+  "style-src 'unsafe-inline'",
+].join("; ");
+
+const urlAttributes = ["action", "background", "cite", "formaction", "href", "poster", "src", "xlink:href"];
+
+function isSafeEmbeddedURL(attribute: string, value: string): boolean {
+  const normalized = value.trim();
+  if (attribute === "href" || attribute === "xlink:href") {
+    return normalized.startsWith("#");
+  }
+  return /^(?:blob:|data:(?:audio\/|video\/|image\/(?:avif|gif|jpeg|png|webp)(?:[;,]|$)))/i.test(normalized);
+}
+
+function sanitizeInlineCSS(css: string): string {
+  return css
+    .replace(/@import\s+[^;]+;?/gi, "")
+    .replace(/url\(\s*(['"]?)(.*?)\1\s*\)/gi, (match, _quote: string, url: string) =>
+      isSafeEmbeddedURL("src", url) ? match : "none",
+    );
+}
+
+function sanitizedHTMLFragment(source: string): string {
+  const sourceDocument = new DOMParser().parseFromString(source, "text/html");
+  const styles = Array.from(sourceDocument.querySelectorAll("style"))
+    .map((style) => style.textContent ?? "")
+    .join("\n");
+  sourceDocument.querySelectorAll("style").forEach((style) => style.remove());
+  const sanitized = DOMPurify.sanitize(sourceDocument.body.innerHTML, {
+    // Preserve anchors such as id="forms". This markup is only loaded into an
+    // opaque-origin, script-disabled sandbox, never inserted into the app DOM.
+    SANITIZE_DOM: false,
+    FORBID_ATTR: ["srcdoc"],
+    FORBID_TAGS: ["base", "embed", "iframe", "link", "meta", "object", "script"],
+  });
+  const template = document.createElement("template");
+  template.innerHTML = sanitized;
+  template.content.querySelectorAll<Element>("*").forEach((element) => {
+    element.removeAttribute("srcset");
+    if (element.matches("a, area")) {
+      element.setAttribute("target", "_self");
+      element.removeAttribute("download");
+      element.removeAttribute("ping");
+    }
+    let blockedMediaSource = false;
+    urlAttributes.forEach((attribute) => {
+      const value = element.getAttribute(attribute);
+      if (value !== null && !isSafeEmbeddedURL(attribute, value)) {
+        element.removeAttribute(attribute);
+        if (attribute === "src" && element.matches("audio, img, source, video")) {
+          blockedMediaSource = true;
+        }
+      }
+    });
+    if (element.matches("a, area")) {
+      // srcdoc otherwise resolves fragment links against the parent app URL.
+      for (const attribute of ["href", "xlink:href"]) {
+        const fragment = element.getAttribute(attribute)?.trim();
+        if (fragment?.startsWith("#")) {
+          element.setAttribute(attribute, `about:srcdoc${fragment}`);
+        }
+      }
+    }
+    if (blockedMediaSource) {
+      element.remove();
+      return;
+    }
+    const style = element.getAttribute("style");
+    if (style !== null) {
+      const safeStyle = sanitizeInlineCSS(style).trim();
+      if (safeStyle) {
+        element.setAttribute("style", safeStyle);
+      } else {
+        element.removeAttribute("style");
+      }
+    }
+  });
+  const safeStyles = sanitizeInlineCSS(styles).trim();
+  return `${safeStyles ? `<style>${safeStyles}</style>` : ""}${template.innerHTML}`;
+}
+
+function htmlPreviewDocument(source: string, scale: number): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${htmlPreviewCSP}">
+<style>
+  :root { color-scheme: light; zoom: ${scale}; }
+  html { min-height: 100%; background: #fff; color: #111827; }
+  body { min-height: 100%; margin: 0; padding: 24px; box-sizing: border-box; overflow-wrap: anywhere; }
+  img, video { max-width: 100%; height: auto; }
+</style>
+</head>
+<body>${sanitizedHTMLFragment(source)}</body>
+</html>`;
+}
+
+export default function HtmlPreview({ scale, text, t }: { scale: number; text: string; t: (key: string) => string }) {
+  const [mode, setMode] = useState<"preview" | "source">("preview");
+  const srcDoc = useMemo(() => htmlPreviewDocument(text, scale), [scale, text]);
+
+  return (
+    <div className="document-preview-html-shell">
+      <div className="document-preview-mode-switch" role="tablist" aria-label={t("attachmentPreviewViewMode")}>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "preview"}
+          className={mode === "preview" ? "active" : ""}
+          onClick={() => setMode("preview")}
+        >
+          {t("workspacePreviewPreviewTab")}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "source"}
+          className={mode === "source" ? "active" : ""}
+          onClick={() => setMode("source")}
+        >
+          {t("workspacePreviewCodeTab")}
+        </button>
+      </div>
+      {mode === "preview" ? (
+        <div className="document-preview-html-frame-wrap">
+          <iframe
+            className="document-preview-html-frame"
+            referrerPolicy="no-referrer"
+            sandbox=""
+            srcDoc={srcDoc}
+            title={t("attachmentPreviewHtmlDocument")}
+          />
+        </div>
+      ) : (
+        <SyntaxHighlightedText language="html" scale={scale} text={text} t={t} />
+      )}
+    </div>
+  );
+}

--- a/web/app/src/components/business/DocumentPreviewPanel/previewTypes.ts
+++ b/web/app/src/components/business/DocumentPreviewPanel/previewTypes.ts
@@ -2,6 +2,7 @@ import type { AttachmentPreviewItem } from "@/models/attachments";
 import type { PreviewKind } from "./types";
 
 const mediaKinds = new Map<string, PreviewKind>([
+  ["application/xhtml+xml", "html"],
   ["application/pdf", "pdf"],
   ["application/json", "text"],
   ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"],
@@ -9,6 +10,7 @@ const mediaKinds = new Map<string, PreviewKind>([
   ["application/vnd.ms-excel", "spreadsheet"],
   ["application/vnd.openxmlformats-officedocument.presentationml.presentation", "powerpoint"],
   ["text/csv", "text"],
+  ["text/html", "html"],
   ["text/markdown", "markdown"],
   ["text/plain", "text"],
 ]);
@@ -16,6 +18,8 @@ const mediaKinds = new Map<string, PreviewKind>([
 const extensionKinds = new Map<string, PreviewKind>([
   ["csv", "text"],
   ["docx", "docx"],
+  ["htm", "html"],
+  ["html", "html"],
   ["jpeg", "image"],
   ["jpg", "image"],
   ["json", "text"],
@@ -29,6 +33,7 @@ const extensionKinds = new Map<string, PreviewKind>([
   ["webp", "image"],
   ["xls", "spreadsheet"],
   ["xlsx", "spreadsheet"],
+  ["xhtml", "html"],
 ]);
 
 type TextEncoding = "utf-16be" | "utf-16le" | "utf-8";

--- a/web/app/src/components/business/DocumentPreviewPanel/types.ts
+++ b/web/app/src/components/business/DocumentPreviewPanel/types.ts
@@ -13,4 +13,13 @@ export type DocumentPreviewPanelProps = DocumentPreviewRequest & {
   t: (key: string, params?: Record<string, string | number>) => string;
 };
 
-export type PreviewKind = "docx" | "image" | "markdown" | "pdf" | "powerpoint" | "spreadsheet" | "text" | "unsupported";
+export type PreviewKind =
+  | "docx"
+  | "html"
+  | "image"
+  | "markdown"
+  | "pdf"
+  | "powerpoint"
+  | "spreadsheet"
+  | "text"
+  | "unsupported";

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -861,6 +861,7 @@ export const messages = {
     attachmentPreview: "附件预览",
     attachmentPreviewDescription: "在应用内预览附件内容。",
     attachmentPreviewLoading: "正在加载附件预览…",
+    attachmentPreviewHtmlDocument: "HTML 文档预览",
     attachmentPreviewFailed: "无法加载附件预览，请下载后重试。",
     attachmentPreviewTruncated: "文件较大，仅显示前 256 KiB。下载文件可查看完整内容。",
     attachmentPreviewUnavailable: "此文件类型无法直接预览，可以下载后使用系统应用打开。",
@@ -2432,6 +2433,7 @@ export const messages = {
     attachmentPreview: "Attachment preview",
     attachmentPreviewDescription: "Preview the attachment without leaving the app.",
     attachmentPreviewLoading: "Loading attachment preview…",
+    attachmentPreviewHtmlDocument: "HTML document preview",
     attachmentPreviewFailed: "Unable to load the attachment preview. Download the file to try again.",
     attachmentPreviewTruncated:
       "This file is large, so only the first 256 KiB is shown. Download it to view the full content.",

--- a/web/app/tests/components/DocumentPreviewPanel.test.tsx
+++ b/web/app/tests/components/DocumentPreviewPanel.test.tsx
@@ -74,6 +74,7 @@ const t = (key: string, params?: Record<string, string | number>) => {
     attachmentPreviewFailed: "Preview failed",
     attachmentPreviewFit: "Fit",
     attachmentPreviewFullscreen: "Fullscreen",
+    attachmentPreviewHtmlDocument: "HTML preview document",
     attachmentPreviewExitFullscreen: "Exit fullscreen",
     attachmentPreviewLoading: "Loading preview",
     attachmentPreviewOutline: "Document outline",
@@ -89,6 +90,8 @@ const t = (key: string, params?: Record<string, string | number>) => {
     attachmentsScrollPrevious: "Previous file",
     close: "Close",
     downloadAttachment: "Download",
+    workspacePreviewCodeTab: "Code",
+    workspacePreviewPreviewTab: "Preview",
   };
   return labels[key] ?? `${key}${params ? JSON.stringify(params) : ""}`;
 };
@@ -202,6 +205,64 @@ describe("DocumentPreviewPanel", () => {
     );
     expect(container.querySelector(".document-preview-shiki")).toHaveAttribute("data-language", "toml");
     expect(screen.queryByText("Preview unavailable")).not.toBeInTheDocument();
+  });
+
+  it("renders HTML in an isolated frame and keeps executable content in source mode only", async () => {
+    const user = userEvent.setup();
+    const source = `<!doctype html>
+      <html>
+        <head><style>h1 { color: teal; background-image: url(https://tracker.example/pixel); }</style></head>
+        <body>
+          <h1 onclick="window.hacked = true">Safe report</h1>
+          <a href="#details" target="_blank" download ping="https://tracker.example/ping">Details</a>
+          <section id="details">Report details</section>
+          <a href="#forms">Forms</a><section id="forms">Form section</section>
+          <a href="data:text/html,unexpected">Unsupported navigation</a>
+          <img src="https://tracker.example/image.png" alt="remote">
+          <script>window.hacked = true</script>
+        </body>
+      </html>`;
+    const { container } = render(
+      <DocumentPreviewPanel
+        index={0}
+        items={[
+          {
+            file: new File([source], "report.html", { type: "text/html" }),
+            id: "html",
+            mediaType: "text/html",
+            name: "report.html",
+            sizeBytes: source.length,
+          },
+        ]}
+        t={t}
+        onClose={() => {}}
+        onIndexChange={() => {}}
+      />,
+    );
+
+    const frame = await screen.findByTitle("HTML preview document");
+    const frameDocument = frame.getAttribute("srcdoc") ?? "";
+    const parsed = new DOMParser().parseFromString(frameDocument, "text/html");
+    expect(parsed.querySelector('a[href="about:srcdoc#details"]')?.getAttribute("target")).toBe("_self");
+    expect(parsed.querySelector('a[href="about:srcdoc#details"]')?.hasAttribute("download")).toBe(false);
+    expect(parsed.querySelector('a[href^="data:"]')).toBeNull();
+    expect(parsed.getElementById("forms")?.textContent).toBe("Form section");
+    expect(parsed.querySelector('a[href="about:srcdoc#forms"]')).not.toBeNull();
+    expect(frame).toHaveAttribute("sandbox", "");
+    expect(frame).toHaveAttribute("referrerpolicy", "no-referrer");
+    expect(frameDocument).toContain("Content-Security-Policy");
+    expect(frameDocument).toContain("Safe report");
+    expect(frameDocument).toContain("color: teal");
+    expect(frameDocument).not.toContain('alt="remote"');
+    expect(frameDocument).not.toContain("window.hacked");
+    expect(frameDocument).not.toContain("tracker.example");
+
+    await user.click(screen.getByRole("tab", { name: "Code" }));
+    await waitFor(() =>
+      expect(container.querySelector('.document-preview-shiki[data-language="html"]')).toHaveTextContent(
+        "window.hacked = true",
+      ),
+    );
   });
 
   it("syntax-highlights Go source with dual light and dark theme tokens", async () => {

--- a/web/app/tests/models/documentPreview.test.ts
+++ b/web/app/tests/models/documentPreview.test.ts
@@ -8,6 +8,9 @@ import {
 describe("document preview helpers", () => {
   it.each([
     ["application/pdf", "file.bin", "pdf"],
+    ["text/html", "file.bin", "html"],
+    ["application/xhtml+xml", "file.bin", "html"],
+    ["application/octet-stream", "report.html", "html"],
     ["application/octet-stream", "report.md", "markdown"],
     ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "file", "docx"],
     ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "file", "spreadsheet"],


### PR DESCRIPTION
## Summary

- Render HTML attachments with inline styles and a highlighted source view.
- Keep in-page links inside the preview while blocking scripts and external resources.

## Screenshots

<img width="691" height="953" alt="image" src="https://github.com/user-attachments/assets/0e8de4cd-20ca-47c2-b980-3475d7b58521" />

<img width="692" height="952" alt="image" src="https://github.com/user-attachments/assets/3aa3a104-146f-4649-8faa-d7436131f726" />
