### PR TITLE
fix(web): polish room collaboration layouts

### DIFF
--- a/web/app/src/components/business/ConversationPane/ConversationThreads.css
+++ b/web/app/src/components/business/ConversationPane/ConversationThreads.css
@@ -613,13 +613,19 @@ button.thread-message-avatar:focus-visible {
   }
 }
 
-/* The task reference shares the existing action strip; it never adds a card
-   row or pushes Copy / Reply below the message. */
+/* Keep task references in the shared action strip and reserve enough room so
+   the following message cannot overlap it. */
 .message-hover-actions.has-leading {
+  position: static;
+  inset: auto;
+  width: 100%;
+  box-sizing: border-box;
+  padding-block: 4px;
   opacity: 1;
 }
 .message-action-leading {
   display: flex;
+  align-items: center;
   min-width: 0;
   margin-right: auto;
 }

--- a/web/app/src/models/roomTasks.ts
+++ b/web/app/src/models/roomTasks.ts
@@ -8,7 +8,12 @@ export function roomTaskGroups(tasks: readonly WorkspaceTask[], roomID: string):
     .filter((task) => !task.parent_id)
     .sort((left, right) => {
       const rank = (t: WorkspaceTask) => (roomTaskExecutionEnded(t) ? 2 : t.status === "queued" ? 1 : 0);
-      return rank(left) - rank(right) || left.created_at.localeCompare(right.created_at);
+      return (
+        rank(left) - rank(right) ||
+        right.created_at.localeCompare(left.created_at) ||
+        right.id.length - left.id.length ||
+        right.id.localeCompare(left.id)
+      );
     })
     .map((task) => ({
       task,

--- a/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.module.css
+++ b/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.module.css
@@ -223,6 +223,9 @@
 .group + .group {
   margin-top: 12px;
 }
+.group > .headingRow + .children {
+  margin-top: 8px;
+}
 .children li:first-child {
   border-top: 0;
 }

--- a/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.test.tsx
+++ b/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.test.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTranslator } from "@/shared/i18n";
+import { TooltipProvider } from "@/components/ui";
 import type { TranslateFn } from "@/models/conversations";
 import { normalizeTaskList } from "@/models/tasks";
 import { RoomTaskDialog, RoomTaskReference } from "./RoomTaskDialog";
@@ -147,10 +148,19 @@ it("shows a partial outcome in the header while leaving reports out of the check
 
 it("uses a compact task number without long titles or progress in the message action area", async () => {
   const onOpen = vi.fn();
-  render(<RoomTaskReference compact task={tasks[0]} tasks={tasks} t={t} onOpen={onOpen} />);
+  const user = userEvent.setup();
+  render(
+    <TooltipProvider delayDuration={0}>
+      <RoomTaskReference compact task={tasks[0]} tasks={tasks} t={t} onOpen={onOpen} />
+    </TooltipProvider>,
+  );
   const button = screen.getByRole("button", { name: /roomTaskView/ });
   expect(button.textContent).toBe(`#${tasks[0].id}`);
   expect(button.textContent).not.toContain("0/2");
-  await userEvent.click(button);
+  await user.hover(button);
+  const tooltip = await screen.findByRole("tooltip");
+  expect(tooltip).toHaveTextContent(`roomTaskView · ${tasks[0].title}`);
+  expect(button).not.toContainElement(tooltip);
+  await user.click(button);
   expect(onOpen).toHaveBeenCalledWith(button);
 });

--- a/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.tsx
+++ b/web/app/src/pages/ConversationPage/components/RoomTaskDialog/RoomTaskDialog.tsx
@@ -1,5 +1,13 @@
 import { ListTodo, CheckCircle2, Circle, Eye } from "lucide-react";
-import { Button, DialogRoot, DialogContent, DialogTitle, DialogDescription, DialogCloseButton } from "@/components/ui";
+import {
+  Button,
+  DialogRoot,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogCloseButton,
+  Tooltip,
+} from "@/components/ui";
 import type { TranslateFn } from "@/models/conversations";
 import type { WorkspaceTask } from "@/models/tasks";
 import { roomTaskGroups, roomTaskParent, roomTaskState } from "@/models/roomTasks";
@@ -29,17 +37,17 @@ export function RoomTaskReference({
   if (compact) {
     const label = `${t("roomTaskView")} · ${task?.title || taskID}`;
     return (
-      <button
-        type="button"
-        className={styles.compactReference}
-        aria-label={label}
-        data-tooltip={label}
-        data-tooltip-side="top"
-        onClick={(event) => onOpen(event.currentTarget)}
-      >
-        <Eye size={13} aria-hidden="true" />
-        <span>{taskID ? taskNumber(taskID) : t("roomTaskView")}</span>
-      </button>
+      <Tooltip content={label} contentProps={{ side: "top" }}>
+        <button
+          type="button"
+          className={styles.compactReference}
+          aria-label={label}
+          onClick={(event) => onOpen(event.currentTarget)}
+        >
+          <Eye size={16} aria-hidden="true" />
+          <span>{taskID ? taskNumber(taskID) : t("roomTaskView")}</span>
+        </button>
+      </Tooltip>
     );
   }
   return (

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceRows/WorkspaceRows.module.css
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceRows/WorkspaceRows.module.css
@@ -385,6 +385,18 @@
   white-space: nowrap;
 }
 
+.conversationTail {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.conversationTail .time {
+  min-width: 5ch;
+  text-align: right;
+}
+
 .statusDot {
   width: 8px;
   height: 8px;
@@ -473,10 +485,42 @@
 .conversationRow {
   padding: 8px;
   grid-template-columns: 32px minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  row-gap: 0;
+}
+
+.conversationRow > .icon {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+.conversationRow > .main {
+  display: contents;
+}
+
+.conversationRow .titleLine {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.conversationRow .meta {
+  grid-column: 2 / -1;
+  grid-row: 2;
+}
+
+.conversationRow > .conversationTail {
+  grid-column: 3;
+  grid-row: 1;
 }
 
 .directConversationRow {
+  grid-template-rows: auto;
   align-items: center;
+}
+
+.directConversationRow > .icon {
+  grid-row: 1;
 }
 
 .taskRow {

--- a/web/app/src/pages/WorkspacePage/components/WorkspaceRows/WorkspaceRows.tsx
+++ b/web/app/src/pages/WorkspacePage/components/WorkspaceRows/WorkspaceRows.tsx
@@ -349,11 +349,6 @@ export function WorkspaceConversationRow({
       <span className={styles.main}>
         <span className={styles.titleLine}>
           <span className={classNames(styles.title, "truncate")}>{title}</span>
-          {isDirect ? null : (
-            <span className={classNames(styles.roomModeBadge, onDemand && styles.roomModeBadgeOnDemand)}>
-              {t(onDemand ? "onDemandCollaborationTag" : "freeCollaborationTag")}
-            </span>
-          )}
           {questionCount > 0 ? (
             <span
               className={styles.pendingQuestionBadge}
@@ -375,7 +370,14 @@ export function WorkspaceConversationRow({
           </span>
         )}
       </span>
-      <span className={styles.time}>{formatSidebarTime(lastMessage?.created_at, locale, t)}</span>
+      <span className={styles.conversationTail}>
+        {isDirect ? null : (
+          <span className={classNames(styles.roomModeBadge, onDemand && styles.roomModeBadgeOnDemand)}>
+            {t(onDemand ? "onDemandCollaborationTag" : "freeCollaborationTag")}
+          </span>
+        )}
+        <span className={styles.time}>{formatSidebarTime(lastMessage?.created_at, locale, t)}</span>
+      </span>
     </button>
   );
 }

--- a/web/app/tests/components/WorkspaceRows.test.tsx
+++ b/web/app/tests/components/WorkspaceRows.test.tsx
@@ -171,7 +171,9 @@ describe("WorkspaceRows", () => {
       />,
     );
 
-    expect(screen.getByText("onDemandCollaborationTag")).toBeInTheDocument();
+    const onDemandBadge = screen.getByText("onDemandCollaborationTag");
+    expect(onDemandBadge).toBeInTheDocument();
+    expect(onDemandBadge.parentElement).toBe(screen.getByRole("button").lastElementChild);
 
     rerender(
       <WorkspaceConversationRow
@@ -185,7 +187,9 @@ describe("WorkspaceRows", () => {
       />,
     );
 
-    expect(screen.getByText("freeCollaborationTag")).toBeInTheDocument();
+    const freeBadge = screen.getByText("freeCollaborationTag");
+    expect(freeBadge).toBeInTheDocument();
+    expect(freeBadge.parentElement).toBe(screen.getByRole("button").lastElementChild);
   });
 
   it("renders thread rows without markdown code-fence language prefixes", () => {

--- a/web/app/tests/models/roomTasks.test.ts
+++ b/web/app/tests/models/roomTasks.test.ts
@@ -25,6 +25,46 @@ describe("room tasks", () => {
     expect(roomTaskGroups(tasks, "empty")).toEqual([]);
   });
 
+  it("keeps active parents first and orders each status group newest first", () => {
+    const tasks = normalizeTaskList([
+      {
+        id: "task-34",
+        assignment_type: "room",
+        assignment_id: "r",
+        status: "completed",
+        created_at: "2026-09-11T09:00:00Z",
+      },
+      {
+        id: "task-52",
+        assignment_type: "room",
+        assignment_id: "r",
+        status: "in_progress",
+        created_at: "2026-09-11T12:00:00Z",
+      },
+      {
+        id: "task-39",
+        assignment_type: "room",
+        assignment_id: "r",
+        status: "completed",
+        created_at: "2026-09-11T10:00:00Z",
+      },
+      {
+        id: "task-50",
+        assignment_type: "room",
+        assignment_id: "r",
+        status: "completed",
+        created_at: "2026-09-11T11:00:00Z",
+      },
+    ]);
+
+    expect(roomTaskGroups(tasks, "r").map((group) => group.task.id)).toEqual([
+      "task-52",
+      "task-50",
+      "task-39",
+      "task-34",
+    ]);
+  });
+
   it("does not confuse execution ending with a successful goal", () => {
     const [task] = normalizeTaskList([
       { id: "root", assignment_type: "room", assignment_id: "r", status: "completed", goal_outcome: "issues" },


### PR DESCRIPTION
- Refine room task spacing and render task-reference tooltips above workspace layers.
- Align room mode badges with timestamps while allowing message previews to use the full second row.
- Keep task actions from overlapping following messages and order task groups newest-first within status priority.
