### PR TITLE
fix: raise file limits and expire attachment warnings

### DIFF
--- a/docs/tech/api.md
+++ b/docs/tech/api.md
@@ -803,7 +803,7 @@ Response fields:
 Notes:
 
 - Non-UTF-8 files return `binary=true`
-- Text content larger than `256 KiB` is truncated and returned with `truncated=true`
+- Text content larger than `32 MiB` is truncated and returned with `truncated=true`
 - Absolute paths and `..` traversal are rejected
 
 ## CLIProxy Auth API
@@ -1094,6 +1094,7 @@ Notes:
 - A thread reply also publishes `thread.updated`
 - To send attachments, use `multipart/form-data` with a `payload` JSON part containing the same fields and one or more `files` parts.
 - Attachment-only messages are valid when at least one file is present.
+- A message accepts up to 10 attachments, with a maximum of `100 MiB` per file and `256 MiB` in total.
 - Each returned message can include `attachments` with `id`, `name`, `kind`, `media_type`, `size_bytes`, `sha256`, `created_at`, `download_url`, optional `preview_url`, optional image dimensions, and optional `workspace_path` for agent-facing deliveries.
 
 Multipart example:
@@ -1112,6 +1113,8 @@ The `download_url` returned in attachment metadata includes an attachment-scoped
 Callers may instead request the bare path with the configured server Bearer token.
 
 The endpoint serves the original bytes with the stored media type and `X-Content-Type-Options: nosniff`.
+
+Downloads return the complete stored file without an additional size limit and support HTTP Range requests.
 
 Treat the capability URL as a secret and avoid sharing it outside the room context.
 

--- a/docs/tech/api.zh.md
+++ b/docs/tech/api.zh.md
@@ -784,7 +784,7 @@ Codex Worker 目前保存 `execution_mode` 和 `memory_mode`，不会保存 `loc
 说明：
 
 - 非 UTF-8 文件会返回 `binary=true`
-- 超过 `256 KiB` 的文本内容会被截断，并返回 `truncated=true`
+- 超过 `32 MiB` 的文本内容会被截断，并返回 `truncated=true`
 - 不允许绝对路径或 `..` 越界路径
 
 ## CLIProxy Auth API
@@ -1072,6 +1072,7 @@ Agent 回复仍只会唤醒被显式提及的 Agent，以防止回复循环。
 - thread reply 还会发布 `thread.updated`
 - 发送附件时使用 `multipart/form-data`，其中 `payload` JSON part 包含同样字段，`files` part 可以出现一次或多次。
 - 至少带有一个文件时允许发送纯附件消息。
+- 每条消息最多包含 10 个附件，单文件上限为 `100 MiB`，总大小上限为 `256 MiB`。
 - 返回的 message 可以包含 `attachments`，字段包括 `id`、`name`、`kind`、`media_type`、`size_bytes`、`sha256`、`created_at`、`download_url`、可选的 `preview_url`、可选图片尺寸，以及面向 agent 投递时可选的 `workspace_path`。
 
 Multipart 示例：
@@ -1090,6 +1091,8 @@ files=@diagram.png;type=image/png
 调用方也可以使用配置的服务端 Bearer token 请求不带 capability token 的基础路径。
 
 该接口会使用存储的 media type 返回原始字节，并设置 `X-Content-Type-Options: nosniff`。
+
+下载会返回完整的已存储文件，不设置额外的大小上限，并支持 HTTP Range 请求。
 
 请将 capability URL 视为敏感信息，不要在 room 上下文之外共享。
 

--- a/internal/agentworkspace/list_test.go
+++ b/internal/agentworkspace/list_test.go
@@ -47,7 +47,7 @@ func TestReadFileTrimsIncompleteUTF8Preview(t *testing.T) {
 		t.Fatal("Binary = true, want false")
 	}
 	if got.Content != prefix {
-		t.Fatalf("content = %q, want %q", got.Content, prefix)
+		t.Fatalf("content bytes = %d, want %d original prefix bytes", len(got.Content), len(prefix))
 	}
 }
 

--- a/internal/api/attachment_limits_test.go
+++ b/internal/api/attachment_limits_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"csgclaw/internal/im"
+)
+
+func TestAttachmentAboveFormerLimitUploadsAndDownloadsOverHTTP(t *testing.T) {
+	imSvc, err := im.NewServiceFromPath(filepath.Join(t.TempDir(), "im", "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, _, err := imSvc.EnsureAgentUser(im.EnsureAgentUserRequest{ID: "worker", Name: "worker", Role: "worker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	room, err := imSvc.CreateRoom(im.CreateRoomRequest{
+		Title: "Large attachment", CreatorID: "user-admin", MemberIDs: []string{worker.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := &Handler{im: imSvc, participantBridge: im.NewParticipantBridge(""), serverAccessToken: "secret"}
+	server := httptest.NewServer(handler.Routes())
+	t.Cleanup(server.Close)
+	client := server.Client()
+	payload := bytes.Repeat([]byte("large-file-data\n"), (26*1024*1024)/16)
+	wantHash := sha256.Sum256(payload)
+	body, contentType := multipartMessageBodyForTest(t, map[string]any{
+		"room_id": room.ID, "sender_id": "user-admin", "content": "",
+	}, "files", "large.txt", "text/plain", payload)
+	response, err := client.Post(server.URL+"/api/v1/channels/csgclaw/messages", contentType, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		detail, _ := io.ReadAll(io.LimitReader(response.Body, 1024))
+		t.Fatalf("upload status = %d, want 201; body=%s", response.StatusCode, detail)
+	}
+	var message im.Message
+	if err := json.NewDecoder(response.Body).Decode(&message); err != nil {
+		t.Fatal(err)
+	}
+	if len(message.Attachments) != 1 {
+		t.Fatalf("attachment count = %d, want 1", len(message.Attachments))
+	}
+	attachment := message.Attachments[0]
+	if attachment.SizeBytes != int64(len(payload)) || attachment.SHA256 != hex.EncodeToString(wantHash[:]) {
+		t.Fatalf("attachment metadata = %+v, want original size and hash", attachment)
+	}
+
+	download, err := client.Get(server.URL + attachment.DownloadURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer download.Body.Close()
+	gotHash := sha256.New()
+	written, err := io.Copy(gotHash, download.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if download.StatusCode != http.StatusOK || written != int64(len(payload)) || !bytes.Equal(gotHash.Sum(nil), wantHash[:]) {
+		t.Fatalf("download status=%d, bytes=%d, hash=%x, want full original file", download.StatusCode, written, gotHash.Sum(nil))
+	}
+
+	const start = 25*1024*1024 - 8
+	const end = start + 31
+	request, err := http.NewRequest(http.MethodGet, server.URL+attachment.DownloadURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+	ranged, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ranged.Body.Close()
+	part, err := io.ReadAll(io.LimitReader(ranged.Body, 1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRange := fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload))
+	if ranged.StatusCode != http.StatusPartialContent || ranged.Header.Get("Content-Range") != wantRange || !bytes.Equal(part, payload[start:end+1]) {
+		t.Fatalf("range status=%d, Content-Range=%q, bytes=%d, want original range", ranged.StatusCode, ranged.Header.Get("Content-Range"), len(part))
+	}
+}

--- a/internal/channel/csgclaw/delivery/im_store_test.go
+++ b/internal/channel/csgclaw/delivery/im_store_test.go
@@ -66,13 +66,16 @@ func TestTranscriptRendererPersistsGeneratedFilesWithFinalMessage(t *testing.T) 
 	}
 	fileStore := agentengine.NewFileStore()
 	files := fileStore.Scope("agent-worker")
-	markdown := []byte("# Generated report\n")
+	// Generated files above the former 25 MiB limit must reach the chat transcript.
+	line := []byte("# Generated report\n")
+	markdown := bytes.Repeat(line, (26*1024*1024)/len(line))
 	created, err := files.Create(context.Background(), agentengine.FileCreateRequest{
 		Name: "report.md", MIMEType: "text/markdown", SizeBytes: int64(len(markdown)),
 	}, bytes.NewReader(markdown))
 	if err != nil {
 		t.Fatalf("Create(output file) error = %v", err)
 	}
+	t.Cleanup(func() { _ = files.Delete(context.Background(), created.ID) })
 	store, err := NewIMTranscriptStore(imService, fixedParticipantResolver{item: apitypes.Participant{
 		ID: "pt-worker", ChannelUserRef: "user-worker",
 	}}, fixedOutputFileSource{files: files})
@@ -128,7 +131,7 @@ func TestTranscriptRendererPersistsGeneratedFilesWithFinalMessage(t *testing.T) 
 	}
 	content, err := os.ReadFile(file.Path)
 	if err != nil || !bytes.Equal(content, markdown) {
-		t.Fatalf("persisted attachment content = %q, error = %v", content, err)
+		t.Fatalf("persisted attachment bytes = %d, want %d original bytes; error = %v", len(content), len(markdown), err)
 	}
 
 	root, err := imService.CreateMessage(im.CreateMessageRequest{

--- a/internal/im/asset_store.go
+++ b/internal/im/asset_store.go
@@ -32,8 +32,8 @@ const (
 	attachmentKindFile         = "file"
 	attachmentKindImage        = "image"
 	MaxAttachmentsPerMessage   = 10
-	MaxAttachmentFileBytes     = 25 * 1024 * 1024
-	MaxAttachmentMessageBytes  = 64 * 1024 * 1024
+	MaxAttachmentFileBytes     = 100 * 1024 * 1024
+	MaxAttachmentMessageBytes  = 256 * 1024 * 1024
 	maxSafeAttachmentNameBytes = 160
 )
 

--- a/internal/template/remote_store.go
+++ b/internal/template/remote_store.go
@@ -22,6 +22,7 @@ import (
 	"unicode/utf8"
 
 	"csgclaw/internal/apitypes"
+	"csgclaw/internal/utils/filebrowse"
 	toml "github.com/pelletier/go-toml/v2"
 )
 
@@ -31,7 +32,6 @@ const (
 	defaultRemoteMaxFileBytes   = 50 * 1024 * 1024
 	officialTemplateNamespace   = "Agentic"
 	remoteManifestFileName      = "agent.toml"
-	remoteFilePreviewMaxBytes   = 256 * 1024
 	remoteAgentTemplatesPerPage = 20
 )
 
@@ -624,8 +624,8 @@ func (s *RemoteStore) ReadWorkspaceFile(
 	}
 	file := apitypes.WorkspaceFile{Path: cleanPath, Size: int64(len(data))}
 	preview := data
-	if len(preview) > remoteFilePreviewMaxBytes {
-		preview = preview[:remoteFilePreviewMaxBytes]
+	if len(preview) > filebrowse.FilePreviewMaxBytes {
+		preview = preview[:filebrowse.FilePreviewMaxBytes]
 		file.Truncated = true
 		validPreview := false
 		for trim := 0; trim < utf8.UTFMax && trim < len(preview); trim++ {
@@ -741,7 +741,9 @@ func (s *RemoteStore) fetchWorkspaceTree(
 
 func (s *RemoteStore) fetchBlob(ctx context.Context, id, filePath, branch string) ([]byte, error) {
 	var payload remoteBlobResponse
-	if err := s.getJSON(ctx, s.blobURL(id, filePath, branch), &payload); err != nil {
+	// Blob responses include base64 file content in addition to ordinary JSON metadata.
+	maxBlobJSON := int64(base64.StdEncoding.EncodedLen(int(s.maxWorkspace))) + s.maxJSON
+	if err := s.getJSONWithLimit(ctx, s.blobURL(id, filePath, branch), &payload, maxBlobJSON); err != nil {
 		return nil, err
 	}
 	data, err := base64.StdEncoding.DecodeString(payload.Data.Content)
@@ -865,12 +867,16 @@ func (s *RemoteStore) blobURL(id, filePath, branch string) string {
 }
 
 func (s *RemoteStore) getJSON(ctx context.Context, endpoint string, out any) error {
-	body, status, err := s.request(ctx, http.MethodGet, endpoint, s.maxJSON+1)
+	return s.getJSONWithLimit(ctx, endpoint, out, s.maxJSON)
+}
+
+func (s *RemoteStore) getJSONWithLimit(ctx context.Context, endpoint string, out any, maxBytes int64) error {
+	body, status, err := s.request(ctx, http.MethodGet, endpoint, maxBytes+1)
 	if err != nil {
 		return err
 	}
-	if int64(len(body)) > s.maxJSON {
-		return fmt.Errorf("remote hub response exceeds %d bytes", s.maxJSON)
+	if int64(len(body)) > maxBytes {
+		return fmt.Errorf("remote hub response exceeds %d bytes", maxBytes)
 	}
 	if status == http.StatusNotFound {
 		return fmt.Errorf("%w", ErrTemplateNotFound)

--- a/internal/template/remote_store_test.go
+++ b/internal/template/remote_store_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"csgclaw/internal/config"
+	"csgclaw/internal/utils/filebrowse"
 )
 
 const remoteTestManifest = `name = "gitlab-assistant"
@@ -481,6 +482,55 @@ func TestRemoteStoreListPaginatesAgentTemplates(t *testing.T) {
 	if got, want := strings.Join(requestedPages, ","), "1,2"; got != want {
 		t.Fatalf("agent template pages = %q, want %q", got, want)
 	}
+}
+
+func TestRemoteStoreLargeFilePreview(t *testing.T) {
+	content := bytes.Repeat([]byte("x"), 4*1024*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/codes/Agentic/large-preview":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"default_branch": "main"}})
+		case "/api/v1/codes/Agentic/large-preview/blob/instructions/AGENTS.md":
+			writeRemoteBlob(t, w, "instructions/AGENTS.md", content)
+		case "/api/v1/codes/Agentic/large-preview/blob/instructions/LARGE.md":
+			writeRemoteBlob(t, w, "instructions/LARGE.md", bytes.Repeat([]byte("x"), filebrowse.FilePreviewMaxBytes+1))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("file above former limit is returned in full", func(t *testing.T) {
+		store := NewRemoteStore(srv.URL, "")
+		file, err := store.ReadWorkspaceFile(context.Background(), "large-preview", "instructions/AGENTS.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if file.Size != int64(len(content)) || file.Truncated || file.Binary || file.Content != string(content) {
+			t.Fatalf("size=%d, truncated=%t, binary=%t, preview bytes=%d, want complete 4 MiB file", file.Size, file.Truncated, file.Binary, len(file.Content))
+		}
+	})
+
+	t.Run("truncated preview retains original size", func(t *testing.T) {
+		store := NewRemoteStore(srv.URL, "")
+		file, err := store.ReadWorkspaceFile(context.Background(), "large-preview", "instructions/LARGE.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if file.Size != int64(filebrowse.FilePreviewMaxBytes+1) || !file.Truncated || file.Binary || len(file.Content) != filebrowse.FilePreviewMaxBytes || strings.Trim(file.Content, "x") != "" {
+			t.Fatalf("size=%d, truncated=%t, binary=%t, preview bytes=%d, want full size and 32 MiB text preview", file.Size, file.Truncated, file.Binary, len(file.Content))
+		}
+	})
+
+	t.Run("decoded size limit remains enforced", func(t *testing.T) {
+		store := NewRemoteStore(srv.URL, "")
+		store.maxWorkspace = int64(len(content) - 1)
+		_, err := store.ReadWorkspaceFile(context.Background(), "large-preview", "instructions/AGENTS.md")
+		want := fmt.Sprintf("remote hub blob %q exceeds %d bytes", "instructions/AGENTS.md", store.maxWorkspace)
+		if err == nil || err.Error() != want {
+			t.Fatalf("ReadWorkspaceFile() error=%v, want %q", err, want)
+		}
+	})
 }
 
 func TestRemoteStoreListGetAndFetchWorkspace(t *testing.T) {

--- a/internal/utils/filebrowse/filebrowse.go
+++ b/internal/utils/filebrowse/filebrowse.go
@@ -13,7 +13,7 @@ import (
 	"csgclaw/internal/apitypes"
 )
 
-const FilePreviewMaxBytes = 256 * 1024
+const FilePreviewMaxBytes = 32 * 1024 * 1024
 
 func List(root, relativePath string) (apitypes.WorkspaceListing, error) {
 	root = strings.TrimSpace(root)

--- a/internal/utils/filebrowse/filebrowse_test.go
+++ b/internal/utils/filebrowse/filebrowse_test.go
@@ -1,0 +1,37 @@
+package filebrowse
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"csgclaw/internal/apitypes"
+)
+
+func TestReadFileAcceptsTextAboveFormerPreviewLimit(t *testing.T) {
+	content := strings.Repeat("preview content\n", (4*1024*1024)/16)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "large.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	source := fstest.MapFS{"workspace/large.txt": &fstest.MapFile{Data: []byte(content)}}
+	readers := map[string]func() (apitypes.WorkspaceFile, error){
+		"local": func() (apitypes.WorkspaceFile, error) { return ReadFile(root, "large.txt") },
+		"embedded": func() (apitypes.WorkspaceFile, error) {
+			return ReadFileFS(source, "workspace", "large.txt")
+		},
+	}
+	for name, read := range readers {
+		t.Run(name, func(t *testing.T) {
+			file, err := read()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if file.Truncated || file.Binary || file.Content != content {
+				t.Fatalf("preview truncated=%t, binary=%t, bytes=%d, want full %d bytes", file.Truncated, file.Binary, len(file.Content), len(content))
+			}
+		})
+	}
+}

--- a/web/app/src/components/business/DocumentPreviewPanel/previewTypes.ts
+++ b/web/app/src/components/business/DocumentPreviewPanel/previewTypes.ts
@@ -40,7 +40,7 @@ type TextEncoding = "utf-16be" | "utf-16le" | "utf-8";
 
 const textSniffBytes = 64 * 1024;
 
-export const MAX_TEXT_PREVIEW_BYTES = 256 * 1024;
+export const MAX_TEXT_PREVIEW_BYTES = 32 * 1024 * 1024;
 
 export function documentPreviewKind(
   item: Pick<AttachmentPreviewItem, "mediaType" | "name">,

--- a/web/app/src/hooks/workspace/useAttachmentWarning.ts
+++ b/web/app/src/hooks/workspace/useAttachmentWarning.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useAttachmentWarning(scopeKey: string) {
+  const [warning, setWarning] = useState("");
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    clearTimer();
+    setWarning("");
+    return clearTimer;
+  }, [clearTimer, scopeKey]);
+
+  const showWarning = useCallback(
+    (message: string) => {
+      clearTimer();
+      setWarning(message);
+      if (message) {
+        timerRef.current = window.setTimeout(() => {
+          timerRef.current = null;
+          setWarning("");
+        }, 5000);
+      }
+    },
+    [clearTimer],
+  );
+
+  return [warning, showWarning] as const;
+}

--- a/web/app/src/hooks/workspace/useConversationController.ts
+++ b/web/app/src/hooks/workspace/useConversationController.ts
@@ -78,6 +78,7 @@ import { localizeAPIError } from "@/shared/i18n";
 import type { IMConversation, IMMessage, IMServerEvent, IMUser, ThreadView, TranslateFn } from "@/models/conversations";
 import type { SlashPickerCandidate } from "@/models/slashCommands";
 import { useLegacyOpenClawWorkingFallback } from "./legacyOpenClawWorking";
+import { useAttachmentWarning } from "./useAttachmentWarning";
 import type { UseConversationControllerArgs } from "./types";
 import { messageListScrollKey, useMessageListAutoScroll } from "./useMessageListAutoScroll";
 import { handleSlashPickerNavigation } from "@/components/business/ConversationPane";
@@ -320,7 +321,7 @@ export function useConversationController({
   const [memberActionBusyID, setMemberActionBusyID] = useState("");
   const [memberActionError, setMemberActionError] = useState("");
   const [composerErrorsByConversationId, setComposerErrorsByConversationId] = useState<ComposerErrorsByKey>({});
-  const [attachmentErrorsByConversationId, setAttachmentErrorsByConversationId] = useState<ComposerErrorsByKey>({});
+  const [attachmentWarning, setAttachmentWarning] = useAttachmentWarning(activeConversationId);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const sendAbortControllersRef = useRef<Record<string, AbortController>>({});
   const sendLocksRef = useRef<Record<string, boolean>>({});
@@ -359,25 +360,7 @@ export function useConversationController({
     },
     [activeConversationId],
   );
-  const setAttachmentError = useCallback((error: string, conversationID: string) => {
-    if (!conversationID) {
-      return;
-    }
-    setAttachmentErrorsByConversationId((current) => {
-      if (current[conversationID] === error) {
-        return current;
-      }
-      if (!error) {
-        const { [conversationID]: _cleared, ...rest } = current;
-        return rest;
-      }
-      return { ...current, [conversationID]: error };
-    });
-  }, []);
-  const composerError =
-    composerErrorsByConversationId[activeConversationId] ??
-    attachmentErrorsByConversationId[activeConversationId] ??
-    "";
+  const composerError = composerErrorsByConversationId[activeConversationId] ?? attachmentWarning;
 
   const usersById = useMemo(() => buildUsersById(data?.users), [data]);
   const activeConversation = useMemo(
@@ -566,6 +549,7 @@ export function useConversationController({
   const slashPickerActive = slashPickerState.active;
   const slashCandidates = slashPickerState.candidates;
   const activeThreadDraftKey = activeThreadRootID ? threadKey(activeConversationId, activeThreadRootID) : "";
+  const [threadAttachmentWarning, setThreadAttachmentWarning] = useAttachmentWarning(activeThreadDraftKey);
   const activeThreadDraftSegments = useMemo(() => {
     if (!activeThreadDraftKey) {
       return [];
@@ -651,10 +635,6 @@ export function useConversationController({
     setSlashIndex(0);
     setSlashPickerDismissed(false);
     setComposerSlashQuery(null);
-  }, [activeConversationId]);
-
-  useEffect(() => {
-    setAttachmentErrorsByConversationId({});
   }, [activeConversationId]);
 
   useEffect(() => {
@@ -1523,7 +1503,7 @@ export function useConversationController({
       return;
     }
     const selection = selectAttachmentFiles(files, attachmentDrafts);
-    setAttachmentError(attachmentSelectionError(selection, t), activeConversationId);
+    setAttachmentWarning(attachmentSelectionError(selection, t));
     if (selection.files.length === 0) {
       return;
     }
@@ -1546,7 +1526,7 @@ export function useConversationController({
     if (index < 0) {
       return;
     }
-    setAttachmentError("", activeConversationId);
+    setAttachmentWarning("");
     setRemovedAttachmentsByConversationId((current) => {
       const existing = current[activeConversationId]?.attachments ?? [];
       return {
@@ -1597,7 +1577,7 @@ export function useConversationController({
       return;
     }
     const selection = selectAttachmentFiles(files, activeThreadAttachmentDrafts);
-    setThreadError(attachmentSelectionError(selection, t));
+    setThreadAttachmentWarning(attachmentSelectionError(selection, t));
     if (selection.files.length === 0) {
       return;
     }
@@ -1612,6 +1592,7 @@ export function useConversationController({
     if (!activeThreadDraftKey) {
       return;
     }
+    setThreadAttachmentWarning("");
     setThreadAttachmentDraftsByKey((current) =>
       updateAttachmentDrafts(
         current,
@@ -1623,7 +1604,7 @@ export function useConversationController({
 
   function clearComposerError() {
     setComposerError("");
-    setAttachmentError("", activeConversationId);
+    setAttachmentWarning("");
   }
 
   function clearMemberActionError() {
@@ -1736,7 +1717,7 @@ export function useConversationController({
       activeThreadRootID,
       activeThreadView,
       threadLoading,
-      threadError,
+      threadError: threadError || threadAttachmentWarning,
       threadDraftSegments: activeThreadDraftSegments,
       threadAttachmentDrafts: activeThreadAttachmentDrafts,
       onOpenThread: openThread,

--- a/web/app/src/models/attachments.test.ts
+++ b/web/app/src/models/attachments.test.ts
@@ -30,6 +30,19 @@ describe("attachment drafts", () => {
     expect(formatAttachmentSize(2 * 1024 * 1024)).toBe("2.0 MiB");
   });
 
+  it("accepts 100 MiB files up to a combined 256 MiB", () => {
+    const files = [
+      fileWithSize("first.bin", 100 * 1024 * 1024),
+      fileWithSize("second.bin", 100 * 1024 * 1024),
+      fileWithSize("third.bin", 56 * 1024 * 1024),
+    ];
+    expect(selectAttachmentFiles(files)).toMatchObject({ files, fileTooLarge: false, totalTooLarge: false });
+    expect(selectAttachmentFiles([...files, fileWithSize("extra.bin", 1)])).toMatchObject({
+      files,
+      totalTooLarge: true,
+    });
+  });
+
   it("enforces count, per-file, and total selection limits", () => {
     const oversized = fileWithSize("large.bin", MAX_ATTACHMENT_FILE_BYTES + 1);
     expect(selectAttachmentFiles([oversized])).toMatchObject({ files: [], fileTooLarge: true });

--- a/web/app/src/models/attachments.ts
+++ b/web/app/src/models/attachments.ts
@@ -1,8 +1,8 @@
 export type AttachmentKind = "image" | "file";
 
 export const MAX_ATTACHMENTS_PER_MESSAGE = 10;
-export const MAX_ATTACHMENT_FILE_BYTES = 25 * 1024 * 1024;
-export const MAX_ATTACHMENT_MESSAGE_BYTES = 64 * 1024 * 1024;
+export const MAX_ATTACHMENT_FILE_BYTES = 100 * 1024 * 1024;
+export const MAX_ATTACHMENT_MESSAGE_BYTES = 256 * 1024 * 1024;
 
 let attachmentDraftSequence = 0;
 

--- a/web/app/src/shared/i18n/messages.ts
+++ b/web/app/src/shared/i18n/messages.ts
@@ -870,7 +870,7 @@ export const messages = {
     attachmentPreviewLoading: "正在加载附件预览…",
     attachmentPreviewHtmlDocument: "HTML 文档预览",
     attachmentPreviewFailed: "无法加载附件预览，请下载后重试。",
-    attachmentPreviewTruncated: "文件较大，仅显示前 256 KiB。下载文件可查看完整内容。",
+    attachmentPreviewTruncated: "文件较大，仅显示前 32 MiB。下载文件可查看完整内容。",
     attachmentPreviewUnavailable: "此文件类型无法直接预览，可以下载后使用系统应用打开。",
     attachmentPreviewResize: "调整文档预览宽度",
     attachmentPreviewZoomOut: "缩小",
@@ -2501,7 +2501,7 @@ export const messages = {
     attachmentPreviewHtmlDocument: "HTML document preview",
     attachmentPreviewFailed: "Unable to load the attachment preview. Download the file to try again.",
     attachmentPreviewTruncated:
-      "This file is large, so only the first 256 KiB is shown. Download it to view the full content.",
+      "This file is large, so only the first 32 MiB is shown. Download it to view the full content.",
     attachmentPreviewUnavailable: "This file type cannot be previewed here. Download it to open with a system app.",
     attachmentPreviewResize: "Resize document preview",
     attachmentPreviewZoomOut: "Zoom out",

--- a/web/app/tests/components/DocumentPreviewPanel.test.tsx
+++ b/web/app/tests/components/DocumentPreviewPanel.test.tsx
@@ -80,7 +80,7 @@ const t = (key: string, params?: Record<string, string | number>) => {
     attachmentPreviewOutline: "Document outline",
     attachmentPreviewPageCount: `Page ${params?.page ?? 0} of ${params?.count ?? 0}`,
     attachmentPreviewSlideCount: `Slide ${params?.page ?? 0} of ${params?.count ?? 0}`,
-    attachmentPreviewTruncated: "Only the first 256 KiB is shown",
+    attachmentPreviewTruncated: "Only the first 32 MiB is shown",
     attachmentPreviewResetZoom: "Reset zoom",
     attachmentPreviewResize: "Resize preview",
     attachmentPreviewUnavailable: "Preview unavailable",
@@ -404,6 +404,30 @@ describe("DocumentPreviewPanel", () => {
     expect(screen.queryByText("Slide 10 of 3")).not.toBeInTheDocument();
   });
 
+  it("previews text past the old 2 MiB limit without truncating", async () => {
+    const fullText = `${"x".repeat(4 * 1024 * 1024)}TAIL`;
+    const { container } = render(
+      <DocumentPreviewPanel
+        index={0}
+        items={[
+          {
+            file: new File([fullText], "report.txt", { type: "text/plain" }),
+            id: "complete-text",
+            mediaType: "text/plain",
+            name: "report.txt",
+            sizeBytes: fullText.length,
+          },
+        ]}
+        t={t}
+        onClose={() => {}}
+        onIndexChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(container.querySelector(".document-preview-text")?.textContent).toBe(fullText));
+    expect(screen.queryByText("Only the first 32 MiB is shown")).not.toBeInTheDocument();
+  });
+
   it("bounds large text previews and keeps the complete file downloadable", async () => {
     const fullText = `${"x".repeat(MAX_TEXT_PREVIEW_BYTES + 32)}TAIL`;
     const { container } = render(
@@ -424,7 +448,7 @@ describe("DocumentPreviewPanel", () => {
       />,
     );
 
-    expect(await screen.findByRole("status")).toHaveTextContent("Only the first 256 KiB is shown");
+    expect(await screen.findByRole("status")).toHaveTextContent("Only the first 32 MiB is shown");
     const preview = container.querySelector(".document-preview-text");
     expect(preview?.textContent).toHaveLength(MAX_TEXT_PREVIEW_BYTES);
     expect(preview).not.toHaveTextContent("TAIL");

--- a/web/app/tests/hooks/useConversationController.test.tsx
+++ b/web/app/tests/hooks/useConversationController.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import { useConversationController } from "@/hooks/workspace/useConversationController";
 import { WorkspacePaneTypes } from "@/models/routing";
+import { MAX_ATTACHMENT_FILE_BYTES } from "@/models/attachments";
 import type { IMConversation, IMData, IMMessage, IMUser, ThreadView, TranslateFn } from "@/models/conversations";
 import type { AgentLike } from "@/models/agents";
 import type { ConversationWorkingParticipant } from "@/components/business/ConversationPane";
@@ -804,6 +805,134 @@ describe("useConversationController", () => {
 
     rerender({ activeConversationId: directConversation.id, data, messageListActive: true });
     expect(result.current.conversationViewProps.composerError).toBe("");
+  });
+
+  describe("attachment warnings", () => {
+    const root: IMMessage = { id: "msg-root", content: "Start here", sender_id: "u-admin" };
+
+    function oversizedFile(): File {
+      const file = new File(["large"], "large.txt", { type: "text/plain" });
+      Object.defineProperty(file, "size", { value: MAX_ATTACHMENT_FILE_BYTES + 1 });
+      return file;
+    }
+
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("expires a composer warning after five seconds and restarts the timeout for the same warning", () => {
+      const { result } = renderConversationController();
+      const file = oversizedFile();
+
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      expect(result.current.conversationViewProps.composerError).toBe("attachmentTooLarge");
+      act(() => vi.advanceTimersByTime(5000));
+      expect(result.current.conversationViewProps.composerError).toBe("");
+
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(4000));
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(result.current.conversationViewProps.composerError).toBe("attachmentTooLarge");
+      act(() => vi.advanceTimersByTime(4000));
+      expect(result.current.conversationViewProps.composerError).toBe("");
+      expect(result.current.conversationViewProps.attachmentDrafts).toHaveLength(0);
+    });
+
+    it("clears a warning on room changes without expiring the next room's warning early", () => {
+      const data: IMData = {
+        ...dataWithMessages([]),
+        rooms: [directConversation, { ...directConversation, id: "room-2" }],
+      };
+      const { result, rerender, unmount } = renderConversationController({ data });
+      const file = oversizedFile();
+
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(4000));
+      rerender({ activeConversationId: "room-2", data });
+      expect(result.current.conversationViewProps.composerError).toBe("");
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(result.current.conversationViewProps.composerError).toBe("attachmentTooLarge");
+
+      rerender({ activeConversationId: directConversation.id, data });
+      expect(result.current.conversationViewProps.composerError).toBe("");
+      act(() => result.current.conversationViewProps.onAddAttachments?.([file]));
+      unmount();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("expires thread warnings and clears them when the thread changes or closes", async () => {
+      const secondRoot: IMMessage = { id: "msg-second", content: "Another thread", sender_id: "u-admin" };
+      const { result, unmount } = renderConversationController({ data: dataWithMessages([root, secondRoot]) });
+      const file = oversizedFile();
+      await act(async () => result.current.conversationViewProps.onOpenThread(root));
+
+      act(() => result.current.conversationViewProps.onAddThreadAttachments?.([file]));
+      expect(result.current.conversationViewProps.threadError).toBe("attachmentTooLarge");
+      act(() => vi.advanceTimersByTime(5000));
+      expect(result.current.conversationViewProps.threadError).toBe("");
+
+      act(() => result.current.conversationViewProps.onAddThreadAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(4000));
+      await act(async () => result.current.conversationViewProps.onOpenThread(secondRoot));
+      expect(result.current.conversationViewProps.threadError).toBe("");
+      act(() => result.current.conversationViewProps.onAddThreadAttachments?.([file]));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(result.current.conversationViewProps.threadError).toBe("attachmentTooLarge");
+      act(() => result.current.conversationViewProps.onCloseThread());
+      await act(async () => result.current.conversationViewProps.onOpenThread(secondRoot));
+      expect(result.current.conversationViewProps.threadError).toBe("");
+
+      act(() => result.current.conversationViewProps.onAddThreadAttachments?.([file]));
+      unmount();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it.each(["composer", "thread"])("preserves a %s send failure when an attachment warning expires", async (scope) => {
+      apiMocks.sendMessageRequest.mockRejectedValue(new Error("Upload failed. Try again."));
+      const { result } = renderConversationController({ data: dataWithMessages([root]) });
+      const file = new File(["valid"], "valid.txt", { type: "text/plain" });
+      if (scope === "thread") {
+        await act(async () => result.current.conversationViewProps.onOpenThread(root));
+      }
+      const addAttachments = () => {
+        const props = result.current.conversationViewProps;
+        return scope === "thread" ? props.onAddThreadAttachments : props.onAddAttachments;
+      };
+      const displayedError = () => {
+        const props = result.current.conversationViewProps;
+        return scope === "thread" ? props.threadError : props.composerError;
+      };
+      act(() => addAttachments()?.([oversizedFile()]));
+      expect(displayedError()).toBe("attachmentTooLarge");
+      act(() => addAttachments()?.([file]));
+      expect(displayedError()).toBe("");
+      act(() => addAttachments()?.([oversizedFile()]));
+      expect(displayedError()).toBe("attachmentTooLarge");
+      act(() => {
+        const props = result.current.conversationViewProps;
+        if (scope === "thread") {
+          props.onRemoveThreadAttachment?.(props.threadAttachmentDrafts?.[0]?.id ?? "");
+        } else {
+          props.onRemoveAttachment?.(props.attachmentDrafts?.[0]?.id ?? "");
+        }
+      });
+      expect(displayedError()).toBe("");
+      act(() => addAttachments()?.([file]));
+      act(() => addAttachments()?.([oversizedFile()]));
+
+      await act(async () => {
+        const props = result.current.conversationViewProps;
+        await (scope === "thread" ? props.onSendThreadReply() : props.onSendMessage());
+      });
+      expect(apiMocks.sendMessageRequest).toHaveBeenCalledOnce();
+      expect(displayedError()).toBe("Upload failed. Try again.");
+      act(() => vi.advanceTimersByTime(5000));
+      expect(displayedError()).toBe("Upload failed. Try again.");
+      act(() => addAttachments()?.([oversizedFile()]));
+      act(() => vi.advanceTimersByTime(5000));
+      expect(displayedError()).toBe("Upload failed. Try again.");
+    });
   });
 
   it("does not derive working participants from recent message history", () => {


### PR DESCRIPTION
## Summary

- Raise text previews to 32 MiB and chat attachments to 100 MiB per file / 256 MiB per message, preserving complete downloads.
- Fix large remote template previews and dismiss attachment warnings after 5 seconds without hiding send failures.